### PR TITLE
feat(mcp): report standard $lib=posthog-node-mcp (drop $mcp_lib)

### DIFF
--- a/.changeset/mcp-lib-identity.md
+++ b/.changeset/mcp-lib-identity.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': minor
+---
+
+Stamp the standard PostHog `$lib` / `$lib_version` (value `posthog-node-mcp`) on every event, so MCP events self-identify the same way every other PostHog SDK does. Both emit paths are covered: `PostHogMCP` overrides its library id, and `instrument()` applies it to the client you pass in. Note that posthog-node sets `$lib` at the client level, so for `instrument()` this relabels every event that client sends as `posthog-node-mcp` — pass a client dedicated to your MCP server's analytics.

--- a/.changeset/mcp-lib-version-property.md
+++ b/.changeset/mcp-lib-version-property.md
@@ -1,5 +1,0 @@
----
-'@posthog/mcp': minor
----
-
-Emit `$mcp_lib` (`@posthog/mcp`) and `$mcp_lib_version` on every `$mcp_*` event (and the `$exception` sibling) so you can tell which analytics SDK release produced the data. The version was already resolved at runtime but never mapped to a property. Namespaced like `@posthog/ai`'s `$ai_lib` rather than overriding `$lib`, which stays the transport SDK (`posthog-node`).

