### PR TITLE
fix(mcp): capture tools/list on servers that register handlers after instrument()

### DIFF
--- a/.changeset/mcp-capture-late-tools-list.md
+++ b/.changeset/mcp-capture-late-tools-list.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': patch
+---
+
+Capture tool listings (and the injected `context` parameter) on MCP servers that register their `tools/list` handler after `instrument()` runs — e.g. `@rekog/mcp-nest`, which hands a bare server to `instrument()` and only then registers its handlers.

--- a/packages/mcp/src/__tests__/late-handler-registration.test.ts
+++ b/packages/mcp/src/__tests__/late-handler-registration.test.ts
@@ -1,0 +1,128 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import {
+  CallToolRequestSchema,
+  CallToolResultSchema,
+  ListToolsRequestSchema,
+  ListToolsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js'
+import { instrument } from '../index'
+import { EventCapture, fakePostHog } from './test-utils'
+
+/**
+ * Regression coverage for adapters that register their request handlers *after*
+ * `instrument()` runs — most notably `@rekog/mcp-nest`, which builds a bare
+ * `McpServer`, hands it to `instrument()` through `serverMutator`, and only then
+ * registers `tools/list` / `tools/call` directly at the low level (bypassing the
+ * high-level `registerTool`, so the `_registeredTools` proxy never fires).
+ *
+ * Before the fix, tools/list instrumentation bailed out when no `tools/list`
+ * handler existed at instrument-time, so the late handler was never wrapped:
+ * listings were not captured and the injected `context` parameter never appeared.
+ * Now a late-registered tools/list handler is wrapped as it lands, just like
+ * tools/call already was.
+ *
+ * The order below is the faithful reproduction: capability declared up front
+ * (mcp-nest configures it before the mutator runs), `instrument()` on the bare
+ * server, then handlers attached at `server.server` afterwards.
+ */
+
+const TOOLS = [
+  {
+    name: 'get_trends',
+    description: 'Return a trends time series for an event.',
+    inputSchema: {
+      type: 'object',
+      properties: { event: { type: 'string' } },
+      required: ['event'],
+    },
+  },
+]
+
+async function setupLateRegisteredServer() {
+  // Capability is declared at construction — mcp-nest does this before the
+  // serverMutator (where instrument runs) is invoked.
+  const server = new McpServer({ name: 'late-reg test', version: '1.0.0' }, { capabilities: { tools: {} } })
+
+  instrument(server, fakePostHog(), { context: true })
+
+  // Handlers registered AFTER instrument(), directly at the low level — this is
+  // the path mcp-nest takes and the case the fix targets.
+  const lowLevel = server.server
+  lowLevel.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
+  lowLevel.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const event = (request.params?.arguments?.event as string) ?? ''
+    return { content: [{ type: 'text', text: `trends for ${event}` }] }
+  })
+
+  const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: {} })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+  return {
+    server,
+    client,
+    async connect() {
+      await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)])
+    },
+    async cleanup() {
+      await clientTransport.close?.()
+      await serverTransport.close?.()
+    },
+  }
+}
+
+describe('Late handler registration (mcp-nest ordering)', () => {
+  let eventCapture: EventCapture
+  let client: Client
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    const setup = await setupLateRegisteredServer()
+    client = setup.client
+    cleanup = setup.cleanup
+    await setup.connect()
+  })
+
+  afterEach(async () => {
+    await cleanup()
+    await eventCapture.stop()
+  })
+
+  it('injects the context parameter into a tools/list handler registered after instrument()', async () => {
+    const response = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+    const tool = response.tools.find((t) => t.name === 'get_trends')
+
+    // The injected `context` parameter is the user-visible symptom of the fix:
+    // without the late-registration watcher the handler runs unwrapped and `context` is absent.
+    expect(tool?.inputSchema?.properties?.context).toBeDefined()
+    expect((tool?.inputSchema?.properties?.context as { type?: string })?.type).toBe('string')
+  })
+
+  it('captures $mcp_tools_list for a handler registered after instrument()', async () => {
+    await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+    await new Promise((r) => setTimeout(r, 50))
+
+    const listings = eventCapture.findCapturesByEvent('$mcp_tools_list')
+    expect(listings).toHaveLength(1)
+    expect(listings[0].properties.$mcp_listed_tool_names).toEqual(expect.arrayContaining(['get_trends']))
+  })
+
+  it('captures $mcp_tool_call for a tools/call handler registered after instrument()', async () => {
+    const result = await client.request(
+      { method: 'tools/call', params: { name: 'get_trends', arguments: { event: 'pageview' } } },
+      CallToolResultSchema
+    )
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect((result.content as { text: string }[])[0].text).toBe('trends for pageview')
+
+    const toolCalls = eventCapture.findCapturesByEvent('$mcp_tool_call')
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0].properties.$mcp_tool_name).toBe('get_trends')
+    expect(toolCalls[0].properties.$mcp_is_error).toBe(false)
+  })
+})

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -2,11 +2,7 @@
 // Copyright (c) 2025 MCPcat
 // Licensed under the MIT License: https://github.com/MCPCat/mcpcat-typescript-sdk/blob/main/LICENSE
 
