### PR TITLE
fix(replay): cap oversized data URIs in SVG <image> elements

### DIFF
--- a/.changeset/replay-cap-svg-image-data-uris.md
+++ b/.changeset/replay-cap-svg-image-data-uris.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Session replay: apply the existing base64 image size cap (`maxBase64ImageLength`) to SVG `<image>` elements with `data:` URIs on both `href` and `xlink:href`. Previously the cap only covered `<img>` elements, so large inline data URIs inside SVGs were recorded in full - this also covers them in mutations, replacing oversized ones with the striped placeholder.

--- a/packages/rrweb/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb/rrweb-snapshot/src/snapshot.ts
@@ -211,8 +211,8 @@ export function transformAttribute(
     // href starts with a # is an id pointer for svg
     const transformedValue = absoluteToDoc(doc, value);
 
-    if (transformedValue.startsWith('data:') && element) {
-      if (tagName === 'img') {
+    if (transformedValue.startsWith('data:')) {
+      if (tagName === 'img' && element) {
         let processedDataURL = transformedValue;
 
         if (dataURLOptions?.type || dataURLOptions?.quality !== undefined) {
@@ -236,7 +236,7 @@ export function transformAttribute(
   } else if (name === 'xlink:href' && value[0] !== '#') {
     // xlink:href starts with # is an id pointer
     const transformedValue = absoluteToDoc(doc, value);
-    if (transformedValue.startsWith('data:')) {
+    if (tagName === 'image' && transformedValue.startsWith('data:')) {
       return capDataURLSize(transformedValue, dataURLOptions);
     }
     return transformedValue;

--- a/packages/rrweb/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb/rrweb-snapshot/src/snapshot.ts
@@ -174,6 +174,16 @@ function getHref(doc: Document, customHref?: string) {
   return a.href;
 }
 
+function capDataURLSize(
+  dataURL: string,
+  dataURLOptions?: DataURLOptions,
+): string {
+  if (dataURLOptions?.maxBase64ImageLength) {
+    return checkDataURLSize(dataURL, dataURLOptions.maxBase64ImageLength);
+  }
+  return dataURL;
+}
+
 export function transformAttribute(
   doc: Document,
   tagName: Lowercase<string>,
@@ -201,34 +211,35 @@ export function transformAttribute(
     // href starts with a # is an id pointer for svg
     const transformedValue = absoluteToDoc(doc, value);
 
-    if (tagName === 'img' && transformedValue.startsWith('data:') && element) {
-      const img = element as HTMLImageElement;
+    if (transformedValue.startsWith('data:') && element) {
+      if (tagName === 'img') {
+        let processedDataURL = transformedValue;
 
-      let processedDataURL = transformedValue;
+        if (dataURLOptions?.type || dataURLOptions?.quality !== undefined) {
+          processedDataURL = recompressBase64Image(
+            element as HTMLImageElement,
+            transformedValue,
+            dataURLOptions.type,
+            dataURLOptions.quality,
+          );
+        }
 
-      if (dataURLOptions?.type || dataURLOptions?.quality !== undefined) {
-        processedDataURL = recompressBase64Image(
-          img,
-          transformedValue,
-          dataURLOptions.type,
-          dataURLOptions.quality,
-        );
+        return capDataURLSize(processedDataURL, dataURLOptions);
       }
 
-      if (dataURLOptions?.maxBase64ImageLength) {
-        processedDataURL = checkDataURLSize(
-          processedDataURL,
-          dataURLOptions.maxBase64ImageLength,
-        );
+      if (tagName === 'image') {
+        return capDataURLSize(transformedValue, dataURLOptions);
       }
-
-      return processedDataURL;
     }
 
     return transformedValue;
   } else if (name === 'xlink:href' && value[0] !== '#') {
     // xlink:href starts with # is an id pointer
-    return absoluteToDoc(doc, value);
+    const transformedValue = absoluteToDoc(doc, value);
+    if (transformedValue.startsWith('data:')) {
+      return capDataURLSize(transformedValue, dataURLOptions);
+    }
+    return transformedValue;
   } else if (
     name === 'background' &&
     (tagName === 'table' || tagName === 'td' || tagName === 'th')

--- a/packages/rrweb/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
@@ -292,7 +292,11 @@ exports[`integration tests > [html file]: base64-images.html 1`] = `
     <img id=\\"small-image\\" src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==\\" alt=\\"Small red pixel\\" width=\\"100\\" height=\\"100\\" />    <!-- Medium 16x16 gradient PNG (base64: ~200 bytes) -->
     <img id=\\"medium-image\\" src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAAdgAAAHYBTnsmCAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAABJSURBVDiNY2AYBaNgFIwCoAAggBhIBP8h+D8DA8N/SjCIjYxBbGQM4oPEkDEMYmNikBgyRjaAZAAQwNRA/0YBqQAggBgYhg4AANm8Awz/4Ll3AAAAAElFTkSuQmCC\\" alt=\\"Medium gradient\\" width=\\"100\\" height=\\"100\\" />    <!-- Script to create a large base64 image dynamically -->
     <noscript>SCRIPT_PLACEHOLDER</noscript><img id=\\"large-image\\" src=\\"data:image/png;base64,CANVAS_GENERATED_IMAGE\\" alt=\\"Large test image\\" width=\\"200\\" height=\\"200\\" />    <!-- Create an extremely large image that should be skipped from recompression -->
-    <noscript>SCRIPT_PLACEHOLDER</noscript><img id=\\"huge-image\\" src=\\"data:image/png;base64,CANVAS_GENERATED_IMAGE\\" alt=\\"Huge test image\\" width=\\"300\\" height=\\"300\\" />
+    <noscript>SCRIPT_PLACEHOLDER</noscript><img id=\\"huge-image\\" src=\\"data:image/png;base64,CANVAS_GENERATED_IMAGE\\" alt=\\"Huge test image\\" width=\\"300\\" height=\\"300\\" />    <!-- Small static SVG <image> with a data: href (under any reasonable cap) -->
+    <svg id=\\"svg-with-small-image\\" xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100\\" height=\\"100\\">
+      <image id=\\"svg-small-image\\" href=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==\\" width=\\"100\\" height=\\"100\\"/>
+    </svg>    <!-- Scripts to create large SVG <image> data URIs for both href and xlink:href -->
+    <noscript>SCRIPT_PLACEHOLDER</noscript><svg xmlns=\\"http://www.w3.org/2000/svg\\" id=\\"svg-with-large-href-image\\" width=\\"200\\" height=\\"200\\"><image id=\\"svg-large-href-image\\" width=\\"200\\" height=\\"200\\" href=\\"data:image/png;base64,CANVAS_GENERATED_IMAGE\\"/></svg><svg xmlns=\\"http://www.w3.org/2000/svg\\" id=\\"svg-with-large-xlink-image\\" width=\\"200\\" height=\\"200\\"><image id=\\"svg-large-xlink-image\\" width=\\"200\\" height=\\"200\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\" xlink:href=\\"data:image/png;base64,CANVAS_GENERATED_IMAGE\\"/></svg>
   </body></html>"
 `;
 

--- a/packages/rrweb/rrweb-snapshot/test/html/base64-images.html
+++ b/packages/rrweb/rrweb-snapshot/test/html/base64-images.html
@@ -78,5 +78,69 @@
       hugeImg.height = 300;
       document.body.appendChild(hugeImg);
     </script>
+
+    <!-- Small static SVG <image> with a data: href (under any reasonable cap) -->
+    <svg
+      id="svg-with-small-image"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100"
+      height="100"
+    >
+      <image
+        id="svg-small-image"
+        href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+        width="100"
+        height="100"
+      />
+    </svg>
+
+    <!-- Scripts to create large SVG <image> data URIs for both href and xlink:href -->
+    <script>
+      const SVG_NS = 'http://www.w3.org/2000/svg';
+      const XLINK_NS = 'http://www.w3.org/1999/xlink';
+
+      function makeLargeDataURL() {
+        const c = document.createElement('canvas');
+        c.width = 2000;
+        c.height = 2000;
+        const cctx = c.getContext('2d');
+        const grad = cctx.createLinearGradient(0, 0, 2000, 2000);
+        grad.addColorStop(0, 'red');
+        grad.addColorStop(0.5, 'blue');
+        grad.addColorStop(1, 'green');
+        cctx.fillStyle = grad;
+        cctx.fillRect(0, 0, 2000, 2000);
+        cctx.fillStyle = 'white';
+        cctx.font = '48px serif';
+        cctx.fillText('Large SVG Image', 100, 100);
+        return c.toDataURL('image/png');
+      }
+
+      // Large SVG <image> using the modern `href` attribute
+      const svgHref = document.createElementNS(SVG_NS, 'svg');
+      svgHref.setAttribute('id', 'svg-with-large-href-image');
+      svgHref.setAttribute('width', '200');
+      svgHref.setAttribute('height', '200');
+      const largeHrefImage = document.createElementNS(SVG_NS, 'image');
+      largeHrefImage.setAttribute('id', 'svg-large-href-image');
+      largeHrefImage.setAttribute('width', '200');
+      largeHrefImage.setAttribute('height', '200');
+      largeHrefImage.setAttribute('href', makeLargeDataURL());
+      svgHref.appendChild(largeHrefImage);
+      document.body.appendChild(svgHref);
+
+      // Large SVG <image> using the legacy `xlink:href` attribute
+      const svgXlink = document.createElementNS(SVG_NS, 'svg');
+      svgXlink.setAttribute('id', 'svg-with-large-xlink-image');
+      svgXlink.setAttribute('width', '200');
+      svgXlink.setAttribute('height', '200');
+      const largeXlinkImage = document.createElementNS(SVG_NS, 'image');
+      largeXlinkImage.setAttribute('id', 'svg-large-xlink-image');
+      largeXlinkImage.setAttribute('width', '200');
+      largeXlinkImage.setAttribute('height', '200');
+      largeXlinkImage.setAttributeNS(XLINK_NS, 'xlink:href', makeLargeDataURL());
+      svgXlink.appendChild(largeXlinkImage);
+      document.body.appendChild(svgXlink);
+    </script>
   </body>
 </html>

--- a/packages/rrweb/rrweb-snapshot/test/integration.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/integration.test.ts
@@ -612,6 +612,92 @@ describe('base64 image compression tests', function (this: ISuite) {
 
     await page.close();
   });
+
+  it.each([
+    { id: 'svg-large-href-image', attr: 'href' },
+    { id: 'svg-large-xlink-image', attr: 'xlink:href' },
+  ])(
+    'should replace oversized SVG <image> $attr data URIs with striped placeholder',
+    async ({ id, attr }) => {
+      const page: puppeteer.Page = await browser.newPage();
+      await page.goto(`${serverURL}/html/base64-images.html`, {
+        waitUntil: 'load',
+      });
+      await page.waitForSelector(`#${id}`, { timeout: 5000 });
+
+      const result = await page.evaluate(`${code}
+        const snapshot = rrwebSnapshot.snapshot(document, {
+          dataURLOptions: { type: "image/webp", quality: 0.4, maxBase64ImageLength: 10000 }
+        });
+
+        function findByTag(node, tagName, acc = []) {
+          if (node.type === 2 && node.tagName === tagName) {
+            acc.push(node);
+          }
+          if (node.childNodes) {
+            node.childNodes.forEach(child => findByTag(child, tagName, acc));
+          }
+          return acc;
+        }
+
+        const svgImages = findByTag(snapshot, 'image');
+        const target = svgImages.find(n => n.attributes.id === '${id}');
+        const href = target.attributes['${attr}'];
+
+        ({
+          href,
+          isPlaceholder: href.startsWith('data:image/svg+xml'),
+          length: href.length
+        });
+      `);
+
+      expect(result.isPlaceholder).toBe(true);
+      expect(result.href).toMatch(/^data:image\/svg\+xml;base64,/);
+      expect(result.length).toBeLessThan(1000);
+
+      await page.close();
+    }
+  );
+
+  it('should preserve small SVG <image> data URIs under the limit', async () => {
+    const page: puppeteer.Page = await browser.newPage();
+    await page.goto(`${serverURL}/html/base64-images.html`, {
+      waitUntil: 'load',
+    });
+    await page.waitForSelector('#svg-small-image', { timeout: 2000 });
+
+    const result = await page.evaluate(`${code}
+      const snapshot = rrwebSnapshot.snapshot(document, {
+        dataURLOptions: { type: "image/webp", quality: 0.4, maxBase64ImageLength: 1048576 }
+      });
+
+      function findByTag(node, tagName, acc = []) {
+        if (node.type === 2 && node.tagName === tagName) {
+          acc.push(node);
+        }
+        if (node.childNodes) {
+          node.childNodes.forEach(child => findByTag(child, tagName, acc));
+        }
+        return acc;
+      }
+
+      const svgImages = findByTag(snapshot, 'image');
+      const small = svgImages.find(n => n.attributes.id === 'svg-small-image');
+      const href = small.attributes.href;
+
+      ({
+        href,
+        isNotPlaceholder: !href.includes('svg+xml'),
+        length: href.length
+      });
+    `);
+
+    expect(result.isNotPlaceholder).toBe(true);
+    expect(result.href).toMatch(/^data:image\/png;base64,/);
+    expect(result.length).toBeGreaterThan(0);
+
+    await page.close();
+  });
 });
 
 describe('iframe integration tests', function (this: ISuite) {

--- a/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
@@ -871,3 +871,62 @@ describe('preload link load-listener accumulation', () => {
     document.head.removeChild(link);
   });
 });
+
+describe('SVG <image> data: URI size cap', () => {
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const SMALL_DATA_URI =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+  const LARGE_DATA_URI = 'data:image/png;base64,' + 'A'.repeat(20000);
+
+  function svgImage(): HTMLElement {
+    return document.createElementNS(SVG_NS, 'image') as unknown as HTMLElement;
+  }
+
+  it.each(['href', 'xlink:href'])(
+    'caps an oversized SVG <image> %s data URI to the striped placeholder',
+    (attrName) => {
+      const result = transformAttribute(
+        document,
+        'image',
+        attrName as Lowercase<string>,
+        LARGE_DATA_URI,
+        svgImage(),
+        { maxBase64ImageLength: 10000 },
+      );
+
+      expect(result).toMatch(/^data:image\/svg\+xml;base64,/);
+    },
+  );
+
+  it.each(['href', 'xlink:href'])(
+    'preserves a small SVG <image> %s data URI under the cap',
+    (attrName) => {
+      const result = transformAttribute(
+        document,
+        'image',
+        attrName as Lowercase<string>,
+        SMALL_DATA_URI,
+        svgImage(),
+        { maxBase64ImageLength: 10000 },
+      );
+
+      expect(result).toBe(SMALL_DATA_URI);
+    },
+  );
+
+  it.each(['href', 'xlink:href'])(
+    'leaves an oversized SVG <image> %s data URI untouched when no cap is configured',
+    (attrName) => {
+      const result = transformAttribute(
+        document,
+        'image',
+        attrName as Lowercase<string>,
+        LARGE_DATA_URI,
+        svgImage(),
+        {},
+      );
+
+      expect(result).toBe(LARGE_DATA_URI);
+    },
+  );
+});

--- a/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
@@ -929,4 +929,24 @@ describe('SVG <image> data: URI size cap', () => {
       expect(result).toBe(LARGE_DATA_URI);
     },
   );
+
+  it.each([
+    { tagName: 'use', attrName: 'xlink:href' },
+    { tagName: 'a', attrName: 'xlink:href' },
+    { tagName: 'use', attrName: 'href' },
+  ])(
+    'does not cap a <$tagName> $attrName data URI — only SVG <image> is an image payload',
+    ({ tagName, attrName }) => {
+      const result = transformAttribute(
+        document,
+        tagName as Lowercase<string>,
+        attrName as Lowercase<string>,
+        LARGE_DATA_URI,
+        document.createElementNS(SVG_NS, tagName) as unknown as HTMLElement,
+        { maxBase64ImageLength: 10000 },
+      );
+
+      expect(result).toBe(LARGE_DATA_URI);
+    },
+  );
 });


### PR DESCRIPTION
## Problem

Session replay already caps oversized base64 `data:` image URIs (via `maxBase64ImageLength`, default 1MB), replacing them with a small striped placeholder so recordings don't balloon. But that cap only applied to `<img>` elements. Inline SVG `<image>` elements with `data:` URIs — common on graphics-heavy marketing pages and animation libraries that render into SVG — slipped through entirely and were recorded in full, both in the full snapshot and in mutations. On pages that re-render these SVGs frequently, that inflates recording storage with large, duplicated image payloads.

## Changes

Extend the existing size cap from `<img>` to SVG `<image>` elements in `transformAttribute`:

- `href` (modern SVG2 attribute) and `xlink:href` (legacy SVG1.1 attribute) `data:` URIs on SVG `<image>` are now size-capped to the striped placeholder when they exceed `maxBase64ImageLength`.
- The cap logic is extracted into a single `capDataURLSize` helper, now shared by the `<img>`, SVG `<image>`, and `xlink:href` paths.
- SVG `<image>` is an `SVGImageElement` and cannot be redrawn through a canvas, so unlike `<img>` we never attempt webp re-encoding for it — only the size cap, which is a pure synchronous string-length check. This keeps the serialization path synchronous (no new async work) and captures nothing extra.

Because `transformAttribute` is the shared serializer, this also covers SVG `<image>` data URIs added via mutations, not just the initial full snapshot.

### Tests

- jsdom unit tests in `snapshot.test.ts` exercising `transformAttribute` directly (parameterized over `href` / `xlink:href`): oversized URIs are capped, small ones preserved, and nothing is touched when no cap is configured.
- Puppeteer integration tests + an extended `base64-images.html` example page covering large SVG `<image>` data URIs for both `href` and `xlink:href`, plus a small-image preservation case.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This started as an investigation into why some recordings carry large inline images despite the existing data-URI cap. The cap turned out to be gated on `tagName === 'img'`, leaving SVG `<image>` data URIs (on both `href` and `xlink:href`) completely unhandled — and the `xlink:href` branch had no data-URL handling at all.

Worked test-first: extended the existing `base64-images.html` example page and added integration tests asserting the placeholder for oversized SVG images; confirmed they failed (proving the gap) before implementing. Chose size-cap-only for SVG `<image>` rather than canvas re-encoding, because `SVGImageElement` has no canvas decode path and the guiding constraint was to keep the serialization path synchronous and avoid capturing anything extra. Verified the unit suite, integration base64 suite, type-check, and lint all pass locally; the one affected round-trip snapshot was regenerated (large canvas URIs collapse to a deterministic placeholder).

Tools: PostHog Code (Claude Opus).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
