### PR TITLE
ci: update watcher action pin

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -21,6 +21,6 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
+              uses: PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f
               with:
                   mode: enqueue

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -39,7 +39,7 @@ jobs:
                   build: 'false'
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
+              uses: PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -45,7 +45,7 @@ jobs:
                   build: 'false'
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
+              uses: PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -72,7 +72,7 @@ jobs:
                   build: 'false'
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@59b8117ff8a05774febfb2c780b3a26c564ea749
+              uses: PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}


### PR DESCRIPTION
## Problem

The PostHog watcher workflows should stay pinned to the latest reviewed `PostHog/posthog-watcher-action` commit SHA.

## Changes

- Updates all PostHog watcher workflow action references to `PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f`, the latest `main` commit at the time of this PR.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to update the pinned PostHog watcher action SHA in a dedicated worktree and verify workflow formatting/parsing before opening the PR.
