### PR TITLE
docs(webpack-plugin): flag broken 1.5.25 release in changelog

### DIFF
--- a/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/webpack-plugin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.5.25
 
+> [!WARNING]
+> Broken release, do not use. The published package is missing `dist/config.js` and `dist/config.mjs`, so builds fail with `Cannot find module './config.js'`. Upgrade to 1.5.26 or later, or pin 1.5.24. See [#3988](https://github.com/PostHog/posthog-js/issues/3988).
+
 ### Patch Changes
 
 - [#3962](https://github.com/PostHog/posthog-js/pull/3962) [`5310a5e`](https://github.com/PostHog/posthog-js/commit/5310a5ea16b1fd463d6ecc14df007df5cad13c66) Thanks [@marandaneto](https://github.com/marandaneto)! - Delete emitted CSS source maps when `deleteAfterUpload` is enabled without uploading CSS assets to PostHog.


### PR DESCRIPTION
## Problem

`@posthog/webpack-plugin@1.5.25` is a broken release: the published tarball is missing `dist/config.js` and `dist/config.mjs`, so builds fail with `Cannot find module './config.js'` (e.g. `next build` via `@posthog/nextjs-config`). The fix ships in 1.5.26 (#3990), but the changelog gives no signal that 1.5.25 should be avoided. Related to #3988.

## Changes

- Adds a `[!WARNING]` callout under the `## 1.5.25` heading in `packages/webpack-plugin/CHANGELOG.md` telling readers the release is broken and to upgrade to 1.5.26+ (or pin 1.5.24), with a link to #3988.

Docs-only change, no changeset (no version bump). Changesets only prepends new version sections on release, so this manual note on the 1.5.25 entry is preserved when 1.5.26 publishes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

DRI: @ioannisj.
