### PR TITLE
refactor(mcp): patch setRequestHandler once instead of once per method

### DIFF
--- a/.changeset/mcp-patch-request-handlers-once.md
+++ b/.changeset/mcp-patch-request-handlers-once.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': patch
+---
+
+Instrument MCP request handlers through a single `setRequestHandler` patch instead of one per method. Internal refactor — no change to the analytics captured.

--- a/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
+++ b/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
@@ -193,3 +193,48 @@ describe('Low-level Server tracing (e2e)', () => {
     }
   })
 })
+
+/**
+ * The low-level path also instruments handlers registered *after* instrument()
+ * (via `patchRequestHandlers`' setRequestHandler interceptor) — the same
+ * late-registration support the high-level/mcp-nest path relies on.
+ */
+describe('Low-level Server — late handler registration', () => {
+  let eventCapture: EventCapture
+
+  beforeEach(async () => {
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+  })
+
+  afterEach(async () => {
+    await eventCapture.stop()
+  })
+
+  it('instruments a tools/list handler registered after instrument()', async () => {
+    const server = new Server({ name: 'late low-level', version: '1.0.0' }, { capabilities: { tools: {} } })
+
+    // instrument() runs first; the tools/list handler is registered afterwards.
+    instrument(server, fakePostHog(), { context: true })
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
+
+    const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: {} })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+    try {
+      await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+      const { tools } = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+      // The injected `context` param proves the late-registered handler was wrapped.
+      expect(tools.find((t) => t.name === 'echo')?.inputSchema?.properties?.context).toBeDefined()
+
+      await new Promise((r) => setTimeout(r, 50))
+      const listings = eventCapture.findCapturesByEvent('$mcp_tools_list')
+      expect(listings).toHaveLength(1)
+      expect(listings[0].properties.$mcp_listed_tool_names).toEqual(expect.arrayContaining(['echo']))
+    } finally {
+      await clientTransport.close?.()
+      await serverTransport.close?.()
+    }
+  })
+})

--- a/packages/mcp/src/extensions/instrument-highlevel.ts
+++ b/packages/mcp/src/extensions/instrument-highlevel.ts
@@ -8,11 +8,12 @@ import { stripConversationId } from './conversation-id'
 import { MCPAnalyticsEventType } from './event-types'
 import { getServerTrackingData } from './internal'
 import { log } from './logger'
-import { createWrappedTool, getLiteralValue, getObjectShape, getToolFunction, hasToolFunction } from './mcp-sdk-compat'
+import { createWrappedTool, getToolFunction, hasToolFunction } from './mcp-sdk-compat'
 import { handleReportMissing, resolveMissingCapabilityToolName } from './tools'
 import {
-  instrumentInitializeHandler,
-  instrumentToolsListHandler,
+  handleInitializeRequest,
+  handleListToolsRequest,
+  patchRequestHandlers,
   captureToolCall,
   readToolMetaCategory,
 } from './instrumentation'
