### PR TITLE
ci: update SDK harness to 0.9.0

### DIFF
--- a/.github/workflows/sdk-compliance-tests-browser.yml
+++ b/.github/workflows/sdk-compliance-tests-browser.yml
@@ -24,9 +24,9 @@ permissions:
 
 jobs:
   test-browser-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
     with:
       adapter-dockerfile: compliance/browser/Dockerfile
       adapter-context: .
-      test-harness-version: "0.8.0"
+      test-harness-version: "0.9.0"
       report-name: browser-sdk-compliance-report

--- a/.github/workflows/sdk-compliance-tests-browser.yml
+++ b/.github/workflows/sdk-compliance-tests-browser.yml
@@ -29,4 +29,5 @@ jobs:
       adapter-dockerfile: compliance/browser/Dockerfile
       adapter-context: .
       test-harness-version: "0.9.0"
+      sdk-type: client
       report-name: browser-sdk-compliance-report

--- a/.github/workflows/sdk-compliance-tests-node.yml
+++ b/.github/workflows/sdk-compliance-tests-node.yml
@@ -24,9 +24,9 @@ permissions:
 
 jobs:
   test-node-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
     with:
       adapter-dockerfile: compliance/node/Dockerfile
       adapter-context: .
-      test-harness-version: "0.8.0"
+      test-harness-version: "0.9.0"
       report-name: node-sdk-compliance-report

--- a/compliance/browser/docker-compose.yml
+++ b/compliance/browser/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.8.0
+    image: ghcr.io/posthog/sdk-test-harness:0.9.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "client", "--debug"]
     networks:
       - test-network

--- a/compliance/node/docker-compose.yml
+++ b/compliance/node/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.8.0
+    image: ghcr.io/posthog/sdk-test-harness:0.9.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
     networks:
       - test-network


### PR DESCRIPTION
## Problem

The browser and Node SDK compliance jobs should run against posthog-sdk-test-harness 0.9.0. The reusable workflow should be pinned to the 0.9.0 release commit SHA (`68498bcf3ae95ac941476e6ca3d42d6086e1c7fd`) instead of a tag.

The browser adapter uses the browser SDK and sends client-style events to `/e/`, so its CI workflow should pass the client harness mode explicitly. The Node adapter uses server-style `/batch/` payloads and can rely on the harness default `server` mode.

## Changes

- Update browser and Node SDK compliance workflows to use the 0.9.0 harness workflow commit SHA.
- Update browser and Node local Docker Compose harness images to `ghcr.io/posthog/sdk-test-harness:0.9.0`.
- Run browser compliance in `client` mode in CI.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Updated SDK compliance harness references only. Set browser compliance to the client harness mode because it uses the browser SDK `/e/` client event format. Left Node compliance on the default server mode because it uses server-style `/batch/` payloads.
