### PR TITLE
ci: add PostHog watcher workflows

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -21,6 +21,6 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@a2e4e91bc854e7a46b36bc1eb42eb38d241ce252
+              uses: PostHog/posthog-watcher-action@2cedc564bac91668ac488bae3304ef196e7b9732
               with:
                   mode: enqueue

--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -1,0 +1,22 @@
+name: PostHog Watcher enqueue
+
+on:
+    issues:
+        types: [opened, reopened, edited]
+    issue_comment:
+        types: [created]
+
+permissions:
+    contents: write # write queue.json to the state branch
+    issues: read
+
+jobs:
+    enqueue:
+        runs-on: ubuntu-24.04
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+            - name: Enqueue watcher event
+              uses: PostHog/posthog-watcher-action@a2e4e91bc854e7a46b36bc1eb42eb38d241ce252
+              with:
+                  mode: enqueue

--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -21,6 +21,6 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@2cedc564bac91668ac488bae3304ef196e7b9732
+              uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
               with:
                   mode: enqueue

--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -10,6 +10,10 @@ permissions:
     contents: write # write queue.json to the state branch
     issues: read
 
+concurrency:
+    group: posthog-watcher-enqueue-${{ github.repository }}-${{ github.event.issue.number }}
+    cancel-in-progress: false
+
 jobs:
     enqueue:
         runs-on: ubuntu-24.04

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -16,7 +16,7 @@ on:
         - cron: '17 8 * * *'
 
 concurrency:
-    group: posthog-watcher-${{ github.repository }}
+    group: posthog-watcher-${{ github.repository }}-sweep
     cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -34,7 +34,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@a2e4e91bc854e7a46b36bc1eb42eb38d241ce252
+              uses: PostHog/posthog-watcher-action@2cedc564bac91668ac488bae3304ef196e7b9732
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -1,0 +1,52 @@
+name: PostHog Watcher issue sweep
+
+on:
+    workflow_dispatch:
+        inputs:
+            max-sweep-items:
+                description: Maximum open issues to process.
+                required: false
+                default: '5'
+            max-sweep-fix-items:
+                description: Maximum sweep issues that may attempt fixes.
+                required: false
+                default: '5'
+    schedule:
+        # Every day at 08:17 UTC.
+        - cron: '17 8 * * *'
+
+concurrency:
+    group: posthog-watcher-${{ github.repository }}
+    cancel-in-progress: false
+
+permissions:
+    contents: write
+    issues: write
+    pull-requests: write
+    actions: read
+
+jobs:
+    sweep:
+        runs-on: ubuntu-24.04
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  fetch-depth: 0
+
+            - name: Sweep issues
+              uses: PostHog/posthog-watcher-action@a2e4e91bc854e7a46b36bc1eb42eb38d241ce252
+              with:
+                  openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
+                  mode: sweep
+                  max-sweep-items: ${{ inputs['max-sweep-items'] || '5' }}
+                  max-sweep-fix-items: ${{ inputs['max-sweep-fix-items'] || '5' }}
+                  labels: 'bug,documentation,enhancement,question,needs-info,good first issue,good-first-issue,help wanted,dependencies,react-native,node,web,web-lite,nuxt,iOS,Android,feature,feature/apm,feature/replay,feature/dead-clicks,feature/autocapture,feature/heatmaps,feature/toolbar,feature/web-analytics,feature/flags,feature/surveys,feature/product-analytics,feature/error-tracking,feature/mobile,feature/experiments,feature/mcp-analytics,frameworks/next-js,team/feature-flags,team/llm-analytics,team/experiments,team/error-tracking,team/logs,team/web-analytics,team/analytics-platform,AdBlocker,sentry,Tree shaking'
+                  allow-fix: 'true'
+                  allow-close: 'true'
+                  allow-security-ai: 'true'
+                  require-reproduction: 'true'
+                  validation-command: 'corepack enable && pnpm install --frozen-lockfile && pnpm test:unit'
+                  max-repair-attempts: '3'
+                  max-pi-calls: '8'
+                  approve-project-resources: 'true'
+                  state-enabled: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -34,19 +34,19 @@ jobs:
                   fetch-depth: 0
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@2cedc564bac91668ac488bae3304ef196e7b9732
+              uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep
                   max-sweep-items: ${{ inputs['max-sweep-items'] || '5' }}
                   max-sweep-fix-items: ${{ inputs['max-sweep-fix-items'] || '5' }}
