### PR TITLE
fix(mcp): stamp $mcp_client_name on every captured event

### DIFF
--- a/.changeset/mcp-client-name-cache.md
+++ b/.changeset/mcp-client-name-cache.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': patch
+---
+
+Fix `$mcp_client_name` being dropped from every other captured event. `getSessionInfo` cached the client identity but then overwrote the cache with `undefined` on the next event, so consecutive tool calls alternated between carrying and lacking the client name (showing up as a large "other" slice in MCP analytics). The cached client name/version are now reused instead of refetched.

--- a/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
+++ b/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
@@ -192,4 +192,32 @@ describe('Low-level Server tracing (e2e)', () => {
       await cleanup()
     }
   })
+
+  it('stamps $mcp_client_name on every tool call, not just the first', async () => {
+    // Regression: getSessionInfo() cached the client name but then overwrote the
+    // cache with `undefined` on the next event, so consecutive tool calls
+    // alternated between having and lacking $mcp_client_name.
+    const { server, client, connect, cleanup } = await setupLowLevelServer()
+    try {
+      instrument(server, fakePostHog())
+      await connect()
+
+      for (let i = 0; i < 4; i++) {
+        await client.request(
+          { method: 'tools/call', params: { name: 'echo', arguments: { text: `hi ${i}` } } },
+          CallToolResultSchema
+        )
+      }
+      await new Promise((r) => setTimeout(r, 50))
+
+      const toolCalls = eventCapture.findCapturesByEvent('$mcp_tool_call')
+      expect(toolCalls).toHaveLength(4)
+      // The InMemory client identifies itself as 'test client' (see setupLowLevelServer).
+      for (const call of toolCalls) {
+        expect(call.properties.$mcp_client_name).toBe('test client')
+      }
+    } finally {
+      await cleanup()
+    }
+  })
 })

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -89,11 +89,13 @@ export function getSessionInfo(
   data: MCPAnalyticsData | undefined,
   sessionId?: string
 ): SessionInfo {
-  let clientInfo: ServerClientInfoLike | undefined = {
-    name: undefined,
-    version: undefined,
-  }
-  if (!data?.sessionInfo.clientName) {
+  let clientInfo: ServerClientInfoLike | undefined
+  if (data?.sessionInfo.clientName) {
+    clientInfo = {
+      name: data.sessionInfo.clientName,
+      version: data.sessionInfo.clientVersion,
+    }
+  } else {
     clientInfo = server.getClientVersion()
   }
   const actorInfo = data?.identifiedSessions.get(sessionId ?? data.sessionId)


### PR DESCRIPTION
`getSessionInfo` cached the client name then overwrote it with `undefined` on the next captured event, so consecutive tool calls alternated between carrying and lacking `$mcp_client_name` — surfacing as a large "Other" slice in MCP analytics. Now reuses the cached name/version instead of refetching. Adds a regression test asserting the name survives across consecutive calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)