### PR TITLE
ci: Configure SDK compliance SDK types

### DIFF
--- a/.github/workflows/sdk-compliance-tests-browser.yml
+++ b/.github/workflows/sdk-compliance-tests-browser.yml
@@ -24,9 +24,12 @@ permissions:
 
 jobs:
   test-browser-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: compliance/browser/Dockerfile
       adapter-context: .
       test-harness-version: "0.8.0"
       report-name: browser-sdk-compliance-report
+      suite: "capture"
+      sdk-type: "client"
+      continue-on-error: true

--- a/.github/workflows/sdk-compliance-tests-node.yml
+++ b/.github/workflows/sdk-compliance-tests-node.yml
@@ -24,9 +24,12 @@ permissions:
 
 jobs:
   test-node-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: compliance/node/Dockerfile
       adapter-context: .
       test-harness-version: "0.8.0"
       report-name: node-sdk-compliance-report
+      suite: "capture"
+      sdk-type: "server"
+      continue-on-error: true

--- a/compliance/browser/docker-compose.yml
+++ b/compliance/browser/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   test-harness:
     image: ghcr.io/posthog/sdk-test-harness:0.8.0
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "client", "--debug"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "client", "--suite", "capture", "--debug"]
     networks:
       - test-network
     depends_on:

--- a/compliance/node/docker-compose.yml
+++ b/compliance/node/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   test-harness:
     image: ghcr.io/posthog/sdk-test-harness:0.8.0
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--suite", "capture"]
     networks:
       - test-network
     depends_on:


### PR DESCRIPTION
## Problem

SDK compliance workflows need explicit harness suite/sdk-type selection and configurable blocking behavior so CI only runs the intended contract checks.

## Changes

- Point browser and node compliance jobs to the harness branch with new workflow inputs.
- Run browser as `sdk-type: client` and node as `sdk-type: server`.
- Run capture v0 suite for both jobs and keep failures non-blocking for now.
- Align local compose commands with the same suite/sdk types.

## Testing

- Parsed workflow YAML.
- Ran `docker compose config` for browser and node compose files.
- Ran `git diff --check`.

## Release / changeset

No SDK package changeset: CI/local compliance configuration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using dedicated git worktrees. The change was requested to align SDK compliance harness setup across SDK repositories while keeping non-ready SDKs non-blocking.
