### PR TITLE
fix(nuxt): augment @nuxt/schema with posthogConfig key

### DIFF
--- a/.changeset/nuxt-schema-augmentation.md
+++ b/.changeset/nuxt-schema-augmentation.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nuxt': patch
+---
+
+Augment `@nuxt/schema` so `posthogConfig` is a known key on `NuxtConfig`/`NuxtOptions`. Without this, using `posthogConfig` in `nuxt.config.ts` (as the wizard generates) reports a TS2353 error.

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -53,6 +53,15 @@ export interface ModuleOptions {
   sourcemaps: SourcemapsConfig | undefined
 }
 
+declare module '@nuxt/schema' {
+  interface NuxtConfig {
+    posthogConfig?: Partial<ModuleOptions>
+  }
+  interface NuxtOptions {
+    posthogConfig?: ModuleOptions
+  }
+}
+
 export interface PostHogCommon {
   publicKey: string
   host: string


### PR DESCRIPTION
## Problem

`@posthog/nuxt` declares `meta.configKey: 'posthogConfig'` and the wizard generates `nuxt.config.ts` with a top-level `posthogConfig: { ... }` block, but the package never augments `@nuxt/schema`'s `NuxtConfig` / `NuxtOptions` interfaces. TypeScript therefore rejects the generated config with `TS2353: Object literal may only specify known properties, and 'posthogConfig' does not exist in type 'InputConfig<NuxtConfig, ConfigLayerMeta>'`.

Repro on `@posthog/nuxt@1.7.77` / Nuxt 4.4.8: install the module, add `posthogConfig` to `nuxt.config.ts`, run `npx tsc --noEmit`.

Closes #3968. Supersedes #3969.

## Changes

- Add a `declare module '@nuxt/schema'` block to `packages/nuxt/src/module.ts` that extends `NuxtConfig` with `posthogConfig?: Partial<ModuleOptions>` and `NuxtOptions` with `posthogConfig?: ModuleOptions`. This is the convention used by Nuxt modules to register their config key with consumer TS configs.
- Add a `@posthog/nuxt` patch changeset.

Type-only — no runtime change, no public type breakage. Verified that the augmentation is preserved in the emitted `dist/module.d.mts` after `nuxt-module-build build`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [x] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged #3968 via Claude Code confirmed against `origin/main` and the published `@posthog/nuxt@1.7.77` tarball that the augmentation is missing in source and in the shipped types. 