--- a/packages/mcp/src/__tests__/lib-identity.test.ts
+++ b/packages/mcp/src/__tests__/lib-identity.test.ts
@@ -1,5 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { instrument, PostHog } from '../index'
+import { instrument, PostHog, PostHogMCP } from '../index'
 import { version } from '../version'
 
 /**
@@ -9,16 +9,36 @@ import { version } from '../version'
  * `getLibraryId()` / `getLibraryVersion()`, so we assert on the getters.
  */
 describe('lib identity', () => {
-  it('instrument() relabels the host client to $lib=posthog-node-mcp', async () => {
-    const posthog = new PostHog('phc_test', { host: 'http://localhost', flushAt: 1, fetchRetryCount: 0 })
+  const options = { host: 'http://localhost', flushAt: 1, fetchRetryCount: 0 } as const
+
+  function instrumented(): PostHog {
+    const posthog = new PostHog('phc_test', options)
+    const server = new McpServer({ name: 'my-mcp', version: '1.0.0' }, { capabilities: { tools: {} } })
+    instrument(server, posthog)
+    return posthog
+  }
+
+  // Both emit paths must report the identical `$lib` / `$lib_version` contract.
+  it.each([
+    { path: 'PostHogMCP', makeClient: () => new PostHogMCP('phc_test', options) },
+    { path: 'instrument()', makeClient: instrumented },
+  ])('$path reports $lib=posthog-node-mcp / $lib_version=<package version>', async ({ makeClient }) => {
+    const client = makeClient()
+    try {
+      expect(client.getLibraryId()).toBe('posthog-node-mcp')
+      expect(client.getLibraryVersion()).toBe(version)
+    } finally {
+      await client.shutdown()
+    }
+  })
+
+  it('instrument() flips the host client from posthog-node to posthog-node-mcp', async () => {
+    const posthog = new PostHog('phc_test', options)
     try {
       expect(posthog.getLibraryId()).toBe('posthog-node')
-
       const server = new McpServer({ name: 'my-mcp', version: '1.0.0' }, { capabilities: { tools: {} } })
       instrument(server, posthog)
-
       expect(posthog.getLibraryId()).toBe('posthog-node-mcp')
-      expect(posthog.getLibraryVersion()).toBe(version)
     } finally {
       await posthog.shutdown()
     }

--- a/packages/mcp/src/__tests__/lib-identity.test.ts
+++ b/packages/mcp/src/__tests__/lib-identity.test.ts
@@ -1,0 +1,26 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { instrument, PostHog } from '../index'
+import { version } from '../version'
+
+/**
+ * Every event @posthog/mcp sends should self-identify with the standard PostHog
+ * `$lib` / `$lib_version` keys (value `posthog-node-mcp`), not the inherited
+ * `posthog-node` transport id. posthog-node stamps those from the client's
+ * `getLibraryId()` / `getLibraryVersion()`, so we assert on the getters.
+ */
+describe('lib identity', () => {
+  it('instrument() relabels the host client to $lib=posthog-node-mcp', async () => {
+    const posthog = new PostHog('phc_test', { host: 'http://localhost', flushAt: 1, fetchRetryCount: 0 })
+    try {
+      expect(posthog.getLibraryId()).toBe('posthog-node')
+
+      const server = new McpServer({ name: 'my-mcp', version: '1.0.0' }, { capabilities: { tools: {} } })
+      instrument(server, posthog)
+
+      expect(posthog.getLibraryId()).toBe('posthog-node-mcp')
+      expect(posthog.getLibraryVersion()).toBe(version)
+    } finally {
+      await posthog.shutdown()
+    }
+  })
+})

--- a/packages/mcp/src/__tests__/posthog-events.test.ts
+++ b/packages/mcp/src/__tests__/posthog-events.test.ts
@@ -6,7 +6,6 @@ import {
 import { MCPAnalyticsEventType } from '../extensions/event-types'
 import { buildPostHogCaptureEvents, type PostHogCaptureEvent } from '../extensions/posthog-events'
 import type { Event } from '../types'
-import { version } from '../version'
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -20,7 +19,6 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     serverVersion: '1.0.0',
     clientName: 'claude-desktop',
     clientVersion: '2.0.0',
-    sdkVersion: version,
     duration: 150,
     isError: false,
     ...overrides,
@@ -57,25 +55,20 @@ describe('buildPostHogCaptureEvents', () => {
     expect(event.properties[PostHogMCPAnalyticsProperty.ServerVersion]).toBe('1.0.0')
     expect(event.properties[PostHogMCPAnalyticsProperty.ClientName]).toBe('claude-desktop')
     expect(event.properties[PostHogMCPAnalyticsProperty.ClientVersion]).toBe('2.0.0')
-    expect(event.properties[PostHogMCPAnalyticsProperty.McpLib]).toBe('@posthog/mcp')
-    expect(event.properties[PostHogMCPAnalyticsProperty.McpLibVersion]).toBe(version)
     expect(event.properties[PostHogMCPAnalyticsProperty.IsError]).toBe(false)
     expect(event.properties).not.toHaveProperty('project_id')
   })
 
-  it.each([
-    { path: 'tool-call event', overrides: {}, eventName: PostHogMCPAnalyticsEvent.ToolCall },
-    {
-      path: '$exception event',
-      overrides: { isError: true, error: makeError('boom') },
-      eventName: PostHogMCPAnalyticsEvent.Exception,
-    },
-  ])('omits the MCP lib properties when sdkVersion is not set ($path)', ({ overrides, eventName }) => {
-    const events = buildPostHogCaptureEvents(makeEvent({ sdkVersion: undefined, ...overrides }))
-    const event = findEvent(events, eventName)
+  it('does not stamp $lib/$lib_version in the built properties (the client owns those)', () => {
+    // `$lib` / `$lib_version` are set by the posthog-node client via
+    // `getLibraryId()` / `getLibraryVersion()` (see `applyMcpLibIdentity`), not
+    // by the event builder — and never as the legacy `$mcp_lib` keys.
+    const [event] = buildPostHogCaptureEvents(makeEvent())
 
-    expect(event?.properties[PostHogMCPAnalyticsProperty.McpLib]).toBeUndefined()
-    expect(event?.properties[PostHogMCPAnalyticsProperty.McpLibVersion]).toBeUndefined()
+    expect(event.properties).not.toHaveProperty('$lib')
+    expect(event.properties).not.toHaveProperty('$lib_version')
+    expect(event.properties).not.toHaveProperty('$mcp_lib')
+    expect(event.properties).not.toHaveProperty('$mcp_lib_version')
   })
 
   it('keeps the canonical MCP analytics event contract stable', () => {
@@ -146,8 +139,8 @@ describe('buildPostHogCaptureEvents', () => {
     expect(exceptionEvent.properties.$mcp_resource_name).toBe('get_weather')
     expect(exceptionEvent.properties.$mcp_tool_name).toBe('get_weather')
     expect(exceptionEvent.properties.$mcp_server_name).toBe('weather-server')
-    expect(exceptionEvent.properties.$mcp_lib).toBe('@posthog/mcp')
-    expect(exceptionEvent.properties.$mcp_lib_version).toBe(version)
+    expect(exceptionEvent.properties).not.toHaveProperty('$mcp_lib')
+    expect(exceptionEvent.properties).not.toHaveProperty('$mcp_lib_version')
   })
 
   it('spreads customer eventProperties onto the $exception event', () => {

--- a/packages/mcp/src/__tests__/posthog-mcp.test.ts
+++ b/packages/mcp/src/__tests__/posthog-mcp.test.ts
@@ -42,6 +42,13 @@ describe('PostHogMCP', () => {
     expect(typeof posthog.shutdown).toBe('function')
   })
 
+  it('reports itself as $lib=posthog-node-mcp instead of the inherited posthog-node', () => {
+    // posthog-node stamps `$lib` / `$lib_version` from these getters, so this is
+    // what every captured event carries on the wire.
+    expect(posthog.getLibraryId()).toBe('posthog-node-mcp')
+    expect(posthog.getLibraryVersion()).toBe(version)
+  })
+
   describe('captureToolCall', () => {
     it('emits $mcp_tool_call with canonical properties, identity, and groups', async () => {
       posthog.captureToolCall({
@@ -66,8 +73,6 @@ describe('PostHogMCP', () => {
       expect(p[PostHogMCPAnalyticsProperty.IsError]).toBe(false)
       expect(p[PostHogMCPAnalyticsProperty.SessionId]).toBe('session-abc')
       expect(p[PostHogMCPAnalyticsProperty.Source]).toBe('posthog_mcp_analytics')
-      expect(p[PostHogMCPAnalyticsProperty.McpLib]).toBe('@posthog/mcp')
-      expect(p[PostHogMCPAnalyticsProperty.McpLibVersion]).toBe(version)
       expect(p.$groups).toEqual({ organization: 'org-1', project: 'proj-1' })
       expect(p.$mcp_client_name).toBe('claude-code')
       expect(p.custom_flag).toBe(true)

--- a/packages/mcp/src/__tests__/posthog-mcp.test.ts
+++ b/packages/mcp/src/__tests__/posthog-mcp.test.ts
@@ -2,7 +2,6 @@ import { getMoreToolsResult, PostHogMCP } from '../index'
 import { PostHogMCPAnalyticsEvent, PostHogMCPAnalyticsProperty } from '../extensions/constants'
 import { GET_MORE_TOOLS_NAME } from '../extensions/tools'
 import type { PostHogCaptureEvent } from '../extensions/posthog-events'
-import { version } from '../version'
 import { EventCapture } from './test-utils'
 
 // The capture methods are fire-and-forget (mirroring posthog-node's `capture()`),
@@ -42,12 +41,7 @@ describe('PostHogMCP', () => {
     expect(typeof posthog.shutdown).toBe('function')
   })
 
-  it('reports itself as $lib=posthog-node-mcp instead of the inherited posthog-node', () => {
-    // posthog-node stamps `$lib` / `$lib_version` from these getters, so this is
-    // what every captured event carries on the wire.
-    expect(posthog.getLibraryId()).toBe('posthog-node-mcp')
-    expect(posthog.getLibraryVersion()).toBe(version)
-  })
+  // `$lib` / `$lib_version` identity is covered for both emit paths in lib-identity.test.ts.
 
   describe('captureToolCall', () => {
     it('emits $mcp_tool_call with canonical properties, identity, and groups', async () => {

--- a/packages/mcp/src/extensions/constants.ts
+++ b/packages/mcp/src/extensions/constants.ts
@@ -11,10 +11,11 @@ export const DEFAULT_CONVERSATION_ID_DESCRIPTION =
 
 export const POSTHOG_MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'
 
-// Identifies the SDK that produced an `$mcp_*` event. Distinct from `$lib`
-// (posthog-node, the transport that actually sends the event) — this names the
-// higher-level analytics layer, mirroring `@posthog/ai`'s `$ai_lib`.
-export const POSTHOG_MCP_LIB_NAME = '@posthog/mcp'
+// The `$lib` identity stamped on every event @posthog/mcp sends. posthog-node
+// would otherwise report itself (`posthog-node`, the transport SDK); we override
+// `getLibraryId()` so MCP events self-identify the same way every other PostHog
+// SDK does. See `applyMcpLibIdentity` in `./lib-identity`.
+export const POSTHOG_MCP_LIB_NAME = 'posthog-node-mcp'
 
 // All PostHog-owned event names start with `$` per the PostHog convention.
 // Non-`$` names would be treated as customer-defined events and confuse the schema.
@@ -43,8 +44,6 @@ export const PostHogMCPAnalyticsProperty = {
   Intent: '$mcp_intent',
   IntentSource: '$mcp_intent_source',
   ListedToolNames: '$mcp_listed_tool_names',
-  McpLib: '$mcp_lib',
-  McpLibVersion: '$mcp_lib_version',
   Parameters: '$mcp_parameters',
   ResourceName: '$mcp_resource_name',
   Response: '$mcp_response',

--- a/packages/mcp/src/extensions/lib-identity.ts
+++ b/packages/mcp/src/extensions/lib-identity.ts
@@ -1,0 +1,25 @@
+import type { PostHog } from 'posthog-node'
+
+import { version } from '../version'
+import { POSTHOG_MCP_LIB_NAME } from './constants'
+
+/**
+ * Make `client` report `@posthog/mcp`'s identity as the standard PostHog `$lib`
+ * / `$lib_version` on every event it sends.
+ *
+ * posthog-node stamps `$lib` / `$lib_version` from `getLibraryId()` /
+ * `getLibraryVersion()` and spreads them *last* when building the payload, so
+ * they can't be overridden per-event via the captured properties (nor via
+ * `before_send`, which runs earlier). Overriding the two methods is the only
+ * lever. Shared by {@link PostHogMCP} (which calls this in its constructor) and
+ * `instrument()` (which applies it to the host-supplied client) so both emit
+ * paths report identical lib metadata.
+ *
+ * Because `$lib` is a client-level property, this relabels *every* event the
+ * client sends as `posthog-node-mcp`, not just `$mcp_*` events — expected for a
+ * dedicated MCP-analytics client.
+ */
+export function applyMcpLibIdentity(client: PostHog): void {
+  client.getLibraryId = () => POSTHOG_MCP_LIB_NAME
+  client.getLibraryVersion = () => version
+}

--- a/packages/mcp/src/extensions/posthog-events.ts
+++ b/packages/mcp/src/extensions/posthog-events.ts
@@ -3,12 +3,7 @@
 // Licensed under the MIT License: https://github.com/MCPCat/mcpcat-typescript-sdk/blob/main/LICENSE
 
 import type { Event } from '../types'
-import {
-  POSTHOG_MCP_ANALYTICS_SOURCE,
-  POSTHOG_MCP_LIB_NAME,
-  PostHogMCPAnalyticsEvent,
-  PostHogMCPAnalyticsProperty,
-} from './constants'
+import { POSTHOG_MCP_ANALYTICS_SOURCE, PostHogMCPAnalyticsEvent, PostHogMCPAnalyticsProperty } from './constants'
 import { MCPAnalyticsEventType } from './event-types'
 
 const BUILT_IN_EVENT_NAME_BY_TYPE = {
@@ -155,7 +150,6 @@ function addCommonEventProperties(event: Event, properties: Record<string, unkno
   if (event.clientVersion) {
     properties[PostHogMCPAnalyticsProperty.ClientVersion] = event.clientVersion
   }
-  addMcpLibProperties(event, properties)
   if (event.userIntent) {
     properties[PostHogMCPAnalyticsProperty.Intent] = event.userIntent
   }
@@ -184,18 +178,6 @@ function addCustomEventProperties(event: Event, properties: Record<string, unkno
     for (const [key, value] of Object.entries(event.properties)) {
       properties[key] = value
     }
-  }
-}
-
-/**
- * Stamps the `@posthog/mcp` SDK identity (`$mcp_lib` / `$mcp_lib_version`) onto
- * the event. Shared by the regular and `$exception` builders so both report
- * which analytics SDK release produced the event.
- */
-function addMcpLibProperties(event: Event, properties: Record<string, unknown>): void {
-  if (event.sdkVersion) {
-    properties[PostHogMCPAnalyticsProperty.McpLib] = POSTHOG_MCP_LIB_NAME
-    properties[PostHogMCPAnalyticsProperty.McpLibVersion] = event.sdkVersion
   }
 }
 
@@ -239,7 +221,6 @@ function buildExceptionEvent(event: Event): PostHogCaptureEvent {
   if (event.clientVersion) {
     properties[PostHogMCPAnalyticsProperty.ClientVersion] = event.clientVersion
   }
-  addMcpLibProperties(event, properties)
 
   addCustomEventProperties(event, properties)
 

--- a/packages/mcp/src/extensions/posthog-mcp.ts
+++ b/packages/mcp/src/extensions/posthog-mcp.ts
@@ -1,6 +1,5 @@
 import { PostHog, type PostHogOptions } from 'posthog-node'
 
-import { version } from '../version'
 import type {
   InitializeCaptureData,
   JsonRecord,
@@ -20,6 +19,7 @@ import {
 } from './context-parameters'
 import { MCPAnalyticsEventType } from './event-types'
 import { captureException } from './exceptions'
+import { applyMcpLibIdentity } from './lib-identity'
 import { log } from './logger'
 import { McpEventSink } from './sink'
 import { GET_MORE_TOOLS_NAME, getReportMissingToolDescriptor } from './tools'
@@ -85,6 +85,8 @@ export class PostHogMCP extends PostHog {
   constructor(apiKey: string, options: PostHogMCPOptions = {}) {
     super(apiKey, options)
     this.#missingCapabilityToolName = options.missingCapabilityToolName ?? GET_MORE_TOOLS_NAME
+    // Report `$lib: 'posthog-node-mcp'` instead of the inherited `posthog-node`.
+    applyMcpLibIdentity(this)
   }
 
   /** Capture a tool invocation. Emits `$mcp_tool_call` (+ an `$exception` sibling on error). */
@@ -242,7 +244,6 @@ function baseEvent(eventType: MCPAnalyticsEventType, common: McpCaptureCommon): 
     timestamp: common.timestamp ?? new Date(),
     properties: common.properties,
     groups: common.groups,
-    sdkVersion: version,
   }
   if (common.distinctId) {
     event.identifyActorGivenId = common.distinctId

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -9,6 +9,7 @@ import { MCPAnalyticsEventType } from './extensions/event-types'
 import { IdentityCache, getServerTrackingData, setServerTrackingData } from './extensions/internal'
 import { log, setLogger } from './extensions/logger'
 import { captureEvent } from './extensions/capture'
+import { applyMcpLibIdentity } from './extensions/lib-identity'
 import { deriveSessionIdFromMCPSession, getSessionInfo, newSessionId } from './extensions/session'
 import { instrumentLowLevelServer } from './extensions/instrument-lowlevel'
 import { instrumentHighLevelServer } from './extensions/instrument-highlevel'
@@ -65,6 +66,11 @@ function instrument(server: unknown, posthog: PostHog, options: MCPAnalyticsOpti
       return createAnalyticsHandle(lowLevelServer)
     }
 
+    if (posthog) {
+      // Report `$lib: 'posthog-node-mcp'` on this client's events instead of the
+      // inherited `posthog-node`. Relabels every event the client sends.
+      applyMcpLibIdentity(posthog)
+    }
     const sink = posthog ? new McpEventSink(posthog) : undefined
     const mcpAnalyticsData = buildTrackingData(lowLevelServer, options, sink)
 


### PR DESCRIPTION
## What

MCP events now use the standard PostHog `$lib` / `$lib_version` schema (value **`posthog-node-mcp`**) instead of the namespaced `$mcp_lib` / `$mcp_lib_version` added in #4022.

## Why

`$lib` is the canonical, materialized "which SDK" dimension. posthog-node forcibly stamps `$lib`/`$lib_version` from `getLibraryId()`/`getLibraryVersion()` (spread last in the payload, after `before_send`), so they can't be overridden per-event via properties — overriding those two methods is the only lever.

## How

A shared `applyMcpLibIdentity` helper sets the identity on both emit paths:
- **`PostHogMCP`** — in its constructor.
- **`instrument(server, client)`** — on the host-supplied client (relabels every event that client sends; pass a client dedicated to MCP analytics).

Removed `addMcpLibProperties` and the `$mcp_lib` keys; replaced the changeset.

## Test

- 336/336 mcp unit tests pass; added lib-identity assertions for both paths.
- Validated end-to-end against a NestJS/`@rekog/mcp-nest` playground: `instrument()` and `PostHogMCP` both report `$lib=posthog-node-mcp` / `$lib_version=0.5.1`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*