### PR TITLE
fix(logs): don't throw on null session timestamps during log init

### DIFF
--- a/.changeset/logs-null-timestamp-fix.md
+++ b/.changeset/logs-null-timestamp-fix.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix a `TypeError: Cannot read properties of null (reading 'toString')` thrown from log capture initialization when the session manager returns null session timestamps. `initializeLogs` now coerces the timestamps safely and never throws out of initialization.

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -116,6 +116,30 @@ describe('logs entrypoint', () => {
                 })
             )
         })
+
+        it('does not throw or break capture when the session manager returns null timestamps', () => {
+            // Older bundles / version skew can hand back null here even though the
+            // type says number. Calling .toString() on it used to throw out of
+            // initializeLogs and break log capture entirely.
+            ;(mockPostHog.sessionManager!.checkAndGetSessionAndWindowId as jest.Mock).mockReturnValue({
+                sessionId: 'session-123',
+                windowId: 'window-456',
+                sessionStartTimestamp: null,
+                lastActivityTimestamp: null,
+            })
+
+            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+            expect(() => initializeLogs(mockPostHog)).not.toThrow()
+
+            assignableWindow.console.log('hello')
+
+            expect(mockEmit).toHaveBeenCalledTimes(1)
+            const attributes = mockEmit.mock.calls[0][0].attributes
+            // Capture still works, and we omit the bad timestamps rather than emitting "null".
+            expect(attributes['window.id']).toBe('window-456')
+            expect(attributes).not.toHaveProperty('sessionStartTimestamp')
+            expect(attributes).not.toHaveProperty('lastActivityTimestamp')
+        })
     })
 
     describe('log truncation features', () => {

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -304,15 +304,24 @@ const LEVEL_MAP: Record<ConsoleLevel, LogSeverityLevel> = {
 const initializeLogs = (posthog: PostHog) => {
     // `host` is carried per record because the core SDK context has no equivalent.
     let attributes: Record<string, string> = { host: assignableWindow.location.host }
-    if (posthog.sessionManager) {
-        const { windowId, sessionStartTimestamp, lastActivityTimestamp } =
-            posthog.sessionManager.checkAndGetSessionAndWindowId(true)
-        attributes = {
-            ...attributes,
-            'window.id': windowId,
-            sessionStartTimestamp: sessionStartTimestamp.toString(),
-            lastActivityTimestamp: lastActivityTimestamp.toString(),
+    // Defensive: the session manager is *typed* to return numbers, but older
+    // bundles / version skew can hand back null (or throw). `null.toString()`
+    // would throw out of initializeLogs (this runs outside the per-log
+    // try/catch), breaking log capture entirely — so wrap it, coerce safely,
+    // and only attach a timestamp attribute when we actually have a value.
+    try {
+        if (posthog.sessionManager) {
+            const { windowId, sessionStartTimestamp, lastActivityTimestamp } =
+                posthog.sessionManager.checkAndGetSessionAndWindowId(true)
+            attributes = {
+                ...attributes,
+                'window.id': windowId,
+                ...(isNumber(sessionStartTimestamp) ? { sessionStartTimestamp: String(sessionStartTimestamp) } : {}),
+                ...(isNumber(lastActivityTimestamp) ? { lastActivityTimestamp: String(lastActivityTimestamp) } : {}),
+            }
         }
+    } catch {
+        // Fall back to the host-only attributes; log capture must still initialize.
     }
 
     for (const level of Object.keys(LEVEL_MAP) as ConsoleLevel[]) {


### PR DESCRIPTION
## Problem

A customer's most-frequent Error Tracking exception — by an order of magnitude — was `TypeError: Cannot read properties of null (reading 'toString')` originating from posthog-js's own `logs.js` bundle. This has recurred across versions despite previous attempts.

**Why:** the only `.toString()` calls in `logs.ts` are on `sessionStartTimestamp` / `lastActivityTimestamp` inside `initializeLogs`, and they run *outside* the per-log `try/catch`. The session manager is typed to return `number`, but older bundles / version skew can hand back `null`, so `null.toString()` throws straight out of log-capture initialization — breaking log capture and surfacing as a high-volume exception.

## Changes

In `initializeLogs`:
- Coerce the timestamps with `String(...)` guarded by `isNumber(...)` instead of calling `.toString()` directly, and omit the attribute entirely when the value isn't a real number (so we never emit a literal `"null"`).
- Wrap the session-manager block in `try/catch` so initialization always falls back to host-only attributes rather than throwing.
- Added a regression test asserting init doesn't throw and capture still works when the session manager returns null timestamps.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — requested by Paul D'Ambra via Slack.

Investigated from a customer report relayed in Slack. Traced the `toString` call sites in `logs.ts` to `checkAndGetSessionAndWindowId` in `sessionid.ts`; confirmed current `sessionid.ts` coerces both timestamps to numbers, so the crash comes from version skew where the session manager returned `null`. Chose to harden the consumer (`logs.ts`) rather than rely on the session-manager contract, since that's what actually ships in the bundle that throws. Verified with the package's jest suite (31/31 in the logs entrypoint tests, including the new case) and eslint.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07AA937K9A/p1782291565011979?thread_ts=1782291565.011979&cid=C07AA937K9A)*
