### PR TITLE
fix(react-native): only scroll survey content when it overflows

### DIFF
--- a/.changeset/rn-survey-auto-scroll.md
+++ b/.changeset/rn-survey-auto-scroll.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Survey question content now scrolls only when it overflows the modal. Short surveys that fit no longer scroll or bounce, while longer surveys remain fully scrollable.

--- a/packages/react-native/src/surveys/components/QuestionTypes.tsx
+++ b/packages/react-native/src/surveys/components/QuestionTypes.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useMemo, useState } from 'react'
-import { Pressable, ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native'
+import { LayoutChangeEvent, Pressable, ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native'
 
 import { createSafeStyleSheet } from '../safeStyleSheet'
 import {
@@ -39,14 +39,25 @@ interface QuestionCommonProps {
 // Wraps question content in a scrollable region with a sticky BottomSection
 // (Submit button) at the bottom. The ScrollView has flexShrink: 1 so it
 // shrinks to fit when the parent modal is capped at its keyboard-aware
-// maxHeight, keeping Submit visible regardless of survey length.
+// maxHeight, keeping Submit visible regardless of survey length. Scrolling is
+// enabled only while the content overflows the viewport, so short surveys don't
+// scroll or bounce.
 function QuestionLayout({ children, footer }: { children: ReactNode; footer: ReactNode }): JSX.Element {
+  const [viewportHeight, setViewportHeight] = useState(0)
+  const [contentHeight, setContentHeight] = useState(0)
+  // 1px threshold absorbs sub-pixel layout rounding.
+  const isOverflowing = contentHeight > viewportHeight + 1
+
   return (
     <View style={questionLayoutStyles.container}>
       <ScrollView
         style={questionLayoutStyles.scroll}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
+        scrollEnabled={isOverflowing}
+        bounces={isOverflowing}
+        onLayout={(e: LayoutChangeEvent) => setViewportHeight(e.nativeEvent.layout.height)}
+        onContentSizeChange={(_width, height) => setContentHeight(height)}
       >
         {children}
       </ScrollView>

--- a/packages/react-native/test/surveys-autoScroll.spec.tsx
+++ b/packages/react-native/test/surveys-autoScroll.spec.tsx
@@ -88,22 +88,16 @@ describe('QuestionLayout auto-scroll', () => {
     expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
   })
 
-  it('disables scrolling when content fits within the viewport', () => {
+  it.each([
+    ['content fits the viewport', 500, 400, 'false'],
+    ['content overflows the viewport', 500, 800, 'true'],
+    ['content is sub-pixel taller than the viewport', 500, 500.4, 'false'],
+    ['content sits exactly at the 1px threshold', 500, 501, 'false'],
+    ['content is just past the 1px threshold', 500, 502, 'true'],
+  ] as const)('%s (viewport=%s, content=%s) -> scrollEnabled=%s', (_label, viewport, content, expected) => {
     const { getByTestId } = renderQuestion()
-    layout(500, 400)
-    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
-  })
-
-  it('enables scrolling when content overflows the viewport', () => {
-    const { getByTestId } = renderQuestion()
-    layout(500, 800)
-    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('true')
-  })
-
-  it('treats sub-pixel content taller than the viewport as fitting', () => {
-    const { getByTestId } = renderQuestion()
-    layout(500, 500.4)
-    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
+    layout(viewport, content)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe(expected)
   })
 
   it('re-disables scrolling when content shrinks back to fit', () => {
@@ -120,14 +114,6 @@ describe('QuestionLayout auto-scroll', () => {
     expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
     // Keyboard shrinks the modal: same content, smaller viewport -> overflow.
     layout(500, 600)
-    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('true')
-  })
-
-  it('treats content exactly at the 1px threshold as fitting', () => {
-    const { getByTestId } = renderQuestion()
-    layout(500, 501)
-    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
-    layout(500, 502)
     expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('true')
   })
 })

--- a/packages/react-native/test/surveys-autoScroll.spec.tsx
+++ b/packages/react-native/test/surveys-autoScroll.spec.tsx
@@ -1,0 +1,133 @@
+/** @jest-environment jsdom */
+import React from 'react'
+import { act, render, cleanup } from '@testing-library/react'
+import { SurveyQuestionType, OpenSurveyQuestion } from '@posthog/core'
+
+// Minimal react-native shim — jest-expo's full preset chain explodes under
+// jsdom. ScrollView reflects scrollEnabled as a data attribute and stashes its
+// layout callbacks so the test can drive viewport/content sizes.
+let scrollViewCallbacks: {
+  onLayout?: (e: { nativeEvent: { layout: { height: number } } }) => void
+  onContentSizeChange?: (width: number, height: number) => void
+} = {}
+
+jest.mock('react-native', () => {
+  const RealReact = jest.requireActual('react')
+  const strip = (props: any) => {
+    const domProps = { ...props }
+    delete domProps.keyboardShouldPersistTaps
+    delete domProps.showsVerticalScrollIndicator
+    delete domProps.bounces
+    delete domProps.multiline
+    delete domProps.numberOfLines
+    delete domProps.placeholderTextColor
+    delete domProps.onChangeText
+    delete domProps.underlineColorAndroid
+    return domProps
+  }
+  const Box = RealReact.forwardRef(({ children, testID, ...rest }: any, ref: any) =>
+    RealReact.createElement('div', { ref, 'data-testid': testID, ...strip(rest) }, children)
+  )
+  const ScrollView = RealReact.forwardRef(
+    ({ children, scrollEnabled, onLayout, onContentSizeChange, ...rest }: any, ref: any) => {
+      scrollViewCallbacks = { onLayout, onContentSizeChange }
+      return RealReact.createElement(
+        'div',
+        {
+          ref,
+          'data-testid': 'survey-scrollview',
+          'data-scroll-enabled': String(!!scrollEnabled),
+          ...strip(rest),
+        },
+        children
+      )
+    }
+  )
+  const Pressable = RealReact.forwardRef(({ children, testID, onPress, ...rest }: any, ref: any) =>
+    RealReact.createElement('div', { ref, 'data-testid': testID, onClick: onPress, ...strip(rest) }, children)
+  )
+  return {
+    View: Box,
+    ScrollView,
+    Text: Box,
+    TextInput: Box,
+    Pressable,
+    TouchableOpacity: Pressable,
+    Linking: { openURL: jest.fn() },
+    StyleSheet: { create: (s: any) => s, flatten: (s: any) => s, absoluteFill: {} },
+  }
+})
+
+import { OpenTextQuestion } from '../src/surveys/components/QuestionTypes'
+import { defaultSurveyAppearance } from '../src/surveys/surveys-utils'
+
+const openQuestion: OpenSurveyQuestion = {
+  type: SurveyQuestionType.Open,
+  question: 'What do you think?',
+  originalQuestionIndex: 0,
+}
+
+const renderQuestion = () =>
+  render(<OpenTextQuestion question={openQuestion} appearance={defaultSurveyAppearance} onSubmit={() => {}} />)
+
+// Simulate a native layout pass measuring viewport and content height.
+const layout = (viewport: number, content: number) =>
+  act(() => {
+    scrollViewCallbacks.onLayout?.({ nativeEvent: { layout: { height: viewport } } })
+    scrollViewCallbacks.onContentSizeChange?.(0, content)
+  })
+
+describe('QuestionLayout auto-scroll', () => {
+  afterEach(() => {
+    cleanup()
+    scrollViewCallbacks = {}
+  })
+
+  it('keeps scrolling disabled before any layout has been measured', () => {
+    const { getByTestId } = renderQuestion()
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
+  })
+
+  it('disables scrolling when content fits within the viewport', () => {
+    const { getByTestId } = renderQuestion()
+    layout(500, 400)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
+  })
+
+  it('enables scrolling when content overflows the viewport', () => {
+    const { getByTestId } = renderQuestion()
+    layout(500, 800)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('true')
+  })
+
+  it('treats sub-pixel content taller than the viewport as fitting', () => {
+    const { getByTestId } = renderQuestion()
+    layout(500, 500.4)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
+  })
+
+  it('re-disables scrolling when content shrinks back to fit', () => {
+    const { getByTestId } = renderQuestion()
+    layout(500, 800)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('true')
+    layout(500, 300)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
+  })
+
+  it('enables scrolling when the viewport shrinks under fixed content (keyboard opens)', () => {
+    const { getByTestId } = renderQuestion()
+    layout(800, 600)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
+    // Keyboard shrinks the modal: same content, smaller viewport -> overflow.
+    layout(500, 600)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('true')
+  })
+
+  it('treats content exactly at the 1px threshold as fitting', () => {
+    const { getByTestId } = renderQuestion()
+    layout(500, 501)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('false')
+    layout(500, 502)
+    expect(getByTestId('survey-scrollview').getAttribute('data-scroll-enabled')).toBe('true')
+  })
+})


### PR DESCRIPTION
## Problem

Closes #3530 

React Native survey question content is always wrapped in a `ScrollView`, so even a short one-question survey that comfortably fits the modal can be dragged and bounces. This was reported in #3530 — the scroll behavior felt wrong on short surveys. Replacing https://github.com/PostHog/posthog-js/pull/4001

## Changes

`QuestionLayout` now enables scrolling only when the content actually overflows the available viewport. It measures the `ScrollView` viewport via `onLayout` and the content via `onContentSizeChange`, and drives `scrollEnabled`/`bounces` from `contentHeight > viewportHeight + 1` (the 1px threshold absorbs sub-pixel rounding).

- Short surveys that fit: no scroll, no bounce — they feel like static content.
- Longer surveys (or when the keyboard shrinks the modal): scrolling re-enables automatically, and the content is never clipped because it always lives inside the `ScrollView`.
- The Submit button stays sticky at the bottom (it is rendered outside the `ScrollView`, unchanged).

No new public API — this is purely a behavior refinement, so it needs no opt-in prop.

### Demo

| Short survey — fits, does not scroll/bounce | Long survey — overflows, scrolls |
| --- | --- |
| https://github.com/user-attachments/assets/e47f81de-adc3-4d17-ae53-7c2e19a64bf2 | https://github.com/user-attachments/assets/58999f2c-d487-46f2-b5d5-b69086a7f717 |

### Testing

- New unit test `surveys-autoScroll.spec.tsx` drives the native layout callbacks and asserts `scrollEnabled` toggles correctly: disabled before measurement, disabled when content fits, enabled on overflow, sub-pixel overflow treated as fitting, and re-disabled when content shrinks back.
- Full survey suite passes (92 tests), lint clean.
- Verified on a physical Android device (Pixel 4): long survey scrolls through its content with the Submit button pinned; short survey does not move or bounce under an aggressive drag; keyboard-open case still scrolls to keep the focused input reachable.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude Code. The original request (#3530) and PR #4001 proposed an opt-in `disableSurveyScroll` prop; while reviewing that, we explored an alternative that needs no API — auto-detecting overflow — and prototyped it here. Decision: this approach solves the reporter's actual problem (no bounce on short surveys) without new surface area or any clipping risk, since content always stays inside the `ScrollView`. Reviewed with the code-reviewer-correctness agent and verified on a physical Android device.
