### PR TITLE
fix(node): handle circular event properties during flush

### DIFF
--- a/.changeset/fuzzy-lobsters-smile.md
+++ b/.changeset/fuzzy-lobsters-smile.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-node': patch
+---
+
+Safely serialize event batches with circular property references instead of crashing during flush.

--- a/packages/core/src/error-tracking/exception-steps.ts
+++ b/packages/core/src/error-tracking/exception-steps.ts
@@ -1,4 +1,4 @@
-import { isArray, isNumber, isObject, isString } from '@/utils'
+import { isArray, isNumber, isObject, isString, safeJsonStringify } from '@/utils'
 
 export const EXCEPTION_STEP_INTERNAL_FIELDS = {
   MESSAGE: '$message',
@@ -134,8 +134,10 @@ function normalizePositiveInteger(input: number | undefined, fallback: number): 
 }
 
 function normalizeAndSerializeStep(step: ExceptionStep): { step: ExceptionStep; json: string } | undefined {
-  const json = safeStringify(step)
-  if (!json) {
+  let json: string
+  try {
+    json = safeJsonStringify(step)
+  } catch {
     return undefined
   }
 
@@ -161,45 +163,6 @@ function normalizeAndSerializeStep(step: ExceptionStep): { step: ExceptionStep; 
       step: parsedStep as ExceptionStep,
       json,
     }
-  } catch {
-    return undefined
-  }
-}
-
-function safeStringify(value: unknown): string | undefined {
-  const seen = new WeakSet<object>()
-
-  try {
-    return JSON.stringify(value, (_key, replacementValue: unknown) => {
-      if (typeof replacementValue === 'bigint') {
-        return replacementValue.toString()
-      }
-
-      if (typeof replacementValue === 'function' || typeof replacementValue === 'symbol') {
-        return undefined
-      }
-
-      if (replacementValue instanceof Date) {
-        return replacementValue.toISOString()
-      }
-
-      if (replacementValue instanceof Error) {
-        return {
-          name: replacementValue.name,
-          message: replacementValue.message,
-          stack: replacementValue.stack,
-        }
-      }
-
-      if (replacementValue && typeof replacementValue === 'object') {
-        if (seen.has(replacementValue)) {
-          return '[Circular]'
-        }
-        seen.add(replacementValue)
-      }
-
-      return replacementValue
-    })
   } catch {
     return undefined
   }

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -34,6 +34,7 @@ import {
   STRING_FORMAT,
   createLogger,
   getEventUuid,
+  safeJsonStringify,
 } from './utils'
 import { uuidv7 } from './vendor/uuidv7'
 import {
@@ -1082,7 +1083,7 @@ export abstract class PostHogCoreStateless {
       data.historical_migration = true
     }
 
-    const payload = JSON.stringify(data)
+    const payload = safeJsonStringify(data)
 
     const url = `${this.host}/batch/`
 
@@ -1278,7 +1279,7 @@ export abstract class PostHogCoreStateless {
         data.historical_migration = true
       }
 
-      const payload = JSON.stringify(data)
+      const payload = safeJsonStringify(data)
 
       const url = `${this.host}/batch/`
 

--- a/packages/core/src/utils/string-utils.spec.ts
+++ b/packages/core/src/utils/string-utils.spec.ts
@@ -1,6 +1,43 @@
-import { getPersonPropertiesHash } from './string-utils'
+import { getPersonPropertiesHash, safeJsonStringify } from './string-utils'
 
 describe('string-utils', () => {
+  describe('safeJsonStringify', () => {
+    it.each([
+      [
+        'replaces circular references',
+        () => {
+          const circular: Record<string, any> = { foo: 'bar' }
+          circular.self = circular
+          return {
+            value: circular,
+            expected: { foo: 'bar', self: '[Circular]' },
+          }
+        },
+      ],
+      [
+        'preserves shared non-circular references',
+        () => {
+          const shared = { id: 1 }
+          return {
+            value: { a: shared, b: shared },
+            expected: { a: { id: 1 }, b: { id: 1 } },
+          }
+        },
+      ],
+      [
+        'serializes bigint values as strings',
+        () => ({
+          value: { count: BigInt(123) },
+          expected: { count: '123' },
+        }),
+      ],
+    ])('%s', (_description, buildCase) => {
+      const { value, expected } = buildCase()
+
+      expect(JSON.parse(safeJsonStringify(value))).toEqual(expected)
+    })
+  })
+
   describe('getPersonPropertiesHash', () => {
     it('should return consistent hash regardless of top-level key order', () => {
       const hash1 = getPersonPropertiesHash('user-1', { b: 'value-b', a: 'value-a' })

--- a/packages/core/src/utils/string-utils.ts
+++ b/packages/core/src/utils/string-utils.ts
@@ -24,6 +24,48 @@ export function isDistinctIdStringLike(value: string): boolean {
   return ['distinct_id', 'distinctid'].includes(value.toLowerCase())
 }
 
+export function safeJsonStringify(value: unknown): string {
+  // Browser replay has `circularReferenceReplacer`, which uses this same
+  // ancestor-chain approach to replace only true cycles. Keep this core helper
+  // separate so Node/RN/core payload serialization does not depend on browser
+  // replay internals, and so we can also handle BigInt and Error values here.
+  const ancestors: object[] = []
+
+  return (
+    JSON.stringify(value, function (this: unknown, _key: string, replacementValue: unknown) {
+      if (typeof replacementValue === 'bigint') {
+        return replacementValue.toString()
+      }
+
+      if (typeof replacementValue === 'function' || typeof replacementValue === 'symbol') {
+        return undefined
+      }
+
+      if (replacementValue instanceof Error) {
+        return {
+          name: replacementValue.name,
+          message: replacementValue.message,
+          stack: replacementValue.stack,
+        }
+      }
+
+      if (replacementValue && typeof replacementValue === 'object') {
+        while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+          ancestors.pop()
+        }
+
+        if (ancestors.includes(replacementValue)) {
+          return '[Circular]'
+        }
+
+        ancestors.push(replacementValue)
+      }
+
+      return replacementValue
+    }) ?? 'null'
+  )
+}
+
 /**
  * Recursively sorts all keys in an object and its nested objects/arrays.
  * Used to ensure deterministic JSON serialization regardless of object construction order.

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -115,6 +115,25 @@ describe('PostHog Node.js', () => {
       ])
     })
 
+    it('safely flushes circular event properties', async () => {
+      const circularProperties: Record<string, any> = { foo: 'bar' }
+      circularProperties.message = circularProperties
+
+      posthog.capture({ distinctId: '123', event: 'test-event', properties: circularProperties })
+      await (posthog as any).promiseQueue.join()
+
+      await expect(posthog.flush()).resolves.toBeUndefined()
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents?.[0].properties).toMatchObject({
+        foo: 'bar',
+        message: {
+          foo: 'bar',
+          message: '[Circular]',
+        },
+      })
+    })
+
     it('should not include $is_server when isServer is false (client/CLI usage)', async () => {
       const cliClient = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',


### PR DESCRIPTION
## Problem

`posthog-node` could crash during flush when an event contained circular property references because the batch payload used `JSON.stringify` directly.

Fixes https://github.com/PostHog/posthog-js/issues/2615

## Changes

- Add `safeJsonStringify` as a shared core utility, based on the existing error-tracking safe stringify behavior.
- Use an ancestor-chain approach, matching browser replay's circular reference handling, so true cycles are replaced while shared non-circular sibling references are preserved.
- Reuse the shared serializer from error-tracking exception steps instead of keeping a duplicate private helper.
- Use the safe serializer for event batch payloads in both queued and immediate flush paths.
- Add core utility tests and a Node SDK regression test covering circular event properties.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The user asked to reproduce and then fix issue #2615 in a dedicated worktree. I first added a failing Node regression test for circular event properties, then pulled the existing core error-tracking safe stringify behavior into a shared core utility and used it for event batch serialization so flush no longer throws on circular references.

Verification run:

```bash
pnpm --filter @posthog/core build
pnpm --filter @posthog/core exec jest src/utils/string-utils.spec.ts src/error-tracking/exception-steps.spec.ts --runInBand --coverage=false
pnpm --filter posthog-node exec jest src/__tests__/posthog-node.spec.ts --runInBand --coverage=false
pnpm --filter @posthog/core exec eslint src/utils/string-utils.ts src/utils/string-utils.spec.ts src/posthog-core-stateless.ts src/error-tracking/exception-steps.ts
pnpm --filter posthog-node exec eslint src/__tests__/posthog-node.spec.ts
git diff --check
```
