### PR TITLE
fix: Dedupe feature flag called events by response

### DIFF
--- a/.changeset/silver-pandas-shake.md
+++ b/.changeset/silver-pandas-shake.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-node': patch
+---
+
+Dedupe feature flag called events per returned flag value.

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -807,7 +807,7 @@ describe('PostHog Feature Flags v4', () => {
         }
       )
 
-      it('should capture $feature_flag_called again if new flags', async () => {
+      it('should not capture $feature_flag_called again if reloaded flags keep the same value', async () => {
         expect(posthog.getFeatureFlag('feature-1')).toEqual(true)
         await waitForPromises()
         expect(mocks.fetch).toHaveBeenCalledTimes(2)
@@ -833,22 +833,7 @@ describe('PostHog Feature Flags v4', () => {
         posthog.getFeatureFlag('feature-1')
 
         await waitForPromises()
-        expect(mocks.fetch).toHaveBeenCalledTimes(4)
-
-        expect(parseBody(mocks.fetch.mock.calls[3])).toMatchObject({
-          batch: [
-            {
-              event: '$feature_flag_called',
-              distinct_id: posthog.getDistinctId(),
-              properties: {
-                $feature_flag: 'feature-1',
-                $feature_flag_response: true,
-                '$feature/feature-1': true,
-                $used_bootstrap_value: false,
-              },
-            },
-          ],
-        })
+        expect(mocks.fetch).toHaveBeenCalledTimes(3)
       })
 
       it('should capture $feature_flag_called when called, but not add all cached flags', async () => {
@@ -1020,7 +1005,7 @@ describe('PostHog Feature Flags v4', () => {
           expect(mocks.fetch).toHaveBeenCalledTimes(2)
         })
 
-        it('should send event again after reloadFeatureFlagsAsync', async () => {
+        it('should not send event again after reloadFeatureFlagsAsync if the value is unchanged', async () => {
           posthog.getFeatureFlagResult('feature-1')
           await waitForPromises()
           expect(mocks.fetch).toHaveBeenCalledTimes(2)
@@ -1028,8 +1013,8 @@ describe('PostHog Feature Flags v4', () => {
           await posthog.reloadFeatureFlagsAsync()
           posthog.getFeatureFlagResult('feature-1')
           await waitForPromises()
-          // flags reload + second event capture
-          expect(mocks.fetch).toHaveBeenCalledTimes(4)
+          // flags reload only, no second event for the same flag value
+          expect(mocks.fetch).toHaveBeenCalledTimes(3)
         })
 
         it('should respect instance-level sendFeatureFlagEvent: false', async () => {
@@ -1791,6 +1776,11 @@ describe('PostHog Feature Flags v4', () => {
       })
       // Locally supplied flags have no server id, so no $feature_flag_id is emitted
       expect(flagCalledProps).not.toHaveProperty('$feature_flag_id')
+
+      posthog.updateFlags({ 'feature-1': true })
+      expect(posthog.getFeatureFlag('feature-1')).toEqual(true)
+      await waitForPromises()
+      expect(mocks.fetch).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -1758,7 +1758,7 @@ describe('PostHog Feature Flags v4', () => {
       expect(posthog.getFeatureFlag('other-flag')).toEqual(true)
     })
 
-    it('should capture $feature_flag_called again after updateFlags changes a value', async () => {
+    it('should capture $feature_flag_called after updateFlags changes to a new value', async () => {
       await posthog.reloadFeatureFlagsAsync()
       expect(posthog.getFeatureFlag('feature-1')).toEqual(true)
       await waitForPromises()
@@ -1776,6 +1776,18 @@ describe('PostHog Feature Flags v4', () => {
       })
       // Locally supplied flags have no server id, so no $feature_flag_id is emitted
       expect(flagCalledProps).not.toHaveProperty('$feature_flag_id')
+    })
+
+    it('should not capture $feature_flag_called after updateFlags cycles back to a previously seen value', async () => {
+      await posthog.reloadFeatureFlagsAsync()
+      expect(posthog.getFeatureFlag('feature-1')).toEqual(true)
+      await waitForPromises()
+      expect(mocks.fetch).toHaveBeenCalledTimes(2)
+
+      posthog.updateFlags({ 'feature-1': false })
+      expect(posthog.getFeatureFlag('feature-1')).toEqual(false)
+      await waitForPromises()
+      expect(mocks.fetch).toHaveBeenCalledTimes(3)
 
       posthog.updateFlags({ 'feature-1': true })
       expect(posthog.getFeatureFlag('feature-1')).toEqual(true)

--- a/packages/core/src/__tests__/posthog.featureflags.v1.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.v1.spec.ts
@@ -453,7 +453,7 @@ describe('PostHog Feature Flags v1', () => {
         expect(mocks.fetch).toHaveBeenCalledTimes(2)
       })
 
-      it('should capture $feature_flag_called again if new flags', async () => {
+      it('should not capture $feature_flag_called again if reloaded flags keep the same value', async () => {
         expect(posthog.getFeatureFlag('feature-1')).toEqual(true)
         await waitForPromises()
         expect(mocks.fetch).toHaveBeenCalledTimes(2)
@@ -477,22 +477,7 @@ describe('PostHog Feature Flags v1', () => {
         posthog.getFeatureFlag('feature-1')
 
         await waitForPromises()
-        expect(mocks.fetch).toHaveBeenCalledTimes(4)
-
-        expect(parseBody(mocks.fetch.mock.calls[3])).toMatchObject({
-          batch: [
-            {
-              event: '$feature_flag_called',
-              distinct_id: posthog.getDistinctId(),
-              properties: {
-                $feature_flag: 'feature-1',
-                $feature_flag_response: true,
-                '$feature/feature-1': true,
-                $used_bootstrap_value: false,
-              },
-            },
-          ],
-        })
+        expect(mocks.fetch).toHaveBeenCalledTimes(3)
       })
 
       it('should capture $feature_flag_called when called, but not add all cached flags', async () => {

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -54,7 +54,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   // options
   private sendFeatureFlagEvent: boolean
   private disableRemoteFeatureFlags: boolean
-  private flagCallReported: { [key: string]: boolean } = {}
+  private flagCallReported: { [key: string]: Set<FeatureFlagValue | undefined> } = {}
   private _beforeSend?: BeforeSendFn | BeforeSendFn[]
 
   // internal
@@ -192,6 +192,14 @@ export abstract class PostHogCore extends PostHogCoreStateless {
         this.reloadFeatureFlags()
       }
     })
+  }
+
+  async _shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {
+    try {
+      return await super._shutdown(shutdownTimeoutMs)
+    } finally {
+      this.flagCallReported = {}
+    }
   }
 
   protected getCommonEventProperties(): PostHogEventProperties {
@@ -808,11 +816,6 @@ export abstract class PostHogCore extends PostHogCoreStateless {
             return res
           }
 
-          // clear flag call reported if we have new flags since they might have changed
-          if (this.sendFeatureFlagEvent) {
-            this.flagCallReported = {}
-          }
-
           let newFeatureFlagDetails = res
           if (res.errorsWhileComputingFlags) {
             // if not all flags were computed, we upsert flags instead of replacing them
@@ -970,8 +973,8 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     const details = this.getFeatureFlagDetails()
     const isQuotaLimited = storedDetails?.quotaLimited?.includes(QuotaLimitedFeature.FeatureFlags)
     const featureFlag = details?.flags[key]
-    const sendEvent = (options.sendEvent ?? this.sendFeatureFlagEvent) && !this.flagCallReported[key]
     const flagValue: FeatureFlagValue | undefined = getFeatureFlagValue(featureFlag)
+    const sendEvent = (options.sendEvent ?? this.sendFeatureFlagEvent) && !this.flagCallReported[key]?.has(flagValue)
 
     if (sendEvent) {
       const errors: string[] = []
@@ -1003,7 +1006,8 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       const bootstrappedPayload = this.getBootstrappedFeatureFlagPayloads()?.[key]
       const featureFlagError = errors.length > 0 ? errors.join(',') : undefined
 
-      this.flagCallReported[key] = true
+      this.flagCallReported[key] = this.flagCallReported[key] ?? new Set()
+      this.flagCallReported[key].add(flagValue)
 
       const properties: Record<string, any> = {
         $feature_flag: key,
@@ -1245,9 +1249,6 @@ export abstract class PostHogCore extends PostHogCoreStateless {
         }
       }
 
-      if (this.sendFeatureFlagEvent) {
-        this.flagCallReported = {}
-      }
       this.setKnownFeatureFlagDetails({ flags: flagDetails })
     })
   }

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -730,6 +730,20 @@ describe('PostHog Node.js', () => {
       jest.useFakeTimers()
     })
 
+    it('clears feature flag call dedupe state on shutdown', async () => {
+      const ph = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        fetchRetryCount: 0,
+        flushAt: 1,
+        disableCompression: true,
+      })
+
+      ;(ph as any).distinctIdHasSentFlagCalls = { user: new Set(['flag_true']) }
+      await ph.shutdown()
+
+      expect((ph as any).distinctIdHasSentFlagCalls).toEqual({})
+    })
+
     it('should shutdown cleanly', async () => {
       const ph = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2200,6 +2200,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     try {
       return await super._shutdown(shutdownTimeoutMs)
     } finally {
+      this.distinctIdHasSentFlagCalls = {}
       resolve?.()
     }
   }


### PR DESCRIPTION
## Problem

Feature flag called events could be emitted again for the same flag response after flags were reloaded or updated. This adds noise to `$feature_flag_called` analytics while still needing to report when a flag's returned value actually changes.

## Changes

- Track feature flag called dedupe state by flag key and returned response in `@posthog/core`.
- Stop clearing core feature flag called dedupe state on flag reload/update; clear it on shutdown instead.
- Clear Node.js feature flag called dedupe state on shutdown.
- Update core v1/v4 feature flag tests and add a Node.js shutdown regression test.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi implementation agent prepared the PR from the existing dedicated worktree at the maintainer's request. The change keeps `$feature_flag_called` deduplication tied to each returned flag value and includes targeted regression tests for core and Node.js behavior.
