### PR TITLE
fix(next): preserve Pages Router request context

### DIFF
--- a/.changeset/next-pages-context-boundary.md
+++ b/.changeset/next-pages-context-boundary.md
@@ -1,0 +1,5 @@
+---
+'@posthog/next': patch
+---
+
+Fix Pages Router server clients to apply request context after async initialization.

--- a/packages/next/src/pages/getServerSidePostHog.ts
+++ b/packages/next/src/pages/getServerSidePostHog.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '@posthog/core'
 import type { GetServerSidePropsContext } from 'next'
 import type { PostHogOptions, IPostHog } from 'posthog-node'
 import { getOrCreateNodeClient } from '../server/clientCache.node.js'
@@ -8,10 +9,10 @@ import { readTracingHeaders, buildContextData } from '../shared/tracing-headers.
 /**
  * Creates a PostHog server client scoped to the current request.
  *
- * Reads the user's identity from the PostHog cookie in request headers
- * and sets it as context via `enterContext()`. The returned client is
- * ready to use — methods like `getAllFlags()`, `getFeatureFlagResult()`,
- * and `capture()` automatically use the current user's identity.
+ * Reads the user's identity from the PostHog cookie in request headers.
+ * The returned client is ready to use — methods like `getAllFlags()`,
+ * `getFeatureFlagResult()`, and `capture()` automatically use the current
+ * user's identity.
  *
  * @param ctx - The Next.js GetServerSidePropsContext
  * @param apiKey - PostHog project API key. If omitted, reads from NEXT_PUBLIC_POSTHOG_KEY.
@@ -44,11 +45,28 @@ export async function getServerSidePostHog(
 
     const cookieStore = cookieStoreFromHeader(ctx.req.headers.cookie || '')
 
-    if (!isOptedOut(cookieStore, resolvedApiKey)) {
-        const state = readPostHogCookie(cookieStore, resolvedApiKey)
-        const tracing = readTracingHeaders(ctx.req.headers)
-        client.enterContext(buildContextData(tracing, state))
+    if (isOptedOut(cookieStore, resolvedApiKey)) {
+        return client
     }
 
-    return client
+    const state = readPostHogCookie(cookieStore, resolvedApiKey)
+    const tracing = readTracingHeaders(ctx.req.headers)
+    const contextData = buildContextData(tracing, state)
+
+    // Wrap the shared client in a Proxy that applies request-scoped context
+    // to every method call. We can't use enterContext() here because
+    // AsyncLocalStorage.enterWith() doesn't propagate back to the caller
+    // across the await boundary of this async function.
+    return new Proxy(client, {
+        get(target, prop, receiver) {
+            if (prop === 'withContext') {
+                return Reflect.get(target, prop, receiver)
+            }
+            const value = Reflect.get(target, prop, receiver)
+            if (isFunction(value)) {
+                return (...args: unknown[]) => target.withContext(contextData, () => value.apply(target, args))
+            }
+            return value
+        },
+    }) as IPostHog
 }

--- a/packages/next/tests/getServerSidePostHog.test.ts
+++ b/packages/next/tests/getServerSidePostHog.test.ts
@@ -1,12 +1,14 @@
 import { getServerSidePostHog } from '../src/pages/getServerSidePostHog'
 
 const mockEnterContext = jest.fn()
+const mockWithContext = jest.fn((_, fn) => fn())
 const mockGetAllFlags = jest.fn()
 const mockGetAllFlagsAndPayloads = jest.fn()
 
 jest.mock('posthog-node', () => ({
     PostHog: jest.fn().mockImplementation(() => ({
         enterContext: mockEnterContext,
+        withContext: mockWithContext,
         getAllFlags: mockGetAllFlags,
         getAllFlagsAndPayloads: mockGetAllFlagsAndPayloads,
     })),
@@ -50,7 +52,7 @@ describe('getServerSidePostHog', () => {
         })
     })
 
-    it('calls enterContext with distinctId and properties', async () => {
+    it('wraps method calls with request context from cookies', async () => {
         const ctx = createMockContext({
             ph_phc_test123_posthog: JSON.stringify({
                 distinct_id: 'user_abc',
@@ -59,12 +61,19 @@ describe('getServerSidePostHog', () => {
             }),
         })
 
-        await getServerSidePostHog(ctx, 'phc_test123')
-        expect(mockEnterContext).toHaveBeenCalledWith({
-            distinctId: 'user_abc',
-            sessionId: 'session-123',
-            properties: { $session_id: 'session-123', $device_id: 'device_xyz' },
-        })
+        const posthog = await getServerSidePostHog(ctx, 'phc_test123')
+        posthog.getAllFlags()
+
+        expect(mockEnterContext).not.toHaveBeenCalled()
+        expect(mockWithContext).toHaveBeenCalledWith(
+            {
+                distinctId: 'user_abc',
+                sessionId: 'session-123',
+                properties: { $session_id: 'session-123', $device_id: 'device_xyz' },
+            },
+            expect.any(Function)
+        )
+        expect(mockGetAllFlags).toHaveBeenCalledWith()
     })
 
     it('reads apiKey from NEXT_PUBLIC_POSTHOG_KEY env when not provided', async () => {
@@ -76,11 +85,16 @@ describe('getServerSidePostHog', () => {
             }),
         })
 
-        await getServerSidePostHog(ctx)
-        expect(mockEnterContext).toHaveBeenCalledWith({
-            distinctId: 'user_abc',
-            properties: { $device_id: 'device_xyz' },
-        })
+        const posthog = await getServerSidePostHog(ctx)
+        posthog.getAllFlags()
+
+        expect(mockWithContext).toHaveBeenCalledWith(
+            {
+                distinctId: 'user_abc',
+                properties: { $device_id: 'device_xyz' },
+            },
+            expect.any(Function)
+        )
     })
 
     it('warns and returns a disabled client when no apiKey provided and env not set', async () => {
@@ -95,6 +109,7 @@ describe('getServerSidePostHog', () => {
             host: 'https://us.i.posthog.com',
         })
         expect(mockEnterContext).not.toHaveBeenCalled()
+        expect(mockWithContext).not.toHaveBeenCalled()
         expect(warnSpy).toHaveBeenCalledWith('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
         warnSpy.mockRestore()
     })
@@ -121,6 +136,23 @@ describe('getServerSidePostHog', () => {
         })
     })
 
+    it('returns the client directly without context wrapping when consent cookie is 0', async () => {
+        const ctx = createMockContext({
+            ph_phc_test123_posthog: JSON.stringify({
+                distinct_id: 'user_abc',
+                $device_id: 'device_xyz',
+            }),
+            __ph_opt_in_out_phc_test123: '0',
+        })
+
+        const posthog = await getServerSidePostHog(ctx, 'phc_test123')
+        posthog.getAllFlags()
+
+        expect(mockEnterContext).not.toHaveBeenCalled()
+        expect(mockWithContext).not.toHaveBeenCalled()
+        expect(mockGetAllFlags).toHaveBeenCalledWith()
+    })
+
     describe('tracing headers', () => {
         it('uses tracing headers when present and no cookie exists', async () => {
             const ctx = createMockContext(
@@ -132,15 +164,20 @@ describe('getServerSidePostHog', () => {
                 }
             )
 
-            await getServerSidePostHog(ctx, 'phc_test123')
-            expect(mockEnterContext).toHaveBeenCalledWith({
-                distinctId: 'header-user-789',
-                sessionId: 'header-session-456',
-                properties: {
-                    $session_id: 'header-session-456',
-                    $window_id: 'window-abc',
+            const posthog = await getServerSidePostHog(ctx, 'phc_test123')
+            posthog.getAllFlags()
+
+            expect(mockWithContext).toHaveBeenCalledWith(
+                {
+                    distinctId: 'header-user-789',
+                    sessionId: 'header-session-456',
+                    properties: {
+                        $session_id: 'header-session-456',
+                        $window_id: 'window-abc',
+                    },
                 },
-            })
+                expect.any(Function)
+            )
         })
 
         it('tracing headers override cookie values for distinctId and sessionId', async () => {
@@ -158,15 +195,20 @@ describe('getServerSidePostHog', () => {
                 }
             )
 
-            await getServerSidePostHog(ctx, 'phc_test123')
-            expect(mockEnterContext).toHaveBeenCalledWith({
-                distinctId: 'header-user',
-                sessionId: 'header-session',
-                properties: {
-                    $session_id: 'header-session',
-                    $device_id: 'device_xyz',
+            const posthog = await getServerSidePostHog(ctx, 'phc_test123')
+            posthog.getAllFlags()
+
+            expect(mockWithContext).toHaveBeenCalledWith(
+                {
+                    distinctId: 'header-user',
+                    sessionId: 'header-session',
+                    properties: {
+                        $session_id: 'header-session',
+                        $device_id: 'device_xyz',
+                    },
                 },
-            })
+                expect.any(Function)
+            )
         })
 
         it('falls back to cookie values when tracing headers are absent', async () => {
@@ -178,12 +220,17 @@ describe('getServerSidePostHog', () => {
                 }),
             })
 
-            await getServerSidePostHog(ctx, 'phc_test123')
-            expect(mockEnterContext).toHaveBeenCalledWith({
-                distinctId: 'cookie-user',
-                sessionId: 'cookie-session',
-                properties: { $session_id: 'cookie-session', $device_id: 'device_xyz' },
-            })
+            const posthog = await getServerSidePostHog(ctx, 'phc_test123')
+            posthog.getAllFlags()
+
+            expect(mockWithContext).toHaveBeenCalledWith(
+                {
+                    distinctId: 'cookie-user',
+                    sessionId: 'cookie-session',
+                    properties: { $session_id: 'cookie-session', $device_id: 'device_xyz' },
+                },
+                expect.any(Function)
+            )
         })
 
         it('adds $window_id from tracing headers alongside cookie properties', async () => {
@@ -200,16 +247,21 @@ describe('getServerSidePostHog', () => {
                 }
             )
 
-            await getServerSidePostHog(ctx, 'phc_test123')
-            expect(mockEnterContext).toHaveBeenCalledWith({
-                distinctId: 'cookie-user',
-                sessionId: 'cookie-session',
-                properties: {
-                    $session_id: 'cookie-session',
-                    $device_id: 'device_xyz',
-                    $window_id: 'window-123',
+            const posthog = await getServerSidePostHog(ctx, 'phc_test123')
+            posthog.getAllFlags()
+
+            expect(mockWithContext).toHaveBeenCalledWith(
+                {
+                    distinctId: 'cookie-user',
+                    sessionId: 'cookie-session',
+                    properties: {
+                        $session_id: 'cookie-session',
+                        $device_id: 'device_xyz',
+                        $window_id: 'window-123',
+                    },
                 },
-            })
+                expect.any(Function)
+            )
         })
     })
 })


### PR DESCRIPTION
## Problem

`getServerSidePostHog(ctx)` awaited the shared node-client cache and then called `enterContext()` before returning the client. Because `enterContext()` uses `AsyncLocalStorage.enterWith()`, setting context after an `await` inside the helper does not propagate back to the caller's `getServerSideProps` continuation.

That means Pages Router server-side flag evaluation/capture could miss the request's cookie/tracing identity even though the helper looked scoped.

## Changes

- Mirror the App Router `getPostHog()` request-scoping approach for `getServerSidePostHog()`.
- Return a proxy that wraps method calls in `client.withContext(contextData, ...)` instead of calling `client.enterContext()` after async initialization.
- Keep disabled/no-key and opted-out paths returning the raw client without context wrapping.
- Update tests to assert method calls after `await getServerSidePostHog(ctx)` are wrapped with the expected request context.
- Add a patch changeset for `@posthog/next`.

Validation:

```bash
pnpm --filter @posthog/next test:unit -- getPostHog.test.ts getServerSidePostHog.test.ts
pnpm --filter @posthog/next lint
```

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This was investigated with Pi and an oracle subagent. The subagent confirmed the async-boundary issue with `AsyncLocalStorage.enterWith()`, and this PR chooses the same proxy + `withContext()` pattern already used by App Router `getPostHog()`.
