### PR TITLE
feat(react-native-plugin): forward requestHeaders to native config

### DIFF
--- a/.changeset/rn-plugin-request-headers.md
+++ b/.changeset/rn-plugin-request-headers.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Forward `requestHeaders` from `sdkOptions` to the native `PostHogConfig` so custom headers (e.g. `Authorization`) are applied to session replay and native error/crash uploads. Requires posthog-ios / posthog-android versions that expose the `requestHeaders` config option.

--- a/.changeset/rn-plugin-request-headers.md
+++ b/.changeset/rn-plugin-request-headers.md
@@ -2,4 +2,4 @@
 '@posthog/react-native-plugin': patch
 ---
 
-Forward `requestHeaders` from `sdkOptions` to the native `PostHogConfig` so custom headers (e.g. `Authorization`) are applied to session replay and native error/crash uploads. Requires posthog-ios / posthog-android versions that expose the `requestHeaders` config option.
+Forward `requestHeaders` from `sdkOptions` to the native `PostHogConfig` so custom headers (e.g. `Authorization`) are applied to session replay and native error/crash uploads. Bumps the native dependencies to posthog-ios 3.63.0 / posthog-android 3.52.0, which add the `requestHeaders` config option.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,6 +85,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.51.1"
+  implementation "com.posthog:posthog-android:3.52.0"
 }
 

--- a/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
+++ b/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
@@ -96,9 +96,9 @@ class PosthogReactNativePluginModule(
           // Forward custom headers (e.g. Authorization for a reverse proxy) so the native SDK
           // attaches them to the requests it sends directly (session replay, crash uploads).
           val theRequestHeaders =
-            getMap(sdkOptions, "requestHeaders")?.toHashMap().orEmpty()
-              .filterValues { it is String }
-              .mapValues { it.value as String }
+            getMap(sdkOptions, "requestHeaders")?.toHashMap()
+              ?.filterValues { it is String }
+              ?.mapValues { it.value as String }
 
           val config =
             PostHogAndroidConfig(apiKey, host).apply {
@@ -107,7 +107,7 @@ class PosthogReactNativePluginModule(
               captureApplicationLifecycleEvents = false
               captureScreenViews = false
               flushAt = theFlushAt
-              requestHeaders = theRequestHeaders
+              theRequestHeaders?.let { requestHeaders = it }
               errorTrackingConfig.autoCapture = nativeErrorTrackingAutocapture
 
               // Keep the native exception-steps buffer aligned with the JS layer (one logical buffer).

--- a/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
+++ b/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
@@ -93,6 +93,13 @@ class PosthogReactNativePluginModule(
           val theSdkVersion = getString(sdkOptions, "sdkVersion", "")
           val theFlushAt = getInt(sdkOptions, "flushAt", DEFAULT_FLUSH_AT)
 
+          // Forward custom headers (e.g. Authorization for a reverse proxy) so the native SDK
+          // attaches them to the requests it sends directly (session replay, crash uploads).
+          val theRequestHeaders =
+            getMap(sdkOptions, "requestHeaders")?.toHashMap().orEmpty()
+              .filterValues { it is String }
+              .mapValues { it.value as String }
+
           val config =
             PostHogAndroidConfig(apiKey, host).apply {
               debug = debugValue
@@ -100,6 +107,7 @@ class PosthogReactNativePluginModule(
               captureApplicationLifecycleEvents = false
               captureScreenViews = false
               flushAt = theFlushAt
+              requestHeaders = theRequestHeaders
               errorTrackingConfig.autoCapture = nativeErrorTrackingAutocapture
 
               // Keep the native exception-steps buffer aligned with the JS layer (one logical buffer).

--- a/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
+++ b/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
@@ -180,8 +180,9 @@ class PosthogReactNativePlugin: NSObject {
 
         // Forward custom headers (e.g. Authorization for a reverse proxy) so the native SDK
         // attaches them to the requests it sends directly (session replay, crash uploads).
-        if let requestHeaders = sdkOptions["requestHeaders"] as? [String: String] {
-            config.requestHeaders = requestHeaders
+        // Keep only string values so a stray non-string doesn't drop every header (matches Android).
+        if let rawHeaders = sdkOptions["requestHeaders"] as? [String: Any] {
+            config.requestHeaders = rawHeaders.compactMapValues { $0 as? String }
         }
 
         if !sdkVersion.isEmpty {

--- a/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
+++ b/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
@@ -178,6 +178,12 @@ class PosthogReactNativePlugin: NSObject {
         let flushAt = sdkOptions["flushAt"] as? Int ?? 20
         config.flushAt = flushAt
 
+        // Forward custom headers (e.g. Authorization for a reverse proxy) so the native SDK
+        // attaches them to the requests it sends directly (session replay, crash uploads).
+        if let requestHeaders = sdkOptions["requestHeaders"] as? [String: String] {
+            config.requestHeaders = requestHeaders
+        }
+
         if !sdkVersion.isEmpty {
             postHogSdkName = "posthog-react-native"
             postHogVersion = sdkVersion

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.61.1'
+posthog_ios_version = '3.63.0'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"


### PR DESCRIPTION
## Problem

Stacked on #4012 / #3970. Those add the `requestHeaders` RN option and forward it into the native plugin's `sdkOptions`, but the plugin's native bridge didn't read it — so session replay snapshots and native crash uploads (sent directly by the native SDK) didn't carry custom headers like `Authorization` for a reverse proxy.

## Changes

- **iOS bridge** (`ios/PosthogReactNativePlugin.swift`): read `sdkOptions["requestHeaders"]` → `config.requestHeaders`.
- **Android bridge** (`android/.../PosthogReactNativePluginModule.kt`): read `requestHeaders` from `sdkOptions` → `config.requestHeaders`.
- **Bump native deps** now that the field is released: posthog-ios `3.61.1 → 3.63.0`, posthog-android `3.51.1 → 3.52.0`.
- Changeset.

Completes the chain: #3970 (RN option) → #4012 (JS forwarding) → **this** (plugin bridge) → posthog-ios#683 / posthog-android#592 (native SDK field, shipped in posthog-ios 3.63.0 / posthog-android 3.52.0).

## Notes for reviewers

- **Stacked** — merge order is #3970 → #4012 → this.
- The Android example build resolves `com.posthog:posthog-android:3.52.0` from Maven Central; CI there may be briefly red until the 3.52.0 release finishes propagating.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code <!-- forwarding covered by #4012 tests + native SDK PR tests; bridge glue exercised by the example apps -->
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Plugin-bridge layer of the cross-SDK `requestHeaders` work for #2132. Previously held as a draft because it referenced the native `config.requestHeaders` field; now unblocked — posthog-ios 3.63.0 and posthog-android 3.52.0 ship that field, and the native deps are bumped accordingly. Tool used: Claude Code.

---

Part of #2132. Stacked on #4012.
