### PR TITLE
fix: preserve $groups passed via properties (#3888)

### DIFF
--- a/.changeset/grumpy-groups-survive.md
+++ b/.changeset/grumpy-groups-survive.md
@@ -1,0 +1,9 @@
+---
+'posthog-node': patch
+'@posthog/mcp': patch
+---
+
+Stop dropping `$groups` on events that pass groups via `properties.$groups`
+(fixes #3888): posthog-node no longer overwrites a set `$groups` with the
+top-level `groups` when none is provided, and the MCP analytics sink forwards
+groups as a first-class `groups` field.

--- a/packages/mcp/src/__tests__/sink.test.ts
+++ b/packages/mcp/src/__tests__/sink.test.ts
@@ -1,0 +1,65 @@
+import type { EventMessage, PostHog } from 'posthog-node'
+
+import { McpEventSink } from '../extensions/sink'
+import { MCPAnalyticsEventType } from '../extensions/event-types'
+import type { McpEvent } from '../types'
+
+/**
+ * Direct coverage for `McpEventSink.capture()` → `posthog.capture()`. The shared
+ * `EventCapture` test harness patches `McpEventSink.prototype.capture` and stops
+ * before the real `posthog.capture()` call, so it cannot assert on the payload
+ * actually handed to posthog-node. These tests spy on a fake client instead.
+ *
+ * Regression guard for https://github.com/PostHog/posthog-js/issues/3888:
+ * posthog-node only stamps the outgoing `$groups` property from the top-level
+ * `groups` field, so the group must be forwarded as a first-class `groups` field
+ * — not only inside `properties.$groups`.
+ */
+describe('McpEventSink groups forwarding', () => {
+  function spyClient(): { posthog: PostHog; calls: EventMessage[] } {
+    const calls: EventMessage[] = []
+    const posthog = {
+      capture: (message: EventMessage): void => {
+        calls.push(message)
+      },
+    } as unknown as PostHog
+    return { posthog, calls }
+  }
+
+  it('forwards a top-level `groups` field when the event carries groups', async () => {
+    const { posthog, calls } = spyClient()
+    const sink = new McpEventSink(posthog)
+
+    const event: McpEvent = {
+      eventType: MCPAnalyticsEventType.mcpToolsCall,
+      sessionId: 'session-1',
+      identifyActorGivenId: 'user-1',
+      groups: { account: 'acct-123' },
+      timestamp: new Date(),
+    }
+
+    await sink.capture(event, { enableExceptionAutocapture: false })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].event).toBe('$mcp_tool_call')
+    expect(calls[0].groups).toEqual({ account: 'acct-123' })
+    // Still present in properties (where the pipeline writes it) for parity.
+    expect((calls[0].properties as Record<string, unknown>).$groups).toEqual({ account: 'acct-123' })
+  })
+
+  it('omits `groups` when the event carries none', async () => {
+    const { posthog, calls } = spyClient()
+    const sink = new McpEventSink(posthog)
+
+    const event: McpEvent = {
+      eventType: MCPAnalyticsEventType.mcpToolsCall,
+      sessionId: 'session-1',
+      timestamp: new Date(),
+    }
+
+    await sink.capture(event, { enableExceptionAutocapture: false })
+
+    expect(calls).toHaveLength(1)
+    expect('groups' in calls[0]).toBe(false)
+  })
+})

