### PR TITLE
ci: update posthog watcher action

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -30,7 +30,7 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@53752eea5b036f37e83da06879ca05e06cb377e9
+              uses: PostHog/posthog-watcher-action@321404b6b373c2efffce607996f7f501c65ed182
               with:
                   mode: enqueue
                   trigger-drain-workflow: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -42,7 +42,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@53752eea5b036f37e83da06879ca05e06cb377e9
+              uses: PostHog/posthog-watcher-action@321404b6b373c2efffce607996f7f501c65ed182
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -48,7 +48,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@53752eea5b036f37e83da06879ca05e06cb377e9
+              uses: PostHog/posthog-watcher-action@321404b6b373c2efffce607996f7f501c65ed182
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -78,7 +78,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@53752eea5b036f37e83da06879ca05e06cb377e9
+              uses: PostHog/posthog-watcher-action@321404b6b373c2efffce607996f7f501c65ed182
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}


### PR DESCRIPTION
## Problem

The PostHog Watcher GitHub workflows were pinned to an older `PostHog/posthog-watcher-action` commit.

## Changes

Updated all GitHub Actions workflow usages of `PostHog/posthog-watcher-action` from `53752eea5b036f37e83da06879ca05e06cb377e9` to the latest HEAD SHA `321404b6b373c2efffce607996f7f501c65ed182`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used pi to locate all workflow references, resolve the latest `PostHog/posthog-watcher-action` HEAD SHA with `git ls-remote`, update the pinned SHAs, and verify all matching references now point to the new commit.