-                  labels: 'bug,documentation,enhancement,question,needs-info,good first issue,good-first-issue,help wanted,dependencies,react-native,node,web,web-lite,nuxt,iOS,Android,feature,feature/apm,feature/replay,feature/dead-clicks,feature/autocapture,feature/heatmaps,feature/toolbar,feature/web-analytics,feature/flags,feature/surveys,feature/product-analytics,feature/error-tracking,feature/mobile,feature/experiments,feature/mcp-analytics,frameworks/next-js,team/feature-flags,team/llm-analytics,team/experiments,team/error-tracking,team/logs,team/web-analytics,team/analytics-platform,AdBlocker,sentry,Tree shaking'
+                  labels: '*'
                   allow-fix: 'true'
                   allow-close: 'true'
                   allow-security-ai: 'true'
                   require-reproduction: 'true'
                   validation-command: 'corepack enable && pnpm install --frozen-lockfile && pnpm test:unit'
                   max-repair-attempts: '3'
-                  max-pi-calls: '8'
+                  max-pi-calls: '16'
                   approve-project-resources: 'true'
                   state-enabled: 'true'

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -40,11 +40,11 @@ jobs:
                   fetch-depth: 0
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@2cedc564bac91668ac488bae3304ef196e7b9732
+              uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
-                  labels: 'bug,documentation,enhancement,question,needs-info,good first issue,good-first-issue,help wanted,dependencies,react-native,node,web,web-lite,nuxt,iOS,Android,feature,feature/apm,feature/replay,feature/dead-clicks,feature/autocapture,feature/heatmaps,feature/toolbar,feature/web-analytics,feature/flags,feature/surveys,feature/product-analytics,feature/error-tracking,feature/mobile,feature/experiments,feature/mcp-analytics,frameworks/next-js,team/feature-flags,team/llm-analytics,team/experiments,team/error-tracking,team/logs,team/web-analytics,team/analytics-platform,AdBlocker,sentry,Tree shaking'
+                  labels: '*'
                   allow-fix: 'true'
                   allow-close: 'true'
                   allow-security-ai: 'true'
@@ -64,12 +64,12 @@ jobs:
                   fetch-depth: 0
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@2cedc564bac91668ac488bae3304ef196e7b9732
+              uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}
                   mode: ${{ inputs.mode }}
