### PR TITLE
fix: retry BrowserStack setup for IE11 TestCafe

### DIFF
--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -71,31 +71,30 @@ jobs:
         run: |
           set -o pipefail
 
-          # The BrowserStack TestCafe provider makes BrowserStack API calls without retries.
-          # BrowserStack occasionally closes compressed API responses early before tests run.
-          retryable_browserstack_api_url='https://api.browserstack.com/'
+          # BrowserStack setup/API retries happen inside browserstack-node-fetch-patch.cjs so
+          # a real IE assertion failure is not retried as infrastructure flakiness.
+          output_file="$(mktemp)"
 
-          for attempt in 1 2 3; do
-            output_file="$(mktemp)"
-            echo "TestCafe attempt ${attempt}/3"
-
-            if pnpm testcafe "${BROWSER}" --stop-on-first-fail 2>&1 | tee "${output_file}"; then
-              rm -f "${output_file}"
-              exit 0
-            fi
-
-            exit_code="${PIPESTATUS[0]}"
-
-            if grep -Fq "${retryable_browserstack_api_url}" "${output_file}" && [ "${attempt}" -lt 3 ]; then
-              echo "::warning::BrowserStack API fetch failed; retrying TestCafe."
-              rm -f "${output_file}"
-              sleep $((attempt * 10))
-              continue
-            fi
-
+          if pnpm testcafe "${BROWSER}" --stop-on-first-fail 2>&1 | tee "${output_file}"; then
             rm -f "${output_file}"
-            exit "${exit_code}"
-          done
+            exit 0
+          fi
+
+          exit_code="${PIPESTATUS[0]}"
+
+          if {
+            grep -Fq "POSTHOG_BROWSERSTACK_SETUP_FAILURE" "${output_file}" ||
+              grep -Fq "BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY" "${output_file}"
+          }; then
+            echo "::error title=BrowserStack setup failed::BrowserStack API/session setup failed after retry/backoff. This is infrastructure setup, not an IE11 test assertion failure."
+          elif grep -Fq "POSTHOG_BROWSERSTACK_API_FAILURE" "${output_file}"; then
+            echo "::error title=BrowserStack API failed::BrowserStack API failed after retry/backoff outside initial setup."
+          else
+            echo "::error title=IE11 TestCafe failed::TestCafe reached IE11 and failed without a BrowserStack setup marker. Treat this as a browser/test failure."
+          fi
+
+          rm -f "${output_file}"
+          exit "${exit_code}"
         working-directory: packages/browser
 
       - name: Check ${{ matrix.name }} events

