### PR TITLE
fix(node): respect URL hash capture config

### DIFF
--- a/.changeset/fuzzy-urls-strip.md
+++ b/.changeset/fuzzy-urls-strip.md
@@ -1,0 +1,5 @@
+---
+"posthog-node": patch
+---
+
+Respect `disable_capture_url_hashes` when capturing Express and NestJS request URLs.

--- a/packages/node/src/__tests__/extensions/express.spec.ts
+++ b/packages/node/src/__tests__/extensions/express.spec.ts
@@ -52,17 +52,21 @@ const createErrorHandlerMiddleware = (posthog: PostHog): any => {
   return app.use.mock.calls[0][0]
 }
 
+const createPostHog = (options: Record<string, any> = {}): PostHog =>
+  new PostHog('TEST_API_KEY', {
+    host: 'http://example.com',
+    fetchRetryCount: 0,
+    disableCompression: true,
+    flushAt: 1,
+    flushInterval: 0,
+    ...options,
+  })
+
 describe('Express extension', () => {
   let posthog: PostHog
 
   beforeEach(() => {
-    posthog = new PostHog('TEST_API_KEY', {
-      host: 'http://example.com',
-      fetchRetryCount: 0,
-      disableCompression: true,
-      flushAt: 1,
-      flushInterval: 0,
-    })
+    posthog = createPostHog()
 
     mockedFetch.mockResolvedValue({
       status: 200,
@@ -117,6 +121,46 @@ describe('Express extension', () => {
       expect(event.properties.$request_path).toBe('/api/test')
       expect(event.properties.$user_agent).toBe('TestAgent/1.0')
       expect(event.properties.$ip).toBe('10.0.0.1')
+    })
+
+    it('should strip request path search and preserve URL hash by default', async () => {
+      const middleware = createRequestContextMiddleware(posthog)
+      const req = createMockRequest({
+        originalUrl: '/api/test?token=secret#details',
+        path: '/api/test?token=secret#details',
+      })
+      const res = createMockResponse()
+
+      middleware(req, res, () => {
+        posthog.capture({ event: 'handler_event' })
+      })
+      await waitForFlushTimer(posthog)
+
+      const batchEvents = getLastBatchEvents()
+      const event = batchEvents!.find((e: any) => e.event === 'handler_event')
+      expect(event.properties.$current_url).toBe('/api/test?token=secret#details')
+      expect(event.properties.$request_path).toBe('/api/test#details')
+    })
+
+    it('should strip request URL hashes when disable_capture_url_hashes is enabled', async () => {
+      await posthog.shutdown()
+      posthog = createPostHog({ disable_capture_url_hashes: true })
+      const middleware = createRequestContextMiddleware(posthog)
+      const req = createMockRequest({
+        originalUrl: '/api/test?token=secret#details',
+        path: '/api/test?token=secret#details',
+      })
+      const res = createMockResponse()
+
+      middleware(req, res, () => {
+        posthog.capture({ event: 'handler_event' })
+      })
+      await waitForFlushTimer(posthog)
+
+      const batchEvents = getLastBatchEvents()
+      const event = batchEvents!.find((e: any) => e.event === 'handler_event')
+      expect(event.properties.$current_url).toBe('/api/test?token=secret')
+      expect(event.properties.$request_path).toBe('/api/test')
     })
 
     it('should sanitize tracing header values and preserve explicit capture properties', async () => {

--- a/packages/node/src/__tests__/extensions/express.spec.ts
+++ b/packages/node/src/__tests__/extensions/express.spec.ts
@@ -123,28 +123,22 @@ describe('Express extension', () => {
       expect(event.properties.$ip).toBe('10.0.0.1')
     })
 
-    it('should strip request path search and preserve URL hash by default', async () => {
-      const middleware = createRequestContextMiddleware(posthog)
-      const req = createMockRequest({
-        originalUrl: '/api/test?token=secret#details',
-        path: '/api/test?token=secret#details',
-      })
-      const res = createMockResponse()
-
-      middleware(req, res, () => {
-        posthog.capture({ event: 'handler_event' })
-      })
-      await waitForFlushTimer(posthog)
-
-      const batchEvents = getLastBatchEvents()
-      const event = batchEvents!.find((e: any) => e.event === 'handler_event')
-      expect(event.properties.$current_url).toBe('/api/test?token=secret#details')
-      expect(event.properties.$request_path).toBe('/api/test#details')
-    })
-
-    it('should strip request URL hashes when disable_capture_url_hashes is enabled', async () => {
+    it.each([
+      {
+        name: 'strips request path search and preserves URL hash by default',
+        options: {},
+        expectedCurrentUrl: '/api/test?token=secret#details',
+        expectedRequestPath: '/api/test#details',
+      },
+      {
+        name: 'strips request URL hashes when disable_capture_url_hashes is enabled',
+        options: { disable_capture_url_hashes: true },
+        expectedCurrentUrl: '/api/test?token=secret',
+        expectedRequestPath: '/api/test',
+      },
+    ])('should $name', async ({ options, expectedCurrentUrl, expectedRequestPath }) => {
       await posthog.shutdown()
-      posthog = createPostHog({ disable_capture_url_hashes: true })
+      posthog = createPostHog(options)
       const middleware = createRequestContextMiddleware(posthog)
       const req = createMockRequest({
         originalUrl: '/api/test?token=secret#details',
@@ -159,8 +153,8 @@ describe('Express extension', () => {
 
       const batchEvents = getLastBatchEvents()
       const event = batchEvents!.find((e: any) => e.event === 'handler_event')
-      expect(event.properties.$current_url).toBe('/api/test?token=secret')
-      expect(event.properties.$request_path).toBe('/api/test')
+      expect(event.properties.$current_url).toBe(expectedCurrentUrl)
+      expect(event.properties.$request_path).toBe(expectedRequestPath)
     })
 
     it('should sanitize tracing header values and preserve explicit capture properties', async () => {

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -118,30 +118,22 @@ describe('PostHogInterceptor', () => {
       expect(capturedContext.properties.$ip).toBe('192.168.1.1')
     })
 
-    it('should strip request path search and preserve URL hash by default', async () => {
-      const interceptor = new PostHogInterceptor(posthog)
-      const context = createMockContext({
-        url: '/api/test?token=secret#details',
-        path: '/api/test?token=secret#details',
-      })
-
-      let capturedContext: any
-      const handler = {
-        handle: () => {
-          capturedContext = posthog.getContext()
-          return of({ success: true })
-        },
-      }
-
-      await lastValueFrom(interceptor.intercept(context, handler))
-
-      expect(capturedContext.properties.$current_url).toBe('/api/test?token=secret#details')
-      expect(capturedContext.properties.$request_path).toBe('/api/test#details')
-    })
-
-    it('should strip request URL hashes when disable_capture_url_hashes is enabled', async () => {
+    it.each([
+      {
+        name: 'strips request path search and preserves URL hash by default',
+        options: {},
+        expectedCurrentUrl: '/api/test?token=secret#details',
+        expectedRequestPath: '/api/test#details',
+      },
+      {
+        name: 'strips request URL hashes when disable_capture_url_hashes is enabled',
+        options: { disable_capture_url_hashes: true },
+        expectedCurrentUrl: '/api/test?token=secret',
+        expectedRequestPath: '/api/test',
+      },
+    ])('should $name', async ({ options, expectedCurrentUrl, expectedRequestPath }) => {
       await posthog.shutdown()
-      posthog = createPostHog({ disable_capture_url_hashes: true })
+      posthog = createPostHog(options)
       const interceptor = new PostHogInterceptor(posthog)
       const context = createMockContext({
         url: '/api/test?token=secret#details',
@@ -158,8 +150,8 @@ describe('PostHogInterceptor', () => {
 
       await lastValueFrom(interceptor.intercept(context, handler))
 
-      expect(capturedContext.properties.$current_url).toBe('/api/test?token=secret')
-      expect(capturedContext.properties.$request_path).toBe('/api/test')
+      expect(capturedContext.properties.$current_url).toBe(expectedCurrentUrl)
+      expect(capturedContext.properties.$request_path).toBe(expectedRequestPath)
     })
 
     it('should sanitize tracing headers and only include present values', async () => {

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -56,17 +56,21 @@ const createMockCallHandler = (error?: Error) => ({
   handle: () => (error ? throwError(() => error) : of(undefined)),
 })
 
+const createPostHog = (options: Record<string, any> = {}): PostHog =>
+  new PostHog('TEST_API_KEY', {
+    host: 'http://example.com',
+    fetchRetryCount: 0,
+    disableCompression: true,
+    flushAt: 1,
+    flushInterval: 0,
+    ...options,
+  })
+
 describe('PostHogInterceptor', () => {
   let posthog: PostHog
 
   beforeEach(() => {
-    posthog = new PostHog('TEST_API_KEY', {
-      host: 'http://example.com',
-      fetchRetryCount: 0,
-      disableCompression: true,
-      flushAt: 1,
-      flushInterval: 0,
-    })
+    posthog = createPostHog()
 
     mockedFetch.mockResolvedValue({
       status: 200,
@@ -112,6 +116,50 @@ describe('PostHogInterceptor', () => {
       expect(capturedContext.properties.$request_path).toBe('/api/test')
       expect(capturedContext.properties.$user_agent).toBe('TestAgent/1.0')
       expect(capturedContext.properties.$ip).toBe('192.168.1.1')
+    })
+
+    it('should strip request path search and preserve URL hash by default', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
+      const context = createMockContext({
+        url: '/api/test?token=secret#details',
+        path: '/api/test?token=secret#details',
+      })
+
+      let capturedContext: any
+      const handler = {
+        handle: () => {
+          capturedContext = posthog.getContext()
+          return of({ success: true })
+        },
+      }
+
+      await lastValueFrom(interceptor.intercept(context, handler))
+
+      expect(capturedContext.properties.$current_url).toBe('/api/test?token=secret#details')
+      expect(capturedContext.properties.$request_path).toBe('/api/test#details')
+    })
+
+    it('should strip request URL hashes when disable_capture_url_hashes is enabled', async () => {
+      await posthog.shutdown()
+      posthog = createPostHog({ disable_capture_url_hashes: true })
+      const interceptor = new PostHogInterceptor(posthog)
+      const context = createMockContext({
+        url: '/api/test?token=secret#details',
+        path: '/api/test?token=secret#details',
+      })
+
+      let capturedContext: any
+      const handler = {
+        handle: () => {
+          capturedContext = posthog.getContext()
+          return of({ success: true })
+        },
+      }
+
+      await lastValueFrom(interceptor.intercept(context, handler))
+
+      expect(capturedContext.properties.$current_url).toBe('/api/test?token=secret')
+      expect(capturedContext.properties.$request_path).toBe('/api/test')
     })
 
     it('should sanitize tracing headers and only include present values', async () => {

--- a/packages/node/src/__tests__/extensions/url-utils.spec.ts
+++ b/packages/node/src/__tests__/extensions/url-utils.spec.ts
@@ -1,0 +1,38 @@
+import { normalizeRequestCurrentUrl, normalizeRequestPath } from '@/extensions/url-utils'
+
+describe('url-utils', () => {
+  describe('normalizeRequestCurrentUrl', () => {
+    it('preserves search and hash by default', () => {
+      expect(normalizeRequestCurrentUrl('/api/items?token=secret#details', false)).toBe(
+        '/api/items?token=secret#details'
+      )
+    })
+
+    it('preserves search but strips hash when disable_capture_url_hashes is enabled', () => {
+      expect(normalizeRequestCurrentUrl('/api/items?token=secret#details', true)).toBe('/api/items?token=secret')
+    })
+
+    it('passes through undefined', () => {
+      expect(normalizeRequestCurrentUrl(undefined, true)).toBeUndefined()
+    })
+  })
+
+  describe('normalizeRequestPath', () => {
+    it('always strips search and preserves hash by default', () => {
+      expect(normalizeRequestPath('/api/items?token=secret#details', false)).toBe('/api/items#details')
+    })
+
+    it('always strips search and strips hash when disable_capture_url_hashes is enabled', () => {
+      expect(normalizeRequestPath('/api/items?token=secret#details', true)).toBe('/api/items')
+    })
+
+    it('does not treat hashes before question marks as search params', () => {
+      expect(normalizeRequestPath('/api/items#details?token=secret', false)).toBe('/api/items#details?token=secret')
+      expect(normalizeRequestPath('/api/items#details?token=secret', true)).toBe('/api/items')
+    })
+
+    it('passes through undefined', () => {
+      expect(normalizeRequestPath(undefined, false)).toBeUndefined()
+    })
+  })
+})

--- a/packages/node/src/__tests__/extensions/url-utils.spec.ts
+++ b/packages/node/src/__tests__/extensions/url-utils.spec.ts
@@ -2,37 +2,76 @@ import { normalizeRequestCurrentUrl, normalizeRequestPath } from '@/extensions/u
 
 describe('url-utils', () => {
   describe('normalizeRequestCurrentUrl', () => {
-    it('preserves search and hash by default', () => {
-      expect(normalizeRequestCurrentUrl('/api/items?token=secret#details', false)).toBe(
-        '/api/items?token=secret#details'
-      )
-    })
-
-    it('preserves search but strips hash when disable_capture_url_hashes is enabled', () => {
-      expect(normalizeRequestCurrentUrl('/api/items?token=secret#details', true)).toBe('/api/items?token=secret')
-    })
-
-    it('passes through undefined', () => {
-      expect(normalizeRequestCurrentUrl(undefined, true)).toBeUndefined()
+    it.each([
+      {
+        name: 'preserves search and hash by default',
+        input: '/api/items?token=secret#details',
+        disableCaptureUrlHashes: false,
+        expected: '/api/items?token=secret#details',
+      },
+      {
+        name: 'preserves search but strips hash when disable_capture_url_hashes is enabled',
+        input: '/api/items?token=secret#details',
+        disableCaptureUrlHashes: true,
+        expected: '/api/items?token=secret',
+      },
+      {
+        name: 'passes through undefined when hash stripping is disabled',
+        input: undefined,
+        disableCaptureUrlHashes: false,
+        expected: undefined,
+      },
+      {
+        name: 'passes through undefined when hash stripping is enabled',
+        input: undefined,
+        disableCaptureUrlHashes: true,
+        expected: undefined,
+      },
+    ])('$name', ({ input, disableCaptureUrlHashes, expected }) => {
+      expect(normalizeRequestCurrentUrl(input, disableCaptureUrlHashes)).toBe(expected)
     })
   })
 
   describe('normalizeRequestPath', () => {
-    it('always strips search and preserves hash by default', () => {
-      expect(normalizeRequestPath('/api/items?token=secret#details', false)).toBe('/api/items#details')
-    })
-
-    it('always strips search and strips hash when disable_capture_url_hashes is enabled', () => {
-      expect(normalizeRequestPath('/api/items?token=secret#details', true)).toBe('/api/items')
-    })
-
-    it('does not treat hashes before question marks as search params', () => {
-      expect(normalizeRequestPath('/api/items#details?token=secret', false)).toBe('/api/items#details?token=secret')
-      expect(normalizeRequestPath('/api/items#details?token=secret', true)).toBe('/api/items')
-    })
-
-    it('passes through undefined', () => {
-      expect(normalizeRequestPath(undefined, false)).toBeUndefined()
+    it.each([
+      {
+        name: 'always strips search and preserves hash by default',
+        input: '/api/items?token=secret#details',
+        disableCaptureUrlHashes: false,
+        expected: '/api/items#details',
+      },
+      {
+        name: 'always strips search and strips hash when disable_capture_url_hashes is enabled',
+        input: '/api/items?token=secret#details',
+        disableCaptureUrlHashes: true,
+        expected: '/api/items',
+      },
+      {
+        name: 'does not treat hashes before question marks as search params by default',
+        input: '/api/items#details?token=secret',
+        disableCaptureUrlHashes: false,
+        expected: '/api/items#details?token=secret',
+      },
+      {
+        name: 'strips hash before question marks when disable_capture_url_hashes is enabled',
+        input: '/api/items#details?token=secret',
+        disableCaptureUrlHashes: true,
+        expected: '/api/items',
+      },
+      {
+        name: 'passes through undefined when hash stripping is disabled',
+        input: undefined,
+        disableCaptureUrlHashes: false,
+        expected: undefined,
+      },
+      {
+        name: 'passes through undefined when hash stripping is enabled',
+        input: undefined,
+        disableCaptureUrlHashes: true,
+        expected: undefined,
+      },
+    ])('$name', ({ input, disableCaptureUrlHashes, expected }) => {
+      expect(normalizeRequestPath(input, disableCaptureUrlHashes)).toBe(expected)
     })
   })
 })

--- a/packages/node/src/extensions/express.ts
+++ b/packages/node/src/extensions/express.ts
@@ -2,6 +2,7 @@ import ErrorTracking from './error-tracking'
 import { PostHogBackendClient } from '../client'
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { addProperty, getFirstHeaderValue, getPostHogTracingHeaderValues } from './tracing-headers'
+import { normalizeRequestCurrentUrl, normalizeRequestPath } from './url-utils'
 import type { Request, Response } from 'express'
 import type { ContextData } from './context/types'
 
@@ -32,13 +33,18 @@ function getClientIp(req: Request): string | undefined {
   return req.socket?.remoteAddress
 }
 
-function buildRequestContextData(req: Request): Partial<ContextData> {
+function buildRequestContextData(posthog: PostHogBackendClient, req: Request): Partial<ContextData> {
   const { sessionId, distinctId } = getPostHogTracingHeaderValues(req.headers)
   const properties: Record<string, any> = {}
+  const disableCaptureUrlHashes = posthog.options.disable_capture_url_hashes === true
 
-  addProperty(properties, '$current_url', req.originalUrl || req.url)
+  addProperty(
+    properties,
+    '$current_url',
+    normalizeRequestCurrentUrl(req.originalUrl || req.url, disableCaptureUrlHashes)
+  )
   addProperty(properties, '$request_method', req.method)
-  addProperty(properties, '$request_path', req.path)
+  addProperty(properties, '$request_path', normalizeRequestPath(req.path, disableCaptureUrlHashes))
   addProperty(properties, '$user_agent', getFirstHeaderValue(req.headers['user-agent']))
   addProperty(properties, '$ip', getClientIp(req))
 
@@ -60,7 +66,7 @@ export function setupExpressRequestContext(
 
 function posthogRequestContext(posthog: PostHogBackendClient): ExpressMiddleware {
   return (req, _res, next): void => {
-    posthog.withContext(buildRequestContextData(req), () => next())
+    posthog.withContext(buildRequestContextData(posthog, req), () => next())
   }
 }
 
@@ -80,7 +86,7 @@ function posthogErrorHandler(posthog: PostHogBackendClient): ExpressErrorMiddlew
       return
     }
 
-    const contextData = buildRequestContextData(req)
+    const contextData = buildRequestContextData(posthog, req)
     const syntheticException = new Error('Synthetic exception')
     const hint: CoreErrorTracking.EventHint = { mechanism: { type: 'middleware', handled: false }, syntheticException }
     const additionalProperties: Record<string, any> = {

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -4,6 +4,7 @@ import { catchError } from 'rxjs/operators'
 
 import ErrorTracking from './error-tracking'
 import { addProperty, getFirstHeaderValue, getPostHogTracingHeaderValues } from './tracing-headers'
+import { normalizeRequestCurrentUrl, normalizeRequestPath } from './url-utils'
 import { PostHogBackendClient } from '../client'
 
 // Local interfaces to avoid runtime dependency on @nestjs/common
@@ -77,9 +78,14 @@ export class PostHogInterceptor implements NestInterceptor {
     const { sessionId, distinctId } = getPostHogTracingHeaderValues(headers)
 
     const properties: Record<string, any> = {}
-    addProperty(properties, '$current_url', request?.url)
+    const disableCaptureUrlHashes = this.posthog.options.disable_capture_url_hashes === true
+    addProperty(properties, '$current_url', normalizeRequestCurrentUrl(request?.url, disableCaptureUrlHashes))
     addProperty(properties, '$request_method', request?.method)
-    addProperty(properties, '$request_path', request?.path ?? request?.url)
+    addProperty(
+      properties,
+      '$request_path',
+      normalizeRequestPath(request?.path ?? request?.url, disableCaptureUrlHashes)
+    )
     addProperty(properties, '$user_agent', getFirstHeaderValue(headers['user-agent']))
     addProperty(properties, '$ip', getClientIp(headers, request))
 

--- a/packages/node/src/extensions/url-utils.ts
+++ b/packages/node/src/extensions/url-utils.ts
@@ -1,0 +1,27 @@
+import { stripUrlHash } from '@posthog/core'
+
+export function normalizeRequestCurrentUrl(
+  currentUrl: string | undefined,
+  disableCaptureUrlHashes: boolean
+): string | undefined {
+  return disableCaptureUrlHashes ? stripUrlHash(currentUrl) : currentUrl
+}
+
+export function normalizeRequestPath(path: string | undefined, disableCaptureUrlHashes: boolean): string | undefined {
+  const pathWithoutSearch = stripUrlSearch(path)
+  return disableCaptureUrlHashes ? stripUrlHash(pathWithoutSearch) : pathWithoutSearch
+}
+
+function stripUrlSearch<T extends string | undefined>(url: T): T extends string ? string : undefined {
+  if (!url) {
+    return url as any
+  }
+
+  const searchIndex = url.indexOf('?')
+  const hashIndex = url.indexOf('#')
+  if (searchIndex === -1 || (hashIndex !== -1 && hashIndex < searchIndex)) {
+    return url as any
+  }
+
+  return `${url.slice(0, searchIndex)}${hashIndex === -1 ? '' : url.slice(hashIndex)}` as any
+}


### PR DESCRIPTION
## Problem

`posthog-node` exposes the shared `disable_capture_url_hashes` option, but the Express and NestJS integrations were not applying it to request URL context. This meant server-captured request metadata could retain URL fragments even when users opted into hash stripping.

## Changes

- Adds shared Node URL helpers for request URL normalization.
- Applies the helpers in Express request context and error handler capture.
- Applies the helpers in the NestJS interceptor context and exception capture path.
- Keeps `$current_url` behavior backwards compatible by preserving query/search and only stripping hash when `disable_capture_url_hashes` is enabled.
- Keeps `$request_path` search-free, while preserving hash by default and stripping it when `disable_capture_url_hashes` is enabled.
- Adds unit tests for the URL helper plus Express/NestJS integration coverage.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The change follows the behavior from the Next.js request-error capture work: search is always stripped from request path values, while URL hash stripping is gated behind `disable_capture_url_hashes`. Validation run: `pnpm --filter posthog-node lint` and `pnpm --filter posthog-node test:unit -- extensions/url-utils extensions/express extensions/nestjs`.
