### PR TITLE
feat(replay): opt-in streaming reader for network body size limit

### DIFF
--- a/.changeset/replay-stream-network-body-limit.md
+++ b/.changeset/replay-stream-network-body-limit.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Session replay network capture: add an opt-in streaming reader for request/response bodies that stops at the payload size limit instead of buffering the whole body and then discarding it — bounding memory and pre-request latency when a body is very large. It reads only a clone of the body, so it never consumes the stream the page itself reads, and always resolves (never rejects) into the page's `fetch`. Off by default; enabled for `defaults: '2026-05-30'` and settable directly via `session_recording.streamNetworkBody`.

--- a/.changeset/replay-stream-network-body-limit.md
+++ b/.changeset/replay-stream-network-body-limit.md
@@ -1,5 +1,6 @@
 ---
 'posthog-js': patch
+'@posthog/types': patch
 ---
 
 Session replay network capture: add an opt-in streaming reader for request/response bodies that stops at the payload size limit instead of buffering the whole body and then discarding it — bounding memory and pre-request latency when a body is very large. It reads only a clone of the body, so it never consumes the stream the page itself reads, and always resolves (never rejects) into the page's `fetch`. Off by default; enabled for `defaults: '2026-05-30'` and settable directly via `session_recording.streamNetworkBody`.

--- a/.changeset/replay-stream-network-body-limit.md
+++ b/.changeset/replay-stream-network-body-limit.md
@@ -3,4 +3,4 @@
 '@posthog/types': patch
 ---
 
-Session replay network capture: add an opt-in streaming reader for request/response bodies that stops at the payload size limit instead of buffering the whole body and then discarding it — bounding memory and pre-request latency when a body is very large. It reads only a clone of the body, so it never consumes the stream the page itself reads, and always resolves (never rejects) into the page's `fetch`. Off by default; enabled for `defaults: '2026-05-30'` and settable directly via `session_recording.streamNetworkBody`.
+Session replay network capture: add an opt-in streaming reader for request/response bodies that stops at the payload size limit instead of buffering the whole body and then discarding it — bounding memory and pre-request latency when a body is very large. It reads only a clone of the body, so it never consumes the stream the page itself reads, and always resolves (never rejects) into the page's `fetch`. Off by default; enabled for `defaults: '2026-06-25'` and settable directly via `session_recording.streamNetworkBody`.

--- a/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
@@ -17,164 +17,167 @@ test.beforeEach(async ({ context }) => {
         })
     })
 })