--- a/packages/browser/src/__tests__/browserstack-node-fetch-patch.test.js
+++ b/packages/browser/src/__tests__/browserstack-node-fetch-patch.test.js
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment node
+ */
+
+const {
+    isRetryableError,
+    isRetryableStatus,
+    isSetupRequest,
+    patchNodeFetch,
+} = require('../../testcafe/browserstack-node-fetch-patch.cjs')
+
+const setupUrl = 'https://hub-cloud.browserstack.com/wd/hub/session'
+const browserListUrl = 'https://api.browserstack.com/automate/browsers.json'
+
+function response(status, payload) {
+    return {
+        status,
+        body: { destroy: jest.fn() },
+        json: jest.fn(async () => payload),
+    }
+}
+
+describe('browserstack-node-fetch-patch', () => {
+    let warnSpy
+
+    beforeEach(() => {
+        process.env.BROWSERSTACK_API_MAX_ATTEMPTS = '3'
+        process.env.BROWSERSTACK_API_BACKOFF_MS = '0'
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        delete process.env.BROWSERSTACK_API_MAX_ATTEMPTS
+        delete process.env.BROWSERSTACK_API_BACKOFF_MS
+        warnSpy.mockRestore()
+    })
+
+    it.each([408, 409, 425, 429, 500, 503])('retries retryable HTTP status %s', async (status) => {
+        const firstResponse = response(status, { status: 13 })
+        const secondResponse = response(200, { ok: true })
+        const fetch = jest.fn(async () => (fetch.mock.calls.length === 1 ? firstResponse : secondResponse))
+
+        const patchedFetch = patchNodeFetch(fetch)
+        const patchedResponse = await patchedFetch(browserListUrl)
+        await expect(patchedResponse.json()).resolves.toEqual({ ok: true })
+
+        expect(fetch).toHaveBeenCalledTimes(2)
+        expect(firstResponse.body.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries retryable transport errors', async () => {
+        const error = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
+        const fetch = jest
+            .fn()
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce(response(200, { ok: true }))
+
+        const patchedResponse = await patchNodeFetch(fetch)(browserListUrl)
+
+        await expect(patchedResponse.json()).resolves.toEqual({ ok: true })
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries retryable response body read errors', async () => {
+        const bodyError = Object.assign(new Error('Invalid response body: Premature close'), {
+            code: 'ERR_STREAM_PREMATURE_CLOSE',
+        })
+        const firstResponse = response(200, { unused: true })
+        firstResponse.json.mockRejectedValueOnce(bodyError)
+        const fetch = jest
+            .fn()
+            .mockResolvedValueOnce(firstResponse)
+            .mockResolvedValueOnce(response(200, { recovered: true }))
+
+        const patchedResponse = await patchNodeFetch(fetch)(setupUrl, { method: 'POST' })
+
+        await expect(patchedResponse.json()).resolves.toEqual({ recovered: true })
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries BrowserStack setup payload errors', async () => {
+        const fetch = jest
+            .fn()
+            .mockResolvedValueOnce(response(200, { status: 13, value: { message: 'session not created' } }))
+            .mockResolvedValueOnce(response(200, { status: 0, sessionId: 'session-id' }))
+
+        const patchedResponse = await patchNodeFetch(fetch)(setupUrl, { method: 'POST' })
+
+        await expect(patchedResponse.json()).resolves.toEqual({ status: 0, sessionId: 'session-id' })
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('classifies setup requests separately from later BrowserStack API requests', async () => {
+        expect(isSetupRequest(browserListUrl)).toBe(true)
+        expect(isSetupRequest(setupUrl, { method: 'POST' })).toBe(true)
+        expect(isSetupRequest('https://hub-cloud.browserstack.com/wd/hub/session/session-id/url')).toBe(false)
+    })
+
+    it('reports actual attempts for non-retryable setup failures', async () => {
+        const fetch = jest.fn().mockRejectedValueOnce(new Error('certificate failed'))
+
+        await expect(patchNodeFetch(fetch)(setupUrl, { method: 'POST' })).rejects.toThrow(
+            'POSTHOG_BROWSERSTACK_SETUP_FAILURE: BrowserStack request failed after 1 attempts'
+        )
+        expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports actual attempts for non-retryable body read failures', async () => {
+        const firstResponse = response(200, { unused: true })
+        firstResponse.json.mockRejectedValueOnce(new Error('not json'))
+        const fetch = jest.fn().mockResolvedValueOnce(firstResponse)
+
+        const patchedResponse = await patchNodeFetch(fetch)(setupUrl, { method: 'POST' })
+
+        await expect(patchedResponse.json()).rejects.toThrow(
+            'POSTHOG_BROWSERSTACK_SETUP_FAILURE: BrowserStack request failed after 1 attempts'
+        )
+        expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps non-setup BrowserStack API failures distinct', async () => {
+        const fetch = jest.fn().mockRejectedValueOnce(new Error('certificate failed'))
+
+        await expect(
+            patchNodeFetch(fetch)('https://hub-cloud.browserstack.com/wd/hub/session/session-id/url')
+        ).rejects.toThrow('POSTHOG_BROWSERSTACK_API_FAILURE: BrowserStack request failed after 1 attempts')
+    })
+
+    it('recognizes retryable statuses and errors', () => {
+        expect(isRetryableStatus(429)).toBe(true)
+        expect(isRetryableStatus(500)).toBe(true)
+        expect(isRetryableStatus(401)).toBe(false)
+        expect(isRetryableError(Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }))).toBe(true)
+        expect(isRetryableError(new Error('certificate failed'))).toBe(false)
+    })
+})

--- a/packages/browser/src/__tests__/browserstack-node-fetch-patch.test.js
+++ b/packages/browser/src/__tests__/browserstack-node-fetch-patch.test.js
@@ -78,7 +78,7 @@ describe('browserstack-node-fetch-patch', () => {
         expect(fetch).toHaveBeenCalledTimes(2)
     })
 
-    it('retries BrowserStack setup payload errors', async () => {
+    it('retries BrowserStack setup payload errors for transient server statuses', async () => {
         const fetch = jest
             .fn()
             .mockResolvedValueOnce(response(200, { status: 13, value: { message: 'session not created' } }))
@@ -88,6 +88,28 @@ describe('browserstack-node-fetch-patch', () => {
 
         await expect(patchedResponse.json()).resolves.toEqual({ status: 0, sessionId: 'session-id' })
         expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not retry deterministic BrowserStack setup payload errors', async () => {
+        const payload = { status: 7, value: { message: 'no such element' } }
+        const fetch = jest.fn().mockResolvedValueOnce(response(200, payload))
+
+        const patchedResponse = await patchNodeFetch(fetch)(setupUrl, { method: 'POST' })
+
+        await expect(patchedResponse.json()).resolves.toEqual(payload)
+        expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('falls back to default backoff when the backoff override is invalid', async () => {
+        process.env.BROWSERSTACK_API_BACKOFF_MS = 'abc,def'
+        const fetch = jest
+            .fn()
+            .mockResolvedValueOnce(response(500, { status: 13 }))
+            .mockResolvedValueOnce(response(200, { ok: true }))
+
+        await patchNodeFetch(fetch)(browserListUrl)
+
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Retrying in 1000ms.'))
     })
 
     it('classifies setup requests separately from later BrowserStack API requests', async () => {
@@ -131,6 +153,8 @@ describe('browserstack-node-fetch-patch', () => {
         expect(isRetryableStatus(500)).toBe(true)
         expect(isRetryableStatus(401)).toBe(false)
         expect(isRetryableError(Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }))).toBe(true)
+        expect(isRetryableError(new Error('response aborted'))).toBe(true)
+        expect(isRetryableError(Object.assign(new Error('operation aborted'), { name: 'AbortError' }))).toBe(false)
         expect(isRetryableError(new Error('certificate failed'))).toBe(false)
     })
 })

--- a/packages/browser/src/__tests__/browserstack-node-fetch-patch.test.ts
+++ b/packages/browser/src/__tests__/browserstack-node-fetch-patch.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+/* eslint-disable @typescript-eslint/no-require-imports */
 
 const {
     isRetryableError,
@@ -116,6 +117,9 @@ describe('browserstack-node-fetch-patch', () => {
         expect(isSetupRequest(browserListUrl)).toBe(true)
         expect(isSetupRequest(setupUrl, { method: 'POST' })).toBe(true)
         expect(isSetupRequest('https://hub-cloud.browserstack.com/wd/hub/session/session-id/url')).toBe(false)
+        expect(
+            isSetupRequest('https://hub-cloud.browserstack.com/wd/hub/session/session-id/url', { method: 'POST' })
+        ).toBe(false)
     })
 
     it('reports actual attempts for non-retryable setup failures', async () => {

--- a/packages/browser/testcafe/browserstack-node-fetch-patch.cjs
+++ b/packages/browser/testcafe/browserstack-node-fetch-patch.cjs
@@ -6,7 +6,6 @@ const BROWSERSTACK_HOSTS = new Set(['api.browserstack.com', 'hub-cloud.browserst
 const DEFAULT_MAX_ATTEMPTS = 4
 const DEFAULT_BACKOFF_MS = [1000, 3000, 7000]
 const RETRYABLE_BROWSERSTACK_PAYLOAD_STATUSES = new Set([13])
-const SESSION_URL_PATH = /^\/wd\/hub\/session\/[^/]+\/url$/
 const originalLoad = Module._load
 
 function getMaxAttempts() {
@@ -57,17 +56,11 @@ function isSetupRequest(url, options = {}) {
         return false
     }
 
-    if (
-        target.pathname === '/automate/browsers.json' ||
-        /^\/automate\/sessions\/[^/]+\.json$/.test(target.pathname)
-    ) {
+    if (target.pathname === '/automate/browsers.json' || /^\/automate\/sessions\/[^/]+\.json$/.test(target.pathname)) {
         return true
     }
 
-    return (
-        getMethod(options) === 'POST' &&
-        (target.pathname === '/wd/hub/session' || SESSION_URL_PATH.test(target.pathname))
-    )
+    return getMethod(options) === 'POST' && target.pathname === '/wd/hub/session'
 }
 
 function getMethod(options = {}) {
@@ -207,7 +200,8 @@ function wrapResponseBodyReaders(fetch, url, options, response, attemptsUsed) {
                 return retryResponse[method]()
             }
 
-            const payloadError = method === 'json' && isSetupRequest(url, options) && getBrowserStackPayloadError(payload)
+            const payloadError =
+                method === 'json' && isSetupRequest(url, options) && getBrowserStackPayloadError(payload)
 
             if (!payloadError) {
                 return payload

--- a/packages/browser/testcafe/browserstack-node-fetch-patch.cjs
+++ b/packages/browser/testcafe/browserstack-node-fetch-patch.cjs
@@ -5,6 +5,7 @@ const Module = require('module')
 const BROWSERSTACK_HOSTS = new Set(['api.browserstack.com', 'hub-cloud.browserstack.com'])
 const DEFAULT_MAX_ATTEMPTS = 4
 const DEFAULT_BACKOFF_MS = [1000, 3000, 7000]
+const RETRYABLE_BROWSERSTACK_PAYLOAD_STATUSES = new Set([13])
 const SESSION_URL_PATH = /^\/wd\/hub\/session\/[^/]+\/url$/
 const originalLoad = Module._load
 
@@ -15,12 +16,13 @@ function getMaxAttempts() {
 
 function getBackoffMs(attempt) {
     const configured = process.env.BROWSERSTACK_API_BACKOFF_MS
-    const values = configured
+    const parsed = configured
         ? configured
               .split(',')
               .map((value) => Number(value.trim()))
               .filter((value) => Number.isFinite(value) && value >= 0)
-        : DEFAULT_BACKOFF_MS
+        : []
+    const values = parsed.length > 0 ? parsed : DEFAULT_BACKOFF_MS
 
     return values[Math.min(attempt - 1, values.length - 1)] || 0
 }
@@ -113,7 +115,6 @@ function isRetryableError(error) {
         message.includes('socket hang up') ||
         message.includes('invalid response body') ||
         message.includes('response aborted') ||
-        message.includes('aborted') ||
         message.includes('timeout')
     )
 }
@@ -143,7 +144,12 @@ function logRetry(url, options, attempt, maxAttempts, reason) {
 }
 
 function getBrowserStackPayloadError(payload) {
-    if (!payload || typeof payload !== 'object' || !payload.status) {
+    if (
+        !payload ||
+        typeof payload !== 'object' ||
+        !payload.status ||
+        !RETRYABLE_BROWSERSTACK_PAYLOAD_STATUSES.has(Number(payload.status))
+    ) {
         return null
     }
 

--- a/packages/browser/testcafe/browserstack-node-fetch-patch.cjs
+++ b/packages/browser/testcafe/browserstack-node-fetch-patch.cjs
@@ -3,20 +3,79 @@
 const Module = require('module')
 
 const BROWSERSTACK_HOSTS = new Set(['api.browserstack.com', 'hub-cloud.browserstack.com'])
+const DEFAULT_MAX_ATTEMPTS = 4
+const DEFAULT_BACKOFF_MS = [1000, 3000, 7000]
+const SESSION_URL_PATH = /^\/wd\/hub\/session\/[^/]+\/url$/
 const originalLoad = Module._load
 
-function isBrowserStackRequest(url) {
-    const target = typeof url === 'string' ? url : url && url.url
+function getMaxAttempts() {
+    const configured = Number(process.env.BROWSERSTACK_API_MAX_ATTEMPTS)
+    return Number.isInteger(configured) && configured > 0 ? configured : DEFAULT_MAX_ATTEMPTS
+}
+
+function getBackoffMs(attempt) {
+    const configured = process.env.BROWSERSTACK_API_BACKOFF_MS
+    const values = configured
+        ? configured
+              .split(',')
+              .map((value) => Number(value.trim()))
+              .filter((value) => Number.isFinite(value) && value >= 0)
+        : DEFAULT_BACKOFF_MS
+
+    return values[Math.min(attempt - 1, values.length - 1)] || 0
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function getTarget(url) {
+    const target = typeof url === 'string' ? url : url && (url.url || url.href)
 
     if (!target) {
-        return false
+        return null
     }
 
     try {
-        return BROWSERSTACK_HOSTS.has(new URL(target).hostname)
+        return new URL(target)
     } catch (_) {
+        return null
+    }
+}
+
+function isBrowserStackRequest(url) {
+    const target = getTarget(url)
+    return !!target && BROWSERSTACK_HOSTS.has(target.hostname)
+}
+
+function isSetupRequest(url, options = {}) {
+    const target = getTarget(url)
+
+    if (!target || !BROWSERSTACK_HOSTS.has(target.hostname)) {
         return false
     }
+
+    if (
+        target.pathname === '/automate/browsers.json' ||
+        /^\/automate\/sessions\/[^/]+\.json$/.test(target.pathname)
+    ) {
+        return true
+    }
+
+    return (
+        getMethod(options) === 'POST' &&
+        (target.pathname === '/wd/hub/session' || SESSION_URL_PATH.test(target.pathname))
+    )
+}
+
+function getMethod(options = {}) {
+    return (options.method || 'GET').toUpperCase()
+}
+
+function getRequestDescription(url, options = {}) {
+    const target = getTarget(url)
+    const method = getMethod(options)
+    return target ? `${method} ${target.origin}${target.pathname}` : `${method} ${String(url)}`
 }
 
 function withIdentityEncoding(fetch, headers) {
@@ -32,6 +91,135 @@ function withIdentityEncoding(fetch, headers) {
     }
 }
 
+function isRetryableStatus(status) {
+    return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500
+}
+
+function isRetryableError(error) {
+    const message = String(error?.message || error || '').toLowerCase()
+    const code = String(error?.code || '').toUpperCase()
+    const type = String(error?.type || '').toLowerCase()
+
+    return (
+        code === 'ECONNRESET' ||
+        code === 'ECONNREFUSED' ||
+        code === 'EPIPE' ||
+        code === 'ETIMEDOUT' ||
+        code === 'ERR_STREAM_PREMATURE_CLOSE' ||
+        type === 'request-timeout' ||
+        type === 'system' ||
+        message.includes('premature close') ||
+        message.includes('unexpected end') ||
+        message.includes('socket hang up') ||
+        message.includes('invalid response body') ||
+        message.includes('response aborted') ||
+        message.includes('aborted') ||
+        message.includes('timeout')
+    )
+}
+
+function setupFailurePrefix(url, options) {
+    return isSetupRequest(url, options) ? 'POSTHOG_BROWSERSTACK_SETUP_FAILURE' : 'POSTHOG_BROWSERSTACK_API_FAILURE'
+}
+
+function addBrowserStackContext(error, url, options, attempts) {
+    const prefix = setupFailurePrefix(url, options)
+    const description = getRequestDescription(url, options)
+    const originalMessage = error?.message || String(error)
+    const nextError = error instanceof Error ? error : new Error(originalMessage)
+
+    nextError.message = `${prefix}: BrowserStack request failed after ${attempts} attempts (${description}): ${originalMessage}`
+    return nextError
+}
+
+function logRetry(url, options, attempt, maxAttempts, reason) {
+    const delay = getBackoffMs(attempt)
+    const description = getRequestDescription(url, options)
+
+    console.warn(
+        `[browserstack-retry] ${description} failed on attempt ${attempt}/${maxAttempts}: ${reason}. Retrying in ${delay}ms.`
+    )
+    return delay
+}
+
+function getBrowserStackPayloadError(payload) {
+    if (!payload || typeof payload !== 'object' || !payload.status) {
+        return null
+    }
+
+    const message = payload.value?.message || payload.message || JSON.stringify(payload)
+    return new Error(`BrowserStack API returned status ${payload.status}: ${message}`)
+}
+
+async function fetchBrowserStack(fetch, url, options = {}, firstAttempt = 1) {
+    const maxAttempts = getMaxAttempts()
+
+    for (let attempt = firstAttempt; attempt <= maxAttempts; attempt++) {
+        try {
+            const response = await fetch(url, options)
+
+            if (isRetryableStatus(response.status) && attempt < maxAttempts) {
+                if (response.body?.destroy) {
+                    response.body.destroy()
+                }
+
+                await sleep(logRetry(url, options, attempt, maxAttempts, `HTTP ${response.status}`))
+                continue
+            }
+
+            return wrapResponseBodyReaders(fetch, url, options, response, attempt)
+        } catch (error) {
+            if (!isRetryableError(error) || attempt >= maxAttempts) {
+                throw addBrowserStackContext(error, url, options, maxAttempts)
+            }
+
+            await sleep(logRetry(url, options, attempt, maxAttempts, error.message || error))
+        }
+    }
+}
+
+function wrapResponseBodyReaders(fetch, url, options, response, attemptsUsed) {
+    for (const method of ['json', 'arrayBuffer', 'text']) {
+        if (typeof response[method] !== 'function') {
+            continue
+        }
+
+        const original = response[method].bind(response)
+
+        response[method] = async () => {
+            let payload
+
+            try {
+                payload = await original()
+            } catch (error) {
+                if (!isRetryableError(error) || attemptsUsed >= getMaxAttempts()) {
+                    throw addBrowserStackContext(error, url, options, getMaxAttempts())
+                }
+
+                await sleep(logRetry(url, options, attemptsUsed, getMaxAttempts(), error.message || error))
+                const retryResponse = await fetchBrowserStack(fetch, url, options, attemptsUsed + 1)
+                return retryResponse[method]()
+            }
+
+            const payloadError = method === 'json' && isSetupRequest(url, options) && getBrowserStackPayloadError(payload)
+
+            if (!payloadError) {
+                return payload
+            }
+
+            if (attemptsUsed >= getMaxAttempts()) {
+                throw addBrowserStackContext(payloadError, url, options, getMaxAttempts())
+            }
+
+            await sleep(logRetry(url, options, attemptsUsed, getMaxAttempts(), payloadError.message))
+            const retryResponse = await fetchBrowserStack(fetch, url, options, attemptsUsed + 1)
+            return retryResponse[method]()
+        }
+    }
+
+    return response
+}
+
 function patchNodeFetch(fetch) {
     if (fetch.__posthogBrowserStackFetchPatch) {
         return fetch
@@ -44,6 +232,8 @@ function patchNodeFetch(fetch) {
                 compress: false,
                 headers: withIdentityEncoding(fetch, options.headers),
             }
+
+            return fetchBrowserStack(fetch, url, options)
         }
 
         return fetch(url, options)
@@ -63,4 +253,12 @@ Module._load = function patchedLoad(request, parent, isMain) {
     }
 
     return loadedModule
+}
+
+module.exports = {
+    isBrowserStackRequest,
+    isRetryableError,
+    isRetryableStatus,
+    isSetupRequest,
+    patchNodeFetch,
 }

--- a/packages/browser/testcafe/browserstack-node-fetch-patch.cjs
+++ b/packages/browser/testcafe/browserstack-node-fetch-patch.cjs
@@ -170,7 +170,7 @@ async function fetchBrowserStack(fetch, url, options = {}, firstAttempt = 1) {
             return wrapResponseBodyReaders(fetch, url, options, response, attempt)
         } catch (error) {
             if (!isRetryableError(error) || attempt >= maxAttempts) {
-                throw addBrowserStackContext(error, url, options, maxAttempts)
+                throw addBrowserStackContext(error, url, options, attempt)
             }
 
             await sleep(logRetry(url, options, attempt, maxAttempts, error.message || error))
@@ -193,7 +193,7 @@ function wrapResponseBodyReaders(fetch, url, options, response, attemptsUsed) {
                 payload = await original()
             } catch (error) {
                 if (!isRetryableError(error) || attemptsUsed >= getMaxAttempts()) {
-                    throw addBrowserStackContext(error, url, options, getMaxAttempts())
+                    throw addBrowserStackContext(error, url, options, attemptsUsed)
                 }
 
                 await sleep(logRetry(url, options, attemptsUsed, getMaxAttempts(), error.message || error))
@@ -208,7 +208,7 @@ function wrapResponseBodyReaders(fetch, url, options, response, attemptsUsed) {
             }
 
             if (attemptsUsed >= getMaxAttempts()) {
-                throw addBrowserStackContext(payloadError, url, options, getMaxAttempts())
+                throw addBrowserStackContext(payloadError, url, options, attemptsUsed)
             }
 
             await sleep(logRetry(url, options, attemptsUsed, getMaxAttempts(), payloadError.message))
@@ -245,14 +245,16 @@ function patchNodeFetch(fetch) {
     return patchedFetch
 }
 
-Module._load = function patchedLoad(request, parent, isMain) {
-    const loadedModule = originalLoad.apply(this, arguments)
+if (process.env.JEST_WORKER_ID === undefined) {
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const loadedModule = originalLoad.apply(this, arguments)
 
-    if (request === 'node-fetch') {
-        return patchNodeFetch(loadedModule)
+        if (request === 'node-fetch') {
+            return patchNodeFetch(loadedModule)
+        }
+
+        return loadedModule
     }
-
-    return loadedModule
 }
 
 module.exports = {


### PR DESCRIPTION
## Problem

IE11 TestCafe runs can fail before any browser assertions run when BrowserStack API/session setup is flaky. Those setup failures were retried by rerunning the whole TestCafe command, which made failures harder to classify and could conflate BrowserStack infrastructure flakes with real IE11 test failures.

## Changes

- Add retry/backoff around BrowserStack `node-fetch` calls used by the TestCafe BrowserStack provider.
- Retry transient HTTP statuses, transport/body-read failures, and transient BrowserStack setup/session payload failures.
- Avoid retrying deterministic WebDriver payload errors or intentional abort-style errors.
- Keep post-session navigation failures classified as BrowserStack API failures instead of setup failures.
- Add explicit failure markers for BrowserStack setup/API failures.
- Update the TestCafe workflow to avoid rerunning actual IE tests and to classify BrowserStack setup failures separately from IE11 test failures.
- Add committed Jest coverage for retryable statuses, transport failures, body-read failures, payload failures, setup classification, backoff parsing, and actual-attempt error reporting.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi using shell/file-editing tools. The change keeps retries at the BrowserStack API layer instead of rerunning the whole TestCafe command, so real IE11 assertion failures remain deterministic while setup/session flakes are labeled as infrastructure failures.

Verification run locally: `node --check packages/browser/testcafe/browserstack-node-fetch-patch.cjs`, `git diff --check`, `pnpm lint` from `packages/browser`, and `pnpm exec jest src/__tests__/browserstack-node-fetch-patch.test.ts --runInBand` from `packages/browser`. BrowserStack IE11 itself was not run locally because it depends on CI secrets/session access.
