### PR TITLE
chore: template public API snapshot versions

### DIFF
--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -2,7 +2,7 @@
   "id": "posthog-js",
   "hogRef": "0.3",
   "info": {
-    "version": "1.392.0",
+    "version": "<version>",
     "id": "posthog-js",
     "title": "PostHog JavaScript Web SDK",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",

--- a/packages/browser/scripts/generate-docs.js
+++ b/packages/browser/scripts/generate-docs.js
@@ -36,10 +36,11 @@ if (!fs.existsSync(referencesDir)) {
 }
 
 const output = generateApiSpecs(config);
+const latestOutput = { ...output, info: { ...output.info, version: '<version>' } };
 
 // Always update the rolling public API reference used by CI and docs previews.
 const latestPath = path.resolve(__dirname, '../references/posthog-js-references-latest.json');
-fs.writeFileSync(latestPath, JSON.stringify(output, null, 2));
+fs.writeFileSync(latestPath, JSON.stringify(latestOutput, null, 2));
 
 // Versioned references are release artifacts. Avoid writing them during normal generation
 // so PRs don't accidentally commit package-version-specific reference files.

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -2,7 +2,7 @@
   "id": "posthog-node",
   "hogRef": "0.3",
   "info": {
-    "version": "5.38.2",
+    "version": "<version>",
     "id": "posthog-node",
     "title": "PostHog Node.js SDK",
     "description": "PostHog Node.js SDK allows you to capture events and send them to PostHog from your Node.js applications.",

--- a/packages/node/scripts/generate-docs.mjs
+++ b/packages/node/scripts/generate-docs.mjs
@@ -54,10 +54,11 @@ if (!fs.existsSync(referencesDir)) {
 }
 
 const output = generateApiSpecs(config)
+const latestOutput = { ...output, info: { ...output.info, version: '<version>' } }
 
 // Always update the rolling public API reference used by CI and docs previews.
 const latestPath = path.resolve(import.meta.dirname, '../references/posthog-node-references-latest.json')
-fs.writeFileSync(latestPath, JSON.stringify(output, null, 2))
+fs.writeFileSync(latestPath, JSON.stringify(latestOutput, null, 2))
 
 // Versioned references are release artifacts. Avoid writing them during normal generation
 // so PRs don't accidentally commit package-version-specific reference files.

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2,7 +2,7 @@
   "id": "posthog-react-native",
   "hogRef": "0.3",
   "info": {
-    "version": "4.50.0",
+    "version": "<version>",
     "id": "posthog-react-native",
     "title": "PostHog React Native SDK",
     "description": "PostHog React Native SDK allows you to capture events and send them to PostHog from your React Native applications.",

--- a/packages/react-native/scripts/generate-docs.js
+++ b/packages/react-native/scripts/generate-docs.js
@@ -54,10 +54,11 @@ if (!fs.existsSync(referencesDir)) {
 }
 
 const output = generateApiSpecs(config);
+const latestOutput = { ...output, info: { ...output.info, version: '<version>' } };
 
 // Always update the rolling public API reference used by CI and docs previews.
 const latestPath = path.resolve(__dirname, '../references/posthog-react-native-references-latest.json');
-fs.writeFileSync(latestPath, JSON.stringify(output, null, 2));
+fs.writeFileSync(latestPath, JSON.stringify(latestOutput, null, 2));
 
 // Versioned references are release artifacts. Avoid writing them during normal generation
 // so PRs don't accidentally commit package-version-specific reference files.


### PR DESCRIPTION
## Problem

Version-only release bumps can dirty the checked `*-references-latest.json` public API snapshots because the generated `info.version` field follows each package's concrete package version. That can make public API CI fail even when the API shape has not changed.

## Changes

- Template `info.version` as `"<version>"` in the latest public API reference snapshots for `posthog-js`, `posthog-node`, and `posthog-react-native`.
- Update each package's docs generation script so rolling latest references continue to use the template value.
- Keep versioned release references using the concrete package version.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to make a small generated-reference change. The chosen approach templates only the rolling `latest` snapshots while preserving concrete versions for versioned release artifacts, so release-specific references remain accurate.

Validation run:

- `node --check` for the three modified generator scripts
- JSON parse/assertion that all three latest snapshots contain `info.version: "<version>"`
- `git diff --check`
