### PR TITLE
fix(browser): ignore generated lib in Jest

### DIFF
--- a/packages/browser/jest.config.js
+++ b/packages/browser/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
     testPathIgnorePatterns: ['/node_modules/', '/cypress/', '/react/', '/test_data/', '/testcafe/'],
     moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
     setupFilesAfterEnv: ['./src/__tests__/setup.js'],
-    modulePathIgnorePatterns: ['src/__tests__/setup.js', 'src/__tests__/helpers/'],
+    modulePathIgnorePatterns: ['<rootDir>/lib/', 'src/__tests__/setup.js', 'src/__tests__/helpers/'],
     clearMocks: true,
     testEnvironment: 'jsdom',
     prettierPath: null,


### PR DESCRIPTION
## Problem

`posthog-js` unit tests can emit Jest Haste module collision noise after a build because TypeScript copies `package.json` into `packages/browser/lib/package.json`. Jest then sees both `packages/browser/package.json` and the generated `lib/package.json` as the same `posthog-js` package, making test runs noisy and flaky.

## Changes

- Ignore the generated `<rootDir>/lib/` directory in the browser Jest config's `modulePathIgnorePatterns`.
- This keeps Jest focused on source/tests and prevents the generated build artifact from being indexed by haste-map.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi in a dedicated worktree. I reproduced the haste-map collision by creating `packages/browser/lib/package.json`, then chose the smallest Jest config change: ignore the generated `lib/` artifact directory rather than changing test selection or chasing individual test names.

Verified with:

```bash
pnpm exec jest src --listTests --runInBand
pnpm --filter=posthog-js build
cd packages/browser && pnpm exec jest src --runInBand
```
