### PR TITLE
ci: set up pnpm before watcher validation

### DIFF
--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -33,6 +33,11 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - uses: ./.github/actions/setup
+              with:
+                  install: 'false'
+                  build: 'false'
+
             - name: Sweep issues
               uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
               with:
@@ -45,7 +50,7 @@ jobs:
                   allow-close: 'true'
                   allow-security-ai: 'true'
                   require-reproduction: 'true'
-                  validation-command: 'corepack enable && pnpm install --frozen-lockfile && pnpm test:unit'
+                  validation-command: 'pnpm install --frozen-lockfile && pnpm test:unit'
                   max-repair-attempts: '3'
                   max-pi-calls: '16'
                   approve-project-resources: 'true'

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -39,6 +39,11 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - uses: ./.github/actions/setup
+              with:
+                  install: 'false'
+                  build: 'false'
+
             - name: Drain watcher queue
               uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
               with:
@@ -49,7 +54,7 @@ jobs:
                   allow-close: 'true'
                   allow-security-ai: 'true'
                   require-reproduction: 'true'
-                  validation-command: 'corepack enable && pnpm install --frozen-lockfile && pnpm test:unit'
+                  validation-command: 'pnpm install --frozen-lockfile && pnpm test:unit'
                   max-repair-attempts: '3'
                   max-pi-calls: '16'
                   approve-project-resources: 'true'
@@ -63,6 +68,11 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - uses: ./.github/actions/setup
+              with:
+                  install: 'false'
+                  build: 'false'
+
             - name: Process watcher issue
               uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
               with:
@@ -74,7 +84,7 @@ jobs:
                   allow-close: 'true'
                   allow-security-ai: 'true'
                   require-reproduction: 'true'
-                  validation-command: 'corepack enable && pnpm install --frozen-lockfile && pnpm test:unit'
+                  validation-command: 'pnpm install --frozen-lockfile && pnpm test:unit'
                   max-repair-attempts: '3'
                   max-pi-calls: '16'
                   approve-project-resources: 'true'


### PR DESCRIPTION
## Problem

The PostHog watcher validation command attempted to run `corepack enable && pnpm install --frozen-lockfile && pnpm test:unit`, but the workflow run showed that relying on `corepack enable` inside the watcher-owned validation command was not enough to make validation reliable.

## Changes

- Runs the repository setup action before the watcher action in the worker and sweep workflows.
- Disables dependency installation and build in that setup step so it only prepares the toolchain, including pnpm, without duplicating watcher validation work.
- Removes `corepack enable` from watcher validation commands now that pnpm is configured by the workflow.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to inspect the failing watcher validation setup and update the workflows to use this repository's existing setup action for pnpm, matching the pattern used elsewhere in CI while keeping watcher validation responsible for installing dependencies and running tests.