-                  labels: 'bug,documentation,enhancement,question,needs-info,good first issue,good-first-issue,help wanted,dependencies,react-native,node,web,web-lite,nuxt,iOS,Android,feature,feature/apm,feature/replay,feature/dead-clicks,feature/autocapture,feature/heatmaps,feature/toolbar,feature/web-analytics,feature/flags,feature/surveys,feature/product-analytics,feature/error-tracking,feature/mobile,feature/experiments,feature/mcp-analytics,frameworks/next-js,team/feature-flags,team/llm-analytics,team/experiments,team/error-tracking,team/logs,team/web-analytics,team/analytics-platform,AdBlocker,sentry,Tree shaking'
+                  labels: '*'
                   allow-fix: 'true'
                   allow-close: 'true'
                   allow-security-ai: 'true'

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -40,7 +40,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@a2e4e91bc854e7a46b36bc1eb42eb38d241ce252
+              uses: PostHog/posthog-watcher-action@2cedc564bac91668ac488bae3304ef196e7b9732
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -64,7 +64,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@a2e4e91bc854e7a46b36bc1eb42eb38d241ce252
+              uses: PostHog/posthog-watcher-action@2cedc564bac91668ac488bae3304ef196e7b9732
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -1,0 +1,81 @@
+name: PostHog Watcher worker
+
+on:
+    workflow_dispatch:
+        inputs:
+            issue-number:
+                description: Issue or PR number to process immediately. Leave empty to drain the queue.
+                required: false
+                default: ''
+            mode:
+                description: Processing mode for issue-number.
+                required: false
+                default: auto
+                type: choice
+                options:
+                    - auto
+                    - triage
+                    - investigate
+                    - fix
+    schedule:
+        - cron: '*/15 * * * *'
+
+concurrency:
+    group: posthog-watcher-${{ github.repository }}
+    cancel-in-progress: false
+
+permissions:
+    contents: write
+    issues: write
+    pull-requests: write
+    actions: read
+
+jobs:
+    drain-queue:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs['issue-number'] == '' }}
+        runs-on: ubuntu-24.04
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  fetch-depth: 0
+
+            - name: Drain watcher queue
+              uses: PostHog/posthog-watcher-action@a2e4e91bc854e7a46b36bc1eb42eb38d241ce252
+              with:
+                  openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
+                  mode: drain-queue
+                  labels: 'bug,documentation,enhancement,question,needs-info,good first issue,good-first-issue,help wanted,dependencies,react-native,node,web,web-lite,nuxt,iOS,Android,feature,feature/apm,feature/replay,feature/dead-clicks,feature/autocapture,feature/heatmaps,feature/toolbar,feature/web-analytics,feature/flags,feature/surveys,feature/product-analytics,feature/error-tracking,feature/mobile,feature/experiments,feature/mcp-analytics,frameworks/next-js,team/feature-flags,team/llm-analytics,team/experiments,team/error-tracking,team/logs,team/web-analytics,team/analytics-platform,AdBlocker,sentry,Tree shaking'
+                  allow-fix: 'true'
+                  allow-close: 'true'
+                  allow-security-ai: 'true'
+                  require-reproduction: 'true'
+                  validation-command: 'corepack enable && pnpm install --frozen-lockfile && pnpm test:unit'
+                  max-repair-attempts: '3'
+                  max-pi-calls: '16'
+                  approve-project-resources: 'true'
+                  state-enabled: 'true'
+
+    process-issue:
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs['issue-number'] != '' }}
+        runs-on: ubuntu-24.04
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  fetch-depth: 0
+
+            - name: Process watcher issue
+              uses: PostHog/posthog-watcher-action@a2e4e91bc854e7a46b36bc1eb42eb38d241ce252
+              with:
+                  openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
+                  issue-number: ${{ inputs['issue-number'] }}
+                  mode: ${{ inputs.mode }}
+                  labels: 'bug,documentation,enhancement,question,needs-info,good first issue,good-first-issue,help wanted,dependencies,react-native,node,web,web-lite,nuxt,iOS,Android,feature,feature/apm,feature/replay,feature/dead-clicks,feature/autocapture,feature/heatmaps,feature/toolbar,feature/web-analytics,feature/flags,feature/surveys,feature/product-analytics,feature/error-tracking,feature/mobile,feature/experiments,feature/mcp-analytics,frameworks/next-js,team/feature-flags,team/llm-analytics,team/experiments,team/error-tracking,team/logs,team/web-analytics,team/analytics-platform,AdBlocker,sentry,Tree shaking'
+                  allow-fix: 'true'
+                  allow-close: 'true'
+                  allow-security-ai: 'true'
+                  require-reproduction: 'true'
+                  validation-command: 'corepack enable && pnpm install --frozen-lockfile && pnpm test:unit'
+                  max-repair-attempts: '3'
+                  max-pi-calls: '16'
+                  approve-project-resources: 'true'
+                  state-enabled: 'true'

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -21,7 +21,7 @@ on:
         - cron: '*/15 * * * *'
 
 concurrency:
-    group: posthog-watcher-${{ github.repository }}
+    group: posthog-watcher-${{ github.repository }}-${{ inputs['issue-number'] || 'queue' }}
     cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Problem

We want automated issue triage and issue sweeps for this repository using the PostHog watcher action, with events queued so triage/fix processing is durable and avoids overly broad repository-wide concurrency groups.

## Changes

Adds three PostHog watcher workflows pinned to `PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749`, which is the latest `main` commit at the time of update:

- Event enqueue workflow for issue and issue-comment activity, with concurrency scoped by issue number.
- Queue worker workflow that drains queued items every 15 minutes and supports manual issue/PR processing, with concurrency scoped to either the manual issue number or the queue worker.
- Daily issue sweep workflow at 08:17 UTC, with its own sweep-specific concurrency group.

The worker and sweep workflows enable issue fixing, close handling, durable state, project resources, reproduction-required validation, dynamic repository label loading, and `max-pi-calls: 16` for richer automated processing. They also run the repository setup action first with dependency installation/build disabled, so `pnpm` is available for watcher-owned validation commands without relying on `corepack enable` inside the command.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to add and revise the GitHub Actions workflows based on reviewer feedback. The watcher action is pinned to the requested commit SHA, pull request event enqueueing was omitted to keep this focused on issues, default-valued action inputs were removed where they matched the action defaults, and concurrency groups were narrowed beyond repository-only scope.



