### PR TITLE
feat(mcp): add instrumentMutator for framework serverMutator hooks

### DIFF
--- a/.changeset/mcp-instrument-mutator.md
+++ b/.changeset/mcp-instrument-mutator.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': minor
+---
+
+Add `instrumentMutator(posthog, options?)` — a point-free `(server) => server` helper for framework server-mutation hooks like `@rekog/mcp-nest`'s `serverMutator`. It instruments the server and returns it, so `serverMutator: instrumentMutator(posthog)` just works (no need to remember that `instrument()` returns the analytics handle, not the server).

--- a/packages/mcp/src/__tests__/instrument-mutator.test.ts
+++ b/packages/mcp/src/__tests__/instrument-mutator.test.ts
@@ -1,0 +1,62 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CallToolRequestSchema, CallToolResultSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { instrumentMutator } from '../index'
+import { EventCapture, fakePostHog } from './test-utils'
+
+/**
+ * `instrumentMutator` is the point-free form for framework `serverMutator` hooks
+ * (e.g. `@rekog/mcp-nest`). The two things that matter: it returns the *server*
+ * (not the analytics handle), and the returned server is actually instrumented.
+ */
+describe('instrumentMutator', () => {
+  it('returns the same server it was handed', () => {
+    // The footgun this guards against: returning instrument()'s handle would
+    // replace the server and break the module.
+    const server = new McpServer({ name: 'mutator', version: '1.0.0' }, { capabilities: { tools: {} } })
+    expect(instrumentMutator(fakePostHog())(server)).toBe(server)
+  })
+
+  it('instruments the server it returns (tool calls are captured)', async () => {
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    // Mirror the nest-mcp shape: mutate a bare server, then register handlers after.
+    const server = new McpServer({ name: 'mutator', version: '1.0.0' }, { capabilities: { tools: {} } })
+    const instrumented = instrumentMutator(fakePostHog())(server)
+
+    instrumented.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [
+        {
+          name: 'echo',
+          description: 'echo',
+          inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+        },
+      ],
+    }))
+    instrumented.server.setRequestHandler(CallToolRequestSchema, async (request) => ({
+      content: [{ type: 'text', text: `echo: ${(request.params?.arguments?.text as string) ?? ''}` }],
+    }))
+
+    const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: {} })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    try {
+      await Promise.all([client.connect(clientTransport), instrumented.server.connect(serverTransport)])
+
+      await client.request(
+        { method: 'tools/call', params: { name: 'echo', arguments: { text: 'hi' } } },
+        CallToolResultSchema
+      )
+      await new Promise((r) => setTimeout(r, 50))
+
+      const calls = eventCapture.findCapturesByEvent('$mcp_tool_call')
+      expect(calls).toHaveLength(1)
+      expect(calls[0].properties.$mcp_tool_name).toBe('echo')
+    } finally {
+      await clientTransport.close?.()
+      await serverTransport.close?.()
+      await eventCapture.stop()
+    }
+  })
+})

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -79,6 +79,50 @@ function instrument(server: unknown, posthog: PostHog, options: MCPAnalyticsOpti
   }
 }
 
+/**
+ * Builds a server *mutator* — a `(server) => server` function — that instruments the
+ * server and hands it back. Use it with frameworks that create the server for you and
+ * expose a mutation hook, where there's no `new McpServer` for you to wrap.
+ *
+ * Most notably `@rekog/mcp-nest`, whose `McpModule.forRoot({ serverMutator })` expects a
+ * function that takes the `McpServer` and returns one:
+ *
+ * @example
+ * ```ts
+ * import { McpModule } from "@rekog/mcp-nest"
+ * import { instrumentMutator } from "@posthog/mcp"
+ * import { PostHog } from "posthog-node"
+ *
+ * const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, { host: "https://us.i.posthog.com" })
+ *
+ * McpModule.forRoot({
+ *   name: "my-mcp",
+ *   version: "1.0.0",
+ *   serverMutator: instrumentMutator(posthog),
+ * })
+ * ```
+ *
+ * This exists because {@link instrument} returns the analytics *handle*, not the server, so
+ * the bare `serverMutator: (s) => instrument(s, posthog)` would replace the server with the
+ * handle and break the module. `instrumentMutator` returns the server for you, so the
+ * mutator is point-free and there's nothing to get wrong. Handlers the framework registers
+ * after the mutator runs are still instrumented (single `setRequestHandler` interceptor).
+ *
+ * **Custom events.** The point-free form discards the analytics handle. If you need
+ * `analytics.capture(...)` for custom events, call {@link instrument} directly instead and
+ * return the server yourself: `serverMutator: (s) => { const a = instrument(s, posthog); ...; return s }`.
+ *
+ * @param posthog - A `posthog-node` client you construct and own.
+ * @param options - Optional configuration. See `MCPAnalyticsOptions`.
+ * @returns A `(server) => server` mutator that instruments the server and returns it.
+ */
+function instrumentMutator<TServer>(posthog: PostHog, options?: MCPAnalyticsOptions): (server: TServer) => TServer {
+  return (server: TServer): TServer => {
+    instrument(server, posthog, options)
+    return server
+  }
+}
+
 function createAnalyticsHandle(lowLevelServer: MCPServerLike): McpAnalytics {
   return {
     capture: (eventData) => captureCustomEvent(lowLevelServer, eventData),
@@ -190,4 +234,4 @@ export type {
   UserIdentity,
 } from './types'
 export type IdentifyFunction = MCPAnalyticsOptions['identify']
-export { instrument }
+export { instrument, instrumentMutator }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -80,37 +80,18 @@ function instrument(server: unknown, posthog: PostHog, options: MCPAnalyticsOpti
 }
 
 /**
- * Builds a server *mutator* — a `(server) => server` function — that instruments the
- * server and hands it back. Use it with frameworks that create the server for you and
- * expose a mutation hook, where there's no `new McpServer` for you to wrap.
- *
- * Most notably `@rekog/mcp-nest`, whose `McpModule.forRoot({ serverMutator })` expects a
- * function that takes the `McpServer` and returns one:
+ * A point-free `(server) => server` helper for framework server-mutation hooks (e.g.
+ * `@rekog/mcp-nest`'s `serverMutator`). It instruments the server and returns it, so you
+ * don't trip over {@link instrument} returning the analytics handle rather than the server —
+ * the bare `(s) => instrument(s, posthog)` would replace the server with the handle.
  *
  * @example
  * ```ts
- * import { McpModule } from "@rekog/mcp-nest"
- * import { instrumentMutator } from "@posthog/mcp"
- * import { PostHog } from "posthog-node"
- *
- * const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, { host: "https://us.i.posthog.com" })
- *
- * McpModule.forRoot({
- *   name: "my-mcp",
- *   version: "1.0.0",
- *   serverMutator: instrumentMutator(posthog),
- * })
+ * McpModule.forRoot({ serverMutator: instrumentMutator(posthog) })
  * ```
  *
- * This exists because {@link instrument} returns the analytics *handle*, not the server, so
- * the bare `serverMutator: (s) => instrument(s, posthog)` would replace the server with the
- * handle and break the module. `instrumentMutator` returns the server for you, so the
- * mutator is point-free and there's nothing to get wrong. Handlers the framework registers
- * after the mutator runs are still instrumented (single `setRequestHandler` interceptor).
- *
- * **Custom events.** The point-free form discards the analytics handle. If you need
- * `analytics.capture(...)` for custom events, call {@link instrument} directly instead and
- * return the server yourself: `serverMutator: (s) => { const a = instrument(s, posthog); ...; return s }`.
+ * Need the handle for custom events? Call {@link instrument} directly inside your own mutator
+ * and return the server. See https://posthog.com/docs/mcp-analytics/installation.
  *
  * @param posthog - A `posthog-node` client you construct and own.
  * @param options - Optional configuration. See `MCPAnalyticsOptions`.


### PR DESCRIPTION
## What

Adds `instrumentMutator(posthog, options?)` to `@posthog/mcp` — a point-free `(server) => server` helper for framework server-mutation hooks, most notably [`@rekog/mcp-nest`](https://github.com/rekog-labs/MCP-Nest)'s `serverMutator`:

```ts
McpModule.forRoot({
  serverMutator: instrumentMutator(posthog),
})
```

## Why

`instrument()` returns the analytics *handle*, not the server. So the natural-looking `serverMutator: (s) => instrument(s, posthog)` silently replaces the server with the handle and breaks the module — you have to remember `(s) => { instrument(s, posthog); return s }`. `instrumentMutator` returns the server for you, so the mutator is point-free and there's nothing to get wrong. It generalizes to any `(server) => server` hook, and it's the same shape Sentry exposes with `wrapMcpServerWithSentry`.

This came out of reviewing #3993 (the single `setRequestHandler` interceptor that makes nest's late-registered handlers get captured). The helper is the ergonomic layer on top.

## Notes

- The point-free form discards the analytics handle. Custom-event users (`analytics.capture(...)`) still call `instrument()` directly — documented in the JSDoc.
- Generic over the server type, so it returns the exact `McpServer`/`Server` it was handed.

## Tests

Two tests: it returns the same server instance (the contract), and the returned server actually captures tool calls when handlers are registered after the mutator (the nest-mcp shape). Full `@posthog/mcp` suite green (332). Changeset: minor.

## Follow-up

Once this ships, the context-mill `mcp-analytics` skill's nest path (PostHog/context-mill#204) gets simplified to inject `serverMutator: instrumentMutator(posthog)` instead of the multi-line arrow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
