### PR TITLE
Add 'enabled' property to ModuleOptions interface and quietly exit when no key found

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -44,6 +44,7 @@ interface SourcemapsConfig {
 }
 
 export interface ModuleOptions {
+  enabled: boolean
   host: string
   publicKey: string
   debug?: boolean
@@ -71,6 +72,7 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   defaults: () => ({
+    enabled: true,
     host: 'https://us.i.posthog.com',
     debug: false,
     clientConfig: {},
@@ -78,8 +80,16 @@ export default defineNuxtModule<ModuleOptions>({
   }),
 
   setup(options, nuxt) {
+    if (!enabled) return
+    
     const resolver = createResolver(import.meta.url)
     const normalizedPublicKey = normalizeApiKey(options.publicKey)
+
+    if (!normalizedPublicKey) {
+      console.error('No Posthog public key found. Add posthogConfig.publicKey in your nuxt.config.ts')
+      return
+    }
+    
     const normalizedHost = normalizeHost(options.host)
     addPlugin(resolver.resolve('./runtime/vue-plugin'))
     addServerPlugin(resolver.resolve('./runtime/nitro-plugin'))


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
1. The Nuxt build succeeds but runtime throws a server error if no posthog public key is found. This resulted in a production build failure for us.

2. There should be an easy way to turn the module off to support applications with different build environments. Eg. enabled: false in dev/staging envs.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

1. Check for a public key to exist in the nuxt config and boot out with a console error if none exists.

2. Added an `enabled` flag to the nuxt config options for posthog. Defaults true so is backwards compatible, but if it's set to false the module quietly boots out early.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [x] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
