### PR TITLE
ci: Reuse existing PostHog upgrade PR

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -58,11 +58,23 @@ jobs:
               id: generate-branch-name
               shell: bash
               env:
+                  GH_TOKEN: ${{ steps.upgrader.outputs.token }}
                   PACKAGE_NAME: ${{ github.event.inputs.package_name }}
-                  PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
               run: |
                   PACKAGE_NAME_SANITIZED=$(echo "$PACKAGE_NAME" | sed 's/@//g' | sed 's/\//-/g')
-                  echo "branch_name=${PACKAGE_NAME_SANITIZED}-$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+                  TITLE_PREFIX="chore(deps): Update ${PACKAGE_NAME} to "
+                  EXISTING_BRANCH=$(gh pr list \
+                      --repo PostHog/posthog \
+                      --state open \
+                      --limit 100 \
+                      --json title,headRefName,headRepositoryOwner \
+                      --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")) | select(.headRepositoryOwner.login == \"PostHog\") | .headRefName" | head -n 1)
+
+                  if [ -n "$EXISTING_BRANCH" ]; then
+                      echo "branch_name=$EXISTING_BRANCH" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "branch_name=${PACKAGE_NAME_SANITIZED}-upgrade" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Create main repo pull request
               id: main-repo-pr
@@ -91,12 +103,30 @@ jobs:
               run: |
                   echo "PostHog pull request for $PACKAGE_NAME version $PACKAGE_VERSION ready: $PR_URL"
 
