### PR TITLE
ci: scope workflow secrets to job level to satisfy Semgrep

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -15,4 +15,5 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
+        # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit -- reusable workflow requires inherited secrets
         secrets: inherit

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -15,5 +15,4 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit -- reusable workflow requires inherited secrets
-        secrets: inherit
+        secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit -- reusable workflow requires inherited secrets

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,6 @@
 name: Playwright Integration Tests
 on: [pull_request]
 env:
-  POSTHOG_PROJECT_API_KEY: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
-  POSTHOG_PERSONAL_API_KEY: "${{ secrets.POSTHOG_PERSONAL_API_KEY }}"
   POSTHOG_API_HOST: https://us.i.posthog.com
   POSTHOG_PROJECT_ID: 11213
 
@@ -19,6 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       CAN_RUN_INTEGRATION_TESTS: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      POSTHOG_PROJECT_API_KEY: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
+      POSTHOG_PERSONAL_API_KEY: "${{ secrets.POSTHOG_PERSONAL_API_KEY }}"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -1,10 +1,6 @@
 name: TestCafe
 on: [pull_request]
 env:
-  BROWSERSTACK_ACCESS_KEY: "${{ secrets.BROWSERSTACK_ACCESS_KEY }}"
-  BROWSERSTACK_USERNAME: "${{ secrets.BROWSERSTACK_USERNAME }}"
-  POSTHOG_PROJECT_API_KEY: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
-  POSTHOG_PERSONAL_API_KEY: "${{ secrets.POSTHOG_PERSONAL_API_KEY }}"
   BROWSERSTACK_DEBUG: "true"
   BROWSERSTACK_NETWORK_LOGS: "true"
   BROWSERSTACK_CONSOLE: "info"
@@ -20,6 +16,11 @@ jobs:
   browsers:
     name: Test on ${{ matrix.name }}
     runs-on: ubuntu-22.04
+    env:
+      BROWSERSTACK_ACCESS_KEY: "${{ secrets.BROWSERSTACK_ACCESS_KEY }}"
+      BROWSERSTACK_USERNAME: "${{ secrets.BROWSERSTACK_USERNAME }}"
+      POSTHOG_PROJECT_API_KEY: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
+      POSTHOG_PERSONAL_API_KEY: "${{ secrets.POSTHOG_PERSONAL_API_KEY }}"
 
     strategy:
       matrix:


### PR DESCRIPTION
## Problem

Semgrep (enforced as a required workflow via a branch ruleset) fails on every PR whose merge is scanned, blocking merges. The 7 blocking findings are all pre-existing issues in this repo's own CI workflow files — not in any feature PR — so they surface on unrelated PRs (e.g. #4002, #4031) and cannot be resolved by those branches. This PR fixes them centrally in `main`.

## Changes

- **`integration.yml`, `testcafe.yml`** — moved `secrets.*` values out of the workflow-level `env:` block into the single consuming job's `env:`. Each file has exactly one job, so scope and runtime behaviour are unchanged; this clears the `gha-workflow-env-secret` rule (6 of 7 findings).
- **`call-flags-project-board.yml`** — suppressed the `secrets-inherit` finding (1 of 7) with a `# nosemgrep` directive. The called reusable workflow (`PostHog/.github` `flags-project-board.yml`) references `PROJECT_BOARD_BOT_APP_ID` / `PROJECT_BOARD_BOT_PRIVATE_KEY` but does **not** declare them under `on.workflow_call.secrets`, so they can only be passed via `inherit` — an explicit `secrets:` map would fail to validate. The call is gated to same-repo PRs and targets a first-party, SHA-pinned workflow. The clean fix is to declare those secrets upstream in `PostHog/.github`, then pass them explicitly here (follow-up).

Opened as a **draft** to confirm Semgrep goes green before marking ready.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them

_CI-only change; no library version bump required._

## Checklist

- [ ] Tests for new code — n/a (CI config)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size — n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated why PR #4002 (and others) were stuck at `mergeable_state: blocked` despite green required checks; traced it to a `workflows` ruleset rule enforcing `semgrep.yml`, which flags pre-existing findings in this repo's CI files. Verified the same 7 findings block an unrelated internal PR (#4031), confirming a repo-wide issue rather than a per-PR one. Chose to scope secrets to the job level (behaviour-preserving) and to `nosemgrep` the `secrets: inherit` case after reading the upstream reusable workflow and confirming it cannot accept an explicit secrets map today. Tool: Claude Code.
