### PR TITLE
fix(node): run before_send for all captured events

### DIFF
--- a/.changeset/fuzzy-bananas-listen.md
+++ b/.changeset/fuzzy-bananas-listen.md
@@ -1,0 +1,5 @@
+---
+"posthog-node": patch
+---
+
+Call `before_send` for identify, group identify, and alias events.

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -184,8 +184,7 @@ describe('PostHog Node.js', () => {
     it('should capture identify events on shared queue', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       posthog.identify({ distinctId: '123', properties: { foo: 'bar' } })
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
@@ -205,8 +204,7 @@ describe('PostHog Node.js', () => {
     it('should handle identify using $set and $set_once', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       posthog.identify({ distinctId: '123', properties: { $set: { foo: 'bar' }, $set_once: { vip: true } } })
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
         {
@@ -228,8 +226,7 @@ describe('PostHog Node.js', () => {
     it('should handle identify using $set_once', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       posthog.identify({ distinctId: '123', properties: { foo: 'bar', $set_once: { vip: true } } })
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
         {
@@ -251,8 +248,7 @@ describe('PostHog Node.js', () => {
     it('should capture alias events on shared queue', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       posthog.alias({ distinctId: '123', alias: '1234' })
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
         {
@@ -689,6 +685,142 @@ describe('PostHog Node.js', () => {
       })
     })
 
+    it.each([
+      [
+        'identify',
+        async (ph: PostHog) => {
+          ph.identify({ distinctId: '123', properties: { foo: 'bar' } })
+          await waitForFlushTimer()
+        },
+        '$identify',
+        '123',
+        { $set: { foo: 'bar' }, beforeSend: true },
+      ],
+      [
+        'identifyImmediate',
+        (ph: PostHog) => ph.identifyImmediate({ distinctId: '123', properties: { foo: 'bar' } }),
+        '$identify',
+        '123',
+        { $set: { foo: 'bar' }, beforeSend: true },
+      ],
+      [
+        'groupIdentify',
+        async (ph: PostHog) => {
+          ph.groupIdentify({ groupType: 'posthog', groupKey: 'team-1', properties: { analytics: true } })
+          await waitForFlushTimer()
+        },
+        '$groupidentify',
+        '$posthog_team-1',
+        {
+          $group_type: 'posthog',
+          $group_key: 'team-1',
+          $group_set: { analytics: true },
+          beforeSend: true,
+        },
+      ],
+      [
+        'groupIdentifyImmediate',
+        (ph: PostHog) =>
+          ph.groupIdentifyImmediate({ groupType: 'posthog', groupKey: 'team-1', properties: { analytics: true } }),
+        '$groupidentify',
+        '$posthog_team-1',
+        {
+          $group_type: 'posthog',
+          $group_key: 'team-1',
+          $group_set: { analytics: true },
+          beforeSend: true,
+        },
+      ],
+      [
+        'alias',
+        async (ph: PostHog) => {
+          ph.alias({ distinctId: '123', alias: '1234' })
+          await waitForFlushTimer()
+        },
+        '$create_alias',
+        '123',
+        { distinct_id: '123', alias: '1234', beforeSend: true },
+      ],
+      [
+        'aliasImmediate',
+        (ph: PostHog) => ph.aliasImmediate({ distinctId: '123', alias: '1234' }),
+        '$create_alias',
+        '123',
+        { distinct_id: '123', alias: '1234', beforeSend: true },
+      ],
+    ] as Array<[string, (ph: PostHog) => Promise<void>, string, string, Record<string, any>]>)(
+      'should run before_send for %s',
+      async (_, send, expectedEvent, expectedDistinctId, expectedProperties) => {
+        const beforeSendFn = jest.fn((event) => ({
+          ...event,
+          properties: { ...event?.properties, beforeSend: true },
+        }))
+        const ph = new PostHog('TEST_API_KEY', {
+          host: 'http://example.com',
+          fetchRetryCount: 0,
+          disableCompression: true,
+          before_send: beforeSendFn,
+        })
+
+        await send(ph)
+
+        expect(beforeSendFn).toHaveBeenCalledTimes(1)
+        expect(beforeSendFn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            distinctId: expectedDistinctId,
+            event: expectedEvent,
+          })
+        )
+        const batchEvents = getLastBatchEvents()
+        expect(batchEvents).toHaveLength(1)
+        expect(batchEvents![0]).toMatchObject({
+          distinct_id: expectedDistinctId,
+          event: expectedEvent,
+          properties: expect.objectContaining(expectedProperties),
+        })
+      }
+    )
+
+    it.each([
+      [
+        'identify',
+        async (ph: PostHog) => {
+          ph.identify({ distinctId: '123', properties: { foo: 'bar' } })
+          await waitForFlushTimer()
+        },
+      ],
+      [
+        'groupIdentify',
+        async (ph: PostHog) => {
+          ph.groupIdentify({ groupType: 'posthog', groupKey: 'team-1', properties: { analytics: true } })
+          await waitForFlushTimer()
+        },
+      ],
+      [
+        'alias',
+        async (ph: PostHog) => {
+          ph.alias({ distinctId: '123', alias: '1234' })
+          await waitForFlushTimer()
+        },
+      ],
+    ] as Array<[string, (ph: PostHog) => Promise<void>]>)(
+      'should drop %s when before_send returns null',
+      async (_, send) => {
+        const beforeSendFn = jest.fn(() => null)
+        const ph = new PostHog('TEST_API_KEY', {
+          host: 'http://example.com',
+          fetchRetryCount: 0,
+          disableCompression: true,
+          before_send: beforeSendFn,
+        })
+
+        await send(ph)
+
+        expect(beforeSendFn).toHaveBeenCalledTimes(1)
+        expect(mockedFetch).not.toHaveBeenCalledWith('http://example.com/batch/', expect.anything())
+      }
+    )
+
     it('should log when event is dropped in debug mode', async () => {
       const beforeSendFn = jest.fn(() => null)
       const ph = new PostHog('TEST_API_KEY', {
@@ -869,8 +1001,7 @@ describe('PostHog Node.js', () => {
   describe('groupIdentify', () => {
     it('should identify group with unique id', async () => {
       posthog.groupIdentify({ groupType: 'posthog', groupKey: 'team-1', properties: { analytics: true } })
-      jest.runOnlyPendingTimers()
-      await posthog.flush()
+      await waitForFlushTimer()
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
         {
@@ -894,8 +1025,7 @@ describe('PostHog Node.js', () => {
         properties: { analytics: true },
         distinctId: '123',
       })
-      jest.runOnlyPendingTimers()
-      await posthog.flush()
+      await waitForFlushTimer()
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
         {

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -789,6 +789,7 @@ describe('PostHog Node.js', () => {
           await waitForFlushTimer()
         },
       ],
+      ['identifyImmediate', (ph: PostHog) => ph.identifyImmediate({ distinctId: '123', properties: { foo: 'bar' } })],
       [
         'groupIdentify',
         async (ph: PostHog) => {
@@ -797,12 +798,18 @@ describe('PostHog Node.js', () => {
         },
       ],
       [
+        'groupIdentifyImmediate',
+        (ph: PostHog) =>
+          ph.groupIdentifyImmediate({ groupType: 'posthog', groupKey: 'team-1', properties: { analytics: true } }),
+      ],
+      [
         'alias',
         async (ph: PostHog) => {
           ph.alias({ distinctId: '123', alias: '1234' })
           await waitForFlushTimer()
         },
       ],
+      ['aliasImmediate', (ph: PostHog) => ph.aliasImmediate({ distinctId: '123', alias: '1234' })],
     ] as Array<[string, (ph: PostHog) => Promise<void>]>)(
       'should drop %s when before_send returns null',
       async (_, send) => {
@@ -818,6 +825,54 @@ describe('PostHog Node.js', () => {
 
         expect(beforeSendFn).toHaveBeenCalledTimes(1)
         expect(mockedFetch).not.toHaveBeenCalledWith('http://example.com/batch/', expect.anything())
+      }
+    )
+
+    it.each([
+      [
+        'identify',
+        async (ph: PostHog) => {
+          ph.identify({ distinctId: '123', properties: { foo: 'bar' } })
+          await waitForFlushTimer()
+        },
+        '$identify',
+      ],
+      [
+        'groupIdentify',
+        async (ph: PostHog) => {
+          ph.groupIdentify({ groupType: 'posthog', groupKey: 'team-1', properties: { analytics: true } })
+          await waitForFlushTimer()
+        },
+        '$groupidentify',
+      ],
+      [
+        'alias',
+        async (ph: PostHog) => {
+          ph.alias({ distinctId: '123', alias: '1234' })
+          await waitForFlushTimer()
+        },
+        '$create_alias',
+      ],
+    ] as Array<[string, (ph: PostHog) => Promise<void>, string]>)(
+      'should not add registered or context properties to %s',
+      async (_, send, expectedEvent) => {
+        const ph = new PostHog('TEST_API_KEY', {
+          host: 'http://example.com',
+          fetchRetryCount: 0,
+          disableCompression: true,
+          before_send: (event) => event,
+        })
+        ph.register({ registered_prop: 'registered_value' })
+
+        await ph.withContext({ properties: { context_prop: 'context_value' }, sessionId: 'session-123' }, () =>
+          send(ph)
+        )
+
+        const batchEvents = getLastBatchEvents()
+        expect(batchEvents![0]).toMatchObject({ event: expectedEvent })
+        expect(batchEvents![0].properties).not.toHaveProperty('registered_prop')
+        expect(batchEvents![0].properties).not.toHaveProperty('context_prop')
+        expect(batchEvents![0].properties).not.toHaveProperty('$session_id')
       }
     )
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -532,7 +532,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
   }
 
-  private _capturePreparedEvent(props: EventMessage, immediate: boolean): Promise<void> {
+  private _sendPreparedEvent(type: string, props: EventMessage, immediate: boolean): Promise<void> {
     return this.addPendingPromise(
       this.prepareEventMessage(props)
         .then(({ distinctId, event, properties, options }) => {
@@ -541,9 +541,17 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
             disableGeoip: options.disableGeoip,
             uuid: options.uuid,
           }
+          const message = {
+            distinctId,
+            event,
+            properties: {
+              ...properties,
+              ...this.getCommonEventProperties(),
+            },
+          }
           return immediate
-            ? super.captureStatelessImmediate(distinctId, event, properties, captureOptions)
-            : super.captureStateless(distinctId, event, properties, captureOptions)
+            ? this.sendImmediate(type, message, captureOptions)
+            : this.enqueue(type, message, captureOptions)
         })
         .catch((err) => {
           if (err) {
@@ -551,6 +559,10 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           }
         })
     )
+  }
+
+  private _capturePreparedEvent(props: EventMessage, immediate: boolean): Promise<void> {
+    return this._sendPreparedEvent('capture', props, immediate)
   }
 
   /**
@@ -676,7 +688,11 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       $set_once: setOnceProps,
       $anon_distinct_id: $anon_distinct_id ?? undefined,
     }
-    super.identifyStateless(distinctId, eventProperties, { disableGeoip })
+    this._sendPreparedEvent(
+      'identify',
+      { distinctId, event: '$identify', properties: eventProperties, disableGeoip },
+      false
+    )
   }
 
   /**
@@ -710,7 +726,11 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       $set_once: setOnceProps,
       $anon_distinct_id: $anon_distinct_id ?? undefined,
     }
-    await super.identifyStatelessImmediate(distinctId, eventProperties, { disableGeoip })
+    await this._sendPreparedEvent(
+      'identify',
+      { distinctId, event: '$identify', properties: eventProperties, disableGeoip },
+      true
+    )
   }
 
   /**
@@ -790,7 +810,16 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * @param data - The alias data containing distinctId and alias
    */
   alias(data: { distinctId: string; alias: string; disableGeoip?: boolean }): void {
-    super.aliasStateless(data.alias, data.distinctId, undefined, { disableGeoip: data.disableGeoip })
+    this._sendPreparedEvent(
+      'alias',
+      {
+        distinctId: data.distinctId,
+        event: '$create_alias',
+        properties: { distinct_id: data.distinctId, alias: data.alias },
+        disableGeoip: data.disableGeoip,
+      },
+      false
+    )
   }
 
   /**
@@ -811,7 +840,16 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * @returns Promise that resolves when the alias is processed
    */
   async aliasImmediate(data: { distinctId: string; alias: string; disableGeoip?: boolean }): Promise<void> {
-    await super.aliasStatelessImmediate(data.alias, data.distinctId, undefined, { disableGeoip: data.disableGeoip })
+    await this._sendPreparedEvent(
+      'alias',
+      {
+        distinctId: data.distinctId,
+        event: '$create_alias',
+        properties: { distinct_id: data.distinctId, alias: data.alias },
+        disableGeoip: data.disableGeoip,
+      },
+      true
+    )
   }
 
   /**
@@ -1965,7 +2003,20 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * @param data - The group identify data
    */
   groupIdentify({ groupType, groupKey, properties, distinctId, disableGeoip }: GroupIdentifyMessage): void {
-    super.groupIdentifyStateless(groupType, groupKey, properties, { disableGeoip }, distinctId)
+    this._sendPreparedEvent(
+      'capture',
+      {
+        distinctId: distinctId || `$${groupType}_${groupKey}`,
+        event: '$groupidentify',
+        properties: {
+          $group_type: groupType,
+          $group_key: groupKey,
+          $group_set: properties || {},
+        },
+        disableGeoip,
+      },
+      false
+    )
   }
 
   /**
@@ -1997,7 +2048,20 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     distinctId,
     disableGeoip,
   }: GroupIdentifyMessage): Promise<void> {
-    await super.groupIdentifyStatelessImmediate(groupType, groupKey, properties, { disableGeoip }, distinctId)
+    await this._sendPreparedEvent(
+      'capture',
+      {
+        distinctId: distinctId || `$${groupType}_${groupKey}`,
+        event: '$groupidentify',
+        properties: {
+          $group_type: groupType,
+          $group_key: groupKey,
+          $group_set: properties || {},
+        },
+        disableGeoip,
+      },
+      true
+    )
   }
 
   /**

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -539,7 +539,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     prepareOptions?: { includeContextProperties?: boolean }
   ): Promise<void> {
     return this.addPendingPromise(
-      this.prepareEventMessage(props, prepareOptions)
+      this._prepareEventMessage(props, prepareOptions)
         .then(({ distinctId, event, properties, options }) => {
           const captureOptions: PostHogCaptureOptions = {
             timestamp: options.timestamp,
@@ -2601,7 +2601,16 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
   }
 
-  public async prepareEventMessage(
+  public async prepareEventMessage(props: EventMessage): Promise<{
+    distinctId: string
+    event: string
+    properties: PostHogEventProperties
+    options: PostHogCaptureOptions
+  }> {
+    return this._prepareEventMessage(props)
+  }
+
+  private async _prepareEventMessage(
     props: EventMessage,
     options: { includeContextProperties?: boolean } = {}
   ): Promise<{

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -532,9 +532,14 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
   }
 
-  private _sendPreparedEvent(type: string, props: EventMessage, immediate: boolean): Promise<void> {
+  private _sendPreparedEvent(
+    type: string,
+    props: EventMessage,
+    immediate: boolean,
+    prepareOptions?: { includeContextProperties?: boolean }
+  ): Promise<void> {
     return this.addPendingPromise(
-      this.prepareEventMessage(props)
+      this.prepareEventMessage(props, prepareOptions)
         .then(({ distinctId, event, properties, options }) => {
           const captureOptions: PostHogCaptureOptions = {
             timestamp: options.timestamp,
@@ -691,7 +696,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     this._sendPreparedEvent(
       'identify',
       { distinctId, event: '$identify', properties: eventProperties, disableGeoip },
-      false
+      false,
+      { includeContextProperties: false }
     )
   }
 
@@ -729,7 +735,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     await this._sendPreparedEvent(
       'identify',
       { distinctId, event: '$identify', properties: eventProperties, disableGeoip },
-      true
+      true,
+      { includeContextProperties: false }
     )
   }
 
@@ -818,7 +825,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         properties: { distinct_id: data.distinctId, alias: data.alias },
         disableGeoip: data.disableGeoip,
       },
-      false
+      false,
+      { includeContextProperties: false }
     )
   }
 
@@ -848,7 +856,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         properties: { distinct_id: data.distinctId, alias: data.alias },
         disableGeoip: data.disableGeoip,
       },
-      true
+      true,
+      { includeContextProperties: false }
     )
   }
 
@@ -2015,7 +2024,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         },
         disableGeoip,
       },
-      false
+      false,
+      { includeContextProperties: false }
     )
   }
 
@@ -2060,7 +2070,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         },
         disableGeoip,
       },
-      true
+      true,
+      { includeContextProperties: false }
     )
   }
 
@@ -2590,7 +2601,10 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
   }
 
-  public async prepareEventMessage(props: EventMessage): Promise<{
+  public async prepareEventMessage(
+    props: EventMessage,
+    options: { includeContextProperties?: boolean } = {}
+  ): Promise<{
     distinctId: string
     event: string
     properties: PostHogEventProperties
@@ -2609,21 +2623,24 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }: EventMessage = props
 
     const contextData = this.context?.get()
+    const includeContextProperties = options.includeContextProperties ?? true
 
     let mergedDistinctId = distinctId || contextData?.distinctId
 
-    const mergedProperties = {
-      ...this.props,
-      ...(contextData?.properties || {}),
-      ...(properties || {}),
-    }
+    const mergedProperties = includeContextProperties
+      ? {
+          ...this.props,
+          ...(contextData?.properties || {}),
+          ...(properties || {}),
+        }
+      : { ...(properties || {}) }
 
     if (!mergedDistinctId) {
       mergedDistinctId = uuidv7()
       mergedProperties.$process_person_profile = false
     }
 
-    if (contextData?.sessionId && !mergedProperties.$session_id) {
+    if (includeContextProperties && contextData?.sessionId && !mergedProperties.$session_id) {
       mergedProperties.$session_id = contextData.sessionId
     }
 


### PR DESCRIPTION
## Problem

`posthog-node` only ran `before_send` for events sent through `capture`, so `$identify`, `$groupidentify`, and `$create_alias` could not be inspected, modified, or dropped by the hook. This differs from the expectation that `before_send` applies to all captured events and fixes #2546.

Fixes #2546

## Changes

- Route `identify`, `identifyImmediate`, `groupIdentify`, `groupIdentifyImmediate`, `alias`, and `aliasImmediate` through the prepared-event path so they run `before_send` before enqueue/send.
- Preserve existing identify, group identify, and alias payload shapes by not merging registered or context properties into those non-capture event types.
- Add Node SDK tests for running and dropping events via `before_send` across identify, group identify, and alias APIs, including immediate variants.
- Add a patch changeset for `posthog-node`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi in a dedicated git worktree after investigating issue #2546. Chose to reuse the Node SDK's prepared-event path for `before_send`, while explicitly avoiding registered/context property merging for non-capture APIs to preserve their existing payload shapes.

Verification performed:

```bash
pnpm --dir ../posthog-js-before-send/packages/node lint
pnpm --dir ../posthog-js-before-send/packages/node exec jest src/__tests__/posthog-node.spec.ts --runInBand -t before_send
pnpm --dir ../posthog-js-before-send exec turbo --filter=posthog-node build
pnpm --dir ../posthog-js-before-send/packages/node exec jest --runInBand
```
