### PR TITLE
perf(browser): speed up truncated log capture

### DIFF
--- a/.changeset/slow-logs-walk.md
+++ b/.changeset/slow-logs-walk.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Improve console log capture performance for truncated large objects.

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -152,6 +152,28 @@ describe('logs entrypoint', () => {
             )
         })
 
+        it('should preserve bounded attributes when the log body is truncated', () => {
+            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+            initializeLogs(mockPostHog)
+
+            assignableWindow.console.log({
+                code: 'E_TOO_LARGE',
+                userId: 'user-123',
+                payload: 'x'.repeat(10001),
+            })
+
+            expect(mockEmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.stringContaining('...'),
+                    attributes: expect.objectContaining({
+                        body_truncated: 'true',
+                        code: 'E_TOO_LARGE',
+                        userId: 'user-123',
+                    }),
+                })
+            )
+        })
+
         it('should not read object properties after the body size limit is reached', () => {
             const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
             initializeLogs(mockPostHog)

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -451,6 +451,10 @@ describe('logs entrypoint', () => {
             expect(mockEmit.mock.calls[0][0].attributes).toEqual(
                 expect.objectContaining({
                     'log.source': 'console.error',
+                    code: 'E_BOOM',
+                    name: 'CustomError',
+                    message: 'boom',
+                    stack: 'CustomError: boom\n    at test',
                 })
             )
         })

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -97,7 +97,7 @@ const collectFlattenedAttributes = (value: any, key: string, collector: Attribut
         return
     }
 
-    if (typeof value === 'object' && !isNull(value) && !isArray(value)) {
+    if (isObject(value)) {
         if (collector.seen.has(value)) {
             collectAttributeValue(key || 'circular', '[Circular]', collector)
             return

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -325,7 +325,9 @@ const initializeLogs = (posthog: PostHog) => {
                             attributes: {
                                 'log.source': `console.${level}`,
                                 ...logAttributes,
-                                ...(isObject(args[0]) ? flattenObject(args[0]) : {}),
+                                // If the body already hit the size limit, avoid walking the same large object
+                                // again just to collect duplicate partial attributes.
+                                ...(!truncated && isObject(args[0]) ? flattenObject(args[0]) : {}),
                             },
                         })
                     }

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -197,7 +197,7 @@ const stringifyValueWithLimit = (
         try {
             errorObject.stack = value.stack
         } catch {}
-        return stringifyValueWithLimit(errorObject, parts, budget, seen, inArray)
+        return stringifyValueWithLimit(errorObject, parts, budget, seen, inArray, attributeCollector)
     }
 
     if (isArray(value)) {

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -11,6 +11,14 @@ type StringifyBudget = {
     truncated: boolean
 }
 
+type AttributeCollector = {
+    result: Record<string, any>
+    keysRemaining: number
+    sizeRemaining: number
+    truncated: boolean
+    seen: WeakSet<object>
+}
+
 const appendWithLimit = (parts: string[], text: string, budget: StringifyBudget): boolean => {
     if (budget.remaining <= 0) {
         budget.truncated = true
@@ -68,12 +76,65 @@ const isNumberOrBoolean = (value: any): boolean => {
     }
 }
 
+const collectAttributeValue = (key: string, value: any, collector: AttributeCollector): void => {
+    if (collector.truncated) {
+        return
+    }
+
+    collector.keysRemaining -= 1
+    collector.sizeRemaining -= String(value).length + key.length
+    if (collector.keysRemaining <= 0 || collector.sizeRemaining <= 0) {
+        collector.truncated = true
+        collector.result['attributes_truncated'] = true
+        return
+    }
+
+    collector.result[key] = value
+}
+
+const collectFlattenedAttributes = (value: any, key: string, collector: AttributeCollector): void => {
+    if (collector.truncated) {
+        return
+    }
+
+    if (typeof value === 'object' && !isNull(value) && !isArray(value)) {
+        if (collector.seen.has(value)) {
+            collectAttributeValue(key || 'circular', '[Circular]', collector)
+            return
+        }
+        collector.seen.add(value)
+
+        try {
+            for (const childKey in value) {
+                try {
+                    if (!Object.prototype.hasOwnProperty.call(value, childKey)) {
+                        continue
+                    }
+                    const childValue = value[childKey]
+                    collectFlattenedAttributes(childValue, key ? `${key}.${childKey}` : childKey, collector)
+                    if (collector.truncated) {
+                        return
+                    }
+                } catch {
+                    continue
+                }
+            }
+        } catch {
+            // we'll omit this object's properties considering we can't enumerate them
+        }
+        return
+    }
+
+    collectAttributeValue(key, value, collector)
+}
+
 const stringifyValueWithLimit = (
     value: any,
     parts: string[],
     budget: StringifyBudget,
     seen: WeakSet<object>,
-    inArray = false
+    inArray = false,
+    attributeCollector?: AttributeCollector
 ): boolean => {
     if (!isJSONSerializablePrimitive(value)) {
         return inArray ? appendWithLimit(parts, 'null', budget) : true
@@ -180,6 +241,14 @@ const stringifyValueWithLimit = (
             } catch {
                 continue
             }
+            if (attributeCollector) {
+                try {
+                    collectFlattenedAttributes(propertyValue, key, attributeCollector)
+                } catch {
+                    // we'll omit this object's attributes considering we can't read them safely
+                }
+            }
+
             if (!isJSONSerializablePrimitive(propertyValue)) {
                 continue
             }
@@ -221,14 +290,36 @@ const stringifyValueWithLimit = (
     return appendWithLimit(parts, '}', budget)
 }
 
-const stringifyArgsSafely = (args: any[], sizeLimit: number): { body: string; truncated: boolean } => {
+const stringifyArgsSafely = (
+    args: any[],
+    sizeLimit: number
+): { body: string; truncated: boolean; attributes: Record<string, any> } => {
     const parts: string[] = []
     const budget = { remaining: sizeLimit, truncated: false }
+    const attributeCollector = isObject(args[0])
+        ? {
+              result: {} as Record<string, any>,
+              keysRemaining: LOG_ATTRIBUTES_LIMIT,
+              sizeRemaining: LOG_BODY_SIZE_LIMIT,
+              truncated: false,
+              seen: new WeakSet<object>([args[0]]),
+          }
+        : undefined
+
     for (let i = 0; i < args.length; i++) {
         if (i > 0 && !appendWithLimit(parts, ' ', budget)) {
             break
         }
-        if (!stringifyValueWithLimit(args[i], parts, budget, new WeakSet<object>())) {
+        if (
+            !stringifyValueWithLimit(
+                args[i],
+                parts,
+                budget,
+                new WeakSet<object>(),
+                false,
+                i === 0 ? attributeCollector : undefined
+            )
+        ) {
             break
         }
     }
@@ -236,57 +327,8 @@ const stringifyArgsSafely = (args: any[], sizeLimit: number): { body: string; tr
     return {
         body: parts.join('') + (budget.truncated ? '...' : ''),
         truncated: budget.truncated,
+        attributes: attributeCollector?.result || {},
     }
-}
-
-/**
- * Flattens a nested object into a single level dot-notation object.
- * By default limit to 200kB or 50 keys.
- */
-const flattenObject = (
-    obj: any,
-    prefix = '',
-    result = {} as Record<string, any>,
-    keys_limit = LOG_ATTRIBUTES_LIMIT,
-    size_limit = LOG_BODY_SIZE_LIMIT,
-    seen = new WeakSet()
-) => {
-    if (seen.has(obj)) {
-        result[prefix || 'circular'] = '[Circular]'
-        return result
-    }
-    seen.add(obj)
-
-    try {
-        for (const key in obj) {
-            try {
-                if (!Object.prototype.hasOwnProperty.call(obj, key)) {
-                    continue
-                }
-                const value = obj[key]
-                const newKey = prefix ? `${prefix}.${key}` : key
-
-                if (isObject(value)) {
-                    flattenObject(value, newKey, result, keys_limit, size_limit, seen)
-                } else {
-                    keys_limit -= 1
-                    size_limit -= String(value).length
-                    size_limit -= newKey.length
-                    if (keys_limit <= 0 || size_limit <= 0) {
-                        result['attributes_truncated'] = true
-                        return
-                    } else {
-                        result[newKey] = value
-                    }
-                }
-            } catch {
-                continue
-            }
-        }
-    } catch {
-        // we'll omit this object's properties considering we can't enumerate them
-    }
-    return result
 }
 
 type ConsoleLevel = 'debug' | 'log' | 'warn' | 'error' | 'info'
@@ -313,7 +355,11 @@ const initializeLogs = (posthog: PostHog) => {
             (...args: any[]) => {
                 try {
                     if (args.length > 0 && posthog.is_capturing()) {
-                        const { body, truncated } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
+                        const {
+                            body,
+                            truncated,
+                            attributes: flattenedAttributes,
+                        } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
                         const logAttributes = {
                             ...attributes,
                             ...(truncated ? { body_truncated: 'true' } : {}),
@@ -325,9 +371,7 @@ const initializeLogs = (posthog: PostHog) => {
                             attributes: {
                                 'log.source': `console.${level}`,
                                 ...logAttributes,
-                                // If the body already hit the size limit, avoid walking the same large object
-                                // again just to collect duplicate partial attributes.
-                                ...(!truncated && isObject(args[0]) ? flattenObject(args[0]) : {}),
+                                ...flattenedAttributes,
                             },
                         })
                     }


### PR DESCRIPTION
## Problem

Console log capture performance tests can be flaky on CI for large objects with many keys. The motivating CI failure was [the logs performance test exceeding the 100ms threshold](https://github.com/PostHog/posthog-js/actions/runs/28094176074/job/83179337718?pr=3939). Profiling showed the hot path walked large objects twice: once to build the bounded log body and again to flatten object attributes.

## Changes

- Collect flattened attributes during the bounded body serialization pass, avoiding a second walk over the same large object.
- Preserve bounded structured attributes even when the serialized body is truncated.
- Added regression coverage for preserving useful attributes on truncated large logs.
- Added a patch changeset for `posthog-js`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An agent profiled the flaky logs performance path and found time split between bounded body serialization and flattening the same large object into attributes. After review feedback, the fix now keeps structured attributes for truncated logs while avoiding the duplicate root-object walk by collecting attributes during serialization. Verification included the targeted logs entrypoint Jest suite, ESLint for the changed files, browser typecheck, and `git diff --check`.