--- a/packages/mcp/src/extensions/sink.ts
+++ b/packages/mcp/src/extensions/sink.ts
@@ -114,10 +114,18 @@ export class McpEventSink {
     const { event: fullEvent, captures } = result
     try {
       for (const captureEvent of captures) {
+        // `$groups` is written into `properties` by `buildPostHogCaptureEvents`, but
+        // posthog-node only stamps the outgoing `$groups` from the top-level `groups`
+        // field. Forward it as a first-class `groups` so the group association survives
+        // and group-scoped flag evaluation is correct. See
+        // https://github.com/PostHog/posthog-js/issues/3888.
+        const groups = captureEvent.properties.$groups as Record<string, string> | undefined
+
         this.posthog.capture({
           distinctId: captureEvent.distinct_id,
           event: captureEvent.event,
           properties: captureEvent.properties,
+          ...(groups ? { groups } : {}),
           timestamp: new Date(captureEvent.timestamp),
           uuid: uuidv7(),
         })

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -181,6 +181,27 @@ describe('PostHog Node.js', () => {
       )
     })
 
+    it('should keep $groups passed via properties when no top-level groups is set (#3888)', async () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+      posthog.capture({
+        distinctId: '123',
+        event: 'test-event',
+        properties: { foo: 'bar', $groups: { account: 'acct-123' } },
+      })
+
+      await waitForFlushTimer()
+      expect(getLastBatchEvents()?.[0]).toEqual(
+        expect.objectContaining({
+          distinct_id: '123',
+          event: 'test-event',
+          properties: expect.objectContaining({
+            $groups: { account: 'acct-123' },
+            foo: 'bar',
+          }),
+        })
+      )
+    })
+
     it('should capture identify events on shared queue', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       posthog.identify({ distinctId: '123', properties: { foo: 'bar' } })

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2591,10 +2591,13 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       })
       .then((additionalProperties) => {
         // No matter what - capture the event
+        const resolvedGroups = eventMessage.groups || groups
         const props = {
           ...additionalProperties,
           ...(eventMessage.properties || {}),
-          $groups: eventMessage.groups || groups,
+          // Only stamp $groups from the top-level `groups` when present — otherwise a
+          // caller-provided properties.$groups would be clobbered with undefined (#3888).
+          ...(resolvedGroups !== undefined ? { $groups: resolvedGroups } : {}),
         } as PostHogEventProperties
         return props
       })


### PR DESCRIPTION
## Problem

`$groups` is always `undefined` on `$mcp_*` events even when `identify` returns a valid `groups` map (#3888).

The group flows correctly through `@posthog/mcp` (`identify` → `event.groups` → `addGroupsProperty` writes `properties.$groups`), but it's wiped before the event leaves posthog-node. In `prepareEventMessage` (`packages/node/src/client.ts`):

```ts
$groups: eventMessage.groups || groups,
```

This line **unconditionally** overwrites `$groups` with the top-level `groups`. The MCP sink (`packages/mcp/src/extensions/sink.ts`) only sets the group inside `properties.$groups` and never sets a top-level `groups`, so this resolves to `undefined` and the group association is dropped. It's also why the reporter's `eventProperties.$groups` workaround failed — same line overwrites it.

## Changes

Fixes both layers:

- **`packages/node/src/client.ts`** — only stamp `$groups` from the top-level `groups` when it's actually present; otherwise a caller-provided `properties.$groups` survives. Precedence is unchanged (top-level `groups` still wins when set). This protects every direct `capture()` caller, not just MCP.
- **`packages/mcp/src/extensions/sink.ts`** — forward `groups` as a first-class field on `posthog.capture()` (derived from `properties.$groups`, only when present). This is the idiomatic posthog-node contract and keeps group-scoped flag evaluation correct.

Adds regression tests in both packages (`posthog-node.spec.ts`, new `sink.test.ts`) and a `posthog-node` + `@posthog/mcp` patch changeset.

## How to test

```
cd packages/node && npx jest posthog-node.spec -t "groups"
cd packages/mcp  && npx jest sink.test
```

The new posthog-node test asserts `capture({ properties: { $groups: { account: 'acct-123' } } })` (no top-level `groups`) emits `$groups: { account: 'acct-123' }`. The sink test asserts a top-level `groups` field is forwarded when present and omitted otherwise.

## Credit

Root cause was diagnosed by @GauthierPLM in #3888, who also opened #3896 fixing the sink layer. This PR incorporates that sink fix + test and adds the posthog-node root-cause fix so all direct callers are protected. Supersedes #3896.

## Release info

### Libraries affected

- [x] posthog-node
- [x] @posthog/mcp

Closes #3888

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*