### PR TITLE
feat(mcp): emit $mcp_lib / $mcp_lib_version on MCP events

### DIFF
--- a/.changeset/mcp-lib-version-property.md
+++ b/.changeset/mcp-lib-version-property.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': minor
+---
+
+Emit `$mcp_lib` (`@posthog/mcp`) and `$mcp_lib_version` on every `$mcp_*` event (and the `$exception` sibling) so you can tell which analytics SDK release produced the data. The version was already resolved at runtime but never mapped to a property. Namespaced like `@posthog/ai`'s `$ai_lib` rather than overriding `$lib`, which stays the transport SDK (`posthog-node`).

--- a/packages/mcp/src/__tests__/posthog-events.test.ts
+++ b/packages/mcp/src/__tests__/posthog-events.test.ts
@@ -6,6 +6,7 @@ import {
 import { MCPAnalyticsEventType } from '../extensions/event-types'
 import { buildPostHogCaptureEvents, type PostHogCaptureEvent } from '../extensions/posthog-events'
 import type { Event } from '../types'
+import { version } from '../version'
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -19,6 +20,7 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     serverVersion: '1.0.0',
     clientName: 'claude-desktop',
     clientVersion: '2.0.0',
+    sdkVersion: version,
     duration: 150,
     isError: false,
     ...overrides,
@@ -55,8 +57,17 @@ describe('buildPostHogCaptureEvents', () => {
     expect(event.properties[PostHogMCPAnalyticsProperty.ServerVersion]).toBe('1.0.0')
     expect(event.properties[PostHogMCPAnalyticsProperty.ClientName]).toBe('claude-desktop')
     expect(event.properties[PostHogMCPAnalyticsProperty.ClientVersion]).toBe('2.0.0')
+    expect(event.properties[PostHogMCPAnalyticsProperty.McpLib]).toBe('@posthog/mcp')
+    expect(event.properties[PostHogMCPAnalyticsProperty.McpLibVersion]).toBe(version)
     expect(event.properties[PostHogMCPAnalyticsProperty.IsError]).toBe(false)
     expect(event.properties).not.toHaveProperty('project_id')
+  })
+
+  it('omits the MCP lib properties when sdkVersion is not set', () => {
+    const [event] = buildPostHogCaptureEvents(makeEvent({ sdkVersion: undefined }))
+
+    expect(event.properties[PostHogMCPAnalyticsProperty.McpLib]).toBeUndefined()
+    expect(event.properties[PostHogMCPAnalyticsProperty.McpLibVersion]).toBeUndefined()
   })
 
   it('keeps the canonical MCP analytics event contract stable', () => {
@@ -127,6 +138,8 @@ describe('buildPostHogCaptureEvents', () => {
     expect(exceptionEvent.properties.$mcp_resource_name).toBe('get_weather')
     expect(exceptionEvent.properties.$mcp_tool_name).toBe('get_weather')
     expect(exceptionEvent.properties.$mcp_server_name).toBe('weather-server')
+    expect(exceptionEvent.properties.$mcp_lib).toBe('@posthog/mcp')
+    expect(exceptionEvent.properties.$mcp_lib_version).toBe(version)
   })
 
   it('spreads customer eventProperties onto the $exception event', () => {

--- a/packages/mcp/src/__tests__/posthog-events.test.ts
+++ b/packages/mcp/src/__tests__/posthog-events.test.ts
@@ -63,11 +63,19 @@ describe('buildPostHogCaptureEvents', () => {
     expect(event.properties).not.toHaveProperty('project_id')
   })
 
-  it('omits the MCP lib properties when sdkVersion is not set', () => {
-    const [event] = buildPostHogCaptureEvents(makeEvent({ sdkVersion: undefined }))
+  it.each([
+    { path: 'tool-call event', overrides: {}, eventName: PostHogMCPAnalyticsEvent.ToolCall },
+    {
+      path: '$exception event',
+      overrides: { isError: true, error: makeError('boom') },
+      eventName: PostHogMCPAnalyticsEvent.Exception,
+    },
+  ])('omits the MCP lib properties when sdkVersion is not set ($path)', ({ overrides, eventName }) => {
+    const events = buildPostHogCaptureEvents(makeEvent({ sdkVersion: undefined, ...overrides }))
+    const event = findEvent(events, eventName)
 
-    expect(event.properties[PostHogMCPAnalyticsProperty.McpLib]).toBeUndefined()
-    expect(event.properties[PostHogMCPAnalyticsProperty.McpLibVersion]).toBeUndefined()
+    expect(event?.properties[PostHogMCPAnalyticsProperty.McpLib]).toBeUndefined()
+    expect(event?.properties[PostHogMCPAnalyticsProperty.McpLibVersion]).toBeUndefined()
   })
 
   it('keeps the canonical MCP analytics event contract stable', () => {

--- a/packages/mcp/src/__tests__/posthog-mcp.test.ts
+++ b/packages/mcp/src/__tests__/posthog-mcp.test.ts
@@ -2,6 +2,7 @@ import { getMoreToolsResult, PostHogMCP } from '../index'
 import { PostHogMCPAnalyticsEvent, PostHogMCPAnalyticsProperty } from '../extensions/constants'
 import { GET_MORE_TOOLS_NAME } from '../extensions/tools'
 import type { PostHogCaptureEvent } from '../extensions/posthog-events'
+import { version } from '../version'
 import { EventCapture } from './test-utils'
 
 // The capture methods are fire-and-forget (mirroring posthog-node's `capture()`),
@@ -65,6 +66,8 @@ describe('PostHogMCP', () => {
       expect(p[PostHogMCPAnalyticsProperty.IsError]).toBe(false)
       expect(p[PostHogMCPAnalyticsProperty.SessionId]).toBe('session-abc')
       expect(p[PostHogMCPAnalyticsProperty.Source]).toBe('posthog_mcp_analytics')
+      expect(p[PostHogMCPAnalyticsProperty.McpLib]).toBe('@posthog/mcp')
+      expect(p[PostHogMCPAnalyticsProperty.McpLibVersion]).toBe(version)
       expect(p.$groups).toEqual({ organization: 'org-1', project: 'proj-1' })
       expect(p.$mcp_client_name).toBe('claude-code')
       expect(p.custom_flag).toBe(true)

--- a/packages/mcp/src/extensions/constants.ts
+++ b/packages/mcp/src/extensions/constants.ts
@@ -11,6 +11,11 @@ export const DEFAULT_CONVERSATION_ID_DESCRIPTION =
 
 export const POSTHOG_MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'
 
+// Identifies the SDK that produced an `$mcp_*` event. Distinct from `$lib`
+// (posthog-node, the transport that actually sends the event) — this names the
+// higher-level analytics layer, mirroring `@posthog/ai`'s `$ai_lib`.
+export const POSTHOG_MCP_LIB_NAME = '@posthog/mcp'
+
 // All PostHog-owned event names start with `$` per the PostHog convention.
 // Non-`$` names would be treated as customer-defined events and confuse the schema.
 export const PostHogMCPAnalyticsEvent = {
@@ -38,6 +43,8 @@ export const PostHogMCPAnalyticsProperty = {
   Intent: '$mcp_intent',
   IntentSource: '$mcp_intent_source',
   ListedToolNames: '$mcp_listed_tool_names',
+  McpLib: '$mcp_lib',
+  McpLibVersion: '$mcp_lib_version',
   Parameters: '$mcp_parameters',
   ResourceName: '$mcp_resource_name',
   Response: '$mcp_response',

--- a/packages/mcp/src/extensions/posthog-events.ts
+++ b/packages/mcp/src/extensions/posthog-events.ts
@@ -3,7 +3,12 @@
 // Licensed under the MIT License: https://github.com/MCPCat/mcpcat-typescript-sdk/blob/main/LICENSE
 
 import type { Event } from '../types'
-import { POSTHOG_MCP_ANALYTICS_SOURCE, PostHogMCPAnalyticsEvent, PostHogMCPAnalyticsProperty } from './constants'
+import {
+  POSTHOG_MCP_ANALYTICS_SOURCE,
+  POSTHOG_MCP_LIB_NAME,
+  PostHogMCPAnalyticsEvent,
+  PostHogMCPAnalyticsProperty,
+} from './constants'
 import { MCPAnalyticsEventType } from './event-types'
 
 const BUILT_IN_EVENT_NAME_BY_TYPE = {
@@ -150,6 +155,10 @@ function addCommonEventProperties(event: Event, properties: Record<string, unkno
   if (event.clientVersion) {
     properties[PostHogMCPAnalyticsProperty.ClientVersion] = event.clientVersion
   }
+  if (event.sdkVersion) {
+    properties[PostHogMCPAnalyticsProperty.McpLib] = POSTHOG_MCP_LIB_NAME
+    properties[PostHogMCPAnalyticsProperty.McpLibVersion] = event.sdkVersion
+  }
   if (event.userIntent) {
     properties[PostHogMCPAnalyticsProperty.Intent] = event.userIntent
   }
@@ -220,6 +229,10 @@ function buildExceptionEvent(event: Event): PostHogCaptureEvent {
   }
   if (event.clientVersion) {
     properties[PostHogMCPAnalyticsProperty.ClientVersion] = event.clientVersion
+  }
+  if (event.sdkVersion) {
+    properties[PostHogMCPAnalyticsProperty.McpLib] = POSTHOG_MCP_LIB_NAME
+    properties[PostHogMCPAnalyticsProperty.McpLibVersion] = event.sdkVersion
   }
 
   addCustomEventProperties(event, properties)

--- a/packages/mcp/src/extensions/posthog-events.ts
+++ b/packages/mcp/src/extensions/posthog-events.ts
@@ -155,10 +155,7 @@ function addCommonEventProperties(event: Event, properties: Record<string, unkno
   if (event.clientVersion) {
     properties[PostHogMCPAnalyticsProperty.ClientVersion] = event.clientVersion
   }
-  if (event.sdkVersion) {
-    properties[PostHogMCPAnalyticsProperty.McpLib] = POSTHOG_MCP_LIB_NAME
-    properties[PostHogMCPAnalyticsProperty.McpLibVersion] = event.sdkVersion
-  }
+  addMcpLibProperties(event, properties)
   if (event.userIntent) {
     properties[PostHogMCPAnalyticsProperty.Intent] = event.userIntent
   }
@@ -187,6 +184,18 @@ function addCustomEventProperties(event: Event, properties: Record<string, unkno
     for (const [key, value] of Object.entries(event.properties)) {
       properties[key] = value
     }
+  }
+}
+
+/**
+ * Stamps the `@posthog/mcp` SDK identity (`$mcp_lib` / `$mcp_lib_version`) onto
+ * the event. Shared by the regular and `$exception` builders so both report
+ * which analytics SDK release produced the event.
+ */
+function addMcpLibProperties(event: Event, properties: Record<string, unknown>): void {
+  if (event.sdkVersion) {
+    properties[PostHogMCPAnalyticsProperty.McpLib] = POSTHOG_MCP_LIB_NAME
+    properties[PostHogMCPAnalyticsProperty.McpLibVersion] = event.sdkVersion
   }
 }
 
@@ -230,10 +239,7 @@ function buildExceptionEvent(event: Event): PostHogCaptureEvent {
   if (event.clientVersion) {
     properties[PostHogMCPAnalyticsProperty.ClientVersion] = event.clientVersion
   }
-  if (event.sdkVersion) {
-    properties[PostHogMCPAnalyticsProperty.McpLib] = POSTHOG_MCP_LIB_NAME
-    properties[PostHogMCPAnalyticsProperty.McpLibVersion] = event.sdkVersion
-  }
+  addMcpLibProperties(event, properties)
 
   addCustomEventProperties(event, properties)
 

--- a/packages/mcp/src/extensions/posthog-mcp.ts
+++ b/packages/mcp/src/extensions/posthog-mcp.ts
@@ -1,5 +1,6 @@
 import { PostHog, type PostHogOptions } from 'posthog-node'
 
+import { version } from '../version'
 import type {
   InitializeCaptureData,
   JsonRecord,
@@ -241,6 +242,7 @@ function baseEvent(eventType: MCPAnalyticsEventType, common: McpCaptureCommon): 
     timestamp: common.timestamp ?? new Date(),
     properties: common.properties,
     groups: common.groups,
+    sdkVersion: version,
   }
   if (common.distinctId) {
     event.identifyActorGivenId = common.distinctId


### PR DESCRIPTION
## Summary

Stamp the `@posthog/mcp` SDK name + version onto every `$mcp_*` event as `$mcp_lib` (`@posthog/mcp`) and `$mcp_lib_version` (e.g. `0.5.1`), so you can tell which analytics SDK release produced the data.

The version was already resolved at runtime (`Event.sdkVersion`) but never mapped to a property; the name wasn't stored at all. This wires it the last mile.

### Why a namespaced `$mcp_lib` rather than reusing `$lib`
- posthog-node forcibly stamps `$lib` / `$lib_version` *after* event properties (`posthog-core-stateless.ts:382-385`), so the property bag can't override it — `$lib` correctly stays the transport SDK (`posthog-node`).
- Mirrors the sibling `@posthog/ai`, which keeps `$lib` and adds `$ai_lib` / `$ai_lib_version`.
- Avoids colliding with "MCP SDK" = `@modelcontextprotocol/sdk` (deliberately not tracked here).

## Changes
- `constants.ts` — `POSTHOG_MCP_LIB_NAME` + `McpLib` / `McpLibVersion` keys
- `posthog-events.ts` — stamp both on the regular and `$exception` events
- `posthog-mcp.ts` — populate `sdkVersion` on the server-agnostic `PostHogMCP` path
- tests in `posthog-events.test.ts` / `posthog-mcp.test.ts`

## Testing
- `pnpm test:unit` — 30 suites / 334 tests pass
- `pnpm lint` — clean
- Verified live in a `dummy-nest-mcp` server: `$mcp_tool_call` now carries `$mcp_lib: "@posthog/mcp"` + `$mcp_lib_version`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*