### PR TITLE
feat(mcp): re-export PostHog from @posthog/mcp for a unified import

### DIFF
--- a/.changeset/mcp-reexport-posthog.md
+++ b/.changeset/mcp-reexport-posthog.md
@@ -1,0 +1,11 @@
+---
+'@posthog/mcp': patch
+---
+
+Re-export `PostHog` (and the `PostHogOptions` type) from `@posthog/mcp`, so you can import the client and `instrument` from a single package:
+
+```ts
+import { PostHog, instrument } from "@posthog/mcp"
+```
+
+`posthog-node` remains a peer dependency (resolved from the host app's installed copy); this only unifies the import. `PostHogMCP` is also already accepted by `instrument()` if you prefer a single client class.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -169,6 +169,10 @@ export {
 export { PostHogMCP, type PostHogMCPOptions } from './extensions/posthog-mcp'
 export { getMoreToolsResult } from './extensions/tools'
 export { setLogger } from './extensions/logger'
+// Re-export the posthog-node client so a single import works:
+//   import { PostHog, instrument } from "@posthog/mcp"
+// posthog-node stays a peer dependency, so this resolves the host app's installed copy.
+export { PostHog, type PostHogOptions } from 'posthog-node'
 export type {
   BeforeSendFn,
   CaptureEventData,


### PR DESCRIPTION
## What

Re-export the `PostHog` client (and the `PostHogOptions` type) from `@posthog/mcp`, so the client and `instrument` come from one package:

```ts
// before
import { PostHog } from "posthog-node"
import { instrument } from "@posthog/mcp"

// after
import { PostHog, instrument } from "@posthog/mcp"
```

## Why

A common bit of friction setting up MCP analytics is importing from two packages. This collapses it to one import line.

## Scope / non-goals

- `posthog-node` stays a **peer dependency** — the re-export resolves the host app's installed copy (kept external in the build; verified in `dist/index.js` → `require("posthog-node")`). So this **unifies the import, not the install**: a consumer still installs `@posthog/mcp` + `posthog-node` (modern npm/pnpm auto-install the peer). Flipping the peer to a regular dependency for a true single-install was considered and intentionally deferred to stay consistent with `@posthog/ai`'s peer convention.
- `instrument()` already accepts a `PostHogMCP` (it's a `PostHog` subclass and the sink only needs `.capture()`), so single-client setups work too.

## Tests

`pnpm --filter @posthog/mcp build` / `lint` / `test:unit` all green (324 tests). Re-export confirmed in the built JS and `.d.ts`.

Part of the MCP analytics work (mega-issue PostHog/posthog#64016). Docs will switch to the unified import once this publishes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*