### PR TITLE
fix(surveys): guard handlePageUnload against version-skewed surveys instance

### DIFF
--- a/.changeset/proud-ferns-wander.md
+++ b/.changeset/proud-ferns-wander.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(surveys): guard handlePageUnload against version-skewed surveys instance missing the method

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -805,6 +805,40 @@ describe('posthog core', () => {
             expect(flushLogs).toHaveBeenCalledWith('sendBeacon')
         })
 
+        it('calls surveys.handlePageUnload when present', () => {
+            const handlePageUnload = jest.fn()
+            const posthog = posthogWith(
+                {
+                    capture_pageview: true,
+                    capture_pageleave: 'if_capture_pageview',
+                    request_batching: true,
+                },
+                { surveys: { handlePageUnload } as unknown as PostHog['surveys'] }
+            )
+
+            posthog._handle_unload()
+
+            expect(handlePageUnload).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not throw when a stale surveys instance is missing handlePageUnload', () => {
+            // Version skew: a cached older lazy-loaded surveys chunk can yield a truthy
+            // surveys instance whose prototype lacks handlePageUnload. Optional chaining alone
+            // would still throw "handlePageUnload is not a function" here.
+            const posthog = posthogWith(
+                {
+                    capture_pageview: true,
+                    capture_pageleave: 'if_capture_pageview',
+                    request_batching: true,
+                },
+                { capture: jest.fn(), surveys: {} as unknown as PostHog['surveys'] }
+            )
+
+            expect(() => posthog._handle_unload()).not.toThrow()
+            // the rest of the unload path still runs
+            expect(posthog.capture).toHaveBeenCalledWith('$pageleave')
+        })
+
         describe('without batching', () => {
             it('captures $pageleave', () => {
                 const posthog = posthogWith(

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1051,7 +1051,12 @@ export class PostHog implements PostHogInterface {
     }
 
     _handle_unload(): void {
-        this.surveys?.handlePageUnload()
+        // Guard on the method being callable, not just present: after a deploy a cached older
+        // lazy-loaded surveys chunk can yield an instance whose prototype lacks handlePageUnload,
+        // and optional chaining alone would still throw "handlePageUnload is not a function".
+        if (isFunction(this.surveys?.handlePageUnload)) {
+            this.surveys.handlePageUnload()
+        }
 
         if (!this.config.request_batching) {
             if (this._shouldCapturePageleave()) {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1051,12 +1051,10 @@ export class PostHog implements PostHogInterface {
     }
 
     _handle_unload(): void {
-        // Guard on the method being callable, not just present: after a deploy a cached older
+        // Optional-call the method, not just the receiver: after a deploy a cached older
         // lazy-loaded surveys chunk can yield an instance whose prototype lacks handlePageUnload,
-        // and optional chaining alone would still throw "handlePageUnload is not a function".
-        if (isFunction(this.surveys?.handlePageUnload)) {
-            this.surveys.handlePageUnload()
-        }
+        // and `this.surveys?.handlePageUnload()` would still throw "handlePageUnload is not a function".
+        this.surveys?.handlePageUnload?.()
 
         if (!this.config.request_batching) {
             if (this._shouldCapturePageleave()) {


### PR DESCRIPTION
## Problem

Closes #3251

On page unload PostHog calls `this.surveys.handlePageUnload()`. After a deploy, a browser can still be holding a **cached, older surveys extensions bundle** from the CDN whose `PostHogSurveys` instance predates `handlePageUnload`. The method is absent on that stale instance, so the unload handler throws:

```
TypeError: t2.handlePageUnload is not a function
```

A previous patch (#3165, v1.358.0) added optional chaining — `this.surveys?.handlePageUnload()` — and the issue was closed, but it was reopened because the crash still reproduces. Optional chaining on the *receiver* only guards against `surveys` being `undefined`/`null`; when `surveys` is a real object whose `handlePageUnload` is `undefined`, calling it still throws.

## Changes

Optional-call the method, not just the receiver:

```ts
// before
this.surveys?.handlePageUnload()

// after
this.surveys?.handlePageUnload?.()
```

- `?.()` short-circuits when `handlePageUnload` is absent (reads as `undefined`), which is exactly the version-skew failure mode. Matches the existing `?.()` idiom in this file (e.g. `extension.initialize?.()`).
- Scope is deliberately narrow: only `handlePageUnload` is guarded, since it's the only auto-invoked surveys method new enough to be missing from cached bundles. The sibling auto-calls (`reset()`, `loadIfEnabled()`) are older methods present in any cached bundle, so they don't reproduce this crash.
- Added unit tests in `posthog-core-also.test.ts`: method-present is still invoked once; a stale `surveys: {}` stub missing the method no longer throws and the rest of the unload path (`$pageleave` capture) still runs.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @ioannisj.
