### PR TITLE
fix(webpack-plugin): delete CSS sourcemaps after upload

### DIFF
--- a/.changeset/delete-css-sourcemaps.md
+++ b/.changeset/delete-css-sourcemaps.md
@@ -1,0 +1,6 @@
+---
+"@posthog/nextjs-config": patch
+"@posthog/webpack-plugin": patch
+---
+
+Delete emitted CSS source maps when `deleteAfterUpload` is enabled without uploading CSS assets to PostHog.

--- a/.changeset/delete-css-sourcemaps.md
+++ b/.changeset/delete-css-sourcemaps.md
@@ -1,5 +1,4 @@
 ---
-"@posthog/nextjs-config": patch
 "@posthog/webpack-plugin": patch
 ---
 

--- a/packages/webpack-plugin/jest.config.mjs
+++ b/packages/webpack-plugin/jest.config.mjs
@@ -1,0 +1,15 @@
+import { createDefaultPreset } from 'ts-jest'
+
+const tsJestTransformCfg = createDefaultPreset().transform
+
+/** @type {import('jest').Config} **/
+export default {
+    testEnvironment: 'node',
+    testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+    transform: {
+        ...tsJestTransformCfg,
+    },
+    moduleNameMapper: {
+        '^@posthog/plugin-utils$': '<rootDir>/../plugin-utils/src',
+    },
+}

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -26,7 +26,8 @@
     },
     "files": [
         "dist",
-        "src"
+        "src",
+        "!src/**/*.spec.ts"
     ],
     "peerDependencies": {
         "webpack": "^5"
@@ -35,6 +36,7 @@
         "@posthog-tooling/tsconfig-base": "workspace:*",
         "@rslib/core": "catalog:",
         "jest": "catalog:",
+        "ts-jest": "catalog:",
         "webpack": "^5"
     },
     "scripts": {

--- a/packages/webpack-plugin/rslib.config.mjs
+++ b/packages/webpack-plugin/rslib.config.mjs
@@ -6,4 +6,10 @@ export default defineConfig({
     shims: { esm: { __dirname: true } },
     syntax: 'es6',
     lib: [{ format: 'esm' }, { format: 'cjs' }],
+    source: {
+        entry: {
+            index: 'src/index.ts',
+        },
+        tsconfigPath: './tsconfig.build.json',
+    },
 })

--- a/packages/webpack-plugin/src/index.spec.ts
+++ b/packages/webpack-plugin/src/index.spec.ts
@@ -1,0 +1,107 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import type webpack from 'webpack'
+import { runSourcemapCli } from '@posthog/plugin-utils'
+import { PosthogWebpackPlugin } from './index'
+import type { ResolvedPluginConfig } from './config'
+
+jest.mock(
+    '@posthog/core',
+    () => ({
+        createLogger: () => ({ error: jest.fn() }),
+    }),
+    { virtual: true }
+)
+
+jest.mock('@posthog/plugin-utils', () => ({
+    runSourcemapCli: jest.fn().mockResolvedValue(undefined),
+}))
+
+const runSourcemapCliMock = runSourcemapCli as jest.MockedFunction<typeof runSourcemapCli>
+
+const config: ResolvedPluginConfig = {
+    personalApiKey: 'phx_test',
+    projectId: '1',
+    host: 'https://us.i.posthog.com',
+    logLevel: 'info',
+    cliBinaryPath: 'posthog-cli',
+    sourcemaps: {
+        enabled: true,
+        deleteAfterUpload: true,
+    },
+}
+
+type TestAsset = { name: string }
+type TestChunk = { files: Set<string> }
+
+function createCompilation(outputDirectory: string, chunks: TestChunk[], assets: TestAsset[]): webpack.Compilation {
+    return {
+        outputOptions: { path: outputDirectory },
+        chunks: new Set(chunks),
+        getAssets: () => assets,
+    } as unknown as webpack.Compilation
+}
+
+async function exists(filePath: string): Promise<boolean> {
+    try {
+        await fs.access(filePath)
+        return true
+    } catch {
+        return false
+    }
+}
+
+describe('PosthogWebpackPlugin', () => {
+    let outputDirectory: string
+
+    beforeEach(async () => {
+        runSourcemapCliMock.mockClear()
+        outputDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-webpack-plugin-'))
+    })
+
+    afterEach(async () => {
+        await fs.rm(outputDirectory, { force: true, recursive: true })
+    })
+
+    it('deletes emitted CSS source maps after upload when deleteAfterUpload is enabled', async () => {
+        const cssSourceMap = path.join(outputDirectory, 'static/css/app.css.map')
+        await fs.mkdir(path.dirname(cssSourceMap), { recursive: true })
+        await fs.writeFile(cssSourceMap, '{}')
+
+        const plugin = new PosthogWebpackPlugin(config, true)
+        const compilation = createCompilation(
+            outputDirectory,
+            [{ files: new Set(['static/chunks/app.js']) }],
+            [{ name: 'static/css/app.css.map' }]
+        )
+
+        await plugin.processSourceMaps(compilation, config)
+
+        expect(await exists(cssSourceMap)).toBe(false)
+    })
+
+    it('keeps emitted CSS source maps after upload when deleteAfterUpload is disabled', async () => {
+        const cssSourceMap = path.join(outputDirectory, 'static/css/app.css.map')
+        await fs.mkdir(path.dirname(cssSourceMap), { recursive: true })
+        await fs.writeFile(cssSourceMap, '{}')
+
+        const keepSourceMapsConfig = {
+            ...config,
+            sourcemaps: {
+                ...config.sourcemaps,
+                deleteAfterUpload: false,
+            },
+        }
+        const plugin = new PosthogWebpackPlugin(keepSourceMapsConfig, true)
+        const compilation = createCompilation(
+            outputDirectory,
+            [{ files: new Set(['static/chunks/app.js']) }],
+            [{ name: 'static/css/app.css.map' }]
+        )
+
+        await plugin.processSourceMaps(compilation, keepSourceMapsConfig)
+
+        expect(await exists(cssSourceMap)).toBe(true)
+    })
+})

--- a/packages/webpack-plugin/src/index.spec.ts
+++ b/packages/webpack-plugin/src/index.spec.ts
@@ -6,10 +6,12 @@ import { runSourcemapCli } from '@posthog/plugin-utils'
 import { PosthogWebpackPlugin } from './index'
 import type { ResolvedPluginConfig } from './config'
 
+const mockLoggerError = jest.fn()
+
 jest.mock(
     '@posthog/core',
     () => ({
-        createLogger: () => ({ error: jest.fn() }),
+        createLogger: () => ({ error: mockLoggerError }),
     }),
     { virtual: true }
 )
@@ -57,10 +59,12 @@ describe('PosthogWebpackPlugin', () => {
 
     beforeEach(async () => {
         runSourcemapCliMock.mockClear()
+        mockLoggerError.mockClear()
         outputDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-webpack-plugin-'))
     })
 
     afterEach(async () => {
+        jest.restoreAllMocks()
         await fs.rm(outputDirectory, { force: true, recursive: true })
     })
 
@@ -97,5 +101,39 @@ describe('PosthogWebpackPlugin', () => {
         await plugin.processSourceMaps(compilation, testConfig)
 
         expect(await exists(cssSourceMap)).toBe(expectedExists)
+    })
+
+    it('continues deleting CSS source maps and logs each deletion failure', async () => {
+        const originalRm = fs.rm.bind(fs)
+        const failedCssSourceMap = path.join(outputDirectory, 'static/css/app.css.map')
+        const deletedCssSourceMap = path.join(outputDirectory, 'static/css/vendor.css.map')
+        await fs.mkdir(path.dirname(failedCssSourceMap), { recursive: true })
+        await fs.writeFile(failedCssSourceMap, '{}')
+        await fs.writeFile(deletedCssSourceMap, '{}')
+
+        jest.spyOn(fs, 'rm').mockImplementation(async (filePath, options) => {
+            if (filePath === failedCssSourceMap) {
+                throw new Error('permission denied')
+            }
+
+            return originalRm(filePath, options)
+        })
+
+        const plugin = new PosthogWebpackPlugin(config, true)
+        const compilation = createCompilation(
+            outputDirectory,
+            [{ files: new Set(['static/chunks/app.js']) }],
+            [{ name: 'static/css/app.css.map' }, { name: 'static/css/vendor.css.map' }]
+        )
+
+        await plugin.processSourceMaps(compilation, config)
+
+        expect(await exists(failedCssSourceMap)).toBe(true)
+        expect(await exists(deletedCssSourceMap)).toBe(false)
+        expect(mockLoggerError).toHaveBeenCalledWith(
+            'PostHog sourcemaps uploaded, but failed to delete CSS source map:',
+            failedCssSourceMap,
+            'permission denied'
+        )
     })
 })

--- a/packages/webpack-plugin/src/index.spec.ts
+++ b/packages/webpack-plugin/src/index.spec.ts
@@ -64,44 +64,38 @@ describe('PosthogWebpackPlugin', () => {
         await fs.rm(outputDirectory, { force: true, recursive: true })
     })
 
-    it('deletes emitted CSS source maps after upload when deleteAfterUpload is enabled', async () => {
+    it.each([
+        {
+            deleteAfterUpload: true,
+            expectedExists: false,
+            label: 'deletes emitted CSS source maps after upload when deleteAfterUpload is enabled',
+        },
+        {
+            deleteAfterUpload: false,
+            expectedExists: true,
+            label: 'keeps emitted CSS source maps after upload when deleteAfterUpload is disabled',
+        },
+    ])('$label', async ({ deleteAfterUpload, expectedExists }) => {
         const cssSourceMap = path.join(outputDirectory, 'static/css/app.css.map')
         await fs.mkdir(path.dirname(cssSourceMap), { recursive: true })
         await fs.writeFile(cssSourceMap, '{}')
 
-        const plugin = new PosthogWebpackPlugin(config, true)
-        const compilation = createCompilation(
-            outputDirectory,
-            [{ files: new Set(['static/chunks/app.js']) }],
-            [{ name: 'static/css/app.css.map' }]
-        )
-
-        await plugin.processSourceMaps(compilation, config)
-
-        expect(await exists(cssSourceMap)).toBe(false)
-    })
-
-    it('keeps emitted CSS source maps after upload when deleteAfterUpload is disabled', async () => {
-        const cssSourceMap = path.join(outputDirectory, 'static/css/app.css.map')
-        await fs.mkdir(path.dirname(cssSourceMap), { recursive: true })
-        await fs.writeFile(cssSourceMap, '{}')
-
-        const keepSourceMapsConfig = {
+        const testConfig = {
             ...config,
             sourcemaps: {
                 ...config.sourcemaps,
-                deleteAfterUpload: false,
+                deleteAfterUpload,
             },
         }
-        const plugin = new PosthogWebpackPlugin(keepSourceMapsConfig, true)
+        const plugin = new PosthogWebpackPlugin(testConfig, true)
         const compilation = createCompilation(
             outputDirectory,
             [{ files: new Set(['static/chunks/app.js']) }],
             [{ name: 'static/css/app.css.map' }]
         )
 
-        await plugin.processSourceMaps(compilation, keepSourceMapsConfig)
+        await plugin.processSourceMaps(compilation, testConfig)
 
-        expect(await exists(cssSourceMap)).toBe(true)
+        expect(await exists(cssSourceMap)).toBe(expectedExists)
     })
 })

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -3,6 +3,7 @@ import { PluginConfig, resolveConfig, ResolvedPluginConfig } from './config'
 import { runSourcemapCli } from '@posthog/plugin-utils'
 import webpack from 'webpack'
 import path from 'path'
+import fs from 'fs/promises'
 
 export * from './config'
 
@@ -67,5 +68,18 @@ export class PosthogWebpackPlugin {
         )
 
         await runSourcemapCli(config, { filePaths })
+
+        if (config.sourcemaps.deleteAfterUpload) {
+            await this.deleteCssSourceMaps(compilation, outputDirectory)
+        }
+    }
+
+    private async deleteCssSourceMaps(compilation: webpack.Compilation, outputDirectory: string): Promise<void> {
+        const cssSourceMaps = compilation
+            .getAssets()
+            .filter((asset) => asset.name.endsWith('.css.map'))
+            .map((asset) => path.resolve(outputDirectory, asset.name))
+
+        await Promise.all(cssSourceMaps.map((filePath) => fs.rm(filePath, { force: true })))
     }
 }

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -80,6 +80,19 @@ export class PosthogWebpackPlugin {
             .filter((asset) => asset.name.endsWith('.css.map'))
             .map((asset) => path.resolve(outputDirectory, asset.name))
 
-        await Promise.all(cssSourceMaps.map((filePath) => fs.rm(filePath, { force: true })))
+        const deletionResults = await Promise.allSettled(
+            cssSourceMaps.map((filePath) => fs.rm(filePath, { force: true }))
+        )
+
+        deletionResults.forEach((result, index) => {
+            if (result.status === 'rejected') {
+                const errorMessage = result.reason instanceof Error ? result.reason.message : result.reason
+                this.logger.error(
+                    'PostHog sourcemaps uploaded, but failed to delete CSS source map:',
+                    cssSourceMaps[index],
+                    errorMessage
+                )
+            }
+        })
     }
 }

