### PR TITLE
feat(replay): redact credential headers on request and response in network capture

### DIFF
--- a/.changeset/replay-redact-credential-headers.md
+++ b/.changeset/replay-redact-credential-headers.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Session replay network capture: redact credential-bearing headers on both request and response (previously only request), and match credential-shaped custom header names by substring (e.g. `x-gist-encoded-user-token`) in addition to the exact deny list - avoiding accidental capture of tokens/cookies in recordings.

--- a/packages/browser/src/__tests__/extensions/replay/config.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/config.test.ts
@@ -67,6 +67,34 @@ describe('config', () => {
                 })
             })
 
+            it('redacts denied request and response headers, including credential-shaped custom names', () => {
+                const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
+                const cleaned = networkOptions.maskRequestFn!({
+                    name: 'something',
+                    requestHeaders: {
+                        'x-gist-encoded-user-token': 'abc',
+                        'content-type': 'application/json',
+                    },
+                    responseHeaders: {
+                        'set-cookie': 'session=secret',
+                        'x-session-id': 'xyz',
+                        'content-type': 'application/json',
+                    },
+                } as Partial<CapturedNetworkRequest> as CapturedNetworkRequest)
+                expect(cleaned).toEqual({
+                    name: 'something',
+                    requestHeaders: {
+                        'x-gist-encoded-user-token': 'redacted',
+                        'content-type': 'application/json',
+                    },
+                    responseHeaders: {
+                        'set-cookie': 'redacted',
+                        'x-session-id': 'redacted',
+                        'content-type': 'application/json',
+                    },
+                })
+            })
+
             it.each([
                 [
                     {

--- a/packages/browser/src/extensions/replay/external/config.ts
+++ b/packages/browser/src/extensions/replay/external/config.ts
@@ -105,16 +105,44 @@ const PAYLOAD_CONTENT_DENY_LIST = [
     'token',
 ]
 
-// we always remove headers on the deny list because we never want to capture this sensitive data
-const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetworkRequest => {
-    const headers = data.requestHeaders
+// substrings that mark a header as credential-bearing - catches custom names
+// (e.g. x-gist-encoded-user-token) that aren't in the exact deny list above
+const HEADER_DENY_SUBSTRINGS = [
+    'auth',
+    'token',
+    'secret',
+    'session',
+    'api-key',
+    'apikey',
+    'api_key',
+    'credential',
+    'password',
+    'passwd',
+    'cookie',
+    'csrf',
+    'xsrf',
+]
+
+const isDeniedHeader = (header: string): boolean => {
+    const lower = header.toLowerCase()
+    return HEADER_DENY_LIST.includes(lower) || HEADER_DENY_SUBSTRINGS.some((s) => lower.includes(s))
+}
+
+const redactDeniedHeaders = (headers: CapturedNetworkRequest['requestHeaders']): void => {
     if (!isNullish(headers)) {
-        each(Object.keys(headers ?? {}), (header) => {
-            if (HEADER_DENY_LIST.includes(header.toLowerCase())) {
+        each(Object.keys(headers), (header) => {
+            if (isDeniedHeader(header)) {
                 headers[header] = REDACTED
             }
         })
     }
+}
+
+// we always remove headers on the deny list because we never want to capture this sensitive data.
+// applies to both request and response headers (e.g. set-cookie is a response header)
+const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetworkRequest => {
+    redactDeniedHeaders(data.requestHeaders)
+    redactDeniedHeaders(data.responseHeaders)
     return data
 }
 


### PR DESCRIPTION
## Problem

Header redaction in network capture only ran on **request** headers and matched an exact deny list. So response-side credentials (`set-cookie`) and credential-shaped *custom* header names were captured verbatim — an analysed recording contained an `x-gist-encoded-user-token` value in the clear.

## Changes

- Redact denied headers on **both request and response** headers.
- Match credential-shaped names by substring (`auth`, `token`, `secret`, `session`, `api-key`/`apikey`/`api_key`, `credential`, `password`, `passwd`, `cookie`, `csrf`, `xsrf`) in addition to the exact deny list.

**Stack 3/3** of the replay network-capture reductions. (A separate follow-up will make the payload size cap enforce on the decompressed/stored body length rather than `content-length`.)

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (no breaking changes)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) at Paul's direction. Errs toward redaction for headers (low debugging value, high leak risk), consistent with the existing "if someone complains we'll add an opt-in" stance in this module.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*