### PR TITLE
fix(posthog-js): use SPDX expression for license field

### DIFF
--- a/.changeset/spdx-license-expression.md
+++ b/.changeset/spdx-license-expression.md
@@ -1,5 +1,0 @@
----
-'posthog-js': patch
----
-
-Use SPDX expression `(Apache-2.0 AND MIT)` for the `license` field instead of the deprecated `SEE LICENSE IN LICENSE` value. This lets automated license-compliance tools resolve the package metadata without falling back to LICENSE-file scanning.

--- a/.changeset/spdx-license-expression.md
+++ b/.changeset/spdx-license-expression.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Use SPDX expression `(Apache-2.0 AND MIT)` for the `license` field instead of the deprecated `SEE LICENSE IN LICENSE` value. This lets automated license-compliance tools resolve the package metadata without falling back to LICENSE-file scanning.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -7,7 +7,7 @@
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "engineering@posthog.com",
-    "license": "SEE LICENSE IN LICENSE",
+    "license": "(Apache-2.0 AND MIT)",
     "homepage": "https://posthog.com/docs/libraries/js",
     "packageManager": "pnpm@10.12.4",
     "scripts": {


### PR DESCRIPTION
Fixes #2627

## Summary
- Replace the deprecated npm license metadata value with a valid SPDX expression.
- Add a patch changeset for `posthog-js`.

## Verification
- [x] `git diff --check main...HEAD`
- [x] Verified issue is open and no competing open PR exists

## Risk
Low. This changes package metadata only.