+            - name: Update pull request metadata
+              env:
+                  GH_TOKEN: ${{ steps.upgrader.outputs.token }}
+                  PACKAGE_NAME: ${{ github.event.inputs.package_name }}
+                  PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
+                  PR_NUMBER: ${{ steps.main-repo-pr.outputs.pull-request-number }}
+              run: |
+                  gh pr edit "$PR_NUMBER" \
+                      --repo PostHog/posthog \
+                      --title "chore(deps): Update $PACKAGE_NAME to $PACKAGE_VERSION" \
+                      --body "## Changes
+
+                  $PACKAGE_NAME version $PACKAGE_VERSION has been released. This updates PostHog to use it.
+
+                  [GitHub releases](https://github.com/PostHog/posthog-js/releases) • [npm releases](https://www.npmjs.com/package/${PACKAGE_NAME}?activeTab=version)"
+
             - name: Enable automerge
               env:
                   GH_TOKEN: ${{ steps.upgrader.outputs.token }}
                   PR_NUMBER: ${{ steps.main-repo-pr.outputs.pull-request-number }}
               run: |
-                  gh pr merge "$PR_NUMBER" --auto --squash
+                  if [ "$(gh pr view "$PR_NUMBER" --repo PostHog/posthog --json autoMergeRequest --jq '.autoMergeRequest != null')" = "false" ]; then
+                      gh pr merge "$PR_NUMBER" --repo PostHog/posthog --auto --squash
+                  fi
 
             - name: Assign reviewers
               env:

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -54,15 +54,17 @@ jobs:
                   sed -i "s|${PACKAGE_NAME}:.*|${PACKAGE_NAME}: ^${PACKAGE_VERSION}|" pnpm-workspace.yaml
                   pnpm i --no-frozen-lockfile
 
-            - name: Generate branch name
-              id: generate-branch-name
+            - name: Generate pull request details
+              id: generate-pr-details
               shell: bash
               env:
                   GH_TOKEN: ${{ steps.upgrader.outputs.token }}
                   PACKAGE_NAME: ${{ github.event.inputs.package_name }}
+                  PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
               run: |
                   PACKAGE_NAME_SANITIZED=$(echo "$PACKAGE_NAME" | sed 's/@//g' | sed 's/\//-/g')
                   TITLE_PREFIX="chore(deps): Update ${PACKAGE_NAME} to "
+                  PR_TITLE="${TITLE_PREFIX}${PACKAGE_VERSION}"
                   EXISTING_BRANCH=$(gh pr list \
                       --repo PostHog/posthog \
                       --state open \
@@ -71,10 +73,22 @@ jobs:
                       --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")) | select(.headRepositoryOwner.login == \"PostHog\") | .headRefName" | head -n 1)
 
                   if [ -n "$EXISTING_BRANCH" ]; then
-                      echo "branch_name=$EXISTING_BRANCH" >> "$GITHUB_OUTPUT"
+                      BRANCH_NAME="$EXISTING_BRANCH"
                   else
-                      echo "branch_name=${PACKAGE_NAME_SANITIZED}-upgrade" >> "$GITHUB_OUTPUT"
+                      BRANCH_NAME="${PACKAGE_NAME_SANITIZED}-upgrade"
                   fi
+
+                  echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+                  echo "title=$PR_TITLE" >> "$GITHUB_OUTPUT"
+                  {
+                      echo 'body<<EOF'
+                      echo '## Changes'
+                      echo
+                      echo "$PACKAGE_NAME version $PACKAGE_VERSION has been released. This updates PostHog to use it."
+                      echo
+                      echo "[GitHub releases](https://github.com/PostHog/posthog-js/releases) • [npm releases](https://www.npmjs.com/package/${PACKAGE_NAME}?activeTab=version)"
+                      echo 'EOF'
+                  } >> "$GITHUB_OUTPUT"
 
             - name: Create main repo pull request
               id: main-repo-pr
@@ -83,16 +97,11 @@ jobs:
                   HUSKY: '0'
               with:
                   token: ${{ steps.upgrader.outputs.token }}
-                  commit-message: 'chore(deps): Update ${{ github.event.inputs.package_name }} to ${{ github.event.inputs.package_version }}'
-                  branch: ${{ steps.generate-branch-name.outputs.branch_name }}
+                  commit-message: ${{ steps.generate-pr-details.outputs.title }}
+                  branch: ${{ steps.generate-pr-details.outputs.branch_name }}
                   delete-branch: true
-                  title: 'chore(deps): Update ${{ github.event.inputs.package_name }} to ${{ github.event.inputs.package_version }}'
-                  body: |
-                      ## Changes
-
-                      ${{ github.event.inputs.package_name }} version ${{ github.event.inputs.package_version }} has been released. This updates PostHog to use it.
-
-                      [GitHub releases](https://github.com/PostHog/posthog-js/releases) • [npm releases](https://www.npmjs.com/package/${{ github.event.inputs.package_name }}?activeTab=version)
+                  title: ${{ steps.generate-pr-details.outputs.title }}
+                  body: ${{ steps.generate-pr-details.outputs.body }}
 
             - name: Output pull request result
               shell: bash
@@ -106,18 +115,14 @@ jobs:
             - name: Update pull request metadata
               env:
                   GH_TOKEN: ${{ steps.upgrader.outputs.token }}
-                  PACKAGE_NAME: ${{ github.event.inputs.package_name }}
-                  PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
+                  PR_BODY: ${{ steps.generate-pr-details.outputs.body }}
                   PR_NUMBER: ${{ steps.main-repo-pr.outputs.pull-request-number }}
+                  PR_TITLE: ${{ steps.generate-pr-details.outputs.title }}
               run: |
                   gh pr edit "$PR_NUMBER" \
                       --repo PostHog/posthog \
-                      --title "chore(deps): Update $PACKAGE_NAME to $PACKAGE_VERSION" \
-                      --body "## Changes
-
-                  $PACKAGE_NAME version $PACKAGE_VERSION has been released. This updates PostHog to use it.
-
-                  [GitHub releases](https://github.com/PostHog/posthog-js/releases) • [npm releases](https://www.npmjs.com/package/${PACKAGE_NAME}?activeTab=version)"
+                      --title "$PR_TITLE" \
+                      --body "$PR_BODY"
 
             - name: Enable automerge
               env:


### PR DESCRIPTION
## Problem

The PostHog upgrade workflow currently creates a version-specific branch for each release. When multiple releases happen before the previous upgrade PR merges, the workflow opens multiple PostHog/posthog PRs instead of updating the existing one to the latest version.

## Changes

The workflow now looks for an open PostHog/posthog upgrade PR for the selected package and reuses that branch when found. New upgrade PRs use a stable package-based branch name, and reruns update the PR title/body to the latest package version.

The PR title, body, and branch-selection title prefix are generated once as step outputs and reused by the lookup, `create-pull-request`, and metadata update steps, so the matching format cannot drift between steps. Auto-merge enabling is also idempotent so rerunning against an existing PR does not fail just because auto-merge is already enabled.

Verified with YAML parsing, `bash -n` over workflow `run:` blocks, and `git diff --check`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi in a dedicated git worktree. The chosen approach keeps a single open PostHog/posthog upgrade PR per package by reusing the branch from an existing open upgrade PR when present, while preserving the normal create-pull-request behavior when no such PR exists. Review feedback was addressed by generating shared PR details once and reusing them across the workflow.
