### PR TITLE
fix(webpack-plugin): ship dist/config.js and config.mjs in published package

### DIFF
--- a/.changeset/fuzzy-eels-march.md
+++ b/.changeset/fuzzy-eels-march.md
@@ -1,0 +1,5 @@
+---
+'@posthog/webpack-plugin': patch
+---
+
+Put `dist/config.js` and `dist/config.mjs` back in the published package. 1.5.25 shipped only `config.d.ts`, so `next build` (via `@posthog/nextjs-config`) failed with `Cannot find module './config.js'`. The build now emits config again.


### PR DESCRIPTION
## Problem

Closes #3988

`@posthog/webpack-plugin@1.5.25` (current `latest`) shipped a broken tarball: `dist/index.js`/`dist/index.mjs` resolve `./config.js`/`./config.mjs`, but only `dist/config.d.ts` made it into the published package. `next build` (via `@posthog/nextjs-config`, whose `^1.5.24` range resolves to 1.5.25) fails with `Error: Cannot find module './config.js'`. 

The source-level cause landed in #3962 (`source.entry: { index: 'src/index.ts' }` under `bundle: false` dropped `config.ts` from emission) and the rslib config was already corrected on `main` in #3985 (`index: ['src/**/*', '!src/**/*.spec.ts']`). That fix was never released — there was no changeset — so npm `latest` is still the broken 1.5.25.

## Changes

- Adds a patch changeset for `@posthog/webpack-plugin` so the already-merged build fix is released as 1.5.26.

Verified the fix on `main` before opening this PR:

```
$ rslib build
File (cjs)       Size
dist/config.js   1.5 kB
dist/index.js    6.7 kB

$ npm pack --dry-run
dist/config.js
dist/config.mjs
dist/config.d.ts
dist/index.js
dist/index.mjs
# no src/**/*.spec.ts in the tarball
```

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [x] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

DRI: @ioannisj.
