### PR TITLE
fix(flags): suppress misleading older-endpoint warning for valid v2 responses

### DIFF
--- a/.changeset/brave-otters-jump.md
+++ b/.changeset/brave-otters-jump.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Stop logging a misleading "upgrade your PostHog server" warning for valid v2 flags responses that have no flags.

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -3004,6 +3004,20 @@ describe('parseFlagsResponse', () => {
         expect(persistence.unregister).not.toHaveBeenCalled()
     })
 
+    it('does not warn about an older endpoint for a valid v2 response with no flags', () => {
+        // Ensure warnings would actually be emitted so the assertion below is meaningful.
+        ;(window as any).POSTHOG_DEBUG = true
+        jest.spyOn(window.console, 'warn').mockImplementation()
+
+        // A project with no feature flags returns a valid v2 response that omits the `flags` key.
+        parseFlagsResponse({}, persistence)
+
+        expect(window.console.warn).not.toHaveBeenCalledWith(
+            '[PostHog.js] [FeatureFlags]',
+            'Using an older version of the feature flags endpoint. Please upgrade your PostHog server to the latest version'
+        )
+    })
+
     it('parses the requestId from the /flags?v=1 response', () => {
         const flagsResponse = {
             featureFlags: { 'test-flag': true },

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -3011,7 +3011,11 @@ describe('parseFlagsResponse', () => {
         // A modern v2 response carries `flags` and must not warn.
         { name: 'v2 response with flags', response: { flags: { f: { key: 'f', enabled: true } } }, shouldWarn: false },
         // Only a genuinely old server returns the v1 shape (`featureFlags`, no `flags`) — keep the warning there.
-        { name: 'v1-shaped response (featureFlags present)', response: { featureFlags: { f: true } }, shouldWarn: true },
+        {
+            name: 'v1-shaped response (featureFlags present)',
+            response: { featureFlags: { f: true } },
+            shouldWarn: true,
+        },
         // A project with no feature flags returns a valid v2 response that omits `flags` — must not warn.
         { name: 'valid v2 response with no flags', response: {}, shouldWarn: false },
     ])('older-endpoint warning — $name (warns: $shouldWarn)', ({ response, shouldWarn }) => {

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -3004,18 +3004,33 @@ describe('parseFlagsResponse', () => {
         expect(persistence.unregister).not.toHaveBeenCalled()
     })
 
-    it('does not warn about an older endpoint for a valid v2 response with no flags', () => {
-        // Ensure warnings would actually be emitted so the assertion below is meaningful.
+    const OLD_ENDPOINT_WARNING =
+        'Using an older version of the feature flags endpoint. Please upgrade your PostHog server to the latest version'
+
+    it.each([
+        // A modern v2 response carries `flags` and must not warn.
+        { name: 'v2 response with flags', response: { flags: { f: { key: 'f', enabled: true } } }, shouldWarn: false },
+        // Only a genuinely old server returns the v1 shape (`featureFlags`, no `flags`) — keep the warning there.
+        { name: 'v1-shaped response (featureFlags present)', response: { featureFlags: { f: true } }, shouldWarn: true },
+        // A project with no feature flags returns a valid v2 response that omits `flags` — must not warn.
+        { name: 'valid v2 response with no flags', response: {}, shouldWarn: false },
+    ])('older-endpoint warning — $name (warns: $shouldWarn)', ({ response, shouldWarn }) => {
+        // Ensure warnings would actually be emitted so the assertions below are meaningful, and
+        // restore the previous value so this test stays self-contained.
+        const previousDebug = (window as any).POSTHOG_DEBUG
         ;(window as any).POSTHOG_DEBUG = true
         jest.spyOn(window.console, 'warn').mockImplementation()
 
-        // A project with no feature flags returns a valid v2 response that omits the `flags` key.
-        parseFlagsResponse({}, persistence)
+        // @ts-expect-error testing partial/legacy response shapes
+        parseFlagsResponse(response, persistence)
 
-        expect(window.console.warn).not.toHaveBeenCalledWith(
-            '[PostHog.js] [FeatureFlags]',
-            'Using an older version of the feature flags endpoint. Please upgrade your PostHog server to the latest version'
-        )
+        const expectation = expect(window.console.warn)
+        if (shouldWarn) {
+            expectation.toHaveBeenCalledWith('[PostHog.js] [FeatureFlags]', OLD_ENDPOINT_WARNING)
+        } else {
+            expectation.not.toHaveBeenCalledWith('[PostHog.js] [FeatureFlags]', OLD_ENDPOINT_WARNING)
+        }
+        ;(window as any).POSTHOG_DEBUG = previousDebug
     })
 
     it('parses the requestId from the /flags?v=1 response', () => {

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -188,7 +188,11 @@ const normalizeFlagsResponse = (response: Partial<FlagsResponse>): Partial<Flags
                 .filter((flag) => flagDetails[flag].metadata?.payload)
                 .map((flag) => [flag, flagDetails[flag].metadata?.payload])
         )
-    } else {
+    } else if (response['featureFlags']) {
+        // The response has no `flags` key but does carry top-level `featureFlags`, which is the
+        // shape returned by older servers that don't understand `?v=2`. A valid v2 response with no
+        // flags (e.g. a project without any feature flags) legitimately omits `flags`, so we must
+        // not warn in that case.
         logger.warn(
             'Using an older version of the feature flags endpoint. Please upgrade your PostHog server to the latest version'
         )


### PR DESCRIPTION
## Problem

PostHog Cloud users see a misleading, unactionable warning in the console whenever the `/flags?v=2` response doesn't contain a `flags` key:

```
[PostHog.js] [FeatureFlags] Using an older version of the feature flags endpoint. Please upgrade your PostHog server to the latest version
```

This is purely cosmetic — feature flags work correctly. Two problems with it:

1. Cloud users can't "upgrade the server" — it's managed by PostHog.
2. Per the feature-flags team on #2994, a normal v2 response **does** include `flags`; the warning only fires when the response has *neither* `flags` nor a v1-style `featureFlags` key — i.e. an empty/no-flags response or a 503 error body. Neither is an "upgrade your server" situation.

`normalizeFlagsResponse` was warning on every response lacking a `flags` key, which swept up those legitimate-but-empty responses.

## Changes

- Gate the warning so it only fires when the response carries the genuine **old v1 shape** (top-level `featureFlags` present but no `flags`) — the one case where "upgrade your server" is actually true and actionable. Self-hosted users on a genuinely old server still get warned; empty/no-flags and 503-error responses no longer trigger it.
- No change to request behavior — the SDK still requests `?v=2`.
- Added a unit test asserting no warning is logged for a valid v2 response with no flags (verified it fails without the source change and passes with it). Existing tests covering the old-server (v1-shape) path remain green.

Diagnostic signal isn't lost: non-200 responses are still independently recorded via `flagErrors.push(FeatureFlagError.apiError(...))`, separate from this warning.

Closes #2994

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @ioannisj. 