@@ -72,8 +73,6 @@ function setupListenerToRegisteredTools(server: HighLevelMCPServerLike): void {
 
             const nextValue = addTracingToToolCallbackInternal(value, property, server)
 
-            instrumentToolsListHandler(server.server as MCPServerLike)
-
             if (typeof nextValue.update === 'function') {
               const originalUpdate = nextValue.update
               nextValue.update = function (...updateArgs: unknown[]) {
@@ -130,7 +129,7 @@ function setupListenerToRegisteredTools(server: HighLevelMCPServerLike): void {
  * (the high-level SDK turns thrown errors into `isError` results otherwise).
  *
  * This is purely the tool-facing concern; event capture lives in
- * {@link captureToolCall} via {@link handleWrappedToolsCall}.
+ * {@link captureToolCall} via {@link handleToolCallRequest}.
  */
 function addTracingToToolCallbackInternal(
   tool: RegisteredTool,
@@ -202,38 +201,9 @@ function addTracingToToolCallbackInternal(
   return wrappedTool
 }
 
-function setupToolsCallHandlerWrapping(server: HighLevelMCPServerLike): void {
-  const lowLevelServer = server.server as MCPServerLike
-
-  const existingHandler = lowLevelServer._requestHandlers.get('tools/call')
-  if (existingHandler) {
-    const wrappedHandler = createToolsCallWrapper(existingHandler, lowLevelServer)
-    lowLevelServer._requestHandlers.set('tools/call', wrappedHandler)
-  }
-
-  const originalSetRequestHandler = lowLevelServer.setRequestHandler.bind(lowLevelServer)
-
-  lowLevelServer.setRequestHandler = ((requestSchema: unknown, handler: MCPRequestHandler) => {
-    const shape = getObjectShape(requestSchema)
-    const method = shape?.method ? getLiteralValue(shape.method) : undefined
-
-    if (method === 'tools/call') {
-      const wrappedHandler = createToolsCallWrapper(handler, lowLevelServer)
-      return originalSetRequestHandler(requestSchema, wrappedHandler)
-    }
-
-    return originalSetRequestHandler(requestSchema, handler)
-  }) as MCPServerLike['setRequestHandler']
-}
-
-function createToolsCallWrapper(originalHandler: MCPRequestHandler, server: MCPServerLike): MCPRequestHandler {
-  return async (request: MCPRequest, extra: MCPRequestExtra) =>
-    await handleWrappedToolsCall(originalHandler, server, request, extra)
-}
-
-async function handleWrappedToolsCall(
-  originalHandler: MCPRequestHandler,
+async function handleToolCallRequest(
   server: MCPServerLike,
+  originalCallToolHandler: MCPRequestHandler,
   request: MCPRequest,
   extra: MCPRequestExtra
 ): Promise<unknown> {
@@ -242,7 +212,7 @@ async function handleWrappedToolsCall(
     log(
       'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called instrument(server, options) before using tool calls.'
     )
-    return await originalHandler(request, extra)
+    return await originalCallToolHandler(request, extra)
   }
 
   if (request.params?.name === resolveMissingCapabilityToolName(data.options)) {
@@ -267,7 +237,7 @@ async function handleWrappedToolsCall(
     data,
     request,
     extra,
-    execute: () => originalHandler(request, extra),
+    execute: () => originalCallToolHandler(request, extra),
     takeCapturedError: () => {
       const captured = extra?.__mcp_analytics_error
       if (extra) {
@@ -280,11 +250,16 @@ async function handleWrappedToolsCall(
 
 export function instrumentHighLevelServer(server: HighLevelMCPServerLike): void {
   try {
-    const mcpAnalyticsData = getServerTrackingData(server.server)
+    const lowLevelServer = server.server
+    const mcpAnalyticsData = getServerTrackingData(lowLevelServer)
 
-    setupToolsCallHandlerWrapping(server)
-
-    instrumentInitializeHandler(server.server)
+    // Patch already existing handlers, and patch setRequestHandler to capture dynamically created handlers.
+    const handlers = {
+      initialize: handleInitializeRequest,
+      'tools/list': handleListToolsRequest,
+      'tools/call': handleToolCallRequest,
+    }
+    patchRequestHandlers(lowLevelServer, handlers)
 
     server._registeredTools = addTracingToToolRegistry(server._registeredTools, server)
 
@@ -292,8 +267,6 @@ export function instrumentHighLevelServer(server: HighLevelMCPServerLike): void 
       seedToolDescriptionsFromRegistry(mcpAnalyticsData.toolDescriptions, server._registeredTools)
       seedToolCategoriesFromRegistry(mcpAnalyticsData.toolCategories, server._registeredTools)
     }
-
-    instrumentToolsListHandler(server.server)
 
     setupListenerToRegisteredTools(server)
   } catch (error) {

--- a/packages/mcp/src/extensions/instrument-lowlevel.ts
+++ b/packages/mcp/src/extensions/instrument-lowlevel.ts
@@ -8,7 +8,12 @@ import { MCPAnalyticsEventType } from './event-types'
 import { getServerTrackingData } from './internal'
 import { log } from './logger'
 import { handleReportMissing, resolveMissingCapabilityToolName } from './tools'
-import { instrumentInitializeHandler, instrumentToolsListHandler, captureToolCall } from './instrumentation'
+import {
+  handleInitializeRequest,
+  handleListToolsRequest,
+  patchRequestHandlers,
+  captureToolCall,
+} from './instrumentation'
 import { getContextArgument } from './tracing-helpers'
 
 type MCPRequestHandler = NonNullable<
@@ -24,8 +29,12 @@ type MCPRequestExtra = Parameters<MCPRequestHandler>[1]
  */
 export function instrumentLowLevelServer(server: MCPServerLike): void {
   try {
-    instrumentInitializeHandler(server)
-    instrumentToolsListHandler(server)
+    // Patch already existing handlers, and patch setRequestHandler to capture dynamically created handlers.
+    const handlers = {
+      initialize: handleInitializeRequest,
+      'tools/list': handleListToolsRequest,
+    }
+    patchRequestHandlers(server, handlers)
 
     const originalCallToolHandler = server._requestHandlers.get('tools/call')
     server.setRequestHandler(

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 MCPcat
 // Licensed under the MIT License: https://github.com/MCPCat/mcpcat-typescript-sdk/blob/main/LICENSE
 
-import { InitializeRequestSchema, type ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
+import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
 import type { CompatibleRequestHandlerExtra, MCPAnalyticsData, MCPRequestLike, MCPServerLike, McpEvent } from '../types'
 import { addContextParameterToTools, getContextDescription, isContextEnabled } from './context-parameters'
 import {
@@ -228,63 +228,53 @@ function publishFailedToolEvent(
 
 // --- tools/list -----------------------------------------------------------
 
-type MCPServerWithCapabilities = MCPServerLike & {
-  _capabilities?: {
-    tools?: unknown
-  }
-}
-
-const listToolsTracingSetup = new WeakMap<MCPServerLike, boolean>()
+/**
+ * A method's patch: runs the original handler and captures analytics. `server`
+ * and `originalHandler` are bound by {@link patchRequestHandlers}; the SDK
+ * supplies `request` and `extra` per call.
+ */
+export type HandlerPatch = (
+  server: MCPServerLike,
+  originalHandler: MCPRequestHandler,
+  request: MCPRequestLike,
+  extra: CompatibleRequestHandlerExtra | undefined
+) => Promise<unknown>
 
 /**
- * Wraps the server's `tools/list` handler so each listing is captured and the
- * SDK-managed tools (context parameter, conversation id, `get_more_tools`) are
- * injected. Idempotent per server. Works for both low-level and high-level
- * servers — the high-level wrapper passes its underlying `server`.
- *
- * The handler can reach us two ways, and we cover both:
- *  1. It already exists when instrument() runs (tools registered first) — wrap
- *     the entry in `_requestHandlers` directly.
- *  2. It's registered after instrument() (e.g. `@rekog/mcp-nest` registers it at
- *     the low level once it gets the server) — intercept `setRequestHandler` and
- *     wrap the handler as it lands, mirroring how `tools/call` already works.
+ * Applies the `patches` (keyed by method, e.g. `initialize`, `tools/list`) to the
+ * handlers already registered, and patches `setRequestHandler` so matching
+ * handlers registered later are patched too. The latter is what makes adapters
+ * that register handlers post-construction work — e.g. `@rekog/mcp-nest` hands a
+ * bare server to instrument() and only then registers its handlers.
  */
-export function instrumentToolsListHandler(server: MCPServerLike): void {
-  if (!(server as MCPServerWithCapabilities)._capabilities?.tools) {
-    return
+export function patchRequestHandlers(server: MCPServerLike, patches: Record<string, HandlerPatch>): void {
+  // Monkey patch existing handlers.
+  for (const [handlerName, patch] of Object.entries(patches)) {
+    const originalHandler = server._requestHandlers.get(handlerName)
+    if (originalHandler) {
+      server._requestHandlers.set(handlerName, (request, extra) => patch(server, originalHandler, request, extra))
+    }
   }
-  if (listToolsTracingSetup.get(server)) {
-    return
-  }
-  listToolsTracingSetup.set(server, true)
 
-  try {
-    // A handler already registered before instrument() — wrap it in place.
-    const existingHandler = server._requestHandlers.get('tools/list')
-    if (existingHandler) {
-      server._requestHandlers.set('tools/list', (request, extra) =>
-        handleListToolsRequest(server, existingHandler, request, extra)
-      )
+  // Monkey patch dynamically added handlers (registered after instrument()).
+  const originalSetRequestHandler = server.setRequestHandler.bind(server)
+  server.setRequestHandler = ((requestSchema: unknown, originalHandler: MCPRequestHandler) => {
+    const shape = getObjectShape(requestSchema)
+    const handlerName = shape?.method ? getLiteralValue(shape.method) : undefined
+    const patch = typeof handlerName === 'string' ? patches[handlerName] : undefined
+    if (!patch) {
+      return originalSetRequestHandler(requestSchema, originalHandler)
     }
 
-    // A handler registered after instrument() — intercept the registration.
-    const originalSetRequestHandler = server.setRequestHandler.bind(server)
-    server.setRequestHandler = ((requestSchema: unknown, handler: MCPRequestHandler) => {
-      const shape = getObjectShape(requestSchema)
-      const method = shape?.method ? getLiteralValue(shape.method) : undefined
-      if (method === 'tools/list') {
-        return originalSetRequestHandler(requestSchema, (request, extra) =>
-          handleListToolsRequest(server, handler, request, extra)
-        )
-      }
-      return originalSetRequestHandler(requestSchema, handler)
-    }) as MCPServerLike['setRequestHandler']
-  } catch (error) {
-    log(`Warning: Failed to override list tools handler - ${error}`)
-  }
+    return originalSetRequestHandler(requestSchema, (request, extra) => patch(server, originalHandler, request, extra))
+  }) as MCPServerLike['setRequestHandler']
 }
 
-async function handleListToolsRequest(
+/**
+ * Captures each `tools/list` and injects the SDK-managed tools (context
+ * parameter, conversation id, `get_more_tools`) into the returned list.
+ */
+export async function handleListToolsRequest(
   server: MCPServerLike,
   originalListToolsHandler: MCPRequestHandler,
   request: MCPRequestLike,
@@ -421,40 +411,38 @@ export function cacheToolCategories(cache: Map<string, string>, tools: ListTools
 // --- initialize -----------------------------------------------------------
 
 /**
- * Wraps the server's `initialize` handler so the connection handshake is
- * captured (and identity resolved) before the original handler runs.
+ * Captures the connection handshake (and resolves identity) on `initialize`
+ * before the original handler runs.
  */
-export function instrumentInitializeHandler(server: MCPServerLike): void {
-  const originalInitializeHandler = server._requestHandlers.get('initialize')
-  if (!originalInitializeHandler) {
-    return
+export async function handleInitializeRequest(
+  server: MCPServerLike,
+  originalInitializeHandler: MCPRequestHandler,
+  request: MCPRequestLike,
+  extra?: CompatibleRequestHandlerExtra
+): Promise<unknown> {
+  const data = getServerTrackingData(server)
+  if (!data) {
+    log(
+      'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called instrument(server, options) before using tool calls.'
+    )
+    return await originalInitializeHandler(request, extra)
   }
 
-  server.setRequestHandler(InitializeRequestSchema, async (request, extra) => {
-    const data = getServerTrackingData(server)
-    if (!data) {
-      log(
-        'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called instrument(server, options) before using tool calls.'
-      )
-      return await originalInitializeHandler(request, extra)
-    }
+  const sessionId = getServerSessionId(server, extra)
+  await handleIdentify(server, data, sessionId, request, extra)
 
-    const sessionId = getServerSessionId(server, extra)
-    await handleIdentify(server, data, sessionId, request, extra)
+  const event: McpEvent = {
+    sessionId,
+    resourceName: request.params?.name || 'Unknown Tool Name',
+    eventType: MCPAnalyticsEventType.mcpInitialize,
+    parameters: buildCapturedMcpParameters(request),
+    timestamp: new Date(),
+  }
 
-    const event: McpEvent = {
-      sessionId,
-      resourceName: request.params?.name || 'Unknown Tool Name',
-      eventType: MCPAnalyticsEventType.mcpInitialize,
-      parameters: buildCapturedMcpParameters(request),
-      timestamp: new Date(),
-    }
+  await applyResolvedMetadata(event, data, request, extra)
 
-    await applyResolvedMetadata(event, data, request, extra)
-
-    const result = await originalInitializeHandler(request, extra)
-    event.response = result
-    captureEvent(server, event)
-    return result
-  })
+  const result = await originalInitializeHandler(request, extra)
+  event.response = result
+  captureEvent(server, event)
+  return result
 }


### PR DESCRIPTION
## What
Refactor how `@posthog/mcp` plugs analytics into MCP request handlers.

Behavior-preserving, with **one intentional simplification**: the `tools/list` instrumentation no longer early-returns when the server hasn't declared `capabilities.tools`. In practice it's inert — clients gate requests on the capabilities advertised in `initialize`, so a compliant client won't call `tools/list` on a server that didn't declare `tools`.

## Why
We instrument several methods (`initialize`, `tools/list`, `tools/call`). Each was wrapped separately, and late-registration support meant each one **overrode `setRequestHandler`** — so the overrides stacked: a registration flowed through one interceptor per method, each chained onto the previous. The `tools/list` fix made it two; more methods would mean more.

## Change
One helper replaces the per-method patchers. Given a `{ method: handler }` map it (1) wraps the handlers already registered and (2) patches `setRequestHandler` **once** to capture any registered later — a single interceptor per server instead of one override per method.

```ts
patchRequestHandlers(server, {
  'initialize': handleInitializeRequest,
  'tools/list': handleListToolsRequest,
  'tools/call': handleToolCallRequest,
})
```

The low-level path routes `initialize` / `tools/list` through it and keeps its existing explicit `tools/call` registration. Flat `(server, originalHandler, request, extra)` handler implementations replace the curried wrapper factories.

\+ a low-level late-registration regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
