### PR TITLE
fix: Address triaged easy bug reports

### DIFF
--- a/.changeset/clever-hedgehogs-fix.md
+++ b/.changeset/clever-hedgehogs-fix.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+'@posthog/ai': patch
+'@posthog/webpack-plugin': patch
+---
+
+Fix triaged browser serialization, OpenAI background response, webpack CSS sourcemap, and React peer metadata issues.

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -81,6 +81,20 @@ function preserveAPIPromiseHelpers<Input, Output>(
   return apiPromise
 }
 
+const TERMINAL_RESPONSE_STATUSES = new Set(['completed', 'failed', 'cancelled', 'incomplete'])
+
+function isPendingBackgroundResponse(
+  params: { background?: boolean | null },
+  response: { status?: string | null; usage?: unknown | null }
+): boolean {
+  return (
+    params.background === true &&
+    !response.usage &&
+    !!response.status &&
+    !TERMINAL_RESPONSE_STATUSES.has(response.status)
+  )
+}
+
 export class PostHogOpenAI extends OpenAIOrignal {
   private readonly phClient: PostHog
   public chat: WrappedChat
@@ -593,6 +607,10 @@ export class WrappedResponses extends Responses {
       const wrappedPromise = parentPromise.then(
         async (result) => {
           if ('output' in result) {
+            if (isPendingBackgroundResponse(openAIParams, result)) {
+              return result
+            }
+
             const latency = (Date.now() - startTime) / 1000
             const availableTools = extractAvailableToolCalls('openai', openAIParams)
             const formattedOutput = formatResponseOpenAI({ output: result.output })
@@ -669,6 +687,10 @@ export class WrappedResponses extends Responses {
 
       const wrappedPromise = parentPromise.then(
         async (result) => {
+          if (isPendingBackgroundResponse(openAIParams, result)) {
+            return result
+          }
+
           const latency = (Date.now() - startTime) / 1000
           await captureAiGeneration(this.phClient, {
             ...posthogParams,

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -745,6 +745,49 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
   })
 
+  test('responses create skips queued background responses without usage', async () => {
+    mockOpenAiParsedResponse = {
+      ...mockOpenAiParsedResponse,
+      id: 'resp_queued',
+      status: 'queued',
+      output: [],
+      usage: null,
+    } as unknown as ParsedResponse<any>
+
+    const response = await client.responses.create({
+      model: 'gpt-4o-2024-08-06',
+      input: [{ role: 'user', content: 'Hello' }],
+      background: true,
+      posthogDistinctId: 'test-id',
+    } as any)
+
+    expect(response).toEqual(mockOpenAiParsedResponse)
+    expect(mockPostHogClient.capture).not.toHaveBeenCalled()
+    expect(mockPostHogClient.captureImmediate).not.toHaveBeenCalled()
+  })
+
+  test('responses parse skips queued background responses without usage', async () => {
+    mockOpenAiParsedResponse = {
+      ...mockOpenAiParsedResponse,
+      id: 'resp_queued_parse',
+      status: 'queued',
+      output: [],
+      usage: null,
+    } as unknown as ParsedResponse<any>
+
+    const response = await client.responses.parse({
+      model: 'gpt-4o-2024-08-06',
+      input: [{ role: 'user', content: 'Hello' }],
+      background: true,
+      text: { format: { type: 'text' } },
+      posthogDistinctId: 'test-id',
+    } as any)
+
+    expect(response).toEqual(mockOpenAiParsedResponse)
+    expect(mockPostHogClient.capture).not.toHaveBeenCalled()
+    expect(mockPostHogClient.captureImmediate).not.toHaveBeenCalled()
+  })
+
   conditionalTest('responses parse with instructions parameter', async () => {
     const response = await client.responses.parse({
       model: 'gpt-4o-2024-08-06',

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -60,6 +60,14 @@
         "rrweb-types/package.json",
         "rrweb-plugin-console-record/package.json"
     ],
+    "peerDependencies": {
+        "react": ">=16.8.0"
+    },
+    "peerDependenciesMeta": {
+        "react": {
+            "optional": true
+        }
+    },
     "dependencies": {
         "@posthog/core": "workspace:^",
         "@posthog/types": "workspace:^",

--- a/packages/browser/src/__tests__/package-metadata.test.ts
+++ b/packages/browser/src/__tests__/package-metadata.test.ts
@@ -1,0 +1,15 @@
+import fs from 'fs'
+import path from 'path'
+
+const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'))
+
+describe('package metadata', () => {
+    it('declares react as an optional peer for the legacy posthog-js/react entrypoint', () => {
+        expect(packageJson.files).toEqual(expect.arrayContaining(['react/dist/**', 'react/package.json']))
+        expect(packageJson.peerDependencies).toEqual(expect.objectContaining({ react: '>=16.8.0' }))
+        expect(packageJson.peerDependenciesMeta).toEqual(
+            expect.objectContaining({ react: expect.objectContaining({ optional: true }) })
+        )
+        expect(packageJson.dependencies?.react).toBeUndefined()
+    })
+})

--- a/packages/browser/src/__tests__/request-queue.test.ts
+++ b/packages/browser/src/__tests__/request-queue.test.ts
@@ -133,6 +133,37 @@ describe('RequestQueue', () => {
             })
         })
 
+        it('keeps flushing queued requests if one request throws', () => {
+            sendRequest = jest.fn((req) => {
+                if (req.url === '/e') {
+                    throw new RangeError('Invalid string length')
+                }
+            })
+            queue = new RequestQueue(sendRequest, {})
+            queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: EPOCH - 3000 } })
+            queue.enqueue({ url: '/identify', data: { event: '$identify', timestamp: EPOCH - 2000 } })
+
+            queue.enable()
+            expect(() => jest.runOnlyPendingTimers()).not.toThrow()
+
+            expect(sendRequest).toHaveBeenCalledTimes(2)
+        })
+
+        it('keeps sending unload requests if one request throws', () => {
+            sendRequest = jest.fn((req) => {
+                if (req.url === '/e') {
+                    throw new RangeError('Invalid string length')
+                }
+            })
+            queue = new RequestQueue(sendRequest, {})
+            queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: EPOCH } })
+            queue.enqueue({ url: '/s', data: { recording_payload: 'example' } })
+
+            expect(() => queue.unload()).not.toThrow()
+
+            expect(sendRequest).toHaveBeenCalledTimes(2)
+        })
+
         it('handles unload with batchKeys', () => {
             queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: 1_610_000_000 }, transport: 'XHR' })
             queue.enqueue({ url: '/identify', data: { event: '$identify', timestamp: 1_620_000_000 } })

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -133,6 +133,29 @@ describe('request', () => {
             request(createRequest())
             expect(mockedXHR.withCredentials).toBe(false)
         })
+
+        it('reports JSON serialization failures through the callback instead of throwing', () => {
+            const error = new RangeError('Invalid string length')
+            const callback = jest.fn()
+            const stringifySpy = jest.spyOn(JSON, 'stringify').mockImplementation(() => {
+                throw error
+            })
+
+            expect(() =>
+                request(
+                    createRequest({
+                        method: 'POST',
+                        data: { event: 'too-large' },
+                        callback,
+                    })
+                )
+            ).not.toThrow()
+
+            expect(callback).toHaveBeenCalledWith({ statusCode: 0, error })
+            expect(mockedXMLHttpRequest).not.toHaveBeenCalled()
+
+            stringifySpy.mockRestore()
+        })
     })
 
     describe('fetch', () => {

--- a/packages/browser/src/request-queue.ts
+++ b/packages/browser/src/request-queue.ts
@@ -44,7 +44,7 @@ export class RequestQueue {
             ...requestValues.filter((r) => r.url.indexOf('/e') !== 0),
         ]
         sortedRequests.map((req) => {
-            this._sendRequest({ ...req, transport: 'sendBeacon' })
+            this._sendRequestSafely({ ...req, transport: 'sendBeacon' })
         })
     }
 
@@ -71,10 +71,18 @@ export class RequestQueue {
                             delete data['timestamp']
                         })
                     }
