### PR TITLE
chore(node): mark Sentry integration deprecated

### DIFF
--- a/.changeset/deprecate-node-sentry-integration.md
+++ b/.changeset/deprecate-node-sentry-integration.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+Deprecate the Node SDK Sentry integration and point users to PostHog Error Tracking for Node.

--- a/packages/node/src/extensions/sentry-integration.ts
+++ b/packages/node/src/extensions/sentry-integration.ts
@@ -4,6 +4,9 @@
 /**
  * Integrate Sentry with PostHog. This will add a direct link to the person in Sentry, and an $exception event in PostHog.
  *
+ * @deprecated This integration is deprecated and will be removed in a future major version. Use PostHog Error Tracking for Node instead:
+ * https://posthog.com/docs/error-tracking/installation/node
+ *
  * ### Usage
  *
  *     Sentry.init({
@@ -76,6 +79,12 @@ export type SentryIntegrationOptions = {
 
 const NAME = 'posthog-node'
 
+/**
+ * Creates an event processor for the deprecated Sentry integration.
+ *
+ * @deprecated This integration is deprecated and will be removed in a future major version. Use PostHog Error Tracking for Node instead:
+ * https://posthog.com/docs/error-tracking/installation/node
+ */
 export function createEventProcessor(
   _posthog: PostHogBackendClient,
   {
@@ -162,6 +171,12 @@ export function createEventProcessor(
 }
 
 // V8 integration - function based
+/**
+ * Creates the function-based Sentry integration.
+ *
+ * @deprecated This integration is deprecated and will be removed in a future major version. Use PostHog Error Tracking for Node instead:
+ * https://posthog.com/docs/error-tracking/installation/node
+ */
 export function sentryIntegration(
   _posthog: PostHogBackendClient,
   options?: SentryIntegrationOptions
@@ -176,6 +191,12 @@ export function sentryIntegration(
 }
 
 // V7 integration - class based
+/**
+ * Class-based Sentry integration.
+ *
+ * @deprecated This integration is deprecated and will be removed in a future major version. Use PostHog Error Tracking for Node instead:
+ * https://posthog.com/docs/error-tracking/installation/node
+ */
 export class PostHogSentryIntegration implements _SentryIntegrationClass {
   public readonly name = NAME
 


### PR DESCRIPTION
## Problem

The Node SDK Sentry integration is deprecated, but its public API entrypoints did not communicate that to users in TypeScript/editor docs.

## Changes

- Added `@deprecated` JSDoc to the public Sentry integration entrypoints:
  - `createEventProcessor`
  - `sentryIntegration`
  - `PostHogSentryIntegration`
- Pointed users to the Node Error Tracking installation docs.
- Noted that the integration will be removed in a future major version.
- Added a patch changeset for `posthog-node`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was created with Pi using shell/git/GitHub CLI tooling. The implementation is limited to JSDoc deprecation annotations for the deprecated Node Sentry integration and a changeset so the notice is included in the next `posthog-node` release.

Validation: `NODE_PATH=/Users/marandaneto/Github/posthog-js/node_modules /Users/marandaneto/Github/posthog-js/node_modules/.bin/eslint src` from `packages/node` in the PR worktree. The normal `pnpm --filter=posthog-node lint` command could not run directly in the fresh worktree because it has no local `node_modules`, so the existing checkout dependencies were used for linting.
