### PR TITLE
fix(convex): honour POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS

### DIFF
--- a/.changeset/convex-polling-interval.md
+++ b/.changeset/convex-polling-interval.md
@@ -1,0 +1,7 @@
+---
+'@posthog/convex': patch
+---
+
+Fix `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` being ignored. The flag-refresh interval was read when the cron was registered, but Convex forwards component env vars only at runtime, so the value was always empty there and the cron was pinned to the 60s default. The refresh now runs as a self-rescheduling loop that reads the interval at runtime, with a supervisor cron that keeps the loop alive, so the configured interval is honoured.
+
+Fixes [#3957](https://github.com/PostHog/posthog-js/issues/3957).

--- a/packages/convex/src/component/convex.config.ts
+++ b/packages/convex/src/component/convex.config.ts
@@ -14,9 +14,10 @@ export default defineComponent('posthog', {
     POSTHOG_HOST: v.optional(v.string()),
     POSTHOG_PERSONAL_API_KEY: v.optional(v.string()),
     /**
-     * Polling interval for the local-evaluation refresh cron, in whole seconds. Optional
-     * (defaults to 60). Convex component env vars are string-typed on the wire, so this is
-     * parsed at module load — invalid values log a warning and fall back to the default.
+     * Polling interval for the local-evaluation refresh, in whole seconds. Optional (defaults
+     * to 60). Convex component env vars are string-typed on the wire and only forwarded at
+     * runtime, so it's read by the self-rescheduling refresh loop in `lib.ts` rather than at
+     * cron-registration time — invalid values log a warning and fall back to the default.
      */
     POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS: v.optional(v.string()),
   },

--- a/packages/convex/src/component/crons.test.ts
+++ b/packages/convex/src/component/crons.test.ts
@@ -3,14 +3,34 @@ import type { Crons } from 'convex/server'
 import { DEFAULT_INTERVAL_SECONDS, readPollingIntervalSeconds } from './lib.js'
 
 describe('cron registration', () => {
+  let originalPak: string | undefined
+
   beforeEach(() => {
+    originalPak = process.env.POSTHOG_PERSONAL_API_KEY
     jest.resetModules()
+  })
+
+  afterEach(() => {
+    if (originalPak === undefined) {
+      delete process.env.POSTHOG_PERSONAL_API_KEY
+    } else {
+      process.env.POSTHOG_PERSONAL_API_KEY = originalPak
+    }
   })
 
   // The cron is only a supervisor for the self-rescheduling refresh loop — it registers
   // unconditionally and reads no env vars at module load (which would be empty at deploy-time
-  // analysis anyway; see #3957). The configured interval governs the loop, not this cron.
-  test('registers the refresh-loop supervisor cron', async () => {
+  // analysis anyway; see #3957). Parameterised over POSTHOG_PERSONAL_API_KEY to lock in that the
+  // cron registers regardless of env, so no future load-time gate silently drops it (see #3683).
+  test.each<[string, string | undefined]>([
+    ['unset', undefined],
+    ['set', 'phx_test'],
+  ])('registers the refresh-loop supervisor cron when POSTHOG_PERSONAL_API_KEY is %s', async (_label, pak) => {
+    if (pak === undefined) {
+      delete process.env.POSTHOG_PERSONAL_API_KEY
+    } else {
+      process.env.POSTHOG_PERSONAL_API_KEY = pak
+    }
     const mod = (await import('./crons.js')) as { default: Crons }
     expect(Object.keys(mod.default.crons)).toContain('Ensure PostHog flag refresh loop is running')
   })

--- a/packages/convex/src/component/crons.test.ts
+++ b/packages/convex/src/component/crons.test.ts
@@ -1,37 +1,18 @@
 import { describe, expect, test, beforeEach, afterEach, jest } from '@jest/globals'
 import type { Crons } from 'convex/server'
-import { DEFAULT_INTERVAL_SECONDS, readPollingIntervalSeconds } from './crons.js'
+import { DEFAULT_INTERVAL_SECONDS, readPollingIntervalSeconds } from './lib.js'
 
 describe('cron registration', () => {
-  let originalPak: string | undefined
-
   beforeEach(() => {
-    originalPak = process.env.POSTHOG_PERSONAL_API_KEY
     jest.resetModules()
   })
 
-  afterEach(() => {
-    if (originalPak === undefined) {
-      delete process.env.POSTHOG_PERSONAL_API_KEY
-    } else {
-      process.env.POSTHOG_PERSONAL_API_KEY = originalPak
-    }
-  })
-
-  // Convex forwards component env vars only at runtime, so deploy-time module analysis sees
-  // `process.env.POSTHOG_PERSONAL_API_KEY` empty even when the installing app has set it.
-  // A load-time gate would silently drop the cron — see #3683.
-  test.each<[string, string | undefined]>([
-    ['unset', undefined],
-    ['set', 'phx_test'],
-  ])('registers the refresh cron when POSTHOG_PERSONAL_API_KEY is %s at module load', async (_label, pakValue) => {
-    if (pakValue === undefined) {
-      delete process.env.POSTHOG_PERSONAL_API_KEY
-    } else {
-      process.env.POSTHOG_PERSONAL_API_KEY = pakValue
-    }
+  // The cron is only a supervisor for the self-rescheduling refresh loop — it registers
+  // unconditionally and reads no env vars at module load (which would be empty at deploy-time
+  // analysis anyway; see #3957). The configured interval governs the loop, not this cron.
+  test('registers the refresh-loop supervisor cron', async () => {
     const mod = (await import('./crons.js')) as { default: Crons }
-    expect(Object.keys(mod.default.crons)).toContain('Refresh PostHog feature flag definitions')
+    expect(Object.keys(mod.default.crons)).toContain('Ensure PostHog flag refresh loop is running')
   })
 })
 

--- a/packages/convex/src/component/crons.ts
+++ b/packages/convex/src/component/crons.ts
@@ -11,9 +11,11 @@ const crons = cronJobs()
 // chain (`lib.ts:refreshLoop`) that reads the interval at runtime and queues its own next run.
 //
 // This cron is only a supervisor: `ensureRefreshLoop` starts the chain unless it's already running,
-// which bootstraps a fresh deploy and self-heals if the chain ever stops. It runs often enough to
-// keep bootstrap/heal latency low, but the actual refresh work happens on the configured interval —
-// so raising the interval still cuts function-call usage, which is the point of the knob.
+// which bootstraps a fresh deploy and self-heals if the chain ever stops. The actual refresh work
+// happens on the configured interval, so raising the interval still cuts function-call usage, which
+// is the point of the knob. The supervisor's own cadence is a fixed floor — it can't read the
+// runtime interval (the same reason the cron can't), so at very long intervals the supervisor
+// itself becomes the dominant cost. 5 minutes trades that floor against bootstrap/heal latency.
 crons.interval('Ensure PostHog flag refresh loop is running', { minutes: 5 }, internal.lib.ensureRefreshLoop, {})
 
 export default crons

--- a/packages/convex/src/component/crons.ts
+++ b/packages/convex/src/component/crons.ts
@@ -3,19 +3,13 @@ import { internal } from './_generated/api.js'
 
 const crons = cronJobs()
 
-// The flag-refresh cadence is configurable at runtime via `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`,
-// but a cron's interval is fixed when it's registered — and Convex forwards component env vars only
-// at runtime, so the var is empty during the deploy-time module analysis that registers crons (see
-// #3957, and #3683 for the same constraint biting the `POSTHOG_PERSONAL_API_KEY` gate). A fixed cron
-// therefore can't honour the configured interval. Instead the refresh runs as a self-rescheduling
-// chain (`lib.ts:refreshLoop`) that reads the interval at runtime and queues its own next run.
-//
-// This cron is only a supervisor: `ensureRefreshLoop` starts the chain unless it's already running,
-// which bootstraps a fresh deploy and self-heals if the chain ever stops. The actual refresh work
-// happens on the configured interval, so raising the interval still cuts function-call usage, which
-// is the point of the knob. The supervisor's own cadence is a fixed floor — it can't read the
-// runtime interval (the same reason the cron can't), so at very long intervals the supervisor
-// itself becomes the dominant cost. 5 minutes trades that floor against bootstrap/heal latency.
+// A cron's interval is fixed at registration, but Convex forwards component env vars only at
+// runtime, so `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` is empty when crons are analysed (#3957;
+// #3683 hit the same wall with the `POSTHOG_PERSONAL_API_KEY` gate). So the refresh runs as a
+// self-rescheduling chain (`lib.ts:refreshLoop`) that reads the interval at runtime; this cron only
+// supervises — `ensureRefreshLoop` (re)starts the chain to bootstrap a deploy and self-heal a stop.
+// Its 5-minute cadence is a fixed floor (it can't read the runtime interval either), traded against
+// bootstrap/heal latency; at very long intervals the supervisor itself dominates the cost.
 crons.interval('Ensure PostHog flag refresh loop is running', { minutes: 5 }, internal.lib.ensureRefreshLoop, {})
 
 export default crons

--- a/packages/convex/src/component/crons.ts
+++ b/packages/convex/src/component/crons.ts
@@ -1,36 +1,19 @@
 import { cronJobs } from 'convex/server'
-import { api } from './_generated/api.js'
-import { env } from './_generated/server.js'
+import { internal } from './_generated/api.js'
 
 const crons = cronJobs()
 
-// Override via `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`.
-export const DEFAULT_INTERVAL_SECONDS = 60
-
-// Convex component env vars are string-typed. Invalid values warn and fall back rather than
-// failing the deploy. Exported for unit testing.
-export function readPollingIntervalSeconds(): number {
-  const raw = (env.POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS ?? '').trim()
-  if (!raw) return DEFAULT_INTERVAL_SECONDS
-  const parsed = Number(raw)
-  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
-    console.warn(
-      `[PostHog] POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS="${raw}" is not a positive integer; ` +
-        `falling back to ${DEFAULT_INTERVAL_SECONDS}s.`
-    )
-    return DEFAULT_INTERVAL_SECONDS
-  }
-  return parsed
-}
-
-// Registered unconditionally — Convex forwards component env vars only at runtime, so a
-// load-time gate on `POSTHOG_PERSONAL_API_KEY` sees an empty value at deploy-time module
-// analysis and silently drops the cron. The handler in `lib.ts` gates at runtime instead.
-crons.interval(
-  'Refresh PostHog feature flag definitions',
-  { seconds: readPollingIntervalSeconds() },
-  api.lib.refreshFlagDefinitions,
-  {}
-)
+// The flag-refresh cadence is configurable at runtime via `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`,
+// but a cron's interval is fixed when it's registered — and Convex forwards component env vars only
+// at runtime, so the var is empty during the deploy-time module analysis that registers crons (see
+// #3957, and #3683 for the same constraint biting the `POSTHOG_PERSONAL_API_KEY` gate). A fixed cron
+// therefore can't honour the configured interval. Instead the refresh runs as a self-rescheduling
+// chain (`lib.ts:refreshLoop`) that reads the interval at runtime and queues its own next run.
+//
+// This cron is only a supervisor: `ensureRefreshLoop` starts the chain unless it's already running,
+// which bootstraps a fresh deploy and self-heals if the chain ever stops. It runs often enough to
+// keep bootstrap/heal latency low, but the actual refresh work happens on the configured interval —
+// so raising the interval still cuts function-call usage, which is the point of the knob.
+crons.interval('Ensure PostHog flag refresh loop is running', { minutes: 5 }, internal.lib.ensureRefreshLoop, {})
 
 export default crons

--- a/packages/convex/src/component/lib.ts
+++ b/packages/convex/src/component/lib.ts
@@ -403,7 +403,7 @@ export const ensureRefreshLoop = internalMutation({
   handler: async (ctx) => {
     const state = await ctx.db.query('refreshLoopState').first()
     if (state) {
-      const job = await ctx.db.system.get(state.loopJobId as GenericId<'_scheduled_functions'>)
+      const job = await ctx.db.system.get(state.loopJobId)
       if (job && (job.state.kind === 'pending' || job.state.kind === 'inProgress')) {
         return
       }

--- a/packages/convex/src/component/lib.ts
+++ b/packages/convex/src/component/lib.ts
@@ -338,15 +338,13 @@ export const _getCurrentEtag = internalQuery({
 
 // --- Local-evaluation refresh loop ---
 //
-// The refresh runs as a self-rescheduling chain rather than a fixed-interval cron, so the
-// runtime-only `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` can actually govern the cadence (see the
-// comment in `crons.ts` for why a cron can't). The supervisor cron calls `ensureRefreshLoop`;
-// each `refreshLoop` tick fires a refresh and queues the next tick at the configured interval.
+// A self-rescheduling chain rather than a fixed-interval cron, so the runtime-only
+// `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` governs the cadence (see `crons.ts` for why a cron can't).
 
 export const DEFAULT_INTERVAL_SECONDS = 60
 
-// Convex component env vars are string-typed. Invalid values warn and fall back rather than
-// failing, and are read at runtime where the forwarded value is actually visible. Exported for tests.
+// Read at runtime, where the forwarded value is visible. String-typed on the wire, so an invalid
+// value warns and falls back rather than failing. Exported for tests.
 export function readPollingIntervalSeconds(): number {
   const raw = (env.POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS ?? '').trim()
   if (!raw) return DEFAULT_INTERVAL_SECONDS
@@ -373,16 +371,14 @@ async function recordLoopJob(ctx: MutationCtx, jobId: GenericId<'_scheduled_func
 }
 
 /**
- * One tick of the self-rescheduling refresh chain: kick off a refresh now, then queue the next
- * tick at the configured interval. An `internalMutation` so the chain is durable — Convex runs
- * scheduled mutations exactly once and retries them on transient errors, and queuing the next tick
- * commits atomically with this one, so the chain can't silently break. The fetch itself is a
- * separate at-most-once action; if it fails, the next tick just refetches.
+ * One tick: kick off a refresh now, then queue the next tick at the configured interval. A mutation
+ * so the chain is durable — scheduled mutations run exactly-once with retries, and queuing the next
+ * tick commits atomically with this one, so the chain can't silently break. The fetch is a separate
+ * at-most-once action; if it fails, the next tick refetches.
  *
- * Never invoke this directly (e.g. the dashboard "Run function"): it unconditionally queues its
- * successor, so a manual call forks the chain into two independent loops that both run forever,
- * permanently doubling the refresh cadence — and the supervisor can't detect the fork. The chain
- * owns its own scheduling; use `ensureRefreshLoop` to (re)start it.
+ * Never invoke directly (e.g. dashboard "Run function"): it unconditionally queues a successor, so a
+ * manual call forks the chain into two loops that run forever and double the cadence — the
+ * supervisor can't detect the fork. Use `ensureRefreshLoop` to (re)start it.
  */
 export const refreshLoop = internalMutation({
   args: {},
@@ -394,9 +390,9 @@ export const refreshLoop = internalMutation({
 })
 
 /**
- * Supervisor for the refresh chain, called by the cron in `crons.ts`. Starts the chain unless a
- * tick is already pending or running, recording the new tick's id so a follow-up call sees it as
- * alive. Idempotent — overlapping calls can't spawn duplicate chains.
+ * Supervisor, called by the cron in `crons.ts`: starts the chain unless a tick is already pending
+ * or running, recording the new tick's id so the next call sees it as alive. Idempotent —
+ * overlapping runs can't spawn duplicate chains.
  */
 export const ensureRefreshLoop = internalMutation({
   args: {},

--- a/packages/convex/src/component/lib.ts
+++ b/packages/convex/src/component/lib.ts
@@ -1,7 +1,7 @@
 import { PostHog as PostHogEdge } from 'posthog-node/edge'
-import { action, env, internalMutation, internalQuery, query } from './_generated/server.js'
+import { action, env, internalMutation, internalQuery, query, type MutationCtx } from './_generated/server.js'
 import { api, internal } from './_generated/api.js'
-import { v } from 'convex/values'
+import { v, type GenericId } from 'convex/values'
 import { version } from './version.js'
 
 /**
@@ -336,9 +336,80 @@ export const _getCurrentEtag = internalQuery({
   },
 })
 
+// --- Local-evaluation refresh loop ---
+//
+// The refresh runs as a self-rescheduling chain rather than a fixed-interval cron, so the
+// runtime-only `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` can actually govern the cadence (see the
+// comment in `crons.ts` for why a cron can't). The supervisor cron calls `ensureRefreshLoop`;
+// each `refreshLoop` tick fires a refresh and queues the next tick at the configured interval.
+
+export const DEFAULT_INTERVAL_SECONDS = 60
+
+// Convex component env vars are string-typed. Invalid values warn and fall back rather than
+// failing, and are read at runtime where the forwarded value is actually visible. Exported for tests.
+export function readPollingIntervalSeconds(): number {
+  const raw = (env.POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS ?? '').trim()
+  if (!raw) return DEFAULT_INTERVAL_SECONDS
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    console.warn(
+      `[PostHog] POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS="${raw}" is not a positive integer; ` +
+        `falling back to ${DEFAULT_INTERVAL_SECONDS}s.`
+    )
+    return DEFAULT_INTERVAL_SECONDS
+  }
+  return parsed
+}
+
+// Track the latest queued tick in the `cronState` singleton so `ensureRefreshLoop` can tell a
+// live chain from a dead one before scheduling.
+async function recordLoopJob(ctx: MutationCtx, jobId: GenericId<'_scheduled_functions'>): Promise<void> {
+  const existing = await ctx.db.query('cronState').first()
+  if (existing) {
+    await ctx.db.patch(existing._id, { loopJobId: jobId })
+  } else {
+    await ctx.db.insert('cronState', { loopJobId: jobId })
+  }
+}
+
+/**
+ * One tick of the self-rescheduling refresh chain: kick off a refresh now, then queue the next
+ * tick at the configured interval. An `internalMutation` so the chain is durable — Convex runs
+ * scheduled mutations exactly once and retries them on transient errors, and queuing the next tick
+ * commits atomically with this one, so the chain can't silently break. The fetch itself is a
+ * separate at-most-once action; if it fails, the next tick just refetches.
+ */
+export const refreshLoop = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.scheduler.runAfter(0, api.lib.refreshFlagDefinitions, {})
+    const nextId = await ctx.scheduler.runAfter(readPollingIntervalSeconds() * 1000, internal.lib.refreshLoop, {})
+    await recordLoopJob(ctx, nextId)
+  },
+})
+
+/**
+ * Supervisor for the refresh chain, called by the cron in `crons.ts`. Starts the chain unless a
+ * tick is already pending or running, recording the new tick's id so a follow-up call sees it as
+ * alive. Idempotent — overlapping calls can't spawn duplicate chains.
+ */
+export const ensureRefreshLoop = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const state = await ctx.db.query('cronState').first()
+    if (state) {
+      const job = await ctx.db.system.get(state.loopJobId as GenericId<'_scheduled_functions'>)
+      if (job && (job.state.kind === 'pending' || job.state.kind === 'inProgress')) {
+        return
+      }
+    }
+    await recordLoopJob(ctx, await ctx.scheduler.runAfter(0, internal.lib.refreshLoop, {}))
+  },
+})
+
 /**
  * Fetches flag definitions from PostHog's local-evaluation endpoint and stores them in the
- * `flagDefinitions` table. Called automatically by the cron registered in `crons.ts` when
+ * `flagDefinitions` table. Called automatically by the refresh loop (see above) when
  * `POSTHOG_PERSONAL_API_KEY` is set, and also exposed publicly so the client's
  * `reloadFeatureFlags(ctx)` method (parity with `posthog-node`) can trigger an on-demand refresh.
  */

--- a/packages/convex/src/component/lib.ts
+++ b/packages/convex/src/component/lib.ts
@@ -361,14 +361,14 @@ export function readPollingIntervalSeconds(): number {
   return parsed
 }
 
-// Track the latest queued tick in the `cronState` singleton so `ensureRefreshLoop` can tell a
-// live chain from a dead one before scheduling.
+// Record the latest queued tick in the `refreshLoopState` singleton so `ensureRefreshLoop` can
+// tell a live chain from a dead one before scheduling.
 async function recordLoopJob(ctx: MutationCtx, jobId: GenericId<'_scheduled_functions'>): Promise<void> {
-  const existing = await ctx.db.query('cronState').first()
+  const existing = await ctx.db.query('refreshLoopState').first()
   if (existing) {
     await ctx.db.patch(existing._id, { loopJobId: jobId })
   } else {
-    await ctx.db.insert('cronState', { loopJobId: jobId })
+    await ctx.db.insert('refreshLoopState', { loopJobId: jobId })
   }
 }
 
@@ -378,6 +378,11 @@ async function recordLoopJob(ctx: MutationCtx, jobId: GenericId<'_scheduled_func
  * scheduled mutations exactly once and retries them on transient errors, and queuing the next tick
  * commits atomically with this one, so the chain can't silently break. The fetch itself is a
  * separate at-most-once action; if it fails, the next tick just refetches.
+ *
+ * Never invoke this directly (e.g. the dashboard "Run function"): it unconditionally queues its
+ * successor, so a manual call forks the chain into two independent loops that both run forever,
+ * permanently doubling the refresh cadence — and the supervisor can't detect the fork. The chain
+ * owns its own scheduling; use `ensureRefreshLoop` to (re)start it.
  */
 export const refreshLoop = internalMutation({
   args: {},
@@ -396,14 +401,15 @@ export const refreshLoop = internalMutation({
 export const ensureRefreshLoop = internalMutation({
   args: {},
   handler: async (ctx) => {
-    const state = await ctx.db.query('cronState').first()
+    const state = await ctx.db.query('refreshLoopState').first()
     if (state) {
       const job = await ctx.db.system.get(state.loopJobId as GenericId<'_scheduled_functions'>)
       if (job && (job.state.kind === 'pending' || job.state.kind === 'inProgress')) {
         return
       }
     }
-    await recordLoopJob(ctx, await ctx.scheduler.runAfter(0, internal.lib.refreshLoop, {}))
+    const jobId = await ctx.scheduler.runAfter(0, internal.lib.refreshLoop, {})
+    await recordLoopJob(ctx, jobId)
   },
 })
 

--- a/packages/convex/src/component/refresh-loop.test.ts
+++ b/packages/convex/src/component/refresh-loop.test.ts
@@ -1,0 +1,127 @@
+/// <reference types="vite/client" />
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals'
+import { convexTest } from 'convex-test'
+import schema from './schema.js'
+import { api, internal } from './_generated/api.js'
+
+const modules = import.meta.glob('./**/*.ts')
+
+type ScheduledJob = {
+  _id: string
+  name: string
+  scheduledTime: number
+  state: { kind: 'pending' | 'inProgress' | 'success' | 'failed' | 'canceled' }
+}
+
+const originalFetch = global.fetch
+let flagsFetches = 0
+
+function mockFetch() {
+  flagsFetches = 0
+  return jest.fn(async (url: string | URL) => {
+    if (url.toString().includes('/flags/definitions')) flagsFetches++
+    return new Response(JSON.stringify({ flags: [], group_type_mapping: {}, cohorts: {} }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as unknown as typeof fetch
+}
+
+function scheduledJobs(t: ReturnType<typeof convexTest>): Promise<ScheduledJob[]> {
+  return t.run(async (ctx) => (await ctx.db.system.query('_scheduled_functions').collect()) as ScheduledJob[])
+}
+
+const byName = (jobs: ScheduledJob[], needle: string) => jobs.filter((j) => j.name.includes(needle))
+const pending = (jobs: ScheduledJob[]) => jobs.filter((j) => j.state.kind === 'pending')
+
+// The chain self-reschedules forever, so the usual `finishAllScheduledFunctions` driver would
+// never terminate, and stepping fake timers by hand trips convex-test's transaction tracking.
+// Instead we invoke a single tick directly and inspect what it queued — `scheduler.runAfter`
+// records the job synchronously in `_scheduled_functions`, so the queued cadence is observable
+// without ever firing a timer.
+
+describe('self-rescheduling flag refresh loop', () => {
+  beforeEach(() => {
+    process.env.POSTHOG_PROJECT_TOKEN = 'phc_test'
+    process.env.POSTHOG_HOST = 'https://test.posthog.com'
+    process.env.POSTHOG_PERSONAL_API_KEY = 'phx_test'
+    global.fetch = mockFetch()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    delete process.env.POSTHOG_PROJECT_TOKEN
+    delete process.env.POSTHOG_HOST
+    delete process.env.POSTHOG_PERSONAL_API_KEY
+    delete process.env.POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS
+  })
+
+  test('queues the next tick at the configured interval, not the 60s default', async () => {
+    process.env.POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS = '3600'
+    const t = convexTest(schema, modules)
+
+    await t.mutation(internal.lib.refreshLoop, {})
+
+    const jobs = await scheduledJobs(t)
+    // The tick kicks a refresh now…
+    expect(byName(jobs, 'refreshFlagDefinitions')).toHaveLength(1)
+    // …and queues exactly one successor an interval out. With the old fixed cron the period was
+    // pinned to the 60s default because the env var is invisible at registration (#3957).
+    const next = byName(jobs, 'refreshLoop')
+    expect(next).toHaveLength(1)
+    const delayMs = next[0].scheduledTime - Date.now()
+    expect(delayMs).toBeGreaterThan(3600 * 1000 - 1000)
+    expect(delayMs).toBeLessThanOrEqual(3600 * 1000)
+  })
+
+  test('queues the next tick at the 60s default when the interval is unset', async () => {
+    const t = convexTest(schema, modules)
+
+    await t.mutation(internal.lib.refreshLoop, {})
+
+    const next = byName(await scheduledJobs(t), 'refreshLoop')
+    expect(next).toHaveLength(1)
+    const delayMs = next[0].scheduledTime - Date.now()
+    expect(delayMs).toBeGreaterThan(60 * 1000 - 1000)
+    expect(delayMs).toBeLessThanOrEqual(60 * 1000)
+  })
+
+  test('records the queued tick id so the supervisor can detect a live chain', async () => {
+    process.env.POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS = '3600'
+    const t = convexTest(schema, modules)
+
+    await t.mutation(internal.lib.refreshLoop, {})
+
+    const next = byName(await scheduledJobs(t), 'refreshLoop')
+    const state = await t.run(async (ctx) => ctx.db.query('cronState').first())
+    expect(state?.loopJobId).toBe(next[0]._id)
+  })
+
+  test('supervisor starts the chain when none is running', async () => {
+    const t = convexTest(schema, modules)
+
+    await t.mutation(internal.lib.ensureRefreshLoop, {})
+
+    expect(pending(byName(await scheduledJobs(t), 'refreshLoop'))).toHaveLength(1)
+  })
+
+  test('supervisor is idempotent: a second run does not spawn a rival chain', async () => {
+    const t = convexTest(schema, modules)
+
+    await t.mutation(internal.lib.ensureRefreshLoop, {})
+    await t.mutation(internal.lib.ensureRefreshLoop, {})
+
+    expect(pending(byName(await scheduledJobs(t), 'refreshLoop'))).toHaveLength(1)
+  })
+
+  test('the refresh the loop kicks actually fetches definitions and caches them', async () => {
+    const t = convexTest(schema, modules)
+
+    // refreshLoop schedules this action; running it directly proves the kicked work fetches.
+    await t.action(api.lib.refreshFlagDefinitions, {})
+
+    expect(flagsFetches).toBe(1)
+    const row = await t.run(async (ctx) => ctx.db.query('flagDefinitions').first())
+    expect(row).not.toBeNull()
+  })
+})

--- a/packages/convex/src/component/refresh-loop.test.ts
+++ b/packages/convex/src/component/refresh-loop.test.ts
@@ -65,8 +65,9 @@ describe('self-rescheduling flag refresh loop', () => {
     const jobs = await scheduledJobs(t)
     // The tick kicks a refresh now…
     expect(byName(jobs, 'refreshFlagDefinitions')).toHaveLength(1)
-    // …and queues exactly one successor an interval out. With the old fixed cron the period was
-    // pinned to the 60s default because the env var is invisible at registration (#3957).
+    // …and queues exactly one successor at the runtime interval. This guards the architecture: a
+    // reverted fixed `crons.interval` would queue no successor here at all. (The harness reads the
+    // env var live, so it can't reproduce the deploy-time invisibility that was the root of #3957.)
     const next = byName(jobs, 'refreshLoop')
     expect(next).toHaveLength(1)
     const delayMs = next[0].scheduledTime - Date.now()
@@ -93,7 +94,7 @@ describe('self-rescheduling flag refresh loop', () => {
     await t.mutation(internal.lib.refreshLoop, {})
 
     const next = byName(await scheduledJobs(t), 'refreshLoop')
-    const state = await t.run(async (ctx) => ctx.db.query('cronState').first())
+    const state = await t.run(async (ctx) => ctx.db.query('refreshLoopState').first())
     expect(state?.loopJobId).toBe(next[0]._id)
   })
 
@@ -112,6 +113,30 @@ describe('self-rescheduling flag refresh loop', () => {
     await t.mutation(internal.lib.ensureRefreshLoop, {})
 
     expect(pending(byName(await scheduledJobs(t), 'refreshLoop'))).toHaveLength(1)
+  })
+
+  test('supervisor restarts a dead chain (self-heal)', async () => {
+    const t = convexTest(schema, modules)
+
+    await t.mutation(internal.lib.ensureRefreshLoop, {})
+    const tracked = pending(byName(await scheduledJobs(t), 'refreshLoop'))
+    expect(tracked).toHaveLength(1)
+    const deadId = tracked[0]._id
+
+    // Drive the tracked tick to a terminal state, simulating a chain that stopped.
+    await t.run(async (ctx) => {
+      await ctx.scheduler.cancel(deadId as Parameters<typeof ctx.scheduler.cancel>[0])
+    })
+
+    // The supervisor must notice the recorded job is no longer live and queue a fresh tick —
+    // a regression that treated any recorded job as alive would leave the chain dead forever.
+    await t.mutation(internal.lib.ensureRefreshLoop, {})
+
+    const revived = pending(byName(await scheduledJobs(t), 'refreshLoop'))
+    expect(revived).toHaveLength(1)
+    expect(revived[0]._id).not.toBe(deadId)
+    const state = await t.run(async (ctx) => ctx.db.query('refreshLoopState').first())
+    expect(state?.loopJobId).toBe(revived[0]._id)
   })
 
   test('the refresh the loop kicks actually fetches definitions and caches them', async () => {

--- a/packages/convex/src/component/refresh-loop.test.ts
+++ b/packages/convex/src/component/refresh-loop.test.ts
@@ -34,11 +34,10 @@ function scheduledJobs(t: ReturnType<typeof convexTest>): Promise<ScheduledJob[]
 const byName = (jobs: ScheduledJob[], needle: string) => jobs.filter((j) => j.name.includes(needle))
 const pending = (jobs: ScheduledJob[]) => jobs.filter((j) => j.state.kind === 'pending')
 
-// The chain self-reschedules forever, so the usual `finishAllScheduledFunctions` driver would
-// never terminate, and stepping fake timers by hand trips convex-test's transaction tracking.
-// Instead we invoke a single tick directly and inspect what it queued — `scheduler.runAfter`
-// records the job synchronously in `_scheduled_functions`, so the queued cadence is observable
-// without ever firing a timer.
+// The chain self-reschedules forever, so `finishAllScheduledFunctions` never terminates and hand-
+// stepping fake timers trips convex-test's transaction tracking. Instead we invoke one tick and
+// inspect what it queued — `runAfter` records the job synchronously, so the cadence is observable
+// without firing a timer.
 
 describe('self-rescheduling flag refresh loop', () => {
   beforeEach(() => {

--- a/packages/convex/src/component/schema.ts
+++ b/packages/convex/src/component/schema.ts
@@ -23,6 +23,6 @@ export default defineSchema({
    * one, so overlapping supervisor runs can't spawn duplicate chains.
    */
   refreshLoopState: defineTable({
-    loopJobId: v.string(),
+    loopJobId: v.id('_scheduled_functions'),
   }),
 })

--- a/packages/convex/src/component/schema.ts
+++ b/packages/convex/src/component/schema.ts
@@ -22,7 +22,7 @@ export default defineSchema({
    * supervisor cron reads it to decide whether the chain is still alive before starting a new
    * one, so overlapping supervisor runs can't spawn duplicate chains.
    */
-  cronState: defineTable({
+  refreshLoopState: defineTable({
     loopJobId: v.string(),
   }),
 })

--- a/packages/convex/src/component/schema.ts
+++ b/packages/convex/src/component/schema.ts
@@ -14,4 +14,15 @@ export default defineSchema({
     fetchedAt: v.number(),
     etag: v.optional(v.string()),
   }),
+
+  /**
+   * Singleton table tracking the self-rescheduling flag-refresh chain (see `lib.ts`).
+   *
+   * `loopJobId` is the `_scheduled_functions` id of the next pending `refreshLoop` tick. The
+   * supervisor cron reads it to decide whether the chain is still alive before starting a new
+   * one, so overlapping supervisor runs can't spawn duplicate chains.
+   */
+  cronState: defineTable({
+    loopJobId: v.string(),
+  }),
 })


### PR DESCRIPTION
## Problem

`POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` was a dead knob for `@posthog/convex` users (#3957). The flag-refresh cron read the interval at **registration time**, but Convex forwards component env vars only at **runtime** — so the value was always empty during deploy-time module analysis, `readPollingIntervalSeconds()` fell back to `DEFAULT_INTERVAL_SECONDS = 60`, and `60` was baked into the schedule. No way to change the cadence from an installing app, and no warning either (the value was absent, not malformed, so the existing validation warning never fired). This is the same runtime-only-forwarding constraint that bit the `POSTHOG_PERSONAL_API_KEY` gate in #3683 — but a cron's period can't be deferred to runtime the way that gate was.

## Changes

Replaced the fixed-interval cron with a **self-rescheduling loop** that reads the interval where the forwarded value is actually visible — at runtime.

- `refreshLoop` (internal mutation): one tick kicks a refresh now (`runAfter(0, refreshFlagDefinitions)`) and queues the next tick at `readPollingIntervalSeconds() * 1000`. It's a mutation so the chain is durable — Convex runs scheduled mutations exactly-once with retries, and queuing the next tick commits atomically with the current one, so the chain can't silently break. The fetch is a separate at-most-once action; if it fails, the next tick just refetches.
- `ensureRefreshLoop` (internal mutation): supervisor that starts the chain only if no tick is pending/in-progress, tracked via a new `refreshLoopState` singleton (`loopJobId` + `db.system.get`). Idempotent — overlapping runs can't spawn duplicate chains.
- `crons.ts`: the cron is now a 5-minute supervisor calling `ensureRefreshLoop` and reads no env var at registration. It only bootstraps/heals the chain; the real refresh runs on the configured interval, so raising the interval still cuts function-call usage (the point of the knob). The 5-minute cadence trades a small fixed baseline for low bootstrap/heal latency.
- Moved `readPollingIntervalSeconds`/`DEFAULT_INTERVAL_SECONDS` to `lib.ts` (where they're now used) and fixed the stale "parsed at module load" comments.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/convex

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Richard directed the work.

Investigated #3957, confirmed the root cause (interval read at cron-registration time, when Convex env vars aren't yet forwarded), and weighed three fixes: self-rescheduling loop, a coarse cron + runtime throttle, and removing the knob. Chose the self-rescheduling loop because it's the only option that delivers the knob's stated purpose — cutting function-call usage — since the throttle approach still invokes the cron every 60s.

Tested two ways:
- **Unit/integration** via the component's `convex-test` harness (`refresh-loop.test.ts`): asserts the next tick is queued at the configured interval (3600s) and at the 60s default when unset, that the kicked refresh fetches and caches, and that the supervisor bootstraps and is idempotent. Full suite: 150/150.
- **Live** against a Convex dev deployment: deployed the branch, triggered the supervisor, and read the component's `_scheduled_functions` directly — the next `refreshLoop` was pending ~3600s out (not 60s), `refreshFlagDefinitions` ran successfully, and re-running the supervisor left exactly one pending tick.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
