### PR TITLE
fix(node): apply in/not_in operator on flag-level cohort conditions in local evaluation

### DIFF
--- a/.changeset/warm-windows-doubt.md
+++ b/.changeset/warm-windows-doubt.md
@@ -1,0 +1,7 @@
+---
+'posthog-node': patch
+---
+
+Fix local evaluation ignoring the `in`/`not_in` operator on cohort-based flag conditions. "Not in
+cohort" was evaluated as "in cohort", inverting cohort-exclusion flags. Now applies the operator to
+the cohort membership result.

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -1751,6 +1751,89 @@ describe('local evaluation', () => {
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyFlagsCall)
   })
 
+  it("computes 'not in' cohort conditions locally (negated cohort membership)", async () => {
+    const flags = {
+      flags: [
+        {
+          id: 1,
+          name: 'Exclude Team',
+          key: 'exclude-team',
+          active: true,
+          rollout_percentage: 100,
+          filters: {
+            groups: [
+              {
+                properties: [{ key: 'id', value: 98, type: 'cohort', operator: 'not_in' }],
+                rollout_percentage: 100,
+              },
+            ],
+          },
+        },
+        {
+          id: 2,
+          name: 'Include Team',
+          key: 'include-team',
+          active: true,
+          rollout_percentage: 100,
+          filters: {
+            groups: [
+              {
+                properties: [{ key: 'id', value: 98, type: 'cohort', operator: 'in' }],
+                rollout_percentage: 100,
+              },
+            ],
+          },
+        },
+      ],
+      cohorts: {
+        '98': {
+          type: 'OR',
+          values: [{ key: 'email', operator: 'regex', value: '.*@example\\.com$', type: 'person' }],
+        },
+      },
+    }
+    mockedFetch.mockImplementation(
+      apiImplementation({
+        localFlags: flags,
+        decideFlags: {},
+      })
+    )
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
+    })
+
+    // In the cohort + `not_in` => excluded => OFF. (Pre-fix this incorrectly returned `true`.)
+    expect(
+      await posthog.getFeatureFlag('exclude-team', 'some-distinct-id', {
+        personProperties: { email: 'team@example.com' },
+      })
+    ).toEqual(false)
+    // Not in the cohort + `not_in` => ON.
+    expect(
+      await posthog.getFeatureFlag('exclude-team', 'some-distinct-id', {
+        personProperties: { email: 'outsider@example.org' },
+      })
+    ).toEqual(true)
+
+    // `in` keeps working: in the cohort => ON, not in the cohort => OFF.
+    expect(
+      await posthog.getFeatureFlag('include-team', 'some-distinct-id', {
+        personProperties: { email: 'team@example.com' },
+      })
+    ).toEqual(true)
+    expect(
+      await posthog.getFeatureFlag('include-team', 'some-distinct-id', {
+        personProperties: { email: 'outsider@example.org' },
+      })
+    ).toEqual(false)
+
+    // All evaluated locally; the /flags (decide) API must not be consulted.
+    expect(mockedFetch).not.toHaveBeenCalledWith(...anyFlagsCall)
+  })
+
   it('gets feature flag with variant overrides', async () => {
     const flags = {
       flags: [

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -604,9 +604,14 @@ class FeatureFlagsPoller {
         let matches = false
 
         if (propertyType === 'cohort') {
-          matches = await matchCohort(prop, properties, this.cohorts, this.debugMode, (depProp) =>
+          const inCohort = await matchCohort(prop, properties, this.cohorts, this.debugMode, (depProp) =>
             this.evaluateFlagDependency(depProp, properties, evaluationContext)
           )
+          // A flag-level cohort condition carries a membership operator ('in' | 'not_in').
+          // `matchCohort` only reports raw membership, so the operator must be applied here.
+          // Without this, 'not_in' is silently treated as 'in', inverting any cohort-exclusion
+          // condition (e.g. "enabled for everyone NOT in cohort X").
+          matches = prop.operator === 'not_in' ? !inCohort : inCohort
         } else if (propertyType === 'flag') {
           matches = await this.evaluateFlagDependency(prop, properties, evaluationContext)
         } else {


### PR DESCRIPTION
Fixes https://github.com/PostHog/posthog-js/issues/3972

## Problem

Anyone using `posthog-node` server-side **local evaluation** for a feature flag whose release condition *excludes* a cohort (`Cohort X not_in`) gets the wrong result. Local evaluation ignored the cohort membership operator, so `not in cohort` was evaluated identically to `in cohort` and the negation was silently dropped.

The effect is the opposite of what the flag author intended: a flag meant to be **off** for a cohort (e.g. "enabled for everyone *except* internal/team users") is instead **on** for exactly that cohort. It fails silently and the `$feature_flag_called` event reports `locally_evaluated: true` so it's easy to ship and hard to notice. I hit this with a real "exclude this cohort" flag that was enforcing on the very users it was supposed to exempt.

`operator: "in"` is unaffected (membership → match is already correct); only `not_in` is inverted.

## Changes

In `FeatureFlagsPoller.isConditionMatch`, the `cohort` branch called `matchCohort` (which returns raw membership) and used that boolean directly as the condition match. It  previously never read the property's `in`/`not_in` operator. The fix applies the operator to the membership result:

```ts
const inCohort = await matchCohort(prop, properties, this.cohorts, this.debugMode, ...)
matches = prop.operator === 'not_in' ? !inCohort : inCohort
```

Applied at the condition level (not inside `matchCohort`) on purpose: `matchPropertyGroup` already handles `negation` for cohorts referenced *inside* another cohort's property group, so inverting inside `matchCohort` would double-negate nested cohorts. This change only affects the flag-condition-level cohort operator, which previously had no operator handling at all.

Adds a regression test, `computes 'not in' cohort conditions locally`, that:
- **fails on the previous code** (an in-cohort user gets `true` instead of `false`),
- passes with the fix,
- covers both `not_in` and `in` to confirm `in` is unchanged, and
- asserts the `/decide` (flags) API is never consulted (i.e. it's the local path).

**Behavioral note for reviewers:** flags using a `not_in` cohort condition under local evaluation will now return the *corrected* (opposite) value. That's the intended fix, but it does change evaluated output for those flags — worth calling out for anyone who may have unknowingly come to depend on the inverted behavior. Confirmed against current `main` (`posthog-node@5.38.5`); full `feature-flags.spec.ts` suite passes (227/227).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

## If releasing new changes
- [x] Ran pnpm changeset to generate a changeset file