### PR TITLE
fix(core): isFeatureEnabled returns false instead of undefined

### DIFF
--- a/.changeset/fix-is-feature-enabled-return-false.md
+++ b/.changeset/fix-is-feature-enabled-return-false.md
@@ -1,0 +1,6 @@
+---
+"@posthog/core": patch
+"@posthog/types": patch
+---
+
+fix(core): isFeatureEnabled returns false instead of undefined when flag is not found

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -144,9 +144,9 @@ describe('PostHog Feature Flags v4', () => {
       expect(posthog.getFeatureFlagPayload('my-flag')).toEqual(undefined)
     })
 
-    it('isFeatureEnabled should return undefined if not loaded', () => {
-      expect(posthog.isFeatureEnabled('my-flag')).toEqual(undefined)
-      expect(posthog.isFeatureEnabled('feature-1')).toEqual(undefined)
+    it('isFeatureEnabled should return false if not loaded', () => {
+      expect(posthog.isFeatureEnabled('my-flag')).toEqual(false)
+      expect(posthog.isFeatureEnabled('feature-1')).toEqual(false)
     })
 
     it('should load persisted feature flags', () => {
@@ -332,9 +332,9 @@ describe('PostHog Feature Flags v4', () => {
           expect(posthog.getFeatureFlag('feature-variant')).toEqual(undefined)
           expect(posthog.getFeatureFlag('feature-missing')).toEqual(undefined)
 
-          expect(posthog.isFeatureEnabled('feature-1')).toEqual(undefined)
-          expect(posthog.isFeatureEnabled('feature-variant')).toEqual(undefined)
-          expect(posthog.isFeatureEnabled('feature-missing')).toEqual(undefined)
+          expect(posthog.isFeatureEnabled('feature-1')).toEqual(false)
+          expect(posthog.isFeatureEnabled('feature-variant')).toEqual(false)
+          expect(posthog.isFeatureEnabled('feature-missing')).toEqual(false)
 
           // When errored out, we return cached values (which are empty in this case)
           expect(posthog.getFeatureFlagPayloads()).toEqual({})

--- a/packages/core/src/__tests__/posthog.featureflags.v1.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.v1.spec.ts
@@ -84,9 +84,9 @@ describe('PostHog Feature Flags v1', () => {
       expect(posthog.getFeatureFlagPayload('my-flag')).toEqual(undefined)
     })
 
-    it('isFeatureEnabled should return undefined if not loaded', () => {
-      expect(posthog.isFeatureEnabled('my-flag')).toEqual(undefined)
-      expect(posthog.isFeatureEnabled('feature-1')).toEqual(undefined)
+    it('isFeatureEnabled should return false if not loaded', () => {
+      expect(posthog.isFeatureEnabled('my-flag')).toEqual(false)
+      expect(posthog.isFeatureEnabled('feature-1')).toEqual(false)
     })
 
     it('should load legacy persisted feature flags', () => {
@@ -185,9 +185,9 @@ describe('PostHog Feature Flags v1', () => {
           expect(posthog.getFeatureFlag('feature-variant')).toEqual(undefined)
           expect(posthog.getFeatureFlag('feature-missing')).toEqual(undefined)
 
-          expect(posthog.isFeatureEnabled('feature-1')).toEqual(undefined)
-          expect(posthog.isFeatureEnabled('feature-variant')).toEqual(undefined)
-          expect(posthog.isFeatureEnabled('feature-missing')).toEqual(undefined)
+          expect(posthog.isFeatureEnabled('feature-1')).toEqual(false)
+          expect(posthog.isFeatureEnabled('feature-variant')).toEqual(false)
+          expect(posthog.isFeatureEnabled('feature-missing')).toEqual(false)
 
           // When errored out, we return cached values (which are empty in this case)
           expect(posthog.getFeatureFlagPayloads()).toEqual({})

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -1142,10 +1142,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     }
   }
 
-  isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean | undefined {
+  isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean {
     const response = this.getFeatureFlag(key, options)
     if (response === undefined) {
-      return undefined
+      return false
     }
     return !!response
   }

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -959,9 +959,9 @@ export class PostHog extends PostHogCore {
    *
    * @param key The feature flag key
    * @param options Optional per-call settings
-   * @returns True if enabled, false if disabled, undefined if not loaded
+   * @returns True if enabled, false if disabled
    */
-  isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean | undefined {
+  isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean {
     return super.isFeatureEnabled(key, options)
   }
 

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -333,7 +333,7 @@ export interface PostHog {
      * @param options.fresh - If true, only return values loaded from the server, not cached localStorage values (default: false)
      * @returns Whether the feature flag is enabled
      */
-    isFeatureEnabled(key: string, options?: FeatureFlagOptions): boolean | undefined
+    isFeatureEnabled(key: string, options?: FeatureFlagOptions): boolean
 
     /**
      * Reload feature flags from the server.


### PR DESCRIPTION
## Problem

`isFeatureEnabled` in `@posthog/core` declares a return type of `boolean | undefined` and returns `undefined` when the underlying `getFeatureFlag` call finds no cached flag value. This third state is unnecessary: the function's semantics are \"is this flag enabled?\", and the answer to that question when a flag is absent or not yet loaded is `false`, not an unknown.

Closes #3930

## Changes

`isFeatureEnabled` in `packages/core/src/posthog-core.ts` now returns `false` instead of `undefined` when `getFeatureFlag` returns `undefined`. The return type is narrowed from `boolean | undefined` to `boolean`. The interface in `packages/types/src/posthog.ts` is updated to match.

Tests in `posthog.featureflags.spec.ts` and `posthog.featureflags.v1.spec.ts` that previously asserted `undefined` for the not-loaded and error-state cases are updated to assert `false`.

Note: `posthog-featureflags.ts` in the browser package has its own `isFeatureEnabled` that retains `undefined` for the \"flags still loading\" state — that is an intentional, separate concern and is not changed here.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude Code to help identify the issue, draft the fix, and update the affected test files. Reviewed the changes and verified the browser package's `isFeatureEnabled` was intentionally left unchanged (it has a distinct "not-yet-loaded" semantic that warrants the `undefined` return). The rebase and changeset were also done with Claude's assistance.