### PR TITLE
fix(browser): route log session attributes through shared SDK context

### DIFF
--- a/.changeset/fresh-logs-timestamps.md
+++ b/.changeset/fresh-logs-timestamps.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix browser console log capture when session activity timestamps are missing and refresh session attributes for each log.

--- a/.changeset/fresh-logs-timestamps.md
+++ b/.changeset/fresh-logs-timestamps.md
@@ -1,5 +1,6 @@
 ---
 'posthog-js': patch
+'@posthog/core': patch
 ---
 
 Fix browser console log capture when session activity timestamps are missing and refresh session attributes for each log.

--- a/packages/browser/src/__tests__/entrypoints/logs.golden.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.golden.test.ts
@@ -68,9 +68,6 @@ describe('logs entrypoint — golden (console-capture record handed to core)', (
             attributes: {
                 'log.source': 'console.log',
                 host: 'example.com',
-                'window.id': 'window-456',
-                sessionStartTimestamp: String(SESSION_START),
-                lastActivityTimestamp: String(LAST_ACTIVITY),
             },
         })
     })
@@ -101,9 +98,6 @@ describe('logs entrypoint — golden (console-capture record handed to core)', (
             attributes: {
                 'log.source': 'console.warn',
                 host: 'example.com',
-                'window.id': 'window-456',
-                sessionStartTimestamp: String(SESSION_START),
-                lastActivityTimestamp: String(LAST_ACTIVITY),
                 'user.id': 5,
                 msg: 'hi',
             },

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -117,6 +117,32 @@ describe('logs entrypoint', () => {
             )
         })
 
+        it('refreshes session attributes for each captured log', () => {
+            mockPostHog.sessionManager!.checkAndGetSessionAndWindowId = jest
+                .fn()
+                .mockReturnValueOnce({
+                    sessionId: 'session-123',
+                    windowId: 'window-456',
+                    sessionStartTimestamp: new Date('2023-01-01T10:00:00Z').getTime(),
+                    lastActivityTimestamp: new Date('2023-01-01T10:30:00Z').getTime(),
+                })
+                .mockReturnValueOnce({
+                    sessionId: 'session-789',
+                    windowId: 'window-999',
+                    sessionStartTimestamp: new Date('2023-01-01T11:00:00Z').getTime(),
+                    lastActivityTimestamp: new Date('2023-01-01T11:30:00Z').getTime(),
+                })
+
+            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+            initializeLogs(mockPostHog)
+
+            assignableWindow.console.log('first')
+            assignableWindow.console.log('second')
+
+            expect(mockEmit.mock.calls[0][0].attributes).toEqual(expect.objectContaining({ 'window.id': 'window-456' }))
+            expect(mockEmit.mock.calls[1][0].attributes).toEqual(expect.objectContaining({ 'window.id': 'window-999' }))
+        })
+
         it('should handle a missing last activity timestamp', () => {
             mockPostHog.sessionManager!.checkAndGetSessionAndWindowId = jest.fn(() => ({
                 sessionId: 'session-123',

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -100,7 +100,7 @@ describe('logs entrypoint', () => {
             expect(attributes).not.toHaveProperty('location.href')
         })
 
-        it('includes window.id and session timestamps in attributes', () => {
+        it('sets host on the captured record', () => {
             const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
             initializeLogs(mockPostHog)
 
@@ -108,62 +108,22 @@ describe('logs entrypoint', () => {
 
             expect(mockEmit).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    attributes: expect.objectContaining({
-                        'window.id': 'window-456',
-                        sessionStartTimestamp: expect.any(String),
-                        lastActivityTimestamp: expect.any(String),
-                    }),
+                    attributes: expect.objectContaining({ host: 'example.com' }),
                 })
             )
         })
 
-        it('refreshes session attributes for each captured log', () => {
-            mockPostHog.sessionManager!.checkAndGetSessionAndWindowId = jest
-                .fn()
-                .mockReturnValueOnce({
-                    sessionId: 'session-123',
-                    windowId: 'window-456',
-                    sessionStartTimestamp: new Date('2023-01-01T10:00:00Z').getTime(),
-                    lastActivityTimestamp: new Date('2023-01-01T10:30:00Z').getTime(),
-                })
-                .mockReturnValueOnce({
-                    sessionId: 'session-789',
-                    windowId: 'window-999',
-                    sessionStartTimestamp: new Date('2023-01-01T11:00:00Z').getTime(),
-                    lastActivityTimestamp: new Date('2023-01-01T11:30:00Z').getTime(),
-                })
+        it.each(['window.id', 'sessionStartTimestamp', 'lastActivityTimestamp'])(
+            'does not set %s — core adds session attributes from the SDK context downstream',
+            (attribute) => {
+                const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+                initializeLogs(mockPostHog)
 
-            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
-            initializeLogs(mockPostHog)
+                assignableWindow.console.log('hello')
 
-            assignableWindow.console.log('first')
-            assignableWindow.console.log('second')
-
-            expect(mockEmit.mock.calls[0][0].attributes).toEqual(expect.objectContaining({ 'window.id': 'window-456' }))
-            expect(mockEmit.mock.calls[1][0].attributes).toEqual(expect.objectContaining({ 'window.id': 'window-999' }))
-        })
-
-        it('should handle a missing last activity timestamp', () => {
-            mockPostHog.sessionManager!.checkAndGetSessionAndWindowId = jest.fn(() => ({
-                sessionId: 'session-123',
-                windowId: 'window-456',
-                sessionStartTimestamp: new Date('2023-01-01T10:00:00Z').getTime(),
-                lastActivityTimestamp: null,
-            }))
-
-            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
-            expect(() => initializeLogs(mockPostHog)).not.toThrow()
-
-            assignableWindow.console.log('hello')
-
-            expect(mockEmit).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    attributes: expect.not.objectContaining({
-                        lastActivityTimestamp: expect.any(String),
-                    }),
-                })
-            )
-        })
+                expect(mockEmit.mock.calls[0][0].attributes).not.toHaveProperty(attribute)
+            }
+        )
     })
 
     describe('log truncation features', () => {

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -116,6 +116,28 @@ describe('logs entrypoint', () => {
                 })
             )
         })
+
+        it('should handle a missing last activity timestamp', () => {
+            mockPostHog.sessionManager!.checkAndGetSessionAndWindowId = jest.fn(() => ({
+                sessionId: 'session-123',
+                windowId: 'window-456',
+                sessionStartTimestamp: new Date('2023-01-01T10:00:00Z').getTime(),
+                lastActivityTimestamp: null,
+            }))
+
+            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+            expect(() => initializeLogs(mockPostHog)).not.toThrow()
+
+            assignableWindow.console.log('hello')
+
+            expect(mockEmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    attributes: expect.not.objectContaining({
+                        lastActivityTimestamp: expect.any(String),
+                    }),
+                })
+            )
+        })
     })
 
     describe('log truncation features', () => {

--- a/packages/browser/src/__tests__/extensions/logs.test.ts
+++ b/packages/browser/src/__tests__/extensions/logs.test.ts
@@ -308,7 +308,7 @@ describe('logs entrypoint', () => {
             await import('../../entrypoints/logs')
         })
 
-        it('should include window.id and session timestamps in log attributes', () => {
+        it('sets host on the captured record', () => {
             const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
             initializeLogs(mockPostHog)
 
@@ -317,13 +317,21 @@ describe('logs entrypoint', () => {
             expect(mockEmit).toHaveBeenCalledWith({
                 level: 'info',
                 body: '"Test message"',
-                attributes: expect.objectContaining({
-                    'window.id': 'window-456',
-                    sessionStartTimestamp: expect.any(String),
-                    lastActivityTimestamp: expect.any(String),
-                }),
+                attributes: expect.objectContaining({ host: 'example.com' }),
             })
         })
+
+        it.each(['window.id', 'sessionStartTimestamp', 'lastActivityTimestamp'])(
+            'does not set %s — core adds session attributes from the SDK context downstream',
+            (attribute) => {
+                const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+                initializeLogs(mockPostHog)
+
+                assignableWindow.console.log('Test message')
+
+                expect(mockEmit.mock.calls[0][0].attributes).not.toHaveProperty(attribute)
+            }
+        )
 
         it('should work without session manager', () => {
             const postHogWithoutSession = {

--- a/packages/browser/src/__tests__/posthog-logs.test.ts
+++ b/packages/browser/src/__tests__/posthog-logs.test.ts
@@ -76,6 +76,8 @@ describe('posthog-logs', () => {
                     checkAndGetSessionAndWindowId: jest.fn(() => ({
                         sessionId: 'session-abc',
                         windowId: 'window-xyz',
+                        sessionStartTimestamp: 1672567200000,
+                        lastActivityTimestamp: 1672569000000,
                     })),
                 },
                 consent: {
@@ -586,10 +588,37 @@ describe('posthog-logs', () => {
 
                 expect(attrs['posthogDistinctId']).toEqual({ stringValue: 'distinct-id-123' })
                 expect(attrs['sessionId']).toEqual({ stringValue: 'session-abc' })
+                expect(attrs['window.id']).toEqual({ stringValue: 'window-xyz' })
+                expect(attrs['sessionStartTimestamp']).toEqual({ stringValue: '1672567200000' })
+                expect(attrs['lastActivityTimestamp']).toEqual({ stringValue: '1672569000000' })
                 expect(attrs['feature_flags']).toEqual({
                     arrayValue: { values: [{ stringValue: 'logs-capture-enabled' }] },
                 })
             })
+
+            it.each(['sessionStartTimestamp', 'lastActivityTimestamp'])(
+                'omits %s and does not throw when the session manager returns null for it',
+                (attribute) => {
+                    ;(mockPostHog.sessionManager!.checkAndGetSessionAndWindowId as jest.Mock).mockReturnValue({
+                        sessionId: 'session-abc',
+                        windowId: 'window-xyz',
+                        sessionStartTimestamp: null,
+                        lastActivityTimestamp: null,
+                    })
+
+                    expect(() => {
+                        logs.captureLog({ body: 'test' })
+                        jest.advanceTimersByTime(3000)
+                    }).not.toThrow()
+
+                    const call = (mockPostHog._send_request as jest.Mock).mock.calls[0][0]
+                    const record = call.data.resourceLogs[0].scopeLogs[0].logRecords[0]
+                    const attrs = Object.fromEntries(record.attributes.map((a: any) => [a.key, a.value]))
+
+                    expect(attrs).not.toHaveProperty(attribute)
+                    expect(attrs['window.id']).toEqual({ stringValue: 'window-xyz' })
+                }
+            )
 
             it('should include named config fields in OTLP resource attributes', () => {
                 ;(mockPostHog.config as any).logs = {
@@ -927,6 +956,9 @@ describe('posthog-logs', () => {
 
                 expect(attrs['posthogDistinctId']).toEqual({ stringValue: 'distinct-id-123' })
                 expect(attrs['sessionId']).toEqual({ stringValue: 'session-abc' })
+                expect(attrs['window.id']).toEqual({ stringValue: 'window-xyz' })
+                expect(attrs['sessionStartTimestamp']).toEqual({ stringValue: '1672567200000' })
+                expect(attrs['lastActivityTimestamp']).toEqual({ stringValue: '1672569000000' })
                 expect(attrs['feature_flags']).toEqual({
                     arrayValue: { values: [{ stringValue: 'logs-capture-enabled' }] },
                 })

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -303,15 +303,16 @@ const LEVEL_MAP: Record<ConsoleLevel, LogSeverityLevel> = {
 
 const initializeLogs = (posthog: PostHog) => {
     // `host` is carried per record because the core SDK context has no equivalent.
-    let attributes: Record<string, string> = { host: assignableWindow.location.host }
+    const attributes: Record<string, string> = { host: assignableWindow.location.host }
     if (posthog.sessionManager) {
         const { windowId, sessionStartTimestamp, lastActivityTimestamp } =
             posthog.sessionManager.checkAndGetSessionAndWindowId(true)
-        attributes = {
-            ...attributes,
-            'window.id': windowId,
-            sessionStartTimestamp: sessionStartTimestamp.toString(),
-            lastActivityTimestamp: lastActivityTimestamp.toString(),
+        attributes['window.id'] = windowId
+        if (sessionStartTimestamp != null) {
+            attributes.sessionStartTimestamp = sessionStartTimestamp.toString()
+        }
+        if (lastActivityTimestamp != null) {
+            attributes.lastActivityTimestamp = lastActivityTimestamp.toString()
         }
     }
 

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -302,18 +302,22 @@ const LEVEL_MAP: Record<ConsoleLevel, LogSeverityLevel> = {
 }
 
 const initializeLogs = (posthog: PostHog) => {
-    // `host` is carried per record because the core SDK context has no equivalent.
-    const attributes: Record<string, string> = { host: assignableWindow.location.host }
-    if (posthog.sessionManager) {
-        const { windowId, sessionStartTimestamp, lastActivityTimestamp } =
-            posthog.sessionManager.checkAndGetSessionAndWindowId(true)
-        attributes['window.id'] = windowId
-        if (sessionStartTimestamp != null) {
-            attributes.sessionStartTimestamp = sessionStartTimestamp.toString()
+    const getLogAttributes = (): Record<string, string> => {
+        // `host` is carried per record because the core SDK context has no equivalent.
+        const attributes: Record<string, string> = { host: assignableWindow.location.host }
+        if (posthog.sessionManager) {
+            const { windowId, sessionStartTimestamp, lastActivityTimestamp } =
+                posthog.sessionManager.checkAndGetSessionAndWindowId(true)
+            attributes['window.id'] = windowId
+            if (sessionStartTimestamp != null) {
+                attributes.sessionStartTimestamp = sessionStartTimestamp.toString()
+            }
+            if (lastActivityTimestamp != null) {
+                attributes.lastActivityTimestamp = lastActivityTimestamp.toString()
+            }
         }
-        if (lastActivityTimestamp != null) {
-            attributes.lastActivityTimestamp = lastActivityTimestamp.toString()
-        }
+
+        return attributes
     }
 
     for (const level of Object.keys(LEVEL_MAP) as ConsoleLevel[]) {
@@ -324,7 +328,7 @@ const initializeLogs = (posthog: PostHog) => {
                     if (args.length > 0 && posthog.is_capturing()) {
                         const { body, truncated } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
                         const logAttributes = {
-                            ...attributes,
+                            ...getLogAttributes(),
                             ...(truncated ? { body_truncated: 'true' } : {}),
                         }
                         // The core pipeline adds posthogDistinctId and url.full from the SDK context.

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -302,23 +302,10 @@ const LEVEL_MAP: Record<ConsoleLevel, LogSeverityLevel> = {
 }
 
 const initializeLogs = (posthog: PostHog) => {
-    const getLogAttributes = (): Record<string, string> => {
-        // `host` is carried per record because the core SDK context has no equivalent.
-        const attributes: Record<string, string> = { host: assignableWindow.location.host }
-        if (posthog.sessionManager) {
-            const { windowId, sessionStartTimestamp, lastActivityTimestamp } =
-                posthog.sessionManager.checkAndGetSessionAndWindowId(true)
-            attributes['window.id'] = windowId
-            if (sessionStartTimestamp != null) {
-                attributes.sessionStartTimestamp = sessionStartTimestamp.toString()
-            }
-            if (lastActivityTimestamp != null) {
-                attributes.lastActivityTimestamp = lastActivityTimestamp.toString()
-            }
-        }
-
-        return attributes
-    }
+    // `host` is carried here because the core SDK context has no equivalent. Session
+    // attributes (window.id, sessionStartTimestamp, lastActivityTimestamp) are added
+    // downstream by the core pipeline from the SDK context, alongside sessionId.
+    const attributes: Record<string, string> = { host: assignableWindow.location.host }
 
     for (const level of Object.keys(LEVEL_MAP) as ConsoleLevel[]) {
         const logWrapper =
@@ -328,7 +315,7 @@ const initializeLogs = (posthog: PostHog) => {
                     if (args.length > 0 && posthog.is_capturing()) {
                         const { body, truncated } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
                         const logAttributes = {
-                            ...getLogAttributes(),
+                            ...attributes,
                             ...(truncated ? { body_truncated: 'true' } : {}),
                         }
                         // The core pipeline adds posthogDistinctId and url.full from the SDK context.

--- a/packages/browser/src/posthog-logs.ts
+++ b/packages/browser/src/posthog-logs.ts
@@ -355,8 +355,16 @@ export class PostHogLogs implements Extension {
         context.distinctId = this._instance.get_distinct_id()
 
         if (this._instance.sessionManager) {
-            const { sessionId } = this._instance.sessionManager.checkAndGetSessionAndWindowId(true)
+            const { sessionId, windowId, sessionStartTimestamp, lastActivityTimestamp } =
+                this._instance.sessionManager.checkAndGetSessionAndWindowId(true)
             context.sessionId = sessionId
+            context.windowId = windowId
+            if (!isNullish(sessionStartTimestamp)) {
+                context.sessionStartTimestamp = sessionStartTimestamp
+            }
+            if (!isNullish(lastActivityTimestamp)) {
+                context.lastActivityTimestamp = lastActivityTimestamp
+            }
         }
 
         if (assignableWindow?.location?.href) {

--- a/packages/core/src/logs/logs-utils.spec.ts
+++ b/packages/core/src/logs/logs-utils.spec.ts
@@ -12,6 +12,9 @@ import {
 const browserSdkContext: LogSdkContext = {
   distinctId: 'user-123',
   sessionId: 'session-456',
+  windowId: 'window-789',
+  sessionStartTimestamp: 1672567200000,
+  lastActivityTimestamp: 1672569000000,
   currentUrl: 'https://example.com/page',
   activeFeatureFlags: ['flag-a', 'flag-b'],
 }
@@ -176,6 +179,9 @@ describe('logs-utils', () => {
       const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]))
       expect(attrs['posthogDistinctId']).toEqual({ stringValue: 'user-123' })
       expect(attrs['sessionId']).toEqual({ stringValue: 'session-456' })
+      expect(attrs['window.id']).toEqual({ stringValue: 'window-789' })
+      expect(attrs['sessionStartTimestamp']).toEqual({ stringValue: '1672567200000' })
+      expect(attrs['lastActivityTimestamp']).toEqual({ stringValue: '1672569000000' })
       expect(attrs['url.full']).toEqual({ stringValue: 'https://example.com/page' })
       expect(attrs['feature_flags']).toEqual({
         arrayValue: { values: [{ stringValue: 'flag-a' }, { stringValue: 'flag-b' }] },
@@ -183,6 +189,20 @@ describe('logs-utils', () => {
       // browser context shouldn't leak mobile-only attrs
       expect(attrs['screen.name']).toBeUndefined()
       expect(attrs['app.state']).toBeUndefined()
+    })
+
+    it.each(['window.id', 'sessionStartTimestamp', 'lastActivityTimestamp'])(
+      'omits %s when absent from the SDK context',
+      (attribute) => {
+        const record = buildOtlpLogRecord({ body: 'test' }, minimalSdkContext)
+        expect(record.attributes.map((a) => a.key)).not.toContain(attribute)
+      }
+    )
+
+    it('preserves a sessionStartTimestamp of 0 (epoch)', () => {
+      const record = buildOtlpLogRecord({ body: 'test' }, { ...minimalSdkContext, sessionStartTimestamp: 0 })
+      const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]))
+      expect(attrs['sessionStartTimestamp']).toEqual({ stringValue: '0' })
     })
 
     it('auto-populates mobile SDK context (screenName + appState)', () => {

--- a/packages/core/src/logs/logs-utils.ts
+++ b/packages/core/src/logs/logs-utils.ts
@@ -124,6 +124,15 @@ export function buildOtlpLogRecord(options: CaptureLogOptions, sdkContext: LogSd
   if (sdkContext.sessionId) {
     autoAttributes.sessionId = sdkContext.sessionId
   }
+  if (sdkContext.windowId) {
+    autoAttributes['window.id'] = sdkContext.windowId
+  }
+  if (!isUndefined(sdkContext.sessionStartTimestamp)) {
+    autoAttributes.sessionStartTimestamp = String(sdkContext.sessionStartTimestamp)
+  }
+  if (!isUndefined(sdkContext.lastActivityTimestamp)) {
+    autoAttributes.lastActivityTimestamp = String(sdkContext.lastActivityTimestamp)
+  }
   if (sdkContext.currentUrl) {
     autoAttributes['url.full'] = sdkContext.currentUrl
   }

--- a/packages/core/src/logs/logs-utils.ts
+++ b/packages/core/src/logs/logs-utils.ts
@@ -10,7 +10,7 @@ import type {
   OtlpSeverityText,
 } from '@posthog/types'
 import type { LogSdkContext, ResolvedPostHogLogsConfig } from './types'
-import { isArray, isBoolean, isNull, isUndefined } from '../utils'
+import { isArray, isBoolean, isNull, isNullish, isUndefined } from '../utils'
 
 // ============================================================================
 // Severity mapping
@@ -127,10 +127,10 @@ export function buildOtlpLogRecord(options: CaptureLogOptions, sdkContext: LogSd
   if (sdkContext.windowId) {
     autoAttributes['window.id'] = sdkContext.windowId
   }
-  if (!isUndefined(sdkContext.sessionStartTimestamp)) {
+  if (!isNullish(sdkContext.sessionStartTimestamp)) {
     autoAttributes.sessionStartTimestamp = String(sdkContext.sessionStartTimestamp)
   }
-  if (!isUndefined(sdkContext.lastActivityTimestamp)) {
+  if (!isNullish(sdkContext.lastActivityTimestamp)) {
     autoAttributes.lastActivityTimestamp = String(sdkContext.lastActivityTimestamp)
   }
   if (sdkContext.currentUrl) {

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -25,6 +25,12 @@ export type {
 export interface LogSdkContext {
   distinctId?: string
   sessionId?: string
+  /** Web-only — current window id */
+  windowId?: string
+  /** Web-only — ms epoch when the current session started */
+  sessionStartTimestamp?: number
+  /** Web-only — ms epoch of the most recent session activity */
+  lastActivityTimestamp?: number
   /** Web-only — current page URL */
   currentUrl?: string
   /** Mobile-only — current screen / view name */


### PR DESCRIPTION
## Problem

The browser logs extension could throw during initialization when the session manager returned a null `lastActivityTimestamp`, causing `Cannot read properties of null (reading 'toString')`.

Separately, the console-logs entrypoint hand-rolled session attributes (`window.id`, `sessionStartTimestamp`, `lastActivityTimestamp`) onto each record — duplicating context that the logs pipeline already assembles for `sessionId` / `distinctId` / `url.full` / `feature_flags`.

## Changes

Builds on @hpouillot's original null-timestamp fix (#3942) and routes the session attributes through the shared logs SDK context instead of the console entrypoint:

- Move `window.id` / `sessionStartTimestamp` / `lastActivityTimestamp` into `LogSdkContext` and emit them from `buildOtlpLogRecord` (`@posthog/core`), alongside the existing auto-attributes. Same OTLP keys and stringified values as before.
- Populate them in `_getSdkContext` (browser), guarding the timestamps with `isNullish` — this is where the original null-timestamp crash fix now lives.
- Drop the hand-rolled session block from the console entrypoint; it now carries only `host`. No per-log `getLogAttributes()` closure is needed because `_getSdkContext` is already called per `captureLog`, so the attributes stay live per log line.

**Behavioural note:** these three attributes now appear on **all** log records — user-facing `posthog.log.*` as well as console logs — consistent with how `sessionId` already behaves. The wire format (attribute keys + stringified values) is unchanged.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