-                    this._sendRequest(req)
+                    this._sendRequestSafely(req)
                 }
             }
         }, this._flushTimeoutMs)
+    }
+
+    private _sendRequestSafely(req: QueuedRequestWithOptions): void {
+        try {
+            this._sendRequest(req)
+        } catch (error) {
+            logger.error(error)
+        }
     }
 
     private _clearFlushTimeout(): void {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -164,6 +164,16 @@ const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest =
     }
 }
 
+const encodeRequest = (options: RequestWithEncodedBody): EncodedRequest | undefined => {
+    try {
+        return encodePostDataSafely(options)
+    } catch (error) {
+        logger.error(error)
+        options.callback?.({ statusCode: 0, error })
+        return undefined
+    }
+}
+
 /**
  * Pre-encode the request body using async native CompressionStream.
  * This avoids blocking the main thread with fflate's synchronous gzip,
@@ -203,8 +213,13 @@ const timeoutAbortReason = (timeout?: number): Error => {
 }
 
 const xhr = (options: RequestWithOptions) => {
+    const encodedRequest = encodeRequest(options)
+    if (!encodedRequest) {
+        return
+    }
+
     const req = new XMLHttpRequest!()
-    const { url, encodedBody } = encodePostDataSafely(options)
+    const { url, encodedBody } = encodedRequest
     req.open(options.method || 'GET', url, true)
     const { contentType, body } = encodedBody ?? {}
 
@@ -241,7 +256,12 @@ const xhr = (options: RequestWithOptions) => {
 }
 
 const _fetch = (options: RequestWithOptions) => {
-    const { url, encodedBody } = encodePostDataSafely(options)
+    const encodedRequest = encodeRequest(options)
+    if (!encodedRequest) {
+        return
+    }
+
+    const { url, encodedBody } = encodedRequest
     const { contentType, body, estimatedSize } = encodedBody ?? {}
 
     // eslint-disable-next-line compat/compat

--- a/packages/webpack-plugin/babel.config.mjs
+++ b/packages/webpack-plugin/babel.config.mjs
@@ -1,0 +1,3 @@
+export default {
+    presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+}

--- a/packages/webpack-plugin/jest.config.mjs
+++ b/packages/webpack-plugin/jest.config.mjs
@@ -1,0 +1,10 @@
+export default {
+    clearMocks: true,
+    moduleNameMapper: {
+        '^@posthog/plugin-utils$': '<rootDir>/../plugin-utils/src',
+        '^(\\.{1,2}/.*)\\.js$': '$1',
+    },
+    silent: true,
+    verbose: false,
+    watchman: false,
+}

--- a/packages/webpack-plugin/rslib.config.mjs
+++ b/packages/webpack-plugin/rslib.config.mjs
@@ -6,4 +6,10 @@ export default defineConfig({
     shims: { esm: { __dirname: true } },
     syntax: 'es6',
     lib: [{ format: 'esm' }, { format: 'cjs' }],
+    source: {
+        entry: {
+            index: 'src/index.ts',
+        },
+        tsconfigPath: './tsconfig.build.json',
+    },
 })

--- a/packages/webpack-plugin/src/index.spec.ts
+++ b/packages/webpack-plugin/src/index.spec.ts
@@ -1,0 +1,78 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { runSourcemapCli } from '@posthog/plugin-utils'
+import { PosthogWebpackPlugin } from './index.js'
+
+jest.mock('@posthog/plugin-utils', () => ({
+    ...jest.requireActual('@posthog/plugin-utils'),
+    runSourcemapCli: jest.fn().mockResolvedValue(undefined),
+}))
+
+const baseConfig = {
+    personalApiKey: 'phx_test',
+    projectId: '1',
+    sourcemaps: {
+        enabled: true,
+        deleteAfterUpload: true,
+    },
+} as const
+
+const createCompilation = (outputDirectory: string) =>
+    ({
+        outputOptions: { path: outputDirectory },
+        chunks: [
+            {
+                files: new Set(['static/js/app.js', 'static/js/app.js.map']),
+            },
+        ],
+        getAssets: () => [
+            { name: 'static/css/app.css.map' },
+            { name: 'static/js/app.js.map' },
+            { name: 'static/css/app.css' },
+        ],
+    }) as any
+
+describe('PosthogWebpackPlugin', () => {
+    let outputDirectory: string
+
+    beforeEach(async () => {
+        outputDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-webpack-plugin-'))
+        await fs.mkdir(path.join(outputDirectory, 'static/css'), { recursive: true })
+        await fs.mkdir(path.join(outputDirectory, 'static/js'), { recursive: true })
+        await fs.writeFile(path.join(outputDirectory, 'static/css/app.css.map'), '{}')
+        await fs.writeFile(path.join(outputDirectory, 'static/js/app.js.map'), '{}')
+    })
+
+    afterEach(async () => {
+        await fs.rm(outputDirectory, { recursive: true, force: true })
+    })
+
+    it('deletes emitted CSS sourcemaps after a successful upload when delete-after is enabled', async () => {
+        const plugin = new PosthogWebpackPlugin(baseConfig)
+
+        await plugin.processSourceMaps(createCompilation(outputDirectory), plugin.resolvedConfig)
+
+        await expect(fs.stat(path.join(outputDirectory, 'static/css/app.css.map'))).rejects.toMatchObject({
+            code: 'ENOENT',
+        })
+        await expect(fs.stat(path.join(outputDirectory, 'static/js/app.js.map'))).resolves.toBeDefined()
+        expect(runSourcemapCli).toHaveBeenCalledWith(plugin.resolvedConfig, {
+            filePaths: [
+                path.join(outputDirectory, 'static/js/app.js'),
+                path.join(outputDirectory, 'static/js/app.js.map'),
+            ],
+        })
+    })
+
+    it('keeps emitted CSS sourcemaps when delete-after is disabled', async () => {
+        const plugin = new PosthogWebpackPlugin({
+            ...baseConfig,
+            sourcemaps: { ...baseConfig.sourcemaps, deleteAfterUpload: false },
+        })
+
+        await plugin.processSourceMaps(createCompilation(outputDirectory), plugin.resolvedConfig)
+
+        await expect(fs.stat(path.join(outputDirectory, 'static/css/app.css.map'))).resolves.toBeDefined()
+    })
+})

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -3,6 +3,7 @@ import { PluginConfig, resolveConfig, ResolvedPluginConfig } from './config'
 import { runSourcemapCli } from '@posthog/plugin-utils'
 import webpack from 'webpack'
 import path from 'path'
+import fs from 'fs/promises'
 
 export * from './config'
 
@@ -67,5 +68,18 @@ export class PosthogWebpackPlugin {
         )
 
         await runSourcemapCli(config, { filePaths })
+
+        if (config.sourcemaps.deleteAfterUpload) {
+            await this.deleteCssSourceMaps(compilation, outputDirectory)
+        }
+    }
+
+    private async deleteCssSourceMaps(compilation: webpack.Compilation, outputDirectory: string): Promise<void> {
+        const cssSourceMaps = compilation
+            .getAssets()
+            .filter((asset) => asset.name.endsWith('.css.map'))
+            .map((asset) => path.resolve(outputDirectory, asset.name))
+
+        await Promise.all(cssSourceMaps.map((filePath) => fs.rm(filePath, { force: true })))
     }
 }

--- a/packages/webpack-plugin/tsconfig.build.json
+++ b/packages/webpack-plugin/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src/**/*"],
+    "exclude": ["src/**/*.spec.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       query-selector-shadow-dom:
         specifier: ^1.0.1
         version: 1.0.1
+      react:
+        specifier: '>=16.8.0'
+        version: 19.2.1
       web-vitals:
         specifier: ^5.3.0
         version: 5.3.0


### PR DESCRIPTION
## Problem

Several previously triaged bug reports had narrow SDK-side fixes that did not require additional reporter information or a new repro:

- #1711: legacy `posthog-js/react` package metadata did not declare React as an optional peer.
- #2527: webpack plugin CSS sourcemaps emitted by `SourceMapDevToolPlugin` were not removed after successful upload.
- #2957: OpenAI Responses API `background: true` pending responses could be captured as zero-token `$ai_generation` events.
- #1579: oversized request payload serialization could throw and interrupt queued request flushing.

## Changes

- Declares `react` as an optional peer dependency for `posthog-js`, with a metadata smoke test for the legacy React entrypoint files.
- Deletes emitted `.css.map` assets after successful webpack sourcemap upload when `deleteAfterUpload` is enabled, and adds webpack plugin unit test coverage/config.
- Skips AI generation capture for non-terminal OpenAI background responses with no `usage`, covering both `responses.create` and `responses.parse`.
- Wraps request body encoding and queued request sending so serialization failures are reported/logged without throwing or blocking later queued requests.
- Adds a patch changeset for `posthog-js`, `@posthog/ai`, and `@posthog/webpack-plugin`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [x] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by Pi after triaging open bug reports and selecting fixes with narrow SDK-side scope. The changes were kept to the relevant packages, with focused regression tests added for each behavior.

Validation performed:

- `pnpm install --frozen-lockfile --ignore-scripts`
- Browser focused Jest tests for package metadata, request serialization, and request queue behavior
- `@posthog/ai` OpenAI focused Jest tests
- `@posthog/webpack-plugin` unit tests
- Package lints for `posthog-js`, `@posthog/ai`, and `@posthog/webpack-plugin`
- `@posthog/webpack-plugin` build
- `@posthog/ai` build with dependencies
- `turbo --filter=posthog-js build`
