### PR TITLE
fix(browser): fall back when payload compression fails

### DIFF
--- a/.changeset/cold-buckets-gzip.md
+++ b/.changeset/cold-buckets-gzip.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fall back to uncompressed browser requests when gzip encoding fails.

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -2,6 +2,7 @@
 /// <reference lib="dom" />
 
 import { TextDecoder } from 'util'
+import * as fflate from 'fflate'
 import { extendURLParams, request } from '../request'
 import { Compression, RequestWithOptions } from '../types'
 
@@ -239,6 +240,34 @@ describe('request', () => {
                 },
                 ...overrides,
             } as any)
+
+        it('falls back to JSON if gzip encoding throws before fetch send', async () => {
+            const error = new Error('gzip failed')
+            const gzipSpy = jest.spyOn(fflate, 'gzipSync').mockImplementation(() => {
+                throw error
+            })
+
+            try {
+                request(
+                    createRequest({
+                        method: 'POST',
+                        compression: Compression.GZipJS,
+                        data: { foo: 'bar' },
+                    })
+                )
+
+                expect(mockedFetch).toHaveBeenCalledWith(
+                    expect.not.stringContaining('compression=gzip-js'),
+                    expect.objectContaining({
+                        body: '{"foo":"bar"}',
+                    })
+                )
+                expect((mockedFetch.mock.calls[0][1].headers as Headers).get('Content-Type')).toBe('application/json')
+                expect(mockCallback).not.toHaveBeenCalledWith({ statusCode: 0, error })
+            } finally {
+                gzipSpy.mockRestore()
+            }
+        })
 
         it.each([
             [

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -142,7 +142,30 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
 }
 
 const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest => {
-    const encodedBody = encodePostData(options)
+    const fallbackToUncompressed = (): EncodedRequest => {
+        nativeAsyncGzipDisabled = true
+
+        return {
+            url: removeURLParam(options.url, 'compression'),
+            encodedBody: encodePostData({
+                ...options,
+                compression: undefined,
+                _encodedBody: undefined,
+            }),
+        }
+    }
+
+    let encodedBody: EncodedBody | undefined
+    try {
+        encodedBody = encodePostData(options)
+    } catch (error) {
+        if (isGzipRequest(options.compression, getQueryParam(options.url, 'compression'))) {
+            logger.error('Failed to gzip request body, sending uncompressed payload', error)
+            return fallbackToUncompressed()
+        }
+
+        throw error
+    }
 
     if (
         !encodedBody ||
@@ -152,16 +175,7 @@ const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest =
         return { url: options.url, encodedBody }
     }
 
-    nativeAsyncGzipDisabled = true
-
-    return {
-        url: removeURLParam(options.url, 'compression'),
-        encodedBody: encodePostData({
-            ...options,
-            compression: undefined,
-            _encodedBody: undefined,
-        }),
-    }
+    return fallbackToUncompressed()
 }
 
 const encodeRequest = (options: RequestWithEncodedBody): EncodedRequest | undefined => {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -142,8 +142,10 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
 }
 
 const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest => {
-    const fallbackToUncompressed = (): EncodedRequest => {
-        nativeAsyncGzipDisabled = true
+    const fallbackToUncompressed = (disableAsyncGzip = true): EncodedRequest => {
+        if (disableAsyncGzip) {
+            nativeAsyncGzipDisabled = true
+        }
 
         return {
             url: removeURLParam(options.url, 'compression'),
@@ -161,7 +163,7 @@ const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest =
     } catch (error) {
         if (isGzipRequest(options.compression, getQueryParam(options.url, 'compression'))) {
             logger.error('Failed to gzip request body, sending uncompressed payload', error)
-            return fallbackToUncompressed()
+            return fallbackToUncompressed(false)
         }
 
         throw error

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -142,11 +142,7 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
 }
 
 const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest => {
-    const fallbackToUncompressed = (disableAsyncGzip = true): EncodedRequest => {
-        if (disableAsyncGzip) {
-            nativeAsyncGzipDisabled = true
-        }
-
+    const fallbackToUncompressed = (): EncodedRequest => {
         return {
             url: removeURLParam(options.url, 'compression'),
             encodedBody: encodePostData({
@@ -163,7 +159,7 @@ const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest =
     } catch (error) {
         if (isGzipRequest(options.compression, getQueryParam(options.url, 'compression'))) {
             logger.error('Failed to gzip request body, sending uncompressed payload', error)
-            return fallbackToUncompressed(false)
+            return fallbackToUncompressed()
         }
 
         throw error
@@ -177,6 +173,7 @@ const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest =
         return { url: options.url, encodedBody }
     }
 
+    nativeAsyncGzipDisabled = true
     return fallbackToUncompressed()
 }
 


### PR DESCRIPTION
## Problem

Browser requests using gzip-js could fail locally during synchronous gzip encoding. In that case, the SDK should still send the original payload uncompressed instead of treating the request as a local failure.

## Changes

- Adds an uncompressed fallback around browser request body gzip encoding.
- Reuses the existing URL/header cleanup path so the fallback request does not advertise gzip compression.
- Adds a changeset for `posthog-js`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## Validation

- `pnpm exec eslint src/request.ts`
- `pnpm exec prettier --check src/request.ts`
- Also tried package test/build commands. They were blocked in this fresh worktree by missing generated workspace package artifacts such as `@posthog/core`/rrweb dist outputs, not by this file-level change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented as part of a cross-SDK consistency pass for client-side compression failure fallback. Kept the change focused on the browser request encoding path.
