### PR TITLE
fix(browser): declare React optional peer

### DIFF
--- a/.changeset/react-peer-metadata.md
+++ b/.changeset/react-peer-metadata.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Declare React as an optional peer dependency for the legacy posthog-js/react entrypoint.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -60,6 +60,14 @@
         "rrweb-types/package.json",
         "rrweb-plugin-console-record/package.json"
     ],
+    "peerDependencies": {
+        "react": ">=16.8.0"
+    },
+    "peerDependenciesMeta": {
+        "react": {
+            "optional": true
+        }
+    },
     "dependencies": {
         "@posthog/core": "workspace:^",
         "@posthog/types": "workspace:^",

--- a/packages/browser/src/__tests__/package-metadata.test.ts
+++ b/packages/browser/src/__tests__/package-metadata.test.ts
@@ -1,0 +1,15 @@
+import fs from 'fs'
+import path from 'path'
+
+const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'))
+
+describe('package metadata', () => {
+    it('declares react as an optional peer for the legacy posthog-js/react entrypoint', () => {
+        expect(packageJson.files).toEqual(expect.arrayContaining(['react/dist/**', 'react/package.json']))
+        expect(packageJson.peerDependencies).toEqual(expect.objectContaining({ react: '>=16.8.0' }))
+        expect(packageJson.peerDependenciesMeta).toEqual(
+            expect.objectContaining({ react: expect.objectContaining({ optional: true }) })
+        )
+        expect(packageJson.dependencies?.react).toBeUndefined()
+    })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       query-selector-shadow-dom:
         specifier: ^1.0.1
         version: 1.0.1
+      react:
+        specifier: '>=16.8.0'
+        version: 19.2.1
       web-vitals:
         specifier: ^5.3.0
         version: 5.3.0


### PR DESCRIPTION
## Problem

The legacy `posthog-js/react` entrypoint ships React-specific files, but `posthog-js` did not declare React as a peer dependency. This can break stricter package managers such as Yarn PnP when resolving the legacy React entrypoint.

Fixes #1711

## Changes

- Declares `react` as an optional peer dependency of `posthog-js`.
- Updates the lockfile metadata for the new peer specifier.
- Adds a package metadata smoke test confirming the React files are packaged and React remains an optional peer, not a hard dependency.
- Adds a patch changeset for `posthog-js`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi in a dedicated worktree after splitting the originally combined triage fix into one PR per issue.

Validation performed:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter posthog-js lint`
- `pnpm --dir packages/browser exec jest src/__tests__/package-metadata.test.ts --runInBand`
- `git diff --check`
