### PR TITLE
ci: enable watcher PR review events

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -5,22 +5,32 @@ on:
         types: [opened, reopened, edited]
     issue_comment:
         types: [created]
+    pull_request:
+        types: [opened, synchronize, reopened]
+    pull_request_review:
+        types: [submitted]
+    pull_request_review_comment:
+        types: [created]
 
 permissions:
     contents: write # write queue.json to the state branch
     issues: read
+    pull-requests: read
+    actions: write # dispatch the drain workflow immediately after enqueueing
 
 concurrency:
-    group: posthog-watcher-enqueue-${{ github.repository }}-${{ github.event.issue.number }}
+    group: posthog-watcher-enqueue-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
     cancel-in-progress: false
 
 jobs:
     enqueue:
+        if: ${{ github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event.pull_request.head.repo.full_name == github.repository }}
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f
+              uses: PostHog/posthog-watcher-action@81baedc77a94a4e307d7d711f68c7e59f59009c6
               with:
                   mode: enqueue
+                  trigger-drain-workflow: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -39,7 +39,7 @@ jobs:
                   build: 'false'
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f
+              uses: PostHog/posthog-watcher-action@81baedc77a94a4e307d7d711f68c7e59f59009c6
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -45,7 +45,7 @@ jobs:
                   build: 'false'
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f
+              uses: PostHog/posthog-watcher-action@81baedc77a94a4e307d7d711f68c7e59f59009c6
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -72,7 +72,7 @@ jobs:
                   build: 'false'
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@c06f781acbecaa779eb4276e35aeac97dfbbc80f
+              uses: PostHog/posthog-watcher-action@81baedc77a94a4e307d7d711f68c7e59f59009c6
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}


### PR DESCRIPTION
## Problem

The watcher workflows should use the latest watcher action and support the newer queue features: PR review feedback should enqueue watcher PR repair, and enqueue should be able to dispatch the drain workflow immediately.

## Changes

- Updates all PostHog watcher workflow action references to `PostHog/posthog-watcher-action@81baedc77a94a4e307d7d711f68c7e59f59009c6`, the latest `main` commit at the time of this PR.
- Adds enqueue triggers for:
  - `pull_request`
  - `pull_request_review`
  - `pull_request_review_comment`
- Grants enqueue workflow `pull-requests: read` and `actions: write` permissions.
- Enables `trigger-drain-workflow: 'true'` so new queued work dispatches the worker immediately.
- Broadens enqueue concurrency grouping to use issue number, PR number, or run ID fallback.
- Skips PR/review enqueue jobs for fork-based PR events because their `GITHUB_TOKEN` is read-only and cannot write queue state.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to update the watcher workflow configuration in a dedicated worktree based on the latest `posthog-watcher-action` README and commits for PR review event handling and queue drain dispatch.



