### PR TITLE
feat(replay): redact binary bodies, datadog, and credential headers in network capture

### DIFF
--- a/.changeset/replay-network-redaction.md
+++ b/.changeset/replay-network-redaction.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Session replay network capture: never record binary/asset response bodies (images, video, audio, fonts, etc.), skip Datadog browser-RUM intake hosts, and redact credential-bearing headers on both request and response by name heuristic (e.g. custom `*-token` headers) - reducing recording size and avoiding accidental credential capture.

--- a/packages/browser/src/__tests__/extensions/replay/config.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/config.test.ts
@@ -67,6 +67,34 @@ describe('config', () => {
                 })
             })
 
+            it('redacts denied request and response headers, including credential-shaped custom names', () => {
+                const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
+                const cleaned = networkOptions.maskRequestFn!({
+                    name: 'something',
+                    requestHeaders: {
+                        'x-gist-encoded-user-token': 'abc',
+                        'content-type': 'application/json',
+                    },
+                    responseHeaders: {
+                        'set-cookie': 'session=secret',
+                        'x-session-id': 'xyz',
+                        'content-type': 'application/json',
+                    },
+                } as Partial<CapturedNetworkRequest> as CapturedNetworkRequest)
+                expect(cleaned).toEqual({
+                    name: 'something',
+                    requestHeaders: {
+                        'x-gist-encoded-user-token': 'redacted',
+                        'content-type': 'application/json',
+                    },
+                    responseHeaders: {
+                        'set-cookie': 'redacted',
+                        'x-session-id': 'redacted',
+                        'content-type': 'application/json',
+                    },
+                })
+            })
+
             it.each([
                 [
                     {
@@ -216,6 +244,9 @@ describe('config', () => {
                     '.clarity.ms',
                     'analytics.google.com',
                     'bam.nr-data.net',
+                    'datadoghq.com',
+                    'datadoghq.eu',
+                    'ddog-gov.com',
                 ])
             })
 
@@ -231,6 +262,9 @@ describe('config', () => {
                     '.clarity.ms',
                     'analytics.google.com',
                     'bam.nr-data.net',
+                    'datadoghq.com',
+                    'datadoghq.eu',
+                    'ddog-gov.com',
                 ])
             })
         })

--- a/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
@@ -216,6 +216,28 @@ describe('network plugin', () => {
             })
         })
 
