### PR TITLE
ci: validate Next example packaging

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -319,7 +319,7 @@ jobs:
 
       # Replaces Vercel preview deploy validation for @posthog/next.
       - name: Install Next.js App Router example dependencies from local tarballs
-        run: pnpm install
+        run: pnpm install --lockfile=false
         working-directory: examples/example-next-app-router
 
       - name: Build Next.js App Router example
@@ -331,7 +331,7 @@ jobs:
           NEXT_PUBLIC_POSTHOG_HOST: https://us.i.posthog.com
 
       - name: Install Next.js config example dependencies from local tarballs
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --lockfile=false
         working-directory: examples/example-nextjs
 
       - name: Build Next.js config example

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -317,6 +317,32 @@ jobs:
       - name: Build package tarballs
         run: pnpm package
 
+      # Replaces Vercel preview deploy validation for @posthog/next.
+      - name: Install Next.js App Router example dependencies from local tarballs
+        run: pnpm install
+        working-directory: examples/example-next-app-router
+
+      - name: Build Next.js App Router example
+        run: pnpm build
+        working-directory: examples/example-next-app-router
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+          NEXT_PUBLIC_POSTHOG_KEY: phc_ci_next_app_router
+          NEXT_PUBLIC_POSTHOG_HOST: https://us.i.posthog.com
+
+      - name: Install Next.js config example dependencies from local tarballs
+        run: pnpm install
+        working-directory: examples/example-nextjs
+
+      - name: Build Next.js config example
+        run: pnpm build
+        working-directory: examples/example-nextjs
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+          POSTHOG_PERSONAL_API_KEY: phx_ci
+          POSTHOG_PROJECT_ID: '1'
+          POSTHOG_CLI_PATH: /bin/true
+
   write-mangled-property-names:
     name: Write mangled property names
     runs-on: ubuntu-22.04

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -331,7 +331,7 @@ jobs:
           NEXT_PUBLIC_POSTHOG_HOST: https://us.i.posthog.com
 
       - name: Install Next.js config example dependencies from local tarballs
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
         working-directory: examples/example-nextjs
 
       - name: Build Next.js config example
@@ -341,7 +341,7 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
           POSTHOG_PERSONAL_API_KEY: phx_ci
           POSTHOG_PROJECT_ID: '1'
-          POSTHOG_CLI_PATH: /bin/true
+          POSTHOG_CLI_PATH: /usr/bin/true
 
   write-mangled-property-names:
     name: Write mangled property names

--- a/examples/example-next-app-router/vercel.json
+++ b/examples/example-next-app-router/vercel.json
@@ -1,4 +1,8 @@
 {
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "git": {
+        "deploymentEnabled": false
+    },
     "installCommand": "pnpm --dir=../.. install && pnpm --dir=../.. package --force && pnpm install",
     "buildCommand": "pnpm build",
     "framework": "nextjs"

--- a/packages/webpack-plugin/rslib.config.mjs
+++ b/packages/webpack-plugin/rslib.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
     lib: [{ format: 'esm' }, { format: 'cjs' }],
     source: {
         entry: {
-            index: 'src/index.ts',
+            index: ['src/**/*', '!src/**/*.spec.ts'],
         },
         tsconfigPath: './tsconfig.build.json',
     },


### PR DESCRIPTION
## Problem

We want to stop relying on Vercel preview deployments as CI coverage for the `@posthog/next` demo app while preserving the useful packaging/build validation they provided.

## Changes

- Extends the existing `Package tarballs` workflow job to install and build `examples/example-next-app-router` from the freshly generated local tarballs.
- Adds the same install/build validation for `examples/example-nextjs` so the `@posthog/nextjs-config` demo app path is represented in GitHub Actions as well.
- Disables automatic Vercel git deployments for `examples/example-next-app-router` via `vercel.json`.
- `posthog-js` and `posthog-nextjs-config` Vercel deploys disconnected (these two were managed in Vercel)

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to inspect the existing Vercel-backed example projects and wire equivalent tarball install/build validation into GitHub Actions. The PR intentionally keeps the deploy-removal behavior limited to `example-next-app-router`; the newly added `example-nextjs` build may surface existing packaging issues and is included to make that validation explicit in CI.
