### PR TITLE
fix(react-native): forward requestHeaders to native plugin

### DIFF
--- a/.changeset/posthog-rn-native-request-headers.md
+++ b/.changeset/posthog-rn-native-request-headers.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Forward `requestHeaders` to the native plugin so custom headers (e.g. `Authorization`) are also applied to session replay and native error/crash uploads, which are sent directly by the native SDK. Requires native SDK support for the headers to take effect.

--- a/.changeset/rn-plugin-request-headers.md
+++ b/.changeset/rn-plugin-request-headers.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Forward `requestHeaders` from `sdkOptions` to the native `PostHogConfig` so custom headers (e.g. `Authorization`) are applied to session replay and native error/crash uploads. Bumps the native dependencies to posthog-ios 3.63.0 / posthog-android 3.52.0, which add the `requestHeaders` config option.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,6 +85,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.51.1"
+  implementation "com.posthog:posthog-android:3.52.0"
 }
 

--- a/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
+++ b/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
@@ -93,6 +93,13 @@ class PosthogReactNativePluginModule(
           val theSdkVersion = getString(sdkOptions, "sdkVersion", "")
           val theFlushAt = getInt(sdkOptions, "flushAt", DEFAULT_FLUSH_AT)
 
+          // Forward custom headers (e.g. Authorization for a reverse proxy) so the native SDK
+          // attaches them to the requests it sends directly (session replay, crash uploads).
+          val theRequestHeaders =
+            getMap(sdkOptions, "requestHeaders")?.toHashMap()
+              ?.filterValues { it is String }
+              ?.mapValues { it.value as String }
+
           val config =
             PostHogAndroidConfig(apiKey, host).apply {
               debug = debugValue
@@ -100,6 +107,7 @@ class PosthogReactNativePluginModule(
               captureApplicationLifecycleEvents = false
               captureScreenViews = false
               flushAt = theFlushAt
+              theRequestHeaders?.let { requestHeaders = it }
               errorTrackingConfig.autoCapture = nativeErrorTrackingAutocapture
 
               // Keep the native exception-steps buffer aligned with the JS layer (one logical buffer).

--- a/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
+++ b/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
@@ -178,6 +178,13 @@ class PosthogReactNativePlugin: NSObject {
         let flushAt = sdkOptions["flushAt"] as? Int ?? 20
         config.flushAt = flushAt
 
+        // Forward custom headers (e.g. Authorization for a reverse proxy) so the native SDK
+        // attaches them to the requests it sends directly (session replay, crash uploads).
+        // Keep only string values so a stray non-string doesn't drop every header (matches Android).
+        if let rawHeaders = sdkOptions["requestHeaders"] as? [String: Any] {
+            config.requestHeaders = rawHeaders.compactMapValues { $0 as? String }
+        }
+
         if !sdkVersion.isEmpty {
             postHogSdkName = "posthog-react-native"
             postHogVersion = sdkVersion

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.61.1'
+posthog_ios_version = '3.63.0'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -2121,9 +2121,8 @@ export class PostHog extends PostHogCore {
       anonymousId: this.getAnonymousId(),
       sdkVersion: this.getLibraryVersion(),
       flushAt: this.flushAt,
-      // Forwarded so the native SDK applies the same custom headers (e.g. Authorization
-      // for a reverse proxy) to session replay and native error/crash uploads, which are
-      // sent directly by the native SDK and never pass through the JS request path.
+      // Native-sent requests (session replay, crash uploads) bypass the JS request path,
+      // so the configured headers are passed through to the native plugin as well.
       requestHeaders: this._requestHeaders,
     }
 

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -2126,7 +2126,9 @@ export class PostHog extends PostHogCore {
       requestHeaders: this._requestHeaders,
     }
 
-    this._logger.info(`Native PostHog plugin sdk options: ${JSON.stringify(sdkOptions)}`)
+    // Log header names only: requestHeaders values can carry secrets (e.g. an Authorization token).
+    const loggableSdkOptions = { ...sdkOptions, requestHeaders: Object.keys(this._requestHeaders) }
+    this._logger.info(`Native PostHog plugin sdk options: ${JSON.stringify(loggableSdkOptions)}`)
 
     try {
       const wasSessionReplayEnabled = enableSessionReplay

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -2121,6 +2121,10 @@ export class PostHog extends PostHogCore {
       anonymousId: this.getAnonymousId(),
       sdkVersion: this.getLibraryVersion(),
       flushAt: this.flushAt,
+      // Forwarded so the native SDK applies the same custom headers (e.g. Authorization
+      // for a reverse proxy) to session replay and native error/crash uploads, which are
+      // sent directly by the native SDK and never pass through the JS request path.
+      requestHeaders: this._requestHeaders,
     }
 
     this._logger.info(`Native PostHog plugin sdk options: ${JSON.stringify(sdkOptions)}`)

--- a/packages/react-native/test/session-replay-request-headers.spec.ts
+++ b/packages/react-native/test/session-replay-request-headers.spec.ts
@@ -21,6 +21,7 @@ jest.mock('../src/optional/OptionalPlugin', () => ({
 const replay = OptionalReactNativePlugin as unknown as {
   start: jest.Mock
   isEnabled: jest.Mock
+  setup?: jest.Mock
 }
 
 Linking.getInitialURL = jest.fn(() => Promise.resolve(null))
@@ -52,10 +53,12 @@ describe('PostHog RN session replay request headers', () => {
   })
 
   afterEach(async () => {
-    await posthog.shutdown()
+    if (posthog) {
+      await posthog.shutdown()
+    }
   })
 
-  it('forwards requestHeaders to the native plugin sdkOptions', async () => {
+  it('forwards requestHeaders to the native plugin sdkOptions via the legacy start() path', async () => {
     posthog = new PostHog('test-token', {
       customStorage: mockStorage,
       enableSessionReplay: true,
@@ -68,5 +71,26 @@ describe('PostHog RN session replay request headers', () => {
 
     const sdkOptions = replay.start.mock.calls[0][1]
     expect(sdkOptions).toEqual(expect.objectContaining({ requestHeaders: { Authorization: 'Bearer test-jwt' } }))
+  })
+
+  it('forwards requestHeaders to the native plugin sdkOptions via the setup() path', async () => {
+    // Adding a `setup` mock switches the SDK to the modern setup() dispatch path.
+    replay.setup = jest.fn(async () => {})
+
+    posthog = new PostHog('test-token', {
+      customStorage: mockStorage,
+      enableSessionReplay: true,
+      flushInterval: 0,
+      requestHeaders: { Authorization: 'Bearer test-jwt' },
+    })
+    await posthog.ready()
+
+    await waitForExpect(2000, () => expect(replay.setup).toHaveBeenCalledTimes(1))
+    expect(replay.start).not.toHaveBeenCalled()
+
+    const sdkOptions = replay.setup.mock.calls[0][1]
+    expect(sdkOptions).toEqual(expect.objectContaining({ requestHeaders: { Authorization: 'Bearer test-jwt' } }))
+
+    delete replay.setup
   })
 })

--- a/packages/react-native/test/session-replay-request-headers.spec.ts
+++ b/packages/react-native/test/session-replay-request-headers.spec.ts
@@ -1,0 +1,72 @@
+import { PostHog, PostHogCustomStorage } from '../src'
+import { OptionalReactNativePlugin } from '../src/optional/OptionalPlugin'
+import { Linking, AppState } from 'react-native'
+import { waitForExpect } from './test-utils'
+
+// Mock the native plugin bridge so we can assert which native calls happen. No `setup`
+// key, so the SDK takes the legacy start() path (same surface as the standalone
+// posthog-react-native-session-replay package).
+jest.mock('../src/optional/OptionalPlugin', () => ({
+  OptionalReactNativePlugin: {
+    start: jest.fn(async () => {}),
+    startSession: jest.fn(async () => {}),
+    endSession: jest.fn(async () => {}),
+    isEnabled: jest.fn(async () => false),
+    identify: jest.fn(async () => {}),
+    startRecording: jest.fn(async () => {}),
+    stopRecording: jest.fn(async () => {}),
+  },
+}))
+
+const replay = OptionalReactNativePlugin as unknown as {
+  start: jest.Mock
+  isEnabled: jest.Mock
+}
+
+Linking.getInitialURL = jest.fn(() => Promise.resolve(null))
+AppState.addEventListener = jest.fn()
+
+describe('PostHog RN session replay request headers', () => {
+  jest.useRealTimers()
+
+  let posthog: PostHog
+  let cache: any = {}
+  let mockStorage: PostHogCustomStorage
+
+  beforeEach(() => {
+    replay.start.mockClear()
+    replay.isEnabled.mockImplementation(async () => false)
+    replay.start.mockImplementation(async () => {})
+    ;(globalThis as any).window.fetch = jest.fn(async (url: string) => {
+      const res = url.includes('flags') ? { featureFlags: {}, sessionRecording: { endpoint: '/s/' } } : { status: 'ok' }
+      return { status: 200, json: () => Promise.resolve(res) }
+    })
+
+    cache = {}
+    mockStorage = {
+      getItem: async (key) => cache[key] || null,
+      setItem: async (key, value) => {
+        cache[key] = value
+      },
+    }
+  })
+
+  afterEach(async () => {
+    await posthog.shutdown()
+  })
+
+  it('forwards requestHeaders to the native plugin sdkOptions', async () => {
+    posthog = new PostHog('test-token', {
+      customStorage: mockStorage,
+      enableSessionReplay: true,
+      flushInterval: 0,
+      requestHeaders: { Authorization: 'Bearer test-jwt' },
+    })
+    await posthog.ready()
+
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+
+    const sdkOptions = replay.start.mock.calls[0][1]
+    expect(sdkOptions).toEqual(expect.objectContaining({ requestHeaders: { Authorization: 'Bearer test-jwt' } }))
+  })
+})


### PR DESCRIPTION
## Problem

Stacked on top of #3970. That PR added the `requestHeaders` option but it only reaches **JS-originated** requests (events `/batch/`, `/flags/`, JS `captureException`) via `getCustomHeaders()`. In React Native, **session replay snapshots** and **native error/crash autocapture** are sent *directly by the embedded native SDK* (posthog-ios / posthog-android) and never pass through the JS request path — so they wouldn't carry custom headers such as an `Authorization` header for a reverse proxy. Without this, #2132 is only half-solved for RN apps using replay or native crash capture.

## Changes

- Forward `requestHeaders` into the `sdkOptions` object passed to the native plugin in `startSessionReplay()` (`OptionalReactNativePlugin.setup()` / `.start()`), alongside the existing `apiKey`, `host`, `distinctId`, etc.
- Added a test asserting the headers reach the native `sdkOptions`.
- Added a changeset.

This is the **RN-side wiring only**. For the headers to actually be applied on native uploads, the native plugin bridge (`posthog-react-native-session-replay` / `@posthog/react-native-plugin`) must read `sdkOptions.requestHeaders` and the underlying `posthog-ios` / `posthog-android` SDKs must support a custom-headers config option. Those are tracked as separate follow-up PRs. Passing the key now is forward-compatible — the native bridge ignores unknown `sdkOptions` keys until it adds support.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @turnipdabeets  while reviewing #3970. We identified that `requestHeaders` in #3970 covers JS-layer traffic only, and that RN session replay + native crash uploads originate from the native SDK and bypass it. Scoped this PR to the RN-side forwarding (passing `requestHeaders` through `sdkOptions`), keeping the native SDK + bridge changes as separate follow-ups. Tool used: Claude Code.

---

Part of #2132. Stacked on #3970.