+        describe('binary content types are never recorded', () => {
+            it.each([
+                ['image/webp', false],
+                ['image/png', false],
+                ['video/mp4', false],
+                ['audio/mpeg', false],
+                ['font/woff2', false],
+                ['application/octet-stream', false],
+                ['application/pdf', false],
+                ['application/json', true],
+                ['text/plain', true],
+            ])('recordBody:true with content-type %s should record=%s', (contentType, expected) => {
+                const result = shouldRecordBody({
+                    type: 'response',
+                    headers: { 'content-type': contentType } as unknown as Headers,
+                    url: 'https://example.com/asset',
+                    recordBody: true,
+                })
+                expect(result).toBe(expected)
+            })
+        })
+
         describe('edge cases', () => {
             edgeCaseTestCases.forEach(({ recordBody, headers = {}, url = 'https://example.com', expected }, index) => {
                 it(`should handle edge case ${index + 1}: ${JSON.stringify({ recordBody, headers, url })}`, () => {

--- a/packages/browser/src/extensions/replay/external/config.ts
+++ b/packages/browser/src/extensions/replay/external/config.ts
@@ -55,6 +55,10 @@ export const defaultNetworkOptions: Required<NetworkRecordOptions> = {
         // NB no leading dot here
         'analytics.google.com',
         'bam.nr-data.net',
+        // Datadog browser RUM intake - their telemetry payloads have no replay value
+        'datadoghq.com',
+        'datadoghq.eu',
+        'ddog-gov.com',
     ],
 }
 
@@ -88,16 +92,44 @@ const PAYLOAD_CONTENT_DENY_LIST = [
     'token',
 ]
 
-// we always remove headers on the deny list because we never want to capture this sensitive data
-const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetworkRequest => {
-    const headers = data.requestHeaders
+// substrings that mark a header as credential-bearing - catches custom names
+// (e.g. x-gist-encoded-user-token) that aren't in the exact deny list above
+const HEADER_DENY_SUBSTRINGS = [
+    'auth',
+    'token',
+    'secret',
+    'session',
+    'api-key',
+    'apikey',
+    'api_key',
+    'credential',
+    'password',
+    'passwd',
+    'cookie',
+    'csrf',
+    'xsrf',
+]
+
+const isDeniedHeader = (header: string): boolean => {
+    const lower = header.toLowerCase()
+    return HEADER_DENY_LIST.includes(lower) || HEADER_DENY_SUBSTRINGS.some((s) => lower.includes(s))
+}
+
+const redactDeniedHeaders = (headers: CapturedNetworkRequest['requestHeaders']): void => {
     if (!isNullish(headers)) {
         each(Object.keys(headers ?? {}), (header) => {
-            if (HEADER_DENY_LIST.includes(header.toLowerCase())) {
+            if (isDeniedHeader(header)) {
                 headers[header] = REDACTED
             }
         })
     }
+}
+
+// we always remove headers on the deny list because we never want to capture this sensitive data.
+// applies to both request and response headers (e.g. set-cookie is a response header)
+const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetworkRequest => {
+    redactDeniedHeaders(data.requestHeaders)
+    redactDeniedHeaders(data.responseHeaders)
     return data
 }
 

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -136,6 +136,19 @@ function isRequest(value: unknown): value is Request {
     }
 }
 
+// binary/asset bodies are large and useless for replay debugging (and capturing an image body
+// duplicates what the recording already shows), so we never record them even when recordBody is on
+const NEVER_RECORD_BODY_CONTENT_TYPES = [
+    'image/',
+    'video/',
+    'audio/',
+    'font/',
+    'application/octet-stream',
+    'application/pdf',
+    'application/zip',
+    'application/wasm',
+]
+
 export function shouldRecordBody({
     type,
     recordBody,
@@ -177,6 +190,8 @@ export function shouldRecordBody({
     }
     if (!recordBody) return false
     if (isBlobURL(url)) return false
+    // never record binary/asset bodies, regardless of the recordBody setting
+    if (matchesContentType(NEVER_RECORD_BODY_CONTENT_TYPES)) return false
     if (isBoolean(recordBody)) return true
     if (isArray(recordBody)) return matchesContentType(recordBody)
     const recordBodyType = recordBody[type]


### PR DESCRIPTION
## Problem

Investigating unusually large session recordings, the network-capture plugin was found to be the dominant size driver in some of them — and one example was recording a third-party auth token. Three independent issues, all when a customer has `recordBody`/`recordHeaders` enabled:

- **Binary/asset bodies are recorded.** With `recordBody: true`, every content-type is captured, including image/video/font responses. In one recording, ~80 MB (42% of its captured bodies) was `image/webp` response bodies — duplicating what the replay already shows, for no debugging value.
- **Third-party telemetry is captured.** Datadog browser-RUM intake traffic was recorded (~20 MB in the same recording) despite having no replay value — the deny-list mechanism already exists for similar vendors (Sentry, Clarity, GA, New Relic) but Datadog wasn't on it.
- **Credential headers leak.** Header redaction only ran on **request** headers and matched an exact deny list, so `set-cookie` (a response header) and credential-shaped custom names (observed: `x-gist-encoded-user-token`) were captured verbatim.

## Changes

- `shouldRecordBody`: never record bodies whose content-type is binary/asset (`image/`, `video/`, `audio/`, `font/`, `application/octet-stream`, `pdf`, `zip`, `wasm`), regardless of `recordBody`. Returning `false` here also means the body is never read — no extra processing.
- Add Datadog intake hosts (`datadoghq.com`, `datadoghq.eu`, `ddog-gov.com`) to the default `payloadHostDenyList`.
- Header redaction now applies to **both request and response** headers, and matches credential-shaped names by substring (auth/token/secret/session/api-key/credential/password/cookie/csrf/xsrf) in addition to the exact deny list.

All three are default-on and reduce both recording size and accidental sensitive-data capture. A **follow-up** will make the payload size cap enforce on the decompressed/stored body length (today it trusts `content-length`, which is the compressed size for gzipped responses — so a 0.5 MB-on-the-wire response that decompresses to 3+ MB slips the 1 MB cap).

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) at Paul's direction, from analysis of three exported customer recordings: their size was driven by canvas frames, DOM-mutation churn, and (here) network body capture respectively — i.e. "large recording" wasn't one problem. These three redactions are the network-capture slice. The decompressed-size cap was deliberately split into a follow-up because, for cross-origin responses, `content-encoding` isn't readable and resource-timing sizes are zeroed, so doing it without reading the body needs a separate bounded-reader approach.

Tests: added a parameterized binary-content-type case matrix and a request+response header-redaction case (incl. a credential-shaped custom name). 73 tests pass in the replay config/network/denylist suites.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
