### PR TITLE
chore(next): promote @posthog/next to v1

### DIFF
--- a/.changeset/fuzzy-next-bears.md
+++ b/.changeset/fuzzy-next-bears.md
@@ -2,4 +2,4 @@
 "@posthog/next": major
 ---
 
-Graduate `@posthog/next` to v1.
+Promote `@posthog/next` to v1.

--- a/.changeset/fuzzy-next-bears.md
+++ b/.changeset/fuzzy-next-bears.md
@@ -1,0 +1,5 @@
+---
+"@posthog/next": major
+---
+
+Graduate `@posthog/next` to v1.


### PR DESCRIPTION
## Problem

`@posthog/next` has been iterating as a 0.x package. We want to promote the Next.js SDK package to its v1 stable release.

## Changes

- Adds a major changeset for `@posthog/next` so the next release will publish it as `1.0.0`.
- No runtime code changes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared with Pi. The only decision was to use a major changeset rather than manually editing generated release files, so the existing Changesets release flow owns the `1.0.0` version/changelog update.
