### PR TITLE
fix(ai): skip pending background responses

### DIFF
--- a/.changeset/openai-background-responses.md
+++ b/.changeset/openai-background-responses.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Skip capturing pending OpenAI background Responses without token usage.

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -81,6 +81,20 @@ function preserveAPIPromiseHelpers<Input, Output>(
   return apiPromise
 }
 
+const TERMINAL_RESPONSE_STATUSES = new Set(['completed', 'failed', 'cancelled', 'incomplete'])
+
+function isPendingBackgroundResponse(
+  params: { background?: boolean | null },
+  response: { status?: string | null; usage?: unknown | null }
+): boolean {
+  return (
+    params.background === true &&
+    !response.usage &&
+    !!response.status &&
+    !TERMINAL_RESPONSE_STATUSES.has(response.status)
+  )
+}
+
 export class PostHogOpenAI extends OpenAIOrignal {
   private readonly phClient: PostHog
   public chat: WrappedChat
@@ -593,6 +607,10 @@ export class WrappedResponses extends Responses {
       const wrappedPromise = parentPromise.then(
         async (result) => {
           if ('output' in result) {
+            if (isPendingBackgroundResponse(openAIParams, result)) {
+              return result
+            }
+
             const latency = (Date.now() - startTime) / 1000
             const availableTools = extractAvailableToolCalls('openai', openAIParams)
             const formattedOutput = formatResponseOpenAI({ output: result.output })
@@ -669,6 +687,10 @@ export class WrappedResponses extends Responses {
 
       const wrappedPromise = parentPromise.then(
         async (result) => {
+          if (isPendingBackgroundResponse(openAIParams, result)) {
+            return result
+          }
+
           const latency = (Date.now() - startTime) / 1000
           await captureAiGeneration(this.phClient, {
             ...posthogParams,

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -745,6 +745,49 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
   })
 
+  test('responses create skips queued background responses without usage', async () => {
+    mockOpenAiParsedResponse = {
+      ...mockOpenAiParsedResponse,
+      id: 'resp_queued',
+      status: 'queued',
+      output: [],
+      usage: null,
+    } as unknown as ParsedResponse<any>
+
+    const response = await client.responses.create({
+      model: 'gpt-4o-2024-08-06',
+      input: [{ role: 'user', content: 'Hello' }],
+      background: true,
+      posthogDistinctId: 'test-id',
+    } as any)
+
+    expect(response).toEqual(mockOpenAiParsedResponse)
+    expect(mockPostHogClient.capture).not.toHaveBeenCalled()
+    expect(mockPostHogClient.captureImmediate).not.toHaveBeenCalled()
+  })
+
+  test('responses parse skips queued background responses without usage', async () => {
+    mockOpenAiParsedResponse = {
+      ...mockOpenAiParsedResponse,
+      id: 'resp_queued_parse',
+      status: 'queued',
+      output: [],
+      usage: null,
+    } as unknown as ParsedResponse<any>
+
+    const response = await client.responses.parse({
+      model: 'gpt-4o-2024-08-06',
+      input: [{ role: 'user', content: 'Hello' }],
+      background: true,
+      text: { format: { type: 'text' } },
+      posthogDistinctId: 'test-id',
+    } as any)
+
+    expect(response).toEqual(mockOpenAiParsedResponse)
+    expect(mockPostHogClient.capture).not.toHaveBeenCalled()
+    expect(mockPostHogClient.captureImmediate).not.toHaveBeenCalled()
+  })
+
   conditionalTest('responses parse with instructions parameter', async () => {
     const response = await client.responses.parse({
       model: 'gpt-4o-2024-08-06',

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -745,41 +745,25 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
   })
 
-  test('responses create skips queued background responses without usage', async () => {
+  test.each([
+    { method: 'create' as const, status: 'queued' },
+    { method: 'create' as const, status: 'in_progress' },
+    { method: 'parse' as const, status: 'queued' },
+    { method: 'parse' as const, status: 'in_progress' },
+  ])('responses $method skips $status background responses without usage', async ({ method, status }) => {
     mockOpenAiParsedResponse = {
       ...mockOpenAiParsedResponse,
-      id: 'resp_queued',
-      status: 'queued',
+      id: `resp_${method}_${status}`,
+      status,
       output: [],
       usage: null,
     } as unknown as ParsedResponse<any>
 
-    const response = await client.responses.create({
+    const response = await client.responses[method]({
       model: 'gpt-4o-2024-08-06',
       input: [{ role: 'user', content: 'Hello' }],
       background: true,
-      posthogDistinctId: 'test-id',
-    } as any)
-
-    expect(response).toEqual(mockOpenAiParsedResponse)
-    expect(mockPostHogClient.capture).not.toHaveBeenCalled()
-    expect(mockPostHogClient.captureImmediate).not.toHaveBeenCalled()
-  })
-
-  test('responses parse skips queued background responses without usage', async () => {
-    mockOpenAiParsedResponse = {
-      ...mockOpenAiParsedResponse,
-      id: 'resp_queued_parse',
-      status: 'queued',
-      output: [],
-      usage: null,
-    } as unknown as ParsedResponse<any>
-
-    const response = await client.responses.parse({
-      model: 'gpt-4o-2024-08-06',
-      input: [{ role: 'user', content: 'Hello' }],
-      background: true,
-      text: { format: { type: 'text' } },
+      ...(method === 'parse' ? { text: { format: { type: 'text' } } } : {}),
       posthogDistinctId: 'test-id',
     } as any)
 


### PR DESCRIPTION
## Problem

OpenAI Responses API calls with `background: true` can return a pending response such as `queued` before token usage exists. Capturing those responses immediately creates misleading zero-token `$ai_generation` events.

Fixes #2957

## Changes

- Adds terminal status detection for OpenAI Responses results.
- Skips capture for background responses that are still non-terminal and have no `usage`.
- Covers both `responses.create` and `responses.parse` with parameterized regression tests for `queued` and `in_progress` responses.
- Adds a patch changeset for `@posthog/ai`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi in a dedicated worktree after splitting the originally combined triage fix into one PR per issue.

Validation performed:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @posthog/types --filter @posthog/core build`
- `pnpm --filter @posthog/ai lint`
- `pnpm --filter @posthog/ai test:unit -- tests/openai.test.ts --runInBand`
- `git diff --check`

