### PR TITLE
fix: satisfy SDK compliance harness 0.8.0

### DIFF
--- a/.changeset/slow-foxes-retry.md
+++ b/.changeset/slow-foxes-retry.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Retry capture and logs requests on transient HTTP errors such as 408, 429, and 5xx while continuing to avoid retries for non-retryable 4xx responses.

--- a/.github/workflows/sdk-compliance-tests-browser.yml
+++ b/.github/workflows/sdk-compliance-tests-browser.yml
@@ -24,9 +24,9 @@ permissions:
 
 jobs:
   test-browser-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@39d05346c4638d24f94e591ab89c9c6fcdb52d6b
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
     with:
       adapter-dockerfile: compliance/browser/Dockerfile
       adapter-context: .
-      test-harness-version: latest
+      test-harness-version: "0.8.0"
       report-name: browser-sdk-compliance-report

--- a/.github/workflows/sdk-compliance-tests-node.yml
+++ b/.github/workflows/sdk-compliance-tests-node.yml
@@ -24,9 +24,9 @@ permissions:
 
 jobs:
   test-node-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@39d05346c4638d24f94e591ab89c9c6fcdb52d6b
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
     with:
       adapter-dockerfile: compliance/node/Dockerfile
       adapter-context: .
-      test-harness-version: latest
+      test-harness-version: "0.8.0"
       report-name: node-sdk-compliance-report

--- a/compliance/browser/docker-compose.yml
+++ b/compliance/browser/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - test-network
 
   test-harness:
-    image: posthog-sdk-test-harness:debug
+    image: ghcr.io/posthog/sdk-test-harness:0.8.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "client", "--debug"]
     networks:
       - test-network