-import {
-  InitializeRequestSchema,
-  ListToolsRequestSchema,
-  type ListToolsResult,
-} from '@modelcontextprotocol/sdk/types.js'
+import { InitializeRequestSchema, type ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
 import type { CompatibleRequestHandlerExtra, MCPAnalyticsData, MCPRequestLike, MCPServerLike, McpEvent } from '../types'
 import { addContextParameterToTools, getContextDescription, isContextEnabled } from './context-parameters'
 import {
@@ -24,6 +20,7 @@ import { resolveToolCallIntent, setEventIntent, setExplicitContextIntent } from 
 import { getServerTrackingData, handleIdentify } from './internal'
 import { log } from './logger'
 import { buildCapturedMcpParameters } from './mcp-payloads'
+import { getLiteralValue, getObjectShape } from './mcp-sdk-compat'
 import { getServerSessionId } from './session'
 import { getReportMissingToolDescriptor, resolveMissingCapabilityToolName } from './tools'
 import { applyResolvedMetadata, isToolResultError } from './tracing-helpers'
@@ -244,6 +241,13 @@ const listToolsTracingSetup = new WeakMap<MCPServerLike, boolean>()
  * SDK-managed tools (context parameter, conversation id, `get_more_tools`) are
  * injected. Idempotent per server. Works for both low-level and high-level
  * servers — the high-level wrapper passes its underlying `server`.
+ *
+ * The handler can reach us two ways, and we cover both:
+ *  1. It already exists when instrument() runs (tools registered first) — wrap
+ *     the entry in `_requestHandlers` directly.
+ *  2. It's registered after instrument() (e.g. `@rekog/mcp-nest` registers it at
+ *     the low level once it gets the server) — intercept `setRequestHandler` and
+ *     wrap the handler as it lands, mirroring how `tools/call` already works.
  */
 export function instrumentToolsListHandler(server: MCPServerLike): void {
   if (!(server as MCPServerWithCapabilities)._capabilities?.tools) {
@@ -252,18 +256,29 @@ export function instrumentToolsListHandler(server: MCPServerLike): void {
   if (listToolsTracingSetup.get(server)) {
     return
   }
-
-  const originalListToolsHandler = server._requestHandlers.get('tools/list')
-  if (!originalListToolsHandler) {
-    return
-  }
+  listToolsTracingSetup.set(server, true)
 
   try {
-    server.setRequestHandler(
-      ListToolsRequestSchema,
-      async (request, extra) => await handleListToolsRequest(server, originalListToolsHandler, request, extra)
-    )
-    listToolsTracingSetup.set(server, true)
+    // A handler already registered before instrument() — wrap it in place.
+    const existingHandler = server._requestHandlers.get('tools/list')
+    if (existingHandler) {
+      server._requestHandlers.set('tools/list', (request, extra) =>
+        handleListToolsRequest(server, existingHandler, request, extra)
+      )
+    }
+
+    // A handler registered after instrument() — intercept the registration.
+    const originalSetRequestHandler = server.setRequestHandler.bind(server)
+    server.setRequestHandler = ((requestSchema: unknown, handler: MCPRequestHandler) => {
+      const shape = getObjectShape(requestSchema)
+      const method = shape?.method ? getLiteralValue(shape.method) : undefined
+      if (method === 'tools/list') {
+        return originalSetRequestHandler(requestSchema, (request, extra) =>
+          handleListToolsRequest(server, handler, request, extra)
+        )
+      }
+      return originalSetRequestHandler(requestSchema, handler)
+    }) as MCPServerLike['setRequestHandler']
   } catch (error) {
     log(`Warning: Failed to override list tools handler - ${error}`)
   }


### PR DESCRIPTION
## Why

The injected `context` parameter (and the `$mcp_tools_list` event) was missing when instrumenting an [MCP-Nest](https://github.com/rekog-labs/MCP-Nest) server.

## Why it misses
Our SDK's `instrument()` wraps the `tools/list` handler that exists at call time. MCP-Nest builds a bare server, hands it to `instrument()` via `serverMutator`, and only *then* registers `tools/list` directly at the low level — so there's no handler to wrap yet, and we bail. Unlike `tools/call`, `tools/list` never watched for a handler registered *after* `instrument()`.

## Fix
Monkeypatch `setRequestHandler` so a `tools/list` handler registered after `instrument()` gets wrapped as it lands. Plus a regression test reproducing the MCP-Nest ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
