### PR TITLE
feat(replay): skip binary/asset bodies in network capture

### DIFF
--- a/.changeset/replay-skip-binary-bodies.md
+++ b/.changeset/replay-skip-binary-bodies.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Session replay network capture: never record binary/asset response or request bodies (image, video, audio, font, octet-stream, pdf, zip, wasm) even when `recordBody` is enabled - they bloat recordings, duplicate what the replay already shows, and the body is no longer read.

--- a/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
@@ -1,7 +1,10 @@
 /// <reference lib="dom" />
 
 import { expect } from '@jest/globals'
-import { shouldRecordBody } from '../../../../extensions/replay/external/network-plugin'
+import {
+    NEVER_RECORD_BODY_CONTENT_TYPES,
+    shouldRecordBody,
+} from '../../../../extensions/replay/external/network-plugin'
 
 // Mock Request class since jsdom might not provide it
 class MockRequest {
@@ -213,6 +216,48 @@ describe('network plugin', () => {
                     })
                     expect(result).toBe(expected)
                 })
+            })
+        })
+
+        describe('binary content types are never recorded', () => {
+            const neverRecordCases: [string, boolean][] = NEVER_RECORD_BODY_CONTENT_TYPES.map((prefix) => [
+                prefix.endsWith('/') ? `${prefix}example` : prefix,
+                false,
+            ])
+            const alwaysRecordCases: [string, boolean][] = [
+                ['application/json', true],
+                ['text/plain', true],
+            ]
+            it.each([...neverRecordCases, ...alwaysRecordCases])(
+                'recordBody:true with content-type %s should record=%s',
+                (contentType, expected) => {
+                    const result = shouldRecordBody({
+                        type: 'response',
+                        headers: { 'content-type': contentType } as unknown as Headers,
+                        url: 'https://example.com/asset',
+                        recordBody: true,
+                    })
+                    expect(result).toBe(expected)
+                }
+            )
+
+            it('should ignore content-type casing (RFC 9110)', () => {
+                expect(
+                    shouldRecordBody({
+                        type: 'response',
+                        headers: { 'content-type': 'Image/WebP' } as unknown as Headers,
+                        url: 'https://example.com/asset',
+                        recordBody: true,
+                    })
+                ).toBe(false)
+                expect(
+                    shouldRecordBody({
+                        type: 'response',
+                        headers: { 'content-type': 'APPLICATION/PDF' } as unknown as Headers,
+                        url: 'https://example.com/asset',
+                        recordBody: true,
+                    })
+                ).toBe(false)
             })
         })
 

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -136,6 +136,19 @@ function isRequest(value: unknown): value is Request {
     }
 }
 
+// binary/asset bodies are large and useless for replay debugging (and capturing an image body
+// duplicates what the recording already shows), so we never record them even when recordBody is on
+export const NEVER_RECORD_BODY_CONTENT_TYPES = [
+    'image/',
+    'video/',
+    'audio/',
+    'font/',
+    'application/octet-stream',
+    'application/pdf',
+    'application/zip',
+    'application/wasm',
+]
+
 export function shouldRecordBody({
     type,
     recordBody,
@@ -150,7 +163,7 @@ export function shouldRecordBody({
     function matchesContentType(contentTypes: string[]) {
         const contentTypeHeader = Object.keys(headers).find((key) => key.toLowerCase() === 'content-type')
         const contentType = contentTypeHeader && headers[contentTypeHeader]
-        return contentTypes.some((ct) => contentType?.includes(ct))
+        return contentTypes.some((ct) => contentType?.toLowerCase().includes(ct))
     }
 
     /**
@@ -177,6 +190,8 @@ export function shouldRecordBody({
     }
     if (!recordBody) return false
     if (isBlobURL(url)) return false
+    // never record binary/asset bodies, regardless of the recordBody setting
+    if (matchesContentType(NEVER_RECORD_BODY_CONTENT_TYPES)) return false
     if (isBoolean(recordBody)) return true
     if (isArray(recordBody)) return matchesContentType(recordBody)
     const recordBodyType = recordBody[type]


### PR DESCRIPTION
## Problem

With `recordBody` enabled, the network recorder captures _every_ content-type, including image/video/font response bodies. In analysed recordings this was the single largest size driver (e.g. ~80 MB / 42% of one recording was `image/webp` bodies). The replay network inspector renders bodies only as a text/JSON `CodeSnippet` — it has no image viewer — so a binary body shows as unreadable [mojibake](https://en.wikipedia.org/wiki/Mojibake). Capturing them is pure cost with zero human value.

## Changes

`shouldRecordBody` now returns `false` for binary/asset content-types (`image/`, `video/`, `audio/`, `font/`, `application/octet-stream`, `pdf`, `zip`, `wasm`) regardless of the `recordBody` setting. Returning false here also means the body is never read.

**Stack 1/3** of the replay network-capture reductions (binary bodies → Datadog hosts → credential headers).

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (no breaking changes)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) at Paul's direction, from analysis of exported recordings whose size was dominated by network body capture. Confirmed via the replay inspector code that binary bodies are never rendered as images.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)