### PR TITLE
feat(next): enable same-origin tracing headers by default

### DIFF
--- a/.changeset/tall-ligers-tracing-headers.md
+++ b/.changeset/tall-ligers-tracing-headers.md
@@ -1,5 +1,5 @@
 ---
-"@posthog/next": minor
+'@posthog/next': minor
 ---
 
-Enable same-origin client-side tracing headers by default in `@posthog/next`, while preserving explicit tracing header configuration and opt-outs.
+Enable same-origin client-side tracing headers by default

--- a/.changeset/tall-ligers-tracing-headers.md
+++ b/.changeset/tall-ligers-tracing-headers.md
@@ -1,0 +1,5 @@
+---
+"@posthog/next": minor
+---
+
+Enable same-origin client-side tracing headers by default in `@posthog/next`, while preserving explicit tracing header configuration and opt-outs.

--- a/packages/next/src/client/ClientPostHogProvider.tsx
+++ b/packages/next/src/client/ClientPostHogProvider.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import posthogJs from 'posthog-js'
+import { isUndefined } from '@posthog/core'
 import { PostHogContext } from '@posthog/react'
 import type { BootstrapConfig, PostHogConfig } from 'posthog-js'
 
@@ -9,9 +10,9 @@ export type { BootstrapConfig }
 
 function hasTracingHeadersConfig(options?: Partial<PostHogConfig>): boolean {
     return (
-        options?.tracing_headers !== undefined ||
-        options?.addTracingHeaders !== undefined ||
-        options?.__add_tracing_headers !== undefined
+        !isUndefined(options?.tracing_headers) ||
+        !isUndefined(options?.addTracingHeaders) ||
+        !isUndefined(options?.__add_tracing_headers)
     )
 }
 

--- a/packages/next/src/client/ClientPostHogProvider.tsx
+++ b/packages/next/src/client/ClientPostHogProvider.tsx
@@ -7,6 +7,30 @@ import type { BootstrapConfig, PostHogConfig } from 'posthog-js'
 
 export type { BootstrapConfig }
 
+function hasTracingHeadersConfig(options?: Partial<PostHogConfig>): boolean {
+    return (
+        options?.tracing_headers !== undefined ||
+        options?.addTracingHeaders !== undefined ||
+        options?.__add_tracing_headers !== undefined
+    )
+}
+
+function withDefaultTracingHeaders(options?: Partial<PostHogConfig>): Partial<PostHogConfig> | undefined {
+    if (typeof window === 'undefined' || hasTracingHeadersConfig(options)) {
+        return options
+    }
+
+    const hostname = window.location.hostname
+    if (!hostname) {
+        return options
+    }
+
+    return {
+        ...options,
+        tracing_headers: [hostname],
+    }
+}
+
 export interface ClientPostHogProviderProps {
     /** PostHog project API key (starts with phc_) */
     apiKey: string
@@ -44,7 +68,7 @@ export function ClientPostHogProvider({ apiKey, options, bootstrap, children }: 
     // see a fully configured posthog instance. The `__loaded` guard prevents
     // double-init (e.g. React StrictMode).
     if (typeof window !== 'undefined' && !posthogJs.__loaded) {
-        posthogJs.init(apiKey, mergedOptions)
+        posthogJs.init(apiKey, withDefaultTracingHeaders(mergedOptions))
     }
 
     return <PostHogContext.Provider value={{ client: posthogJs, bootstrap }}>{children}</PostHogContext.Provider>

--- a/packages/next/tests/ClientPostHogProvider.test.tsx
+++ b/packages/next/tests/ClientPostHogProvider.test.tsx
@@ -47,6 +47,44 @@ describe('ClientPostHogProvider', () => {
                 <div>Child</div>
             </ClientPostHogProvider>
         )
+        expect(mockPostHogJs.init).toHaveBeenCalledWith(
+            'phc_test123',
+            expect.objectContaining({
+                api_host: 'https://custom.posthog.com',
+                tracing_headers: [window.location.hostname],
+            })
+        )
+    })
+
+    it('defaults tracing headers to the current hostname', () => {
+        render(
+            <ClientPostHogProvider apiKey="phc_test123">
+                <div>Child</div>
+            </ClientPostHogProvider>
+        )
+        expect(mockPostHogJs.init).toHaveBeenCalledWith(
+            'phc_test123',
+            expect.objectContaining({ tracing_headers: [window.location.hostname] })
+        )
+    })
+
+    it('preserves explicit tracing headers opt-out', () => {
+        const options = { tracing_headers: [] }
+        render(
+            <ClientPostHogProvider apiKey="phc_test123" options={options}>
+                <div>Child</div>
+            </ClientPostHogProvider>
+        )
+        expect(mockPostHogJs.init).toHaveBeenCalledWith('phc_test123', options)
+    })
+
+    it('preserves deprecated tracing header aliases', () => {
+        const options = { addTracingHeaders: ['api.example.com'] } as any
+        render(
+            <ClientPostHogProvider apiKey="phc_test123" options={options}>
+                <div>Child</div>
+            </ClientPostHogProvider>
+        )
         expect(mockPostHogJs.init).toHaveBeenCalledWith('phc_test123', options)
     })
 
@@ -71,7 +109,10 @@ describe('ClientPostHogProvider', () => {
                 <div>Child</div>
             </ClientPostHogProvider>
         )
-        expect(mockPostHogJs.init).toHaveBeenCalledWith('phc_test123', { bootstrap })
+        expect(mockPostHogJs.init).toHaveBeenCalledWith(
+            'phc_test123',
+            expect.objectContaining({ bootstrap, tracing_headers: [window.location.hostname] })
+        )
     })
 
     it('merges bootstrap with existing options without overwriting', () => {

--- a/packages/next/tests/ClientPostHogProvider.test.tsx
+++ b/packages/next/tests/ClientPostHogProvider.test.tsx
@@ -56,36 +56,34 @@ describe('ClientPostHogProvider', () => {
         )
     })
 
-    it('defaults tracing headers to the current hostname', () => {
-        render(
-            <ClientPostHogProvider apiKey="phc_test123">
-                <div>Child</div>
-            </ClientPostHogProvider>
-        )
-        expect(mockPostHogJs.init).toHaveBeenCalledWith(
-            'phc_test123',
-            expect.objectContaining({ tracing_headers: [window.location.hostname] })
-        )
-    })
-
-    it('preserves explicit tracing headers opt-out', () => {
-        const options = { tracing_headers: [] }
-        render(
-            <ClientPostHogProvider apiKey="phc_test123" options={options}>
-                <div>Child</div>
-            </ClientPostHogProvider>
-        )
-        expect(mockPostHogJs.init).toHaveBeenCalledWith('phc_test123', options)
-    })
-
-    it('preserves deprecated tracing header aliases', () => {
-        const options = { addTracingHeaders: ['api.example.com'] } as any
+    it.each([
+        {
+            name: 'defaults tracing headers to the current hostname',
+            options: undefined,
+            expectedOptions: expect.objectContaining({ tracing_headers: [window.location.hostname] }),
+        },
+        {
+            name: 'preserves explicit tracing headers opt-out',
+            options: { tracing_headers: [] },
+            expectedOptions: { tracing_headers: [] },
+        },
+        {
+            name: 'preserves deprecated addTracingHeaders alias',
+            options: { addTracingHeaders: ['api.example.com'] } as any,
+            expectedOptions: { addTracingHeaders: ['api.example.com'] },
+        },
+        {
+            name: 'preserves deprecated __add_tracing_headers alias',
+            options: { __add_tracing_headers: ['api.example.com'] } as any,
+            expectedOptions: { __add_tracing_headers: ['api.example.com'] },
+        },
+    ])('$name', ({ options, expectedOptions }) => {
         render(
             <ClientPostHogProvider apiKey="phc_test123" options={options}>
                 <div>Child</div>
             </ClientPostHogProvider>
         )
-        expect(mockPostHogJs.init).toHaveBeenCalledWith('phc_test123', options)
+        expect(mockPostHogJs.init).toHaveBeenCalledWith('phc_test123', expectedOptions)
     })
 
     it('provides posthog client via context', () => {


### PR DESCRIPTION
## Problem

`@posthog/next` already reads PostHog tracing headers on the server and prioritizes them over cookie identity, but the client provider did not enable same-origin tracing headers by default. That meant server-side `getPostHog()` / `getServerSidePostHog()` could only use those headers when users explicitly configured them.

## Changes

- Default `@posthog/next` client initialization to add tracing headers for the current same-origin hostname.
- Preserve explicit tracing header configuration and opt-outs, including deprecated aliases.
- Add unit coverage for defaulting, opt-out preservation, and bootstrap merging with the default tracing config.
- Add a changeset for `@posthog/next`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi coding agent assistance. The main decision was to keep the runtime hostname lookup in the client provider, since it depends on `window.location.hostname`, while preserving all explicit user tracing-header configuration and opt-outs.

Smoke tested with:

```bash
pnpm --filter @posthog/next test:unit -- --runTestsByPath tests/ClientPostHogProvider.test.tsx tests/tracing-headers.test.ts tests/getPostHog.test.ts tests/getServerSidePostHog.test.ts
pnpm turbo --filter=@posthog/next build
pnpm turbo --filter=@posthog/next test:unit
```