-;[true, false].forEach((isBadlyBehavedWrapper) => {
-    test.describe(`Session recording - network recorder - fetch wrapper ${
-        isBadlyBehavedWrapper ? 'is' : 'is not'
-    } badly behaved`, () => {
-        // these are pretty flaky and annoying, in the short term lets...
-        test.describe.configure({ retries: 6 })
+;[true, false].forEach((streamNetworkBody) => {
+    ;[true, false].forEach((isBadlyBehavedWrapper) => {
+        test.describe(`Session recording - network recorder - streamNetworkBody ${
+            streamNetworkBody ? 'on' : 'off'
+        } - fetch wrapper ${isBadlyBehavedWrapper ? 'is' : 'is not'} badly behaved`, () => {
+            // these are pretty flaky and annoying, in the short term lets...
+            test.describe.configure({ retries: 6 })
 
-        test.beforeEach(async ({ page, context }) => {
-            const wrapInPageContext = async (pg: Page) => {
-                // this is page.evaluate and not page.exposeFunction because we need to execute it in the browser context
-                // or else window is not available...
-                // and we can't pass window.fetch to the node context when using page.exposeFunction
-                await pg.evaluate(() => {
-                    ;(window as any).wrapFetchForTesting = (badlyBehaved: boolean) => {
-                        // eslint-disable-next-line compat/compat
-                        const originalFetch = window.fetch
-                        ;(window as any).originalFetch = originalFetch
-
-                        // eslint-disable-next-line compat/compat
-                        window.fetch = async function (
-                            requestOrURL: URL | RequestInfo,
-                            init?: RequestInit | undefined
-                        ) {
+            test.beforeEach(async ({ page, context }) => {
+                const wrapInPageContext = async (pg: Page) => {
+                    // this is page.evaluate and not page.exposeFunction because we need to execute it in the browser context
+                    // or else window is not available...
+                    // and we can't pass window.fetch to the node context when using page.exposeFunction
+                    await pg.evaluate(() => {
+                        ;(window as any).wrapFetchForTesting = (badlyBehaved: boolean) => {
                             // eslint-disable-next-line compat/compat
-                            const req = new Request(requestOrURL, init)
+                            const originalFetch = window.fetch
+                            ;(window as any).originalFetch = originalFetch
 
-                            const hasBody = typeof requestOrURL !== 'string' && 'body' in requestOrURL
-                            if (hasBody) {
+                            // eslint-disable-next-line compat/compat
+                            window.fetch = async function (
+                                requestOrURL: URL | RequestInfo,
+                                init?: RequestInit | undefined
+                            ) {
+                                // eslint-disable-next-line compat/compat
+                                const req = new Request(requestOrURL, init)
+
+                                const hasBody = typeof requestOrURL !== 'string' && 'body' in requestOrURL
+                                if (hasBody) {
+                                    // we read the body to (maybe) exhaust it
+                                    badlyBehaved ? await requestOrURL.text() : await requestOrURL.clone().text()
+                                }
+
+                                const res = badlyBehaved
+                                    ? await originalFetch(requestOrURL, init)
+                                    : await originalFetch(req)
+
                                 // we read the body to (maybe) exhaust it
-                                badlyBehaved ? await requestOrURL.text() : await requestOrURL.clone().text()
+                                badlyBehaved ? await res.text() : await res.clone().text()
+
+                                return res
                             }
-
-                            const res = badlyBehaved
-                                ? await originalFetch(requestOrURL, init)
-                                : await originalFetch(req)
-
-                            // we read the body to (maybe) exhaust it
-                            badlyBehaved ? await res.text() : await res.clone().text()
-
-                            return res
                         }
-                    }
-                })
-            }
-
-            await page.waitingForNetworkCausedBy({
-                urlPatternsToWaitFor: ['**/*recorder.js*'],
-                action: async () => {
-                    await start(
-                        {
-                            options: {
-                                session_recording: {
-                                    // not the default but makes for easier test assertions
-                                    compress_events: false,
-                                },
-                            },
-                            flagsResponseOverrides: {
-                                sessionRecording: {
-                                    endpoint: '/ses/',
-                                    networkPayloadCapture: { recordBody: true, recordHeaders: true },
-                                },
-                                capturePerformance: true,
-                                autocapture_opt_out: true,
-                            },
-                            url: '/playground/cypress/index.html',
-                            runBeforePostHogInit: wrapInPageContext,
-                            runAfterPostHogInit: wrapInPageContext,
-                        },
-                        page,
-                        context
-                    )
-                },
-            })
-            await waitForSessionRecordingToStart(page)
-
-            // also wrap after posthog is loaded
-            await page.evaluate((isBadlyBehaved) => {
-                ;(window as any).wrapFetchForTesting({
-                    badlyBehaved: isBadlyBehaved,
-                })
-            }, isBadlyBehavedWrapper)
-        })
-
-        test.afterEach(async ({ page }) => {
-            await page.evaluate(() => {
-                if ((window as any).originalFetch) {
-                    window.fetch = (window as any).originalFetch
+                    })
                 }
-            })
-        })
-        ;['fetch', 'xhr'].forEach((networkType) => {
-            test('it captures ' + networkType, async ({ page, browserName }) => {
-                test.skip(
-                    browserName === 'firefox',
-                    'We are trying to misbehave in order to test things, but it looks like Firefox does not let us... good firefox'
-                )
 
                 await page.waitingForNetworkCausedBy({
-                    urlPatternsToWaitFor: ['**/ses/*', 'https://example.com/'],
+                    urlPatternsToWaitFor: ['**/*recorder.js*'],
                     action: async () => {
-                        await page.click(`[data-cy-${networkType}-call-button]`)
+                        await start(
+                            {
+                                options: {
+                                    session_recording: {
+                                        // not the default but makes for easier test assertions
+                                        compress_events: false,
+                                        streamNetworkBody,
+                                    },
+                                },
+                                flagsResponseOverrides: {
+                                    sessionRecording: {
+                                        endpoint: '/ses/',
+                                        networkPayloadCapture: { recordBody: true, recordHeaders: true },
+                                    },
+                                    capturePerformance: true,
+                                    autocapture_opt_out: true,
+                                },
+                                url: '/playground/cypress/index.html',
+                                runBeforePostHogInit: wrapInPageContext,
+                                runAfterPostHogInit: wrapInPageContext,
+                            },
+                            page,
+                            context
+                        )
                     },
                 })
-                const capturedEvents = await page.capturedEvents()
-                const snapshots = capturedEvents.filter((c) => c.event === '$snapshot')
+                await waitForSessionRecordingToStart(page)
 
-                const capturedRequests: Record<string, any>[] = []
-                for (const snapshot of snapshots) {
-                    for (const snapshotData of snapshot.properties['$snapshot_data']) {
-                        if (snapshotData.type === 6) {
-                            for (const req of snapshotData.data.payload.requests) {
-                                capturedRequests.push(req)
+                // also wrap after posthog is loaded
+                await page.evaluate((isBadlyBehaved) => {
+                    ;(window as any).wrapFetchForTesting({
+                        badlyBehaved: isBadlyBehaved,
+                    })
+                }, isBadlyBehavedWrapper)
+            })
+
+            test.afterEach(async ({ page }) => {
+                await page.evaluate(() => {
+                    if ((window as any).originalFetch) {
+                        window.fetch = (window as any).originalFetch
+                    }
+                })
+            })
+            ;['fetch', 'xhr'].forEach((networkType) => {
+                test('it captures ' + networkType, async ({ page, browserName }) => {
+                    test.skip(
+                        browserName === 'firefox',
+                        'We are trying to misbehave in order to test things, but it looks like Firefox does not let us... good firefox'
+                    )
+
+                    await page.waitingForNetworkCausedBy({
+                        urlPatternsToWaitFor: ['**/ses/*', 'https://example.com/'],
+                        action: async () => {
+                            await page.click(`[data-cy-${networkType}-call-button]`)
+                        },
+                    })
+                    const capturedEvents = await page.capturedEvents()
+                    const snapshots = capturedEvents.filter((c) => c.event === '$snapshot')
+
+                    const capturedRequests: Record<string, any>[] = []
+                    for (const snapshot of snapshots) {
+                        for (const snapshotData of snapshot.properties['$snapshot_data']) {
+                            if (snapshotData.type === 6) {
+                                for (const req of snapshotData.data.payload.requests) {
+                                    capturedRequests.push(req)
+                                }
                             }
                         }
                     }
-                }
 
-                const expectedInitiatorType = networkType === 'fetch' ? 'fetch' : 'xmlhttprequest'
+                    const expectedInitiatorType = networkType === 'fetch' ? 'fetch' : 'xmlhttprequest'
 
-                // Verify required network entries exist in the captured requests.
-                // We use set-based checks rather than strict ordering because:
-                //  - config.js script load may or may not appear (it's not mocked, so the failed load
-                //    may or may not show up in Performance Resource Timing entries)
-                //  - flags fetch and recorder.js script load happen concurrently, so their order
-                //    is non-deterministic
-                //  - webkit may or may not capture certain fetches depending on wrapping timing
-                const hasEntry = (pattern: RegExp, type: string) =>
-                    capturedRequests.some((r) => pattern.test(r.name) && r.initiatorType === type)
+                    // Verify required network entries exist in the captured requests.
+                    // We use set-based checks rather than strict ordering because:
+                    //  - config.js script load may or may not appear (it's not mocked, so the failed load
+                    //    may or may not show up in Performance Resource Timing entries)
+                    //  - flags fetch and recorder.js script load happen concurrently, so their order
+                    //    is non-deterministic
+                    //  - webkit may or may not capture certain fetches depending on wrapping timing
+                    const hasEntry = (pattern: RegExp, type: string) =>
+                        capturedRequests.some((r) => pattern.test(r.name) && r.initiatorType === type)
 
-                expect(hasEntry(/http:\/\/localhost:\d+\/playground\/cypress\//, 'navigation')).toBe(true)
-                expect(hasEntry(/https:\/\/localhost:\d+\/static\/array.js/, 'script')).toBe(true)
-                expect(
-                    hasEntry(/https:\/\/localhost:\d+\/array\/test%20token\/config\?_=\d+&ver=1\.\d\d\d\.\d+/, 'fetch')
-                ).toBe(true)
-                expect(
-                    hasEntry(/https:\/\/localhost:\d+\/static\/(lazy-)?recorder.js\?v=1\.\d\d\d\.\d+/, 'script')
-                ).toBe(true)
-                expect(hasEntry(/https:\/\/example.com/, expectedInitiatorType)).toBe(true)
+                    expect(hasEntry(/http:\/\/localhost:\d+\/playground\/cypress\//, 'navigation')).toBe(true)
+                    expect(hasEntry(/https:\/\/localhost:\d+\/static\/array.js/, 'script')).toBe(true)
+                    expect(
+                        hasEntry(/https:\/\/localhost:\d+\/array\/test%20token\/config\?_=\d+&ver=1\.\d\d\d\.\d+/, 'fetch')
+                    ).toBe(true)
+                    expect(
+                        hasEntry(/https:\/\/localhost:\d+\/static\/(lazy-)?recorder.js\?v=1\.\d\d\d\.\d+/, 'script')
+                    ).toBe(true)
+                    expect(hasEntry(/https:\/\/example.com/, expectedInitiatorType)).toBe(true)
 
-                // the HTML file that cypress is operating on (playground/cypress/index.html)
-                // when the button for this test is click makes a post to https://example.com
-                const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
-                expect(capturedFetchRequest).toBeDefined()
+                    // the HTML file that cypress is operating on (playground/cypress/index.html)
+                    // when the button for this test is click makes a post to https://example.com
+                    const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
+                    expect(capturedFetchRequest).toBeDefined()
 
-                // proxy for including network timing info
-                expect(capturedFetchRequest!.fetchStart).toBeGreaterThan(0)
+                    // proxy for including network timing info
+                    expect(capturedFetchRequest!.fetchStart).toBeGreaterThan(0)
 
-                expect(capturedFetchRequest!.initiatorType).toEqual(expectedInitiatorType)
-                expect(capturedFetchRequest!.isInitial).toBeUndefined()
-                expect(capturedFetchRequest!.requestBody).toEqual(`i am the ${networkType} body`)
+                    expect(capturedFetchRequest!.initiatorType).toEqual(expectedInitiatorType)
+                    expect(capturedFetchRequest!.isInitial).toBeUndefined()
+                    expect(capturedFetchRequest!.requestBody).toEqual(`i am the ${networkType} body`)
 
-                expect(capturedFetchRequest!.responseBody).toEqual(
-                    JSON.stringify({
-                        message: 'This is a JSON response',
-                    })
-                )
+                    expect(capturedFetchRequest!.responseBody).toEqual(
+                        JSON.stringify({
+                            message: 'This is a JSON response',
+                        })
+                    )
 
-                expect(capturedFetchRequest!.responseHeaders['x-remote-header']).toEqual('true')
+                    expect(capturedFetchRequest!.responseHeaders['x-remote-header']).toEqual('true')
+                })
             })
         })
     })

--- a/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
@@ -151,7 +151,10 @@ test.beforeEach(async ({ context }) => {
                     expect(hasEntry(/http:\/\/localhost:\d+\/playground\/cypress\//, 'navigation')).toBe(true)
                     expect(hasEntry(/https:\/\/localhost:\d+\/static\/array.js/, 'script')).toBe(true)
                     expect(
-                        hasEntry(/https:\/\/localhost:\d+\/array\/test%20token\/config\?_=\d+&ver=1\.\d\d\d\.\d+/, 'fetch')
+                        hasEntry(
+                            /https:\/\/localhost:\d+\/array\/test%20token\/config\?_=\d+&ver=1\.\d\d\d\.\d+/,
+                            'fetch'
+                        )
                     ).toBe(true)
                     expect(
                         hasEntry(/https:\/\/localhost:\d+\/static\/(lazy-)?recorder.js\?v=1\.\d\d\d\.\d+/, 'script')

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -2794,7 +2794,7 @@
       "name": "NetworkRecordOptions",
       "properties": [],
       "path": "lib/src/types.d.ts",
-      "example": "{\n    initiatorTypes?: InitiatorType[];\n    maskRequestFn?: (data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined;\n    recordHeaders?: boolean | {\n        request: boolean;\n        response: boolean;\n    };\n    recordBody?: boolean | string[] | {\n        request: boolean | string[];\n        response: boolean | string[];\n    };\n    recordInitialRequests?: boolean;\n    recordPerformance?: boolean;\n    performanceEntryTypeToObserve: string[];\n    payloadSizeLimitBytes: number;\n    payloadHostDenyList?: string[];\n}"
+      "example": "{\n    initiatorTypes?: InitiatorType[];\n    maskRequestFn?: (data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined;\n    recordHeaders?: boolean | {\n        request: boolean;\n        response: boolean;\n    };\n    recordBody?: boolean | string[] | {\n        request: boolean | string[];\n        response: boolean | string[];\n    };\n    recordInitialRequests?: boolean;\n    recordPerformance?: boolean;\n    performanceEntryTypeToObserve: string[];\n    payloadSizeLimitBytes: number;\n    streamNetworkBody?: boolean;\n    payloadHostDenyList?: string[];\n}"
     },
     {
       "id": "OverrideConfig",

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -67,7 +67,6 @@ describe('config', () => {
             expect(posthog.config.session_recording).toStrictEqual({
                 strictMinimumDuration: true,
                 canvasCapture: { resolutionScale: 0.6 },
-                streamNetworkBody: true,
                 maskAllInputs: false,
             })
         })
@@ -75,7 +74,7 @@ describe('config', () => {
         it('lets a user-supplied session_recording sub-option override the date-gated default', () => {
             const posthog = new PostHog()
             posthog._init('test-token', {
-                defaults: '2026-05-30',
+                defaults: '2026-06-25',
                 session_recording: { canvasCapture: { resolutionScale: 0.8 } },
             })
             expect(posthog.config.session_recording).toStrictEqual({
@@ -91,6 +90,7 @@ describe('config', () => {
             ['2025-11-30', '2025-11-30' as const, 0],
             ['2026-01-30', '2026-01-30' as const, 0],
             ['2026-05-30', '2026-05-30' as const, 250],
+            ['2026-06-25', '2026-06-25' as const, 250],
         ])('persistence_save_debounce_ms with defaults %s', (_label, defaults, expected) => {
             const posthog = new PostHog()
             posthog._init('test-token', defaults ? { defaults } : undefined)
@@ -103,6 +103,7 @@ describe('config', () => {
             ['2025-11-30', '2025-11-30' as const, false],
             ['2026-01-30', '2026-01-30' as const, false],
             ['2026-05-30', '2026-05-30' as const, true],
+            ['2026-06-25', '2026-06-25' as const, true],
         ])('split_storage with defaults %s', (_label, defaults, expected) => {
             const posthog = new PostHog()
             posthog._init('test-token', defaults ? { defaults } : undefined)
@@ -115,6 +116,7 @@ describe('config', () => {
             ['2025-11-30', '2025-11-30' as const, false],
             ['2026-01-30', '2026-01-30' as const, false],
             ['2026-05-30', '2026-05-30' as const, true],
+            ['2026-06-25', '2026-06-25' as const, true],
         ])('detect_google_search_app with defaults %s', (_label, defaults, expected) => {
             const posthog = new PostHog()
             posthog._init('test-token', defaults ? { defaults } : undefined)
@@ -139,7 +141,8 @@ describe('config', () => {
             ['2025-05-24', '2025-05-24' as const, undefined],
             ['2025-11-30', '2025-11-30' as const, undefined],
             ['2026-01-30', '2026-01-30' as const, undefined],
-            ['2026-05-30', '2026-05-30' as const, true],
+            ['2026-05-30', '2026-05-30' as const, undefined],
+            ['2026-06-25', '2026-06-25' as const, true],
         ])('session_recording.streamNetworkBody with defaults %s', (_label, defaults, expected) => {
             const posthog = new PostHog()
             posthog._init('test-token', defaults ? { defaults } : undefined)

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -67,6 +67,7 @@ describe('config', () => {
             expect(posthog.config.session_recording).toStrictEqual({
                 strictMinimumDuration: true,
                 canvasCapture: { resolutionScale: 0.6 },
+                streamNetworkBody: true,
                 maskAllInputs: false,
             })
         })
@@ -80,6 +81,7 @@ describe('config', () => {
             expect(posthog.config.session_recording).toStrictEqual({
                 strictMinimumDuration: true,
                 canvasCapture: { resolutionScale: 0.8 },
+                streamNetworkBody: true,
             })
         })
 
@@ -130,6 +132,18 @@ describe('config', () => {
             const posthog = new PostHog()
             posthog._init('test-token', defaults ? { defaults } : undefined)
             expect(posthog.config.disable_capture_url_hashes).toBe(expected)
+        })
+
+        it.each([
+            ['unset', undefined, undefined],
+            ['2025-05-24', '2025-05-24' as const, undefined],
+            ['2025-11-30', '2025-11-30' as const, undefined],
+            ['2026-01-30', '2026-01-30' as const, undefined],
+            ['2026-05-30', '2026-05-30' as const, true],
+        ])('session_recording.streamNetworkBody with defaults %s', (_label, defaults, expected) => {
+            const posthog = new PostHog()
+            posthog._init('test-token', defaults ? { defaults } : undefined)
+            expect(posthog.config.session_recording.streamNetworkBody).toBe(expected)
         })
 
         it('should preserve other default config values when setting defaults', () => {

--- a/packages/browser/src/__tests__/extensions/replay/config.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/config.test.ts
@@ -298,8 +298,8 @@ describe('config', () => {
                 expect(networkOptions.streamNetworkBody).toBe(true)
             })
 
-            it('is true when the 2026-05-30 defaults are applied', () => {
-                const networkOptions = buildNetworkRequestOptions(defaultConfig('2026-05-30'), {})
+            it('is true when the 2026-06-25 defaults are applied', () => {
+                const networkOptions = buildNetworkRequestOptions(defaultConfig('2026-06-25'), {})
                 expect(networkOptions.streamNetworkBody).toBe(true)
             })
         })

--- a/packages/browser/src/__tests__/extensions/replay/config.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/config.test.ts
@@ -284,6 +284,25 @@ describe('config', () => {
                 ])
             })
         })
+
+        describe('streamNetworkBody', () => {
+            it('defaults to false when no defaults date and no explicit config', () => {
+                const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
+                expect(networkOptions.streamNetworkBody).toBe(false)
+            })
+
+            it('is true when session_recording.streamNetworkBody is set explicitly', () => {
+                const posthogConfig = defaultConfig()
+                posthogConfig.session_recording.streamNetworkBody = true
+                const networkOptions = buildNetworkRequestOptions(posthogConfig, {})
+                expect(networkOptions.streamNetworkBody).toBe(true)
+            })
+
+            it('is true when the 2026-05-30 defaults are applied', () => {
+                const networkOptions = buildNetworkRequestOptions(defaultConfig('2026-05-30'), {})
+                expect(networkOptions.streamNetworkBody).toBe(true)
+            })
+        })
     })
 
     describe('masking/privacy', () => {

--- a/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
@@ -1,7 +1,9 @@
 /// <reference lib="dom" />
 
 import { expect } from '@jest/globals'
+import { TextDecoder as NodeTextDecoder, TextEncoder as NodeTextEncoder } from 'util'
 import {
+    _tryReadBodyStreaming,
     NEVER_RECORD_BODY_CONTENT_TYPES,
     shouldRecordBody,
 } from '../../../../extensions/replay/external/network-plugin'
@@ -424,6 +426,86 @@ describe('network plugin', () => {
                     expect(testXhr.getListenerCount('timeout')).toBe(0)
                 })
             })
+        })
+    })
+
+    describe('_tryReadBodyStreaming', () => {
+        // jsdom omits TextEncoder/TextDecoder; every browser that supports fetch + streams has them,
+        // so shim them here to exercise the real streaming path (the function falls back to text()
+        // when TextDecoder is absent, which is covered by the no-stream case).
+        const originalTextEncoder = (global as any).TextEncoder
+        const originalTextDecoder = (global as any).TextDecoder
+        beforeAll(() => {
+            ;(global as any).TextEncoder = (global as any).TextEncoder ?? NodeTextEncoder
+            ;(global as any).TextDecoder = (global as any).TextDecoder ?? NodeTextDecoder
+        })
+        afterAll(() => {
+            ;(global as any).TextEncoder = originalTextEncoder
+            ;(global as any).TextDecoder = originalTextDecoder
+        })
+
+        const encode = (s: string): Uint8Array => new TextEncoder().encode(s)
+
+        function fakeStreamingBody(
+            chunks: Uint8Array[],
+            opts: { readRejects?: boolean; cloneThrows?: boolean; noStream?: boolean; textFallback?: string } = {}
+        ): Request | Response {
+            let i = 0
+            const reader = {
+                read: () =>
+                    opts.readRejects
+                        ? Promise.reject(new Error('boom'))
+                        : Promise.resolve(
+                              i < chunks.length ? { done: false, value: chunks[i++] } : { done: true, value: undefined }
+                          ),
+                cancel: () => Promise.resolve(),
+            }
+            const clone = {
+                body: opts.noStream ? null : { getReader: () => reader },
+                text: () => Promise.resolve(opts.textFallback ?? ''),
+            }
+            return {
+                clone: () => {
+                    if (opts.cloneThrows) {
+                        throw new Error('cannot clone')
+                    }
+                    return clone
+                },
+            } as unknown as Response
+        }
+
+        it('returns the full body when under the limit', async () => {
+            const r = fakeStreamingBody([encode('hello '), encode('world')])
+            await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe('hello world')
+        })
+
+        it('stops at the limit and returns a placeholder, without buffering past it', async () => {
+            const r = fakeStreamingBody([encode('a'.repeat(8)), encode('b'.repeat(8))])
+            await expect(_tryReadBodyStreaming(r, 10)).resolves.toBe(
+                '[SessionReplay] Body too large to record (> 10 bytes)'
+            )
+        })
+
+        it('records a body that exactly fills the limit', async () => {
+            const r = fakeStreamingBody([encode('1234567890')])
+            await expect(_tryReadBodyStreaming(r, 10)).resolves.toBe('1234567890')
+        })
+
+        it('falls back to text() when there is no readable stream', async () => {
+            const r = fakeStreamingBody([], { noStream: true, textFallback: 'plain text body' })
+            await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe('plain text body')
+        })
+
+        it('resolves with a failure placeholder when the clone cannot be read', async () => {
+            const r = fakeStreamingBody([], { cloneThrows: true })
+            await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe('[SessionReplay] Failed to read body')
+        })
+
+        it('resolves (never rejects) when the reader errors mid-stream', async () => {
+            const r = fakeStreamingBody([encode('partial')], { readRejects: true })
+            await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe(
+                '[SessionReplay] Failed to read body: Error: boom'
+            )
         })
     })
 })

--- a/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
@@ -505,6 +505,17 @@ describe('network plugin', () => {
             await expect(_tryReadBodyStreaming(r, 10)).resolves.toBe('1234567890')
         })
 
+        it('decodes a multi-byte character split across chunk boundaries', async () => {
+            const bytes = encode('😀')
+            const r = fakeStreamingBody([bytes.slice(0, 2), bytes.slice(2)])
+            await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe('😀')
+        })
+
+        it('decodes an empty body to an empty string', async () => {
+            const r = fakeStreamingBody([])
+            await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe('')
+        })
+
         it('falls back to text() when there is no readable stream', async () => {
             const r = fakeStreamingBody([], { noStream: true, textFallback: 'plain text body' })
             await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe('plain text body')

--- a/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
@@ -451,17 +451,28 @@ describe('network plugin', () => {
 
         function fakeStreamingBody(
             chunks: Uint8Array[],
-            opts: { readRejects?: boolean; cloneThrows?: boolean; noStream?: boolean; textFallback?: string } = {}
+            opts: {
+                readRejects?: boolean
+                cloneThrows?: boolean
+                noStream?: boolean
+                textFallback?: string
+                readNeverResolves?: boolean
+                cancel?: () => Promise<void>
+            } = {}
         ): Request | Response {
             let i = 0
             const reader = {
                 read: () =>
-                    opts.readRejects
-                        ? Promise.reject(new Error('boom'))
-                        : Promise.resolve(
-                              i < chunks.length ? { done: false, value: chunks[i++] } : { done: true, value: undefined }
-                          ),
-                cancel: () => Promise.resolve(),
+                    opts.readNeverResolves
+                        ? new Promise(() => {})
+                        : opts.readRejects
+                          ? Promise.reject(new Error('boom'))
+                          : Promise.resolve(
+                                i < chunks.length
+                                    ? { done: false, value: chunks[i++] }
+                                    : { done: true, value: undefined }
+                            ),
+                cancel: opts.cancel ?? (() => Promise.resolve()),
             }
             const clone = {
                 body: opts.noStream ? null : { getReader: () => reader },
@@ -509,6 +520,20 @@ describe('network plugin', () => {
             await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe(
                 '[SessionReplay] Failed to read body: Error: boom'
             )
+        })
+
+        it('times out a hung stream and cancels the reader so it stops being read', async () => {
+            jest.useFakeTimers()
+            try {
+                const cancel = jest.fn(() => Promise.resolve())
+                const r = fakeStreamingBody([], { readNeverResolves: true, cancel })
+                const result = _tryReadBodyStreaming(r, 1000)
+                jest.advanceTimersByTime(500)
+                await expect(result).resolves.toBe('[SessionReplay] Timeout while trying to read body')
+                expect(cancel).toHaveBeenCalled()
+            } finally {
+                jest.useRealTimers()
+            }
         })
     })
 

--- a/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
@@ -2,7 +2,10 @@
 
 import { expect } from '@jest/globals'
 import { TextDecoder as NodeTextDecoder, TextEncoder as NodeTextEncoder } from 'util'
+import { NetworkRecordOptions } from '../../../../types'
 import {
+    _contentLengthExceedsLimit,
+    _readBody,
     _tryReadBodyStreaming,
     NEVER_RECORD_BODY_CONTENT_TYPES,
     shouldRecordBody,
@@ -506,6 +509,56 @@ describe('network plugin', () => {
             await expect(_tryReadBodyStreaming(r, 1000)).resolves.toBe(
                 '[SessionReplay] Failed to read body: Error: boom'
             )
+        })
+    })
+
+    describe('content-length pre-check', () => {
+        function fakeRequestWith(contentLength: string | null): {
+            r: Request | Response
+            wasCloned: () => boolean
+        } {
+            let cloned = false
+            const r = {
+                headers: {
+                    get: (name: string) => (name.toLowerCase() === 'content-length' ? contentLength : null),
+                },
+                clone: () => {
+                    cloned = true
+                    return { body: null, text: () => Promise.resolve('') }
+                },
+            } as unknown as Response
+            return { r, wasCloned: () => cloned }
+        }
+
+        it.each([
+            ['over the limit', '2000', 1000, true],
+            ['equal to the limit', '1000', 1000, false],
+            ['under the limit', '500', 1000, false],
+            ['absent', null, 1000, false],
+            ['not a number', 'banana', 1000, false],
+        ])('_contentLengthExceedsLimit: content-length %s', (_label, header, limit, expected) => {
+            const { r } = fakeRequestWith(header as string | null)
+            expect(_contentLengthExceedsLimit(r, limit as number)).toBe(expected)
+        })
+
+        it('skips reading the body when content-length is over the limit (flag on)', async () => {
+            const { r, wasCloned } = fakeRequestWith('2000')
+            await expect(
+                _readBody(r, { streamNetworkBody: true, payloadSizeLimitBytes: 1000 } as NetworkRecordOptions)
+            ).resolves.toBe('[SessionReplay] Body too large to record (> 1000 bytes)')
+            expect(wasCloned()).toBe(false)
+        })
+
+        it('still reads the body when content-length is under the limit (flag on)', async () => {
+            const { r, wasCloned } = fakeRequestWith('10')
+            await _readBody(r, { streamNetworkBody: true, payloadSizeLimitBytes: 1000 } as NetworkRecordOptions)
+            expect(wasCloned()).toBe(true)
+        })
+
+        it('ignores the content-length pre-check when the flag is off', async () => {
+            const { r, wasCloned } = fakeRequestWith('2000')
+            await _readBody(r, { streamNetworkBody: false, payloadSizeLimitBytes: 1000 } as NetworkRecordOptions)
+            expect(wasCloned()).toBe(true)
         })
     })
 })

--- a/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
@@ -475,7 +475,7 @@ describe('network plugin', () => {
                 cancel: opts.cancel ?? (() => Promise.resolve()),
             }
             const clone = {
-                body: opts.noStream ? null : { getReader: () => reader },
+                body: opts.noStream ? null : { getReader: () => reader, tee: () => [] },
                 text: () => Promise.resolve(opts.textFallback ?? ''),
             }
             return {

--- a/packages/browser/src/extensions/replay/external/config.ts
+++ b/packages/browser/src/extensions/replay/external/config.ts
@@ -12,6 +12,11 @@ const REDACTED = 'redacted'
 // the hard ceiling for a recorded request/response body — 1MB, even if a larger limit is configured
 export const MAX_PAYLOAD_SIZE_BYTES = 1000000
 
+// the smallest of the 1MB ceiling or the configured limit if there is one
+export function effectivePayloadLimitBytes(options: Pick<NetworkRecordOptions, 'payloadSizeLimitBytes'>): number {
+    return Math.min(MAX_PAYLOAD_SIZE_BYTES, options.payloadSizeLimitBytes ?? MAX_PAYLOAD_SIZE_BYTES)
+}
+
 export const defaultNetworkOptions: Required<NetworkRecordOptions> = {
     initiatorTypes: [
         'audio',
@@ -202,8 +207,7 @@ function enforcePayloadSizeLimit(
 const limitPayloadSize = (
     options: NetworkRecordOptions
 ): ((data: CapturedNetworkRequest | undefined) => CapturedNetworkRequest | undefined) => {
-    // the smallest of 1MB or the specified limit if there is one
-    const limit = Math.min(MAX_PAYLOAD_SIZE_BYTES, options.payloadSizeLimitBytes ?? MAX_PAYLOAD_SIZE_BYTES)
+    const limit = effectivePayloadLimitBytes(options)
 
     return (data) => {
         if (data?.requestBody) {

--- a/packages/browser/src/extensions/replay/external/config.ts
+++ b/packages/browser/src/extensions/replay/external/config.ts
@@ -9,6 +9,9 @@ const LOGGER_PREFIX = '[SessionRecording]'
 
 const REDACTED = 'redacted'
 
+// the hard ceiling for a recorded request/response body — 1MB, even if a larger limit is configured
+export const MAX_PAYLOAD_SIZE_BYTES = 1000000
+
 export const defaultNetworkOptions: Required<NetworkRecordOptions> = {
     initiatorTypes: [
         'audio',
@@ -47,7 +50,7 @@ export const defaultNetworkOptions: Required<NetworkRecordOptions> = {
         'paint',
         'resource',
     ],
-    payloadSizeLimitBytes: 1000000,
+    payloadSizeLimitBytes: MAX_PAYLOAD_SIZE_BYTES,
     payloadHostDenyList: [
         '.lr-ingest.io',
         '.ingest.sentry.io',
@@ -200,7 +203,7 @@ const limitPayloadSize = (
     options: NetworkRecordOptions
 ): ((data: CapturedNetworkRequest | undefined) => CapturedNetworkRequest | undefined) => {
     // the smallest of 1MB or the specified limit if there is one
-    const limit = Math.min(1000000, options.payloadSizeLimitBytes ?? 1000000)
+    const limit = Math.min(MAX_PAYLOAD_SIZE_BYTES, options.payloadSizeLimitBytes ?? MAX_PAYLOAD_SIZE_BYTES)
 
     return (data) => {
         if (data?.requestBody) {

--- a/packages/browser/src/extensions/replay/external/config.ts
+++ b/packages/browser/src/extensions/replay/external/config.ts
@@ -73,6 +73,7 @@ export const defaultNetworkOptions: Required<NetworkRecordOptions> = {
         'hotjar.io',
         'fullstory.com',
     ],
+    streamNetworkBody: false,
 }
 
 const HEADER_DENY_LIST = [
@@ -311,5 +312,6 @@ export const buildNetworkRequestOptions = (
         recordBody: canRecordBody,
         recordPerformance: canRecordPerformance,
         recordInitialRequests: canRecordPerformance,
+        streamNetworkBody: instanceConfig.session_recording.streamNetworkBody === true,
     }
 }

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -651,10 +651,14 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
         const body = clone.body
         // no readable stream (or no TextDecoder) available — fall back to the buffered read of the clone
         if (!isReadableStreamBody(body) || typeof TextDecoder === 'undefined') {
-            clone.text().then(
-                (txt) => done(txt),
-                (reason) => done(bodyReadFailedMessage(reason))
-            )
+            try {
+                clone.text().then(
+                    (txt) => done(txt),
+                    (reason) => done(bodyReadFailedMessage(reason))
+                )
+            } catch {
+                done(BODY_READ_FAILED_MESSAGE)
+            }
             return
         }
 

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -31,7 +31,7 @@ import { createLogger } from '../../../utils/logger'
 import { formDataToQuery } from '../../../utils/request-utils'
 import { patch } from '../rrweb-plugins/patch'
 import { isHostOnDenyList } from '../../../extensions/replay/external/denylist'
-import { defaultNetworkOptions, MAX_PAYLOAD_SIZE_BYTES } from './config'
+import { defaultNetworkOptions, effectivePayloadLimitBytes } from './config'
 
 const logger = createLogger('[Recorder]')
 
@@ -549,10 +549,6 @@ function bodyTooLargeMessage(limitBytes: number): string {
     return `[SessionReplay] Body too large to record (> ${limitBytes} bytes)`
 }
 
-function effectivePayloadLimitBytes(options: NetworkRecordOptions): number {
-    return Math.min(MAX_PAYLOAD_SIZE_BYTES, options.payloadSizeLimitBytes ?? MAX_PAYLOAD_SIZE_BYTES)
-}
-
 // when the body declares a content-length over the limit we can skip reading it entirely.
 // this trusts content-length the same way config.ts enforcePayloadSizeLimit does.
 // known accepted risk: for a compressed response content-length is the compressed size while the
@@ -697,7 +693,7 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
 
                     pump()
                 },
-                (reason) => done('[SessionReplay] Failed to read body: ' + reason)
+                (reason) => done(bodyReadFailedMessage(reason))
             )
         }
 

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -536,6 +536,17 @@ function isReadableStreamBody(body: unknown): body is ReadableStream<Uint8Array>
     return isObject(body) && isFunction(body.getReader) && isFunction(body.tee)
 }
 
+// matches the hard ceiling enforced in config.ts limitPayloadSize
+const MAX_PAYLOAD_SIZE_BYTES = 1000000
+
+function effectivePayloadLimitBytes(options: NetworkRecordOptions): number {
+    return Math.min(MAX_PAYLOAD_SIZE_BYTES, options.payloadSizeLimitBytes ?? MAX_PAYLOAD_SIZE_BYTES)
+}
+
+function _readBody(r: Request | Response, options: NetworkRecordOptions): Promise<string> {
+    return options.streamNetworkBody ? _tryReadBodyStreaming(r, effectivePayloadLimitBytes(options)) : _tryReadBody(r)
+}
+
 function _tryReadBody(r: Request | Response): Promise<string> {
     // there are now already multiple places where we're using Promise...
     // eslint-disable-next-line compat/compat
@@ -556,6 +567,95 @@ function _tryReadBody(r: Request | Response): Promise<string> {
     })
 }
 
+// Reads a clone of the body chunk by chunk, stopping as soon as the running total exceeds the
+// limit, so a very large body is never fully buffered. Like _tryReadBody it only ever reads a
+// clone (never the stream the page consumes) and is guaranteed to resolve, never reject.
+export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number): Promise<string> {
+    // eslint-disable-next-line compat/compat
+    return new Promise((resolve) => {
+        let settled = false
+        const timeout = setTimeout(() => done('[SessionReplay] Timeout while trying to read body'), 500)
+
+        function done(value: string): void {
+            if (settled) {
+                return
+            }
+            settled = true
+            clearTimeout(timeout)
+            resolve(value)
+        }
+
+        let clone: Request | Response
+        try {
+            clone = r.clone()
+        } catch {
+            done('[SessionReplay] Failed to read body')
+            return
+        }
+
+        const body = clone.body
+        // no readable stream (or no TextDecoder) available — fall back to the buffered read of the clone
+        if (!body || !isFunction(body.getReader) || typeof TextDecoder === 'undefined') {
+            clone.text().then(
+                (txt) => done(txt),
+                (reason) => done('[SessionReplay] Failed to read body: ' + reason)
+            )
+            return
+        }
+
+        let reader: ReadableStreamDefaultReader<Uint8Array>
+        try {
+            reader = body.getReader()
+        } catch {
+            done('[SessionReplay] Failed to read body')
+            return
+        }
+
+        function cancel(): void {
+            try {
+                void reader.cancel()
+            } catch {
+                // the reader may already be released; nothing to clean up
+            }
+        }
+
+        const chunks: Uint8Array[] = []
+        let received = 0
+
+        function pump(): void {
+            reader.read().then(
+                ({ done: streamDone, value }) => {
+                    if (streamDone) {
+                        const merged = new Uint8Array(received)
+                        let offset = 0
+                        for (const chunk of chunks) {
+                            merged.set(chunk, offset)
+                            offset += chunk.byteLength
+                        }
+                        done(new TextDecoder().decode(merged))
+                        return
+                    }
+
+                    if (value) {
+                        if (received + value.byteLength > limitBytes) {
+                            cancel()
+                            done(`[SessionReplay] Body too large to record (> ${limitBytes} bytes)`)
+                            return
+                        }
+                        received += value.byteLength
+                        chunks.push(value)
+                    }
+
+                    pump()
+                },
+                (reason) => done('[SessionReplay] Failed to read body: ' + reason)
+            )
+        }
+
+        pump()
+    })
+}
+
 async function _tryReadRequestBody({
     r,
     options,
@@ -570,7 +670,7 @@ async function _tryReadRequestBody({
         return Promise.resolve(hostname + ' is in deny list')
     }
 
-    return _tryReadBody(r)
+    return _readBody(r, options)
 }
 
 async function _tryReadResponseBody({
@@ -587,7 +687,7 @@ async function _tryReadResponseBody({
         return Promise.resolve(cannotReadBodyReason)
     }
 
-    return _tryReadBody(r)
+    return _readBody(r, options)
 }
 
 function initFetchObserver(

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -601,16 +601,29 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
     // eslint-disable-next-line compat/compat
     return new Promise((resolve) => {
         let settled = false
-        const timeout = setTimeout(() => done('[SessionReplay] Timeout while trying to read body'), 500)
+        let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
 
+        function cancel(): void {
+            try {
+                void reader?.cancel()
+            } catch {
+                // the reader may already be released; nothing to clean up
+            }
+        }
+
+        // resolving always releases the reader, so a slow/hung stream stops being pulled (and stops
+        // buffering the clone) the moment we settle — whether via success, the cap, an error, or the timeout
         function done(value: string): void {
             if (settled) {
                 return
             }
             settled = true
             clearTimeout(timeout)
+            cancel()
             resolve(value)
         }
+
+        const timeout = setTimeout(() => done('[SessionReplay] Timeout while trying to read body'), 500)
 
         let clone: Request | Response
         try {
@@ -630,7 +643,6 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
             return
         }
 
-        let reader: ReadableStreamDefaultReader<Uint8Array>
         try {
             reader = body.getReader()
         } catch {
@@ -638,20 +650,18 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
             return
         }
 
-        function cancel(): void {
-            try {
-                void reader.cancel()
-            } catch {
-                // the reader may already be released; nothing to clean up
-            }
-        }
-
         const chunks: Uint8Array[] = []
         let received = 0
 
         function pump(): void {
-            reader.read().then(
+            reader!.read().then(
                 ({ done: streamDone, value }) => {
+                    // already resolved (e.g. the timeout fired) — stop reading and release the stream
+                    if (settled) {
+                        cancel()
+                        return
+                    }
+
                     if (streamDone) {
                         const merged = new Uint8Array(received)
                         let offset = 0
@@ -665,7 +675,6 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
 
                     if (value) {
                         if (received + value.byteLength > limitBytes) {
-                            cancel()
                             done(bodyTooLargeMessage(limitBytes))
                             return
                         }

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -543,8 +543,35 @@ function effectivePayloadLimitBytes(options: NetworkRecordOptions): number {
     return Math.min(MAX_PAYLOAD_SIZE_BYTES, options.payloadSizeLimitBytes ?? MAX_PAYLOAD_SIZE_BYTES)
 }
 
-function _readBody(r: Request | Response, options: NetworkRecordOptions): Promise<string> {
-    return options.streamNetworkBody ? _tryReadBodyStreaming(r, effectivePayloadLimitBytes(options)) : _tryReadBody(r)
+function bodyTooLargeMessage(limitBytes: number): string {
+    return `[SessionReplay] Body too large to record (> ${limitBytes} bytes)`
+}
+
+// when the body declares a content-length over the limit we can skip reading it entirely.
+// this trusts content-length the same way config.ts enforcePayloadSizeLimit does.
+export function _contentLengthExceedsLimit(r: Request | Response, limitBytes: number): boolean {
+    try {
+        const headerValue = r.headers?.get?.('content-length')
+        if (!headerValue) {
+            return false
+        }
+        const contentLength = parseInt(headerValue, 10)
+        return Number.isFinite(contentLength) && contentLength > limitBytes
+    } catch {
+        return false
+    }
+}
+
+export function _readBody(r: Request | Response, options: NetworkRecordOptions): Promise<string> {
+    if (!options.streamNetworkBody) {
+        return _tryReadBody(r)
+    }
+    const limitBytes = effectivePayloadLimitBytes(options)
+    // skip the read for bodies the headers already tell us are over the limit
+    if (_contentLengthExceedsLimit(r, limitBytes)) {
+        return Promise.resolve(bodyTooLargeMessage(limitBytes))
+    }
+    return _tryReadBodyStreaming(r, limitBytes)
 }
 
 function _tryReadBody(r: Request | Response): Promise<string> {
@@ -639,7 +666,7 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
                     if (value) {
                         if (received + value.byteLength > limitBytes) {
                             cancel()
-                            done(`[SessionReplay] Body too large to record (> ${limitBytes} bytes)`)
+                            done(bodyTooLargeMessage(limitBytes))
                             return
                         }
                         received += value.byteLength

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -31,7 +31,7 @@ import { createLogger } from '../../../utils/logger'
 import { formDataToQuery } from '../../../utils/request-utils'
 import { patch } from '../rrweb-plugins/patch'
 import { isHostOnDenyList } from '../../../extensions/replay/external/denylist'
-import { defaultNetworkOptions } from './config'
+import { defaultNetworkOptions, MAX_PAYLOAD_SIZE_BYTES } from './config'
 
 const logger = createLogger('[Recorder]')
 
@@ -536,19 +536,28 @@ function isReadableStreamBody(body: unknown): body is ReadableStream<Uint8Array>
     return isObject(body) && isFunction(body.getReader) && isFunction(body.tee)
 }
 
-// 1MB — matches the hard ceiling enforced in config.ts limitPayloadSize
-const MAX_PAYLOAD_SIZE_BYTES = 1000000
+// reading a body must never hold up the page's request for long, so we cap every read attempt
+const BODY_READ_TIMEOUT_MS = 500
+const BODY_READ_TIMEOUT_MESSAGE = '[SessionReplay] Timeout while trying to read body'
+const BODY_READ_FAILED_MESSAGE = '[SessionReplay] Failed to read body'
 
-function effectivePayloadLimitBytes(options: NetworkRecordOptions): number {
-    return Math.min(MAX_PAYLOAD_SIZE_BYTES, options.payloadSizeLimitBytes ?? MAX_PAYLOAD_SIZE_BYTES)
+function bodyReadFailedMessage(reason: unknown): string {
+    return `${BODY_READ_FAILED_MESSAGE}: ${reason}`
 }
 
 function bodyTooLargeMessage(limitBytes: number): string {
     return `[SessionReplay] Body too large to record (> ${limitBytes} bytes)`
 }
 
+function effectivePayloadLimitBytes(options: NetworkRecordOptions): number {
+    return Math.min(MAX_PAYLOAD_SIZE_BYTES, options.payloadSizeLimitBytes ?? MAX_PAYLOAD_SIZE_BYTES)
+}
+
 // when the body declares a content-length over the limit we can skip reading it entirely.
 // this trusts content-length the same way config.ts enforcePayloadSizeLimit does.
+// known accepted risk: for a compressed response content-length is the compressed size while the
+// streaming reader counts decoded bytes, so a body that is over the limit compressed but under it
+// decoded is dropped to the placeholder rather than recorded. it never breaks the page, so we accept it.
 export function _contentLengthExceedsLimit(r: Request | Response, limitBytes: number): boolean {
     try {
         const headerValue = r.headers?.get?.('content-length')
@@ -578,20 +587,30 @@ function _tryReadBody(r: Request | Response): Promise<string> {
     // there are now already multiple places where we're using Promise...
     // eslint-disable-next-line compat/compat
     return new Promise((resolve) => {
-        const timeout = setTimeout(() => resolve('[SessionReplay] Timeout while trying to read body'), 500)
+        const timeout = setTimeout(() => resolve(BODY_READ_TIMEOUT_MESSAGE), BODY_READ_TIMEOUT_MS)
         try {
             r.clone()
                 .text()
                 .then(
                     (txt) => resolve(txt),
-                    (reason) => resolve('[SessionReplay] Failed to read body: ' + reason)
+                    (reason) => resolve(bodyReadFailedMessage(reason))
                 )
                 .finally(() => clearTimeout(timeout))
         } catch {
             clearTimeout(timeout)
-            resolve('[SessionReplay] Failed to read body')
+            resolve(BODY_READ_FAILED_MESSAGE)
         }
     })
+}
+
+function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+    const merged = new Uint8Array(totalBytes)
+    let offset = 0
+    for (const chunk of chunks) {
+        merged.set(chunk, offset)
+        offset += chunk.byteLength
+    }
+    return merged
 }
 
 // Reads a clone of the body chunk by chunk, stopping as soon as the running total exceeds the
@@ -623,22 +642,22 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
             resolve(value)
         }
 
-        const timeout = setTimeout(() => done('[SessionReplay] Timeout while trying to read body'), 500)
+        const timeout = setTimeout(() => done(BODY_READ_TIMEOUT_MESSAGE), BODY_READ_TIMEOUT_MS)
 
         let clone: Request | Response
         try {
             clone = r.clone()
         } catch {
-            done('[SessionReplay] Failed to read body')
+            done(BODY_READ_FAILED_MESSAGE)
             return
         }
 
         const body = clone.body
         // no readable stream (or no TextDecoder) available — fall back to the buffered read of the clone
-        if (!body || !isFunction(body.getReader) || typeof TextDecoder === 'undefined') {
+        if (!isReadableStreamBody(body) || typeof TextDecoder === 'undefined') {
             clone.text().then(
                 (txt) => done(txt),
-                (reason) => done('[SessionReplay] Failed to read body: ' + reason)
+                (reason) => done(bodyReadFailedMessage(reason))
             )
             return
         }
@@ -646,7 +665,7 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
         try {
             reader = body.getReader()
         } catch {
-            done('[SessionReplay] Failed to read body')
+            done(BODY_READ_FAILED_MESSAGE)
             return
         }
 
@@ -663,13 +682,7 @@ export function _tryReadBodyStreaming(r: Request | Response, limitBytes: number)
                     }
 
                     if (streamDone) {
-                        const merged = new Uint8Array(received)
-                        let offset = 0
-                        for (const chunk of chunks) {
-                            merged.set(chunk, offset)
-                            offset += chunk.byteLength
-                        }
-                        done(new TextDecoder().decode(merged))
+                        done(new TextDecoder().decode(concatChunks(chunks, received)))
                         return
                     }
 

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -536,7 +536,7 @@ function isReadableStreamBody(body: unknown): body is ReadableStream<Uint8Array>
     return isObject(body) && isFunction(body.getReader) && isFunction(body.tee)
 }
 
-// matches the hard ceiling enforced in config.ts limitPayloadSize
+// 1MB — matches the hard ceiling enforced in config.ts limitPayloadSize
 const MAX_PAYLOAD_SIZE_BYTES = 1000000
 
 function effectivePayloadLimitBytes(options: NetworkRecordOptions): number {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -204,11 +204,13 @@ const defaultsThatVaryByConfig = (
               : true,
     capture_pageview: defaults && defaults >= '2025-05-24' ? 'history_change' : true,
     session_recording:
-        defaults && defaults >= '2026-05-30'
+        defaults && defaults >= '2026-06-25'
             ? { strictMinimumDuration: true, canvasCapture: { resolutionScale: 0.6 }, streamNetworkBody: true }
-            : defaults && defaults >= '2025-11-30'
-              ? { strictMinimumDuration: true }
-              : {},
+            : defaults && defaults >= '2026-05-30'
+              ? { strictMinimumDuration: true, canvasCapture: { resolutionScale: 0.6 } }
+              : defaults && defaults >= '2025-11-30'
+                ? { strictMinimumDuration: true }
+                : {},
     external_scripts_inject_target: defaults && defaults >= '2026-01-30' ? 'head' : 'body',
     internal_or_test_user_hostname: defaults && defaults >= '2026-01-30' ? /^(localhost|127\.0\.0\.1)$/ : undefined,
     persistence_save_debounce_ms: defaults && defaults >= '2026-05-30' ? 250 : 0,

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -205,7 +205,7 @@ const defaultsThatVaryByConfig = (
     capture_pageview: defaults && defaults >= '2025-05-24' ? 'history_change' : true,
     session_recording:
         defaults && defaults >= '2026-05-30'
-            ? { strictMinimumDuration: true, canvasCapture: { resolutionScale: 0.6 } }
+            ? { strictMinimumDuration: true, canvasCapture: { resolutionScale: 0.6 }, streamNetworkBody: true }
             : defaults && defaults >= '2025-11-30'
               ? { strictMinimumDuration: true }
               : {},

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -504,6 +504,12 @@ export type NetworkRecordOptions = {
      */
     payloadSizeLimitBytes: number
     /**
+     * when true, read bodies through a streaming reader that stops at payloadSizeLimitBytes
+     * instead of buffering the whole body and then enforcing the limit. Reads only a clone of
+     * the body, so it never consumes the stream the page itself reads.
+     */
+    streamNetworkBody?: boolean
+    /**
      * some domains we should never record the payload
      * for example other companies session replay ingestion payloads aren't super useful but are gigantic
      * if this isn't provided we use a default list

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -507,6 +507,7 @@ export type NetworkRecordOptions = {
      * when true, read bodies through a streaming reader that stops at payloadSizeLimitBytes
      * instead of buffering the whole body and then enforcing the limit. Reads only a clone of
      * the body, so it never consumes the stream the page itself reads.
+     * @default false
      */
     streamNetworkBody?: boolean
     /**

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -454,6 +454,11 @@ exports[`config snapshot for PostHogConfig 1`] = `
       "false",
       "true"
     ],
+    "streamNetworkBody": [
+      "undefined",
+      "false",
+      "true"
+    ],
     "captureCanvas": [
       "undefined",
       "SessionRecordingCanvasOptions"

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1326,6 +1326,7 @@ export interface PostHogConfig {
      * - `'2025-11-30'`: Defaults from '2025-05-24' plus additional changes (e.g. strict minimum duration for replay and rageclick content ignore list defaults to active)
      * - `'2026-01-30'`: Defaults from '2025-11-30' plus external_scripts_inject_target defaults to 'head' (avoids SSR hydration errors)
      * - `'2026-05-30'`: Defaults from '2026-01-30' plus `persistence_save_debounce_ms` defaults to `250`, `split_storage` and `detect_google_search_app` default to `true`, and rageclick defaults also exclude stepper controls and text-selection surfaces
+     * - `'2026-06-25'`: Defaults from '2026-05-30' plus `session_recording.streamNetworkBody` defaults to `true` (streams network bodies to enforce the payload size limit)
      *
      * @default 'unset'
      */

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -559,6 +559,15 @@ export interface SessionRecordingOptions {
     recordBody?: boolean
 
     /**
+     * When recording network bodies, read them through a streaming reader that stops at the
+     * payload size limit instead of buffering the whole body and then discarding it. Bounds the
+     * memory and pre-request latency of capturing a very large body. Reads only a clone of the
+     * body, never the stream the page consumes.
+     * @default false
+     */
+    streamNetworkBody?: boolean
+
+    /**
      * Allows local config to override remote canvas recording settings from the flags response
      */
     captureCanvas?: SessionRecordingCanvasOptions


### PR DESCRIPTION
## Problem

Session replay enforces a network body payload limit (`payloadSizeLimitBytes`, capped at 1MB), but today it does so **after** reading the entire body: `_tryReadBody` buffers the whole request/response body into a string via `clone().text()`, and only then does `config.ts` check the size and replace an over-limit body with a placeholder. For a very large body that means fully materialising it in memory before discarding it — and for **request** bodies the read is awaited *before* the real `fetch`, so it adds work on the page's critical path.

Network capture is the one area where a recording bug becomes a customer-facing outage, so we want a more careful body-limit mechanism, rolled out as conservatively as possible.

## Changes

Add an opt-in **streaming reader** (`_tryReadBodyStreaming`) that reads the body chunk by chunk off a `clone().body` reader and stops as soon as the running total exceeds the limit, so an oversized body is never fully buffered.

A **content-length pre-check** runs first: if the body's `content-length` header already declares it over the limit, we emit the too-large placeholder without cloning or reading the body at all. This trusts `content-length` the same way `config.ts` `enforcePayloadSizeLimit` already does. The streaming reader is the fallback for bodies with no/under-stated content-length (chunked, or a header that lies).

The reader keeps every observer-only invariant of the existing buffered path:

- reads **only a clone** of the body — never the stream the page itself consumes
- **always resolves, never rejects** (success, reader error, sync throw, and a 500ms timeout all resolve) so it can never reject the page's `fetch`
- **feature-detects** `ReadableStream.getReader` / `TextDecoder` and falls back to the buffered `clone().text()` read when they're absent
- returns a placeholder string (not a partial body) when over the limit

**Rollout — defaults-gated, no remote toggle.** The behaviour is off by default and turned on through the date-versioned `defaults` mechanism at `2026-05-30` (already adopted by the PostHog app, so we dogfood it). Existing customers are unaffected until they bump their `defaults` date; it can also be set directly via `session_recording.streamNetworkBody`. There is deliberately no server/remote switch.

The buffered path is unchanged and remains the default, so this is additive.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul flagged that network-capture body handling is the highest-risk area (anything that alters the body or breaks the request can break customers' sites) and asked for the streaming body-limit reader to ship behind the `defaults` flag for the slowest possible opt-in rollout, with no remote change — then asked to check `content-length` first so we never read a body that's already definitely over the limit.

Before writing anything, traced the capture path to confirm the safety boundary (the real `res` is returned before any capture work; capture runs in the `finally` `.then().catch()`; bodies are read from a clone; `isHostOnDenyList` URL parsing is throw-safe). The streaming reader and the content-length pre-check are built to preserve those same invariants, and are wired into the existing `2026-05-30` `session_recording` defaults tier so they dogfood on the PostHog app while every existing customer keeps the buffered path until they opt in. Tests cover the reader directly (under/at/over limit, no-stream fallback, clone failure, reader-error-never-rejects), the content-length pre-check (parameterized over header values, plus "skips the read when over" / "still reads when under" / "ignored when the flag is off"), the config→network-options flow, and the defaults-date gating. The `getEventUuid` typecheck/test noise seen locally was stale workspace `dist` for `@posthog/core` / `@posthog/types`, not part of this change.

Tools: PostHog Code (Claude Opus).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
