### PR TITLE
fix(logs): emit posthogDistinctId from captureConsoleLogs so Logs auto-link to person

### DIFF
--- a/.changeset/captureconsolelogs-posthog-distinct-id.md
+++ b/.changeset/captureconsolelogs-posthog-distinct-id.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix `captureConsoleLogs` so console logs auto-link to person profiles in PostHog Logs. The browser console-logs entrypoint was emitting the person identifier under `distinct_id`, while every other logs path in the SDK (`posthog.logger.*` / `captureLog`, React Native, Node, the OTLP record builder in `@posthog/core`) emits `posthogDistinctId` — which is also the backend default for "Link to person". The mismatched key meant the console-logs path never linked out of the box. The browser path now emits `posthogDistinctId` to match the rest of the SDK and the backend.

--- a/packages/browser/src/__tests__/entrypoints/logs.golden.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.golden.test.ts
@@ -118,7 +118,7 @@ describe('logs entrypoint — golden (current console-capture wire output)', () 
             body: '"hello"',
             attributes: {
                 'log.source': 'console.log',
-                distinct_id: 'user-123',
+                posthogDistinctId: 'user-123',
                 'location.href': 'https://example.com/test',
                 sessionStartTimestamp: String(SESSION_START),
                 lastActivityTimestamp: String(LAST_ACTIVITY),
@@ -151,7 +151,7 @@ describe('logs entrypoint — golden (current console-capture wire output)', () 
             body: '{"user":{"id":5},"msg":"hi"}',
             attributes: {
                 'log.source': 'console.warn',
-                distinct_id: 'user-123',
+                posthogDistinctId: 'user-123',
                 'location.href': 'https://example.com/test',
                 sessionStartTimestamp: String(SESSION_START),
                 lastActivityTimestamp: String(LAST_ACTIVITY),

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -372,7 +372,13 @@ const initializeLogs = (posthog: PostHog) => {
                     body: body,
                     attributes: {
                         'log.source': `console.${level}`,
-                        distinct_id: posthog.get_distinct_id(),
+                        // `posthogDistinctId` matches the OTLP attribute key emitted by the
+                        // canonical `posthog.logger.*` / `captureLog` path (see
+                        // `@posthog/core/src/logs/logs-utils.ts`) and the backend default
+                        // `DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY` used by Logs → "Link
+                        // to person". Without this, console logs never auto-link to a
+                        // profile even though the docs/default imply they should.
+                        posthogDistinctId: posthog.get_distinct_id(),
                         'location.href': assignableWindow.location.href,
                         ...logAttributes,
                         ...(isObject(args[0]) ? flattenObject(args[0]) : {}),


### PR DESCRIPTION
Fixes #3916.

## Problem

`captureConsoleLogs` (the externally-loaded logs extension) stamps the person identifier under `distinct_id`, while every other logs path in the SDK uses `posthogDistinctId`:

- The OTLP record builder in [`@posthog/core/src/logs/logs-utils.ts:122`](https://github.com/PostHog/posthog-js/blob/main/packages/core/src/logs/logs-utils.ts#L122) — `autoAttributes.posthogDistinctId = sdkContext.distinctId`
- The browser `posthog.logger.*` / `captureLog` path
- React Native, Node, Web Worker — same key

The PostHog backend Logs "Link to person" default is also `posthogDistinctId` — [`products/logs/backend/models.py`](https://github.com/PostHog/posthog/blob/master/products/logs/backend/models.py) → `DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY = "posthogDistinctId"`, with a test in `products/logs/backend/test/test_models.py` commenting *"Matches the JS SDK / docs convention so logs from posthog-js are linked to [persons]."* — which holds only for the `posthog.logger.*` path, **not** for `captureConsoleLogs`.

Net effect today: logs captured via `captureConsoleLogs` never auto-link to a profile out of the box. The user has to manually change the project's link key, or move every site to `posthog.logger.*`.

## Fix

Switch the attribute key emitted at [`packages/browser/src/entrypoints/logs.ts:375`](https://github.com/PostHog/posthog-js/blob/main/packages/browser/src/entrypoints/logs.ts#L375) from `distinct_id` to `posthogDistinctId` so the console-logs path matches every other SDK path and the backend default.

```diff
-                        distinct_id: posthog.get_distinct_id(),
+                        posthogDistinctId: posthog.get_distinct_id(),
```

Updates the golden test's exact-record assertions accordingly. The 111 unit tests under `entrypoints/logs.{test,golden.test}.ts` + `posthog-logs.test.ts` pass.

## Risk

- **Backward compat:** Anyone whose Link-to-person key was already overridden to `distinct_id` to work around this bug will need to revert it back to the default `posthogDistinctId` (or keep the override). Anyone using the default (the documented happy path) gets linking working for the first time.
- **No public API surface change** — the attribute is emitted by an extension and only read server-side.

## Notes for maintainers

I left the rest of the divergence between `captureConsoleLogs` (which still uses `location.href`) and the OTLP builder (`url.full`) untouched — it's a separate concern from the linking bug the reporter filed, and the OTLP spec name (`url.full`) for the canonical browser path would be its own change with its own backend coordination. Happy to follow up if you'd like that aligned too.