### PR TITLE
test: Make native error tracking tests deterministic

### DIFF
--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -1,4 +1,3 @@
-
 import { assignableWindow } from '../utils/globals'
 import { PostHog } from '../posthog-core'
 import { isArray, isBoolean, isFunction, isNull, isNumber, isObject } from '@posthog/core'

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -2285,6 +2285,20 @@ export class PostHog extends PostHogCore {
     return this._sessionReplayEvalChain
   }
 
+  /**
+   * @internal Test-only helper for waiting until queued native plugin evaluation has completed.
+   */
+  async _drainNativePluginEvaluationForTesting(): Promise<void> {
+    const isTestEnvironment =
+      (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV === 'test'
+
+    if (!isTestEnvironment) {
+      throw new Error('_drainNativePluginEvaluationForTesting() can only be used in tests.')
+    }
+
+    await this._sessionReplayEvalChain
+  }
+
   private async _evaluateAndStartSessionReplayInternal(
     cachedRemoteConfig?: Omit<PostHogRemoteConfig, 'surveys'>
   ): Promise<void> {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -2285,20 +2285,6 @@ export class PostHog extends PostHogCore {
     return this._sessionReplayEvalChain
   }
 
-  /**
-   * @internal Test-only helper for waiting until queued native plugin evaluation has completed.
-   */
-  async _drainNativePluginEvaluationForTesting(): Promise<void> {
-    const isTestEnvironment =
-      (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV === 'test'
-
-    if (!isTestEnvironment) {
-      throw new Error('_drainNativePluginEvaluationForTesting() can only be used in tests.')
-    }
-
-    await this._sessionReplayEvalChain
-  }
-
   private async _evaluateAndStartSessionReplayInternal(
     cachedRemoteConfig?: Omit<PostHogRemoteConfig, 'surveys'>
   ): Promise<void> {

--- a/packages/react-native/test/native-error-tracking.spec.ts
+++ b/packages/react-native/test/native-error-tracking.spec.ts
@@ -30,6 +30,12 @@ const mockPlugin = OptionalReactNativePlugin as unknown as {
   addExceptionStep: jest.Mock
 }
 
+type PostHogInternalAccess = { _sessionReplayEvalChain: Promise<void> }
+
+const waitForNativePluginEvaluation = async (posthog: PostHog): Promise<void> => {
+  await (posthog as unknown as PostHogInternalAccess)._sessionReplayEvalChain
+}
+
 const resetMockPlugin = (): void => {
   mockPlugin.start.mockImplementation(() => Promise.resolve())
   // `setup` may have been deleted by the legacy-plugin test; restore it if so.
@@ -66,7 +72,7 @@ describe('native error tracking', () => {
     const posthog = new PostHog('test-token', { persistence: 'memory', flushInterval: 0 })
 
     await posthog.ready()
-    await posthog._drainNativePluginEvaluationForTesting()
+    await waitForNativePluginEvaluation(posthog)
 
     expect(mockPlugin.setup).not.toHaveBeenCalled()
     expect(mockPlugin.start).not.toHaveBeenCalled()
@@ -295,7 +301,7 @@ describe('native error tracking', () => {
     const posthog = new PostHog('test-token', { persistence: 'memory', flushInterval: 0 })
 
     await posthog.ready()
-    await posthog._drainNativePluginEvaluationForTesting()
+    await waitForNativePluginEvaluation(posthog)
 
     posthog.addExceptionStep('orphan')
 

--- a/packages/react-native/test/native-error-tracking.spec.ts
+++ b/packages/react-native/test/native-error-tracking.spec.ts
@@ -1,17 +1,50 @@
+import { PostHog } from '../src/posthog-rn'
+import { OptionalReactNativePlugin } from '../src/optional/OptionalPlugin'
 import { waitForExpect } from './test-utils'
+
+jest.mock('../src/optional/OptionalPlugin', () => ({
+  OptionalReactNativePlugin: {
+    start: jest.fn(() => Promise.resolve()),
+    setup: jest.fn(() => Promise.resolve()),
+    startSession: jest.fn(() => Promise.resolve()),
+    endSession: jest.fn(() => Promise.resolve()),
+    isEnabled: jest.fn(() => Promise.resolve(false)),
+    identify: jest.fn(() => Promise.resolve()),
+    startRecording: jest.fn(() => Promise.resolve()),
+    stopRecording: jest.fn(() => Promise.resolve()),
+    addExceptionStep: jest.fn(() => Promise.resolve()),
+  },
+}))
 
 jest.useRealTimers()
 
-const mockPlugin = {
-  start: jest.fn(() => Promise.resolve()),
-  setup: jest.fn(() => Promise.resolve()),
-  startSession: jest.fn(() => Promise.resolve()),
-  endSession: jest.fn(() => Promise.resolve()),
-  isEnabled: jest.fn(() => Promise.resolve(false)),
-  identify: jest.fn(() => Promise.resolve()),
-  startRecording: jest.fn(() => Promise.resolve()),
-  stopRecording: jest.fn(() => Promise.resolve()),
-  addExceptionStep: jest.fn(() => Promise.resolve()),
+const mockPlugin = OptionalReactNativePlugin as unknown as {
+  start: jest.Mock
+  setup: jest.Mock
+  startSession: jest.Mock
+  endSession: jest.Mock
+  isEnabled: jest.Mock
+  identify: jest.Mock
+  startRecording: jest.Mock
+  stopRecording: jest.Mock
+  addExceptionStep: jest.Mock
+}
+
+const waitForNativePluginEvaluation = async (posthog: PostHog): Promise<void> => {
+  await (posthog as unknown as { _sessionReplayEvalChain: Promise<void> })._sessionReplayEvalChain
+}
+
+const resetMockPlugin = (): void => {
+  mockPlugin.start.mockImplementation(() => Promise.resolve())
+  mockPlugin.setup = mockPlugin.setup ?? jest.fn()
+  mockPlugin.setup.mockImplementation(() => Promise.resolve())
+  mockPlugin.startSession.mockImplementation(() => Promise.resolve())
+  mockPlugin.endSession.mockImplementation(() => Promise.resolve())
+  mockPlugin.isEnabled.mockImplementation(() => Promise.resolve(false))
+  mockPlugin.identify.mockImplementation(() => Promise.resolve())
+  mockPlugin.startRecording.mockImplementation(() => Promise.resolve())
+  mockPlugin.stopRecording.mockImplementation(() => Promise.resolve())
+  mockPlugin.addExceptionStep.mockImplementation(() => Promise.resolve())
 }
 
 const setupFetch = (): void => {
@@ -27,24 +60,16 @@ const setupFetch = (): void => {
 
 describe('native error tracking', () => {
   beforeEach(() => {
-    jest.resetModules()
+    resetMockPlugin()
     jest.clearAllMocks()
     setupFetch()
-    jest.doMock('../src/optional/OptionalPlugin', () => ({
-      OptionalReactNativePlugin: mockPlugin,
-    }))
-  })
-
-  afterEach(() => {
-    jest.dontMock('../src/optional/OptionalPlugin')
   })
 
   it('does not initialize the native plugin by default', async () => {
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', { persistence: 'memory', flushInterval: 0 })
 
     await posthog.ready()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await waitForNativePluginEvaluation(posthog)
 
     expect(mockPlugin.setup).not.toHaveBeenCalled()
     expect(mockPlugin.start).not.toHaveBeenCalled()
@@ -53,7 +78,6 @@ describe('native error tracking', () => {
   })
 
   it('initializes native error tracking without enabling session replay', async () => {
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', {
       persistence: 'memory',
       flushInterval: 0,
@@ -74,7 +98,6 @@ describe('native error tracking', () => {
   })
 
   it('starts recording on the existing native instance instead of re-running setup when replay is enabled later', async () => {
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', {
       persistence: 'memory',
       flushInterval: 0,
@@ -100,24 +123,13 @@ describe('native error tracking', () => {
   })
 
   it('with the legacy plugin (no setup), starts replay via start() and does not report native crash capture as started', async () => {
-    jest.resetModules()
-    const legacyPlugin = {
-      start: jest.fn(() => Promise.resolve()),
-      isEnabled: jest.fn(() => Promise.resolve(false)),
-      identify: jest.fn(() => Promise.resolve()),
-      startSession: jest.fn(() => Promise.resolve()),
-      endSession: jest.fn(() => Promise.resolve()),
-      startRecording: jest.fn(() => Promise.resolve()),
-      stopRecording: jest.fn(() => Promise.resolve()),
-      // intentionally no setup() — emulates posthog-react-native-session-replay
-    }
-    jest.doMock('../src/optional/OptionalPlugin', () => ({ OptionalReactNativePlugin: legacyPlugin }))
+    // Emulates posthog-react-native-session-replay: the legacy package has no setup().
+    delete (mockPlugin as { setup?: jest.Mock }).setup
     // _logger only emits when debug is on (isDebug = whether debug() was called), so spy on the
     // console and enable debug before init runs.
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', {
       persistence: 'memory',
       flushInterval: 0,
@@ -129,7 +141,7 @@ describe('native error tracking', () => {
     await posthog.ready()
 
     await waitForExpect(100, () => {
-      expect(legacyPlugin.start).toHaveBeenCalledTimes(1)
+      expect(mockPlugin.start).toHaveBeenCalledTimes(1)
     })
 
     // nativeCrashes was requested but the legacy plugin can't do it: we must warn AND must
@@ -143,9 +155,6 @@ describe('native error tracking', () => {
   })
 
   it('routes to error-tracking-only setup() when session replay is gated off by a linked flag', async () => {
-    jest.resetModules()
-    jest.doMock('../src/optional/OptionalPlugin', () => ({ OptionalReactNativePlugin: mockPlugin }))
-
     // Seed the cached session-replay config with a linkedFlag that resolves off, so
     // recordingActive becomes false while native error tracking stays enabled.
     const seeded = JSON.stringify({
@@ -159,7 +168,6 @@ describe('native error tracking', () => {
       setItem: (_key: string, _value: string) => {},
     }
 
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', {
       persistence: 'file',
       customStorage: customStorage as any,
@@ -184,7 +192,6 @@ describe('native error tracking', () => {
   })
 
   it('passes both session replay and native error tracking config when both are enabled', async () => {
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', {
       persistence: 'memory',
       flushInterval: 0,
@@ -218,7 +225,6 @@ describe('native error tracking', () => {
       return { status: 200, json: () => Promise.resolve(res) }
     })
 
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', {
       persistence: 'memory',
       flushInterval: 0,
@@ -251,7 +257,6 @@ describe('native error tracking', () => {
   })
 
   it('plumbs the exception-steps config to native and forwards both replayed and live steps', async () => {
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', {
       persistence: 'memory',
       flushInterval: 0,
@@ -290,11 +295,10 @@ describe('native error tracking', () => {
   })
 
   it('does not forward exception steps to native when native error tracking is not enabled', async () => {
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', { persistence: 'memory', flushInterval: 0 })
 
     await posthog.ready()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await waitForNativePluginEvaluation(posthog)
 
     posthog.addExceptionStep('orphan')
 
@@ -305,7 +309,6 @@ describe('native error tracking', () => {
   })
 
   it('does not forward exception steps to native when exception steps are disabled', async () => {
-    const { PostHog } = await import('../src/posthog-rn')
     const posthog = new PostHog('test-token', {
       persistence: 'memory',
       flushInterval: 0,

--- a/packages/react-native/test/native-error-tracking.spec.ts
+++ b/packages/react-native/test/native-error-tracking.spec.ts
@@ -30,12 +30,9 @@ const mockPlugin = OptionalReactNativePlugin as unknown as {
   addExceptionStep: jest.Mock
 }
 
-const waitForNativePluginEvaluation = async (posthog: PostHog): Promise<void> => {
-  await (posthog as unknown as { _sessionReplayEvalChain: Promise<void> })._sessionReplayEvalChain
-}
-
 const resetMockPlugin = (): void => {
   mockPlugin.start.mockImplementation(() => Promise.resolve())
+  // `setup` may have been deleted by the legacy-plugin test; restore it if so.
   mockPlugin.setup = mockPlugin.setup ?? jest.fn()
   mockPlugin.setup.mockImplementation(() => Promise.resolve())
   mockPlugin.startSession.mockImplementation(() => Promise.resolve())
@@ -69,7 +66,7 @@ describe('native error tracking', () => {
     const posthog = new PostHog('test-token', { persistence: 'memory', flushInterval: 0 })
 
     await posthog.ready()
-    await waitForNativePluginEvaluation(posthog)
+    await posthog._drainNativePluginEvaluationForTesting()
 
     expect(mockPlugin.setup).not.toHaveBeenCalled()
     expect(mockPlugin.start).not.toHaveBeenCalled()
@@ -298,7 +295,7 @@ describe('native error tracking', () => {
     const posthog = new PostHog('test-token', { persistence: 'memory', flushInterval: 0 })
 
     await posthog.ready()
-    await waitForNativePluginEvaluation(posthog)
+    await posthog._drainNativePluginEvaluationForTesting()
 
     posthog.addExceptionStep('orphan')
 


### PR DESCRIPTION
## Problem

The React Native unit test job intermittently times out in `native-error-tracking.spec.ts`. The timeout comes from test scheduling/module reset behavior rather than the SDK behavior under test, making the suite flaky under CI load.

## Changes

- Mock `OptionalReactNativePlugin` once at module scope instead of resetting modules and dynamically importing `PostHog` in each test.
- Reset mock implementations between tests without reloading the SDK module graph.
- Replace `setTimeout(0)` sleeps with awaiting the SDK's native plugin evaluation chain, so assertions run after the async path under test has settled.
- Keep the legacy plugin scenario deterministic by deleting `setup` from the mock only for that test.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared with the pi coding agent after CI showed a React Native unit test timing out. A timeout increase was tried separately and rejected; this change instead makes the test deterministic by waiting for the actual SDK async work and avoiding repeated module resets.

Validation run:

```bash
pnpm --filter posthog-react-native exec jest -c jest.config.js --runInBand
pnpm --filter posthog-react-native lint
git diff --check
```
