### PR TITLE
ci: install ripgrep for watcher workflows

### DIFF
--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -38,6 +38,9 @@ jobs:
                   install: 'false'
                   build: 'false'
 
+            - name: Install ripgrep for watcher search tools
+              run: sudo apt-get update && sudo apt-get install -y ripgrep
+
             - name: Sweep issues
               uses: PostHog/posthog-watcher-action@53752eea5b036f37e83da06879ca05e06cb377e9
               with:

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -44,6 +44,9 @@ jobs:
                   install: 'false'
                   build: 'false'
 
+            - name: Install ripgrep for watcher search tools
+              run: sudo apt-get update && sudo apt-get install -y ripgrep
+
             - name: Drain watcher queue
               uses: PostHog/posthog-watcher-action@53752eea5b036f37e83da06879ca05e06cb377e9
               with:
@@ -70,6 +73,9 @@ jobs:
               with:
                   install: 'false'
                   build: 'false'
+
+            - name: Install ripgrep for watcher search tools
+              run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Process watcher issue
               uses: PostHog/posthog-watcher-action@53752eea5b036f37e83da06879ca05e06cb377e9


### PR DESCRIPTION
## Problem

The PostHog watcher action gives pi search tools during issue triage and repair. CI should ensure `ripgrep` is available before running the watcher jobs that use those tools.

## Changes

- Installs `ripgrep` before the watcher action runs in the worker workflow.
- Installs `ripgrep` before the watcher action runs in the sweep workflow.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to add explicit `ripgrep` installation steps to the watcher CI workflows in a dedicated worktree and verify workflow formatting/parsing before opening the PR.
