### PR TITLE
ci: fix pnpm setup version mismatch

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -24,8 +24,6 @@ runs:
       uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
       with:
         # TODO: pnpm/setup does not read .nvmrc yet; use the input default above for now.
-        # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
-        version: 11.7.0
         runtime: node@${{ inputs.node_version }}
         cache: false
         install: false

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -21,9 +21,8 @@ jobs:
       - name: Setup pnpm and Node.js
         uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
         with:
-          # TODO: pnpm/setup does not read .nvmrc yet; use this explicit version for now.
+          # TODO: pnpm/setup does not read .nvmrc yet; keep this in sync with .nvmrc.
           # https://github.com/jasongin/nvs/pull/315
-          version: 11.7.0
           runtime: node@24
           cache: false
           install: false

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -36,14 +36,14 @@ jobs:
                   repository: 'PostHog/posthog'
                   token: ${{ steps.upgrader.outputs.token }}
 
-            - name: Setup pnpm and Node.js
+            - name: Setup Node.js
+              uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+              with:
+                node-version: 24
+
+            - name: Setup pnpm
               uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
               with:
-                # TODO: pnpm/setup does not read .nvmrc yet. Keep this in sync with .nvmrc
-                # until https://github.com/jasongin/nvs/pull/315 lands.
-                # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
-                version: 11.7.0
-                runtime: node@24
                 cache: false
                 install: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,14 +439,14 @@ jobs:
                   ref: master
                   fetch-depth: 1
 
-            - name: Setup pnpm and Node.js
+            - name: Setup Node.js
+              uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+              with:
+                node-version: 24
+
+            - name: Setup pnpm
               uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
               with:
-                # TODO: pnpm/setup does not read .nvmrc yet. Keep this in sync with .nvmrc
-                # until https://github.com/jasongin/nvs/pull/315 lands.
-                # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
-                version: 11.7.0
-                runtime: node@24
                 cache: false
                 install: false
 
@@ -585,8 +585,6 @@ jobs:
               with:
                 # TODO: pnpm/setup does not read .nvmrc yet. Keep this in sync with .nvmrc
                 # until https://github.com/jasongin/nvs/pull/315 lands.
-                # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
-                version: 11.7.0
                 runtime: node@24
                 cache: false
                 install: false


### PR DESCRIPTION
## Problem

The manually triggered PostHog Upgrade workflow can fail after checking out `PostHog/posthog` because `pnpm/setup` was configured with `version: 11.7.0` while the checked-out repository declares `packageManager: pnpm@10.29.3`.

## Changes

- Let `pnpm/setup` read the pnpm version from the checked-out repository instead of passing a conflicting explicit version.
- For cross-repo jobs that check out `PostHog/posthog`, install Node 24 with `actions/setup-node` first, then run `pnpm/setup` without the runtime input so it can install `pnpm@10.29.3` safely.
- Removed the same explicit pnpm version from local workflow setup paths to avoid future package manager mismatches.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated the failed workflow run and confirmed it failed in `pnpm/setup` after `PostHog/posthog` was checked out, where `packageManager` is `pnpm@10.29.3`. Chose to remove explicit pnpm versions from `pnpm/setup` inputs and use `actions/setup-node` for cross-repo Node setup so pnpm can follow the checked-out repository's package manager declaration.

Verified the changed workflow/action YAML files parse successfully and that no `version: 11.7.0` remains under `.github`.
