### PR TITLE
feat(replay): skip third-party analytics/telemetry hosts in network capture

### DIFF
--- a/.changeset/replay-denylist-datadog.md
+++ b/.changeset/replay-denylist-datadog.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Session replay network capture: expand the default payload host deny list to skip third-party analytics, RUM, and session-replay telemetry whose payloads have no replay value - Datadog, Segment, RudderStack, Amplitude, Mixpanel, Hotjar (both `.com` and `.io`), and FullStory. Also covers both Google Analytics beacon hosts (`google-analytics.com`, plus `analytics.google.com` which gtag uses when Google Signals is enabled) and widens New Relic to `nr-data.net`.

--- a/packages/browser/src/__tests__/extensions/replay/config.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/config.test.ts
@@ -214,8 +214,19 @@ describe('config', () => {
                     '.lr-ingest.io',
                     '.ingest.sentry.io',
                     '.clarity.ms',
+                    'google-analytics.com',
                     'analytics.google.com',
-                    'bam.nr-data.net',
+                    'nr-data.net',
+                    'datadoghq.com',
+                    'datadoghq.eu',
+                    'ddog-gov.com',
+                    'segment.io',
+                    'rudderstack.com',
+                    'amplitude.com',
+                    'mixpanel.com',
+                    'hotjar.com',
+                    'hotjar.io',
+                    'fullstory.com',
                 ])
             })
 
@@ -229,8 +240,19 @@ describe('config', () => {
                     '.lr-ingest.io',
                     '.ingest.sentry.io',
                     '.clarity.ms',
+                    'google-analytics.com',
                     'analytics.google.com',
-                    'bam.nr-data.net',
+                    'nr-data.net',
+                    'datadoghq.com',
+                    'datadoghq.eu',
+                    'ddog-gov.com',
+                    'segment.io',
+                    'rudderstack.com',
+                    'amplitude.com',
+                    'mixpanel.com',
+                    'hotjar.com',
+                    'hotjar.io',
+                    'fullstory.com',
                 ])
             })
         })

--- a/packages/browser/src/extensions/replay/external/config.ts
+++ b/packages/browser/src/extensions/replay/external/config.ts
@@ -53,8 +53,25 @@ export const defaultNetworkOptions: Required<NetworkRecordOptions> = {
         '.ingest.sentry.io',
         '.clarity.ms',
         // NB no leading dot here
+        // GA4/gtag beacons go to *.google-analytics.com; with Google Signals on they also hit
+        // analytics.google.com (region1.analytics.google.com/g/collect), so deny both
+        'google-analytics.com',
         'analytics.google.com',
-        'bam.nr-data.net',
+        // New Relic browser agent (bam + bam-cell)
+        'nr-data.net',
+        // Datadog browser RUM intake
+        'datadoghq.com',
+        'datadoghq.eu',
+        'ddog-gov.com',
+        // other third-party analytics / session-replay vendors whose telemetry has no replay value
+        'segment.io',
+        'rudderstack.com',
+        'amplitude.com',
+        'mixpanel.com',
+        // Hotjar uses both .com and .io for data collection
+        'hotjar.com',
+        'hotjar.io',
+        'fullstory.com',
     ],
 }
 


### PR DESCRIPTION
## Problem

Session replay was capturing request/response **bodies** sent to third-party analytics, RUM, and session-replay vendors — pure telemetry with no replay-debugging value, and often large batched POSTs. One analysed recording spent ~20 MB on Datadog RUM intake alone. The payload-host deny-list mechanism already existed (Sentry, Clarity, GA, New Relic, LogRocket) but missed the common offenders.

## Changes

Expand the default `payloadHostDenyList` (matched by hostname suffix, so it covers regional intake subdomains):

- **Datadog** — `datadoghq.com`, `datadoghq.eu`, `ddog-gov.com`
- **Segment** — `segment.io`
- **RudderStack** — `rudderstack.com`
- **Amplitude** — `amplitude.com`
- **Mixpanel** — `mixpanel.com`
- **Hotjar** — `hotjar.com`
- **FullStory** — `fullstory.com`

Selection criteria: vendor-owned domains (so suffix-matching can't catch a customer's own API), that POST sizable telemetry batches (GET pixels have no body, so ad pixels are intentionally excluded), and are widely deployed.

Also corrects two existing entries while here:
- **Google Analytics**: `analytics.google.com` → `google-analytics.com`. The old entry was the GA *dashboard* host; GA4/gtag beacons go to `*.google-analytics.com`, so GA bodies weren't actually being skipped.
- **New Relic**: `bam.nr-data.net` → `nr-data.net`, to also cover `bam-cell.nr-data.net`.

The deny-list only suppresses the body — the request still appears in the inspector timeline.

**Stack 2/3** of the replay network-capture reductions.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (no breaking changes)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) at Paul's direction. The vendor set was curated against an explicit "keep the list short" constraint — heavy-deployment vendors that batch-POST telemetry — and deliberately excludes GET-only ad pixels. The GA dashboard-vs-beacon-host correction surfaced while reviewing the existing entries.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*