--- a/compliance/node/adapter.js
+++ b/compliance/node/adapter.js
@@ -153,8 +153,11 @@ app.post('/flush', async (req, res) => {
         await state.client.flush()
         res.json({ success: true, events_flushed: state.totalEventsSent })
     } catch (error) {
+        // The harness deliberately configures mock-server failures for retry
+        // assertions. Treat SDK flush rejections as a completed adapter action
+        // so the harness can inspect the outbound requests it caused.
         state.lastError = error.message
-        res.status(500).json({
+        res.json({
             success: false,
             events_flushed: Math.max(0, state.totalEventsSent - sentBeforeFlush),
             error: error.message,

--- a/compliance/node/adapter.js
+++ b/compliance/node/adapter.js
@@ -64,9 +64,10 @@ app.post('/init', async (req, res) => {
     // Create new client
     state.client = new PostHog(api_key, {
         host,
-        // Keep single-event captures queued until the harness calls /flush;
-        // this avoids racing the SDK's automatic flush with explicit test flushes.
-        flushAt: Math.max(flush_at ?? 1, 2),
+        // Respect the harness batch-size configuration, including flush_at: 1
+        // for auto-flush compliance tests. Default to 2 only when omitted so
+        // ad-hoc single-event captures wait for an explicit /flush call.
+        flushAt: flush_at ?? 2,
         flushInterval: flush_interval_ms ?? 100,
         fetchRetryCount: max_retries ?? 3,
         disableCompression: enable_compression === undefined ? undefined : !enable_compression,
@@ -146,12 +147,18 @@ app.post('/flush', async (req, res) => {
         return res.status(400).json({ error: 'SDK not initialized' })
     }
 
+    const sentBeforeFlush = state.totalEventsSent
+
     try {
         await state.client.flush()
         res.json({ success: true, events_flushed: state.totalEventsSent })
     } catch (error) {
         state.lastError = error.message
-        res.json({ success: true, events_flushed: state.totalEventsSent, error: error.message })
+        res.status(500).json({
+            success: false,
+            events_flushed: Math.max(0, state.totalEventsSent - sentBeforeFlush),
+            error: error.message,
+        })
     }
 })
 

--- a/compliance/node/adapter.js
+++ b/compliance/node/adapter.js
@@ -5,7 +5,7 @@
  */
 
 const express = require('express')
-const { PostHog } = require('../../packages/node/dist/entrypoints/index.node')
+const { PostHog } = require('../packages/node/dist/entrypoints/index.node')
 
 const app = express()
 app.use(express.json())
@@ -20,22 +20,38 @@ const state = {
     pendingEvents: 0,
 }
 
+async function discardClient() {
+    if (!state.client) {
+        return
+    }
+
+    const client = state.client
+    state.client = null
+
+    // Test resets should discard queued events instead of flushing them into
+    // the next mock-server scenario.
+    try {
+        client.clearFlushTimer?.()
+        client.setPersistedProperty?.('queue', [])
+        await client.shutdown(1)
+    } catch (error) {
+        // Ignore reset-time shutdown errors; the next test starts with a fresh client.
+    }
+}
+
 app.get('/health', (req, res) => {
     res.json({
         sdk_name: 'posthog-node',
-        sdk_version: require('../../packages/node/package.json').version,
+        sdk_version: require('../packages/node/package.json').version,
         adapter_version: '1.0.0',
         capabilities: ['capture_v0', 'encoding_gzip'],
     })
 })
 
-app.post('/init', (req, res) => {
-    const { api_key, host, flush_at, flush_interval_ms, max_retries, enable_compression } = req.body
+app.post('/init', async (req, res) => {
+    const { api_key, host, flush_at, flush_interval_ms, max_retries, enable_compression, disable_geoip } = req.body
 
-    // Shutdown existing client
-    if (state.client) {
-        state.client.shutdown()
-    }
+    await discardClient()
 
     // Reset state
     state.totalEventsCaptured = 0
@@ -48,8 +64,13 @@ app.post('/init', (req, res) => {
     // Create new client
     state.client = new PostHog(api_key, {
         host,
-        flushAt: flush_at ?? 1,
+        // Keep single-event captures queued until the harness calls /flush;
+        // this avoids racing the SDK's automatic flush with explicit test flushes.
+        flushAt: Math.max(flush_at ?? 1, 2),
         flushInterval: flush_interval_ms ?? 100,
+        fetchRetryCount: max_retries ?? 3,
+        disableCompression: enable_compression === undefined ? undefined : !enable_compression,
+        disableGeoip: disable_geoip ?? false,
         // Use before_send to track events being sent
         before_send: (event) => {
             // Track that event is being sent
@@ -130,7 +151,7 @@ app.post('/flush', async (req, res) => {
         res.json({ success: true, events_flushed: state.totalEventsSent })
     } catch (error) {
         state.lastError = error.message
-        res.status(500).json({ error: error.message })
+        res.json({ success: true, events_flushed: state.totalEventsSent, error: error.message })
     }
 })
 
@@ -174,8 +195,11 @@ app.post('/get_feature_flag', async (req, res) => {
             groupProperties: group_properties,
             disableGeoip: disable_geoip,
             onlyEvaluateLocally: !force_remote,
-            sendFeatureFlagEvents: false,
         })
+
+        // Feature flag calls enqueue a $feature_flag_called event by default.
+        // Flush it before returning so it cannot leak into the next test case.
+        await state.client.flush()
 
         res.json({ success: true, value })
     } catch (error) {
@@ -184,11 +208,8 @@ app.post('/get_feature_flag', async (req, res) => {
     }
 })
 
-app.post('/reset', (req, res) => {
-    if (state.client) {
-        state.client.shutdown()
-        state.client = null
-    }
+app.post('/reset', async (req, res) => {
+    await discardClient()
 
     state.totalEventsCaptured = 0
     state.totalEventsSent = 0

--- a/compliance/node/docker-compose.yml
+++ b/compliance/node/docker-compose.yml
@@ -3,14 +3,13 @@ services:
     build:
       context: ../..
       dockerfile: compliance/node/Dockerfile
-    ports:
-      # nosemgrep: trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces
-      - "8080:8080"
+    expose:
+      - "8080"
     networks:
       - test-network
 
   test-harness:
-    image: posthog-sdk-test-harness:debug
+    image: ghcr.io/posthog/sdk-test-harness:0.8.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
     networks:
       - test-network

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -73,7 +73,22 @@ describe('PostHog Core', () => {
       }
     })
 
-    it.each([400, 500])('responds with an error after retries with %s error', async (status) => {
+    it.each([400, 401, 403])('responds with an error without retries with %s error', async (status) => {
+      mocks.fetch.mockImplementation(() => {
+        return Promise.resolve({
+          status: status,
+          text: async () => 'err',
+          json: async () => ({ status: 'err' }),
+        })
+      })
+      posthog.capture('test-event-1')
+
+      jest.useRealTimers()
+      await expect(posthog.flush()).rejects.toHaveProperty('name', 'PostHogFetchHttpError')
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([408, 429, 500])('responds with an error after retries with %s error', async (status) => {
       mocks.fetch.mockImplementation(() => {
         return Promise.resolve({
           status: status,

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -116,6 +116,13 @@ function isPostHogFetchContentTooLargeError(err: unknown): err is PostHogFetchHt
   return typeof err === 'object' && err instanceof PostHogFetchHttpError && err.status === 413
 }
 
+function isPostHogFetchRetryableError(err: unknown): err is PostHogFetchHttpError | PostHogFetchNetworkError {
+  if (err instanceof PostHogFetchHttpError) {
+    return err.status === 408 || err.status === 429 || err.status >= 500
+  }
+  return isPostHogFetchNetworkError(err)
+}
+
 function isPostHogEventProperties(value: JsonType | undefined): value is PostHogEventProperties {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
@@ -239,7 +246,7 @@ export abstract class PostHogCoreStateless {
     this._retryOptions = {
       retryCount: options.fetchRetryCount ?? 3,
       retryDelay: options.fetchRetryDelay ?? 3000, // 3 seconds
-      retryCheck: isPostHogFetchError,
+      retryCheck: isPostHogFetchRetryableError,
     }
     this.requestTimeout = options.requestTimeout ?? 10000 // 10 seconds
     this.featureFlagsRequestTimeoutMs = options.featureFlagsRequestTimeoutMs ?? 3000 // 3 seconds
@@ -814,9 +821,8 @@ export abstract class PostHogCoreStateless {
   ): Promise<PostHogFeatureFlagDetails | undefined> {
     await this._initPromise
 
-    const extraPayload: Record<string, any> = {}
-    if (disableGeoip ?? this.disableGeoip) {
-      extraPayload['geoip_disable'] = true
+    const extraPayload: Record<string, any> = {
+      geoip_disable: disableGeoip ?? this.disableGeoip,
     }
     if (flagKeysToEvaluate) {
       extraPayload['flag_keys_to_evaluate'] = flagKeysToEvaluate
@@ -1254,8 +1260,8 @@ export abstract class PostHogCoreStateless {
           if (isPostHogFetchContentTooLargeError(err)) {
             return false
           }
-          // otherwise, retry on network errors
-          return isPostHogFetchError(err)
+          // otherwise, retry on transient HTTP and network errors
+          return isPostHogFetchRetryableError(err)
         },
       }
 
@@ -1328,7 +1334,7 @@ export abstract class PostHogCoreStateless {
           if (isPostHogFetchContentTooLargeError(err)) {
             return false
           }
-          return isPostHogFetchError(err)
+          return isPostHogFetchRetryableError(err)
         },
       })
       return { kind: 'ok' }

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -1312,7 +1312,7 @@ describe('PostHog Node.js', () => {
 
       expect(mockedFetch).toHaveBeenCalledWith(
         'http://example.com/flags/?v=2',
-        expect.objectContaining({ method: 'POST', body: expect.not.stringContaining('geoip_disable') })
+        expect.objectContaining({ method: 'POST', body: expect.stringContaining('"geoip_disable":false') })
       )
 
       expect(getLastBatchEvents()?.[0].properties).toEqual({
@@ -2619,7 +2619,7 @@ describe('PostHog Node.js', () => {
       expect(mockedFetch).toHaveBeenCalledTimes(1)
       expect(mockedFetch).toHaveBeenCalledWith(
         'http://example.com/flags/?v=2',
-        expect.objectContaining({ method: 'POST', body: expect.not.stringContaining('geoip_disable') })
+        expect.objectContaining({ method: 'POST', body: expect.stringContaining('"geoip_disable":false') })
       )
     })
 


### PR DESCRIPTION
## Problem

The SDK compliance workflow and local harness need to use SDK test harness release 0.8.0, with reusable GitHub workflow calls pinned to the release commit SHA instead of a mutable tag/branch. Running the updated harness exposed SDK/adapter compliance gaps in this repository.

## Changes

- Pins the reusable SDK compliance workflow to PostHog/posthog-sdk-test-harness commit be8b8d5a3f94a249659844e94832e874f049c1e4.\n- Uses ghcr.io/posthog/sdk-test-harness:0.8.0 for local Docker harness runs / workflow harness version inputs.\n- Updates SDK compliance adapter and/or SDK behavior needed to pass the 0.8.0 compliance contract.

## Tests

- SDK compliance Docker harness passed locally with project posthog_js_node_compliance.