--- a/packages/webpack-plugin/tsconfig.build.json
+++ b/packages/webpack-plugin/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src/**/*"],
+    "exclude": ["src/**/*.spec.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1602,6 +1602,9 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
+      ts-jest:
+        specifier: 'catalog:'
+        version: 29.4.11(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))(typescript@5.8.2)
       webpack:
         specifier: ^5
         version: 5.102.1(esbuild@0.25.10)


### PR DESCRIPTION
## Problem

`@posthog/nextjs-config` users with SCSS/CSS source maps can still end up with `.next/static/css/**/*.css.map` files in production output after source map upload. We should remove those maps when `deleteAfterUpload` is enabled, but not upload CSS assets to PostHog since error tracking does not process them.

Fixes #2383

Partially addresses #2527 by deleting browser CSS sourcemaps from webpack output when `deleteAfterUpload` is enabled.

## Changes

- Deletes emitted CSS source map assets from the webpack output after the sourcemap CLI succeeds and `deleteAfterUpload` is enabled.
- Leaves the sourcemap CLI input unchanged so CSS assets are not uploaded as a side effect.
- Adds parameterized webpack plugin tests for deleting CSS maps when enabled and keeping them when disabled.
- Adds webpack plugin test/build config so specs are runnable but excluded from packaged/build entries.
- Limits the changeset to `@posthog/webpack-plugin`, since no `@posthog/nextjs-config` source changed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [x] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi in a dedicated worktree. The approach follows reviewer guidance from #3949: CSS source maps are deleted when `deleteAfterUpload` is enabled, without adding CSS assets to sourcemap upload processing.

Validation run:

```bash
pnpm --filter=@posthog/webpack-plugin lint
pnpm --filter=@posthog/webpack-plugin test:unit
pnpm turbo --filter=@posthog/webpack-plugin build
pnpm install --frozen-lockfile --lockfile-only --ignore-scripts --config.trust-policy=ignore
git diff --check
```


