### PR TITLE
fix(ci): include release failure version and links

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -153,8 +153,7 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  job_url="$run_url"
+                  job_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
                       resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
                       if [ -n "$resolved_job_url" ]; then
@@ -163,7 +162,6 @@ jobs:
                   fi
 
                   {
-                      echo "run_url=$run_url"
                       echo "job_url=$job_url"
                   } >> "$GITHUB_OUTPUT"
 
@@ -182,7 +180,6 @@ jobs:
                         "repository": "Posthog/posthog",
                         "packageName": "${{ github.event.inputs.package_name }}",
                         "packageVersion": "${{ github.event.inputs.package_version }}",
-                        "workflowRunUrl": "${{ steps.release-failure-metadata.outputs.run_url }}",
                         "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
     contents: read
-    actions: read
 
 jobs:
     posthog-upgrade:
@@ -144,27 +143,6 @@ jobs:
               run: |
                   gh pr edit "$PR_NUMBER" --repo PostHog/posthog --add-reviewer PostHog/client-libraries-approvers --add-reviewer PostHog/team-client-libraries
 
-            - name: Resolve release failure metadata
-              id: release-failure-metadata
-              if: ${{ failure() }}
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  JOB_NAME: Upgrade PostHog Package
-              run: |
-                  set -euo pipefail
-
-                  job_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
-                      resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
-                      if [ -n "$resolved_job_url" ]; then
-                          job_url="$resolved_job_url"
-                      fi
-                  fi
-
-                  {
-                      echo "job_url=$job_url"
-                  } >> "$GITHUB_OUTPUT"
-
             # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Send failure event to PostHog
               if: ${{ failure() }}
@@ -180,5 +158,5 @@ jobs:
                         "repository": "Posthog/posthog",
                         "packageName": "${{ github.event.inputs.package_name }}",
                         "packageVersion": "${{ github.event.inputs.package_version }}",
-                        "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
+                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                       }

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
     contents: read
+    actions: read
 
 jobs:
     posthog-upgrade:
@@ -143,6 +144,29 @@ jobs:
               run: |
                   gh pr edit "$PR_NUMBER" --repo PostHog/posthog --add-reviewer PostHog/client-libraries-approvers --add-reviewer PostHog/team-client-libraries
 
+            - name: Resolve release failure metadata
+              id: release-failure-metadata
+              if: ${{ failure() }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  JOB_NAME: Upgrade PostHog Package
+              run: |
+                  set -euo pipefail
+
+                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  job_url="$run_url"
+                  if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
+                      resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
+                      if [ -n "$resolved_job_url" ]; then
+                          job_url="$resolved_job_url"
+                      fi
+                  fi
+
+                  {
+                      echo "run_url=$run_url"
+                      echo "job_url=$job_url"
+                  } >> "$GITHUB_OUTPUT"
+
             # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Send failure event to PostHog
               if: ${{ failure() }}
@@ -157,5 +181,8 @@ jobs:
                         "ref": "${{ github.ref }}",
                         "repository": "Posthog/posthog",
                         "packageName": "${{ github.event.inputs.package_name }}",
-                        "packageVersion": "${{ github.event.inputs.package_version }}"
+                        "packageVersion": "${{ github.event.inputs.package_version }}",
+                        "workflowRunUrl": "${{ steps.release-failure-metadata.outputs.run_url }}",
+                        "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
+                        "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -180,6 +180,5 @@ jobs:
                         "repository": "Posthog/posthog",
                         "packageName": "${{ github.event.inputs.package_name }}",
                         "packageVersion": "${{ github.event.inputs.package_version }}",
-                        "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,6 @@ jobs:
                         "jobName": "version-bump",
                         "packageName": "posthog-js",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }
 
@@ -423,7 +422,6 @@ jobs:
                         "jobName": "publish",
                         "packageName": "${{ matrix.package.name }}",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }
 
@@ -750,7 +748,6 @@ jobs:
                         "jobName": "upload-s3",
                         "packageName": "posthog-js",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "region": "${{ matrix.region.name }}",
                         "bucket": "${{ matrix.region.bucket }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,8 +155,7 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  job_url="$run_url"
+                  job_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
                       resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
                       if [ -n "$resolved_job_url" ]; then
@@ -175,7 +174,6 @@ jobs:
                   fi
 
                   {
-                      echo "run_url=$run_url"
                       echo "job_url=$job_url"
                       echo "package_version=$package_version"
                       echo "package_ref=$package_ref"
@@ -195,7 +193,6 @@ jobs:
                         "jobName": "version-bump",
                         "packageName": "posthog-js",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "workflowRunUrl": "${{ steps.release-failure-metadata.outputs.run_url }}",
                         "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }
@@ -388,8 +385,7 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  job_url="$run_url"
+                  job_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
                       resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
                       if [ -n "$resolved_job_url" ]; then
@@ -408,7 +404,6 @@ jobs:
                   fi
 
                   {
-                      echo "run_url=$run_url"
                       echo "job_url=$job_url"
                       echo "package_version=$package_version"
                       echo "package_ref=$package_ref"
@@ -428,7 +423,6 @@ jobs:
                         "jobName": "publish",
                         "packageName": "${{ matrix.package.name }}",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "workflowRunUrl": "${{ steps.release-failure-metadata.outputs.run_url }}",
                         "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }
@@ -723,8 +717,7 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  job_url="$run_url"
+                  job_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
                       resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
                       if [ -n "$resolved_job_url" ]; then
@@ -738,7 +731,6 @@ jobs:
                   fi
 
                   {
-                      echo "run_url=$run_url"
                       echo "job_url=$job_url"
                       echo "package_version=$PACKAGE_VERSION"
                       echo "package_ref=$package_ref"
@@ -758,7 +750,6 @@ jobs:
                         "jobName": "upload-s3",
                         "packageName": "posthog-js",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "workflowRunUrl": "${{ steps.release-failure-metadata.outputs.run_url }}",
                         "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "region": "${{ matrix.region.name }}",
@@ -824,14 +815,13 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   mapfile -t links < <(
                       gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" \
                           --jq '.jobs[] | select(.name | startswith("Upload posthog-js dist to S3 (")) | select(.conclusion == "failure") | "<\(.html_url)|\(.name)>"' 2>/dev/null || true
                   )
 
                   if [ ${#links[@]} -eq 0 ]; then
-                      links=("<$run_url|View workflow run>")
+                      links=("failed S3 job link unavailable")
                   fi
 
                   job_links="${links[0]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: 'Release'
 
 permissions:
     contents: read
+    actions: read
 
 on:
     push:
@@ -63,6 +64,7 @@ jobs:
         environment: 'NPM Release' # This will require an approval from a maintainer, they are notified in Slack above
         permissions:
             contents: read
+            actions: read
         outputs:
             commit-hash: ${{ steps.commit-version-bump.outputs.commit-hash }}
             # posthog-js SDK version after `pnpm bump`. Downstream jobs use this
@@ -143,6 +145,42 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 
+            - name: Resolve release failure metadata
+              id: release-failure-metadata
+              if: ${{ failure() }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  JOB_NAME: Bump versions and commit to main
+                  PACKAGE_VERSION: ${{ steps.get-version.outputs.version }}
+              run: |
+                  set -euo pipefail
+
+                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  job_url="$run_url"
+                  if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
+                      resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
+                      if [ -n "$resolved_job_url" ]; then
+                          job_url="$resolved_job_url"
+                      fi
+                  fi
+
+                  package_version="$PACKAGE_VERSION"
+                  if [ -z "$package_version" ] && [ -f packages/browser/package.json ] && [ -n "$(git status --porcelain -- packages/browser/package.json)" ]; then
+                      package_version=$(jq -r '.version // empty' packages/browser/package.json)
+                  fi
+
+                  package_ref="posthog-js"
+                  if [ -n "$package_version" ]; then
+                      package_ref="posthog-js@v$package_version"
+                  fi
+
+                  {
+                      echo "run_url=$run_url"
+                      echo "job_url=$job_url"
+                      echo "package_version=$package_version"
+                      echo "package_ref=$package_ref"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Send failure event to PostHog
               if: ${{ failure() }}
               uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
@@ -155,7 +193,11 @@ jobs:
                         "jobStatus": "${{ job.status }}",
                         "ref": "${{ github.ref }}",
                         "jobName": "version-bump",
-                        "packageName": "posthog-js"
+                        "packageName": "posthog-js",
+                        "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
+                        "workflowRunUrl": "${{ steps.release-failure-metadata.outputs.run_url }}",
+                        "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
+                        "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }
 
             - name: Notify Slack - Failed
@@ -165,7 +207,7 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to bump versions for `posthog-js`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+                  message: '❌ Failed to bump versions for `${{ steps.release-failure-metadata.outputs.package_ref }}`! <${{ steps.release-failure-metadata.outputs.job_url }}|View failed job>'
                   emoji_reaction: 'x'
 
     notify-rejected:
@@ -334,6 +376,44 @@ jobs:
             ####################################################
             # Notify ourselves in case of a failure here
             # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
+            - name: Resolve release failure metadata
+              id: release-failure-metadata
+              if: ${{ failure() }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  JOB_NAME: Publish packages (${{ matrix.package.name }})
+                  PACKAGE_NAME: ${{ matrix.package.name }}
+                  PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
+                  PACKAGE_PATH: ${{ steps.get-package-path.outputs.path }}
+              run: |
+                  set -euo pipefail
+
+                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  job_url="$run_url"
+                  if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
+                      resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
+                      if [ -n "$resolved_job_url" ]; then
+                          job_url="$resolved_job_url"
+                      fi
+                  fi
+
+                  package_version="$PACKAGE_VERSION"
+                  if [ -z "$package_version" ] && [ -n "$PACKAGE_PATH" ] && [ -f "$PACKAGE_PATH/package.json" ]; then
+                      package_version=$(jq -r '.version // empty' "$PACKAGE_PATH/package.json")
+                  fi
+
+                  package_ref="$PACKAGE_NAME"
+                  if [ -n "$package_version" ]; then
+                      package_ref="$PACKAGE_NAME@v$package_version"
+                  fi
+
+                  {
+                      echo "run_url=$run_url"
+                      echo "job_url=$job_url"
+                      echo "package_version=$package_version"
+                      echo "package_ref=$package_ref"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Send failure event to PostHog
               if: ${{ failure() }}
               uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
@@ -345,8 +425,12 @@ jobs:
                         "commitSha": "${{ github.sha }}",
                         "jobStatus": "${{ job.status }}",
                         "ref": "${{ github.ref }}",
+                        "jobName": "publish",
                         "packageName": "${{ matrix.package.name }}",
-                        "packageVersion": "${{ steps.check-package-version.outputs.committed-version }}"
+                        "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
+                        "workflowRunUrl": "${{ steps.release-failure-metadata.outputs.run_url }}",
+                        "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
+                        "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
                       }
 
             - name: Notify Slack - Failed
@@ -357,7 +441,7 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to release `${{ matrix.package.name }}@v${{ steps.check-package-version.outputs.committed-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+                  message: '❌ Failed to release `${{ steps.release-failure-metadata.outputs.package_ref }}`! <${{ steps.release-failure-metadata.outputs.job_url }}|View failed job>'
                   emoji_reaction: 'x'
 
     build-s3-artifacts:
@@ -558,6 +642,7 @@ jobs:
         environment: 'S3 Upload' # For OIDC credential scoping only — no required reviewers (single approval at NPM Release)
         permissions:
             contents: read
+            actions: read
             id-token: write
         strategy:
             fail-fast: false
@@ -628,6 +713,37 @@ jobs:
                   VERSION: ${{ needs.build-s3-artifacts.outputs.committed-version }}
               run: node tooling/release/src/cli.ts upload-s3 "$BUCKET" "$VERSION"
 
+            - name: Resolve release failure metadata
+              id: release-failure-metadata
+              if: ${{ failure() }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  JOB_NAME: Upload posthog-js dist to S3 (${{ matrix.region.name }})
+                  PACKAGE_VERSION: ${{ needs.build-s3-artifacts.outputs.committed-version }}
+              run: |
+                  set -euo pipefail
+
+                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  job_url="$run_url"
+                  if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
+                      resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
+                      if [ -n "$resolved_job_url" ]; then
+                          job_url="$resolved_job_url"
+                      fi
+                  fi
+
+                  package_ref="posthog-js"
+                  if [ -n "$PACKAGE_VERSION" ]; then
+                      package_ref="posthog-js@v$PACKAGE_VERSION"
+                  fi
+
+                  {
+                      echo "run_url=$run_url"
+                      echo "job_url=$job_url"
+                      echo "package_version=$PACKAGE_VERSION"
+                      echo "package_ref=$package_ref"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Send failure event to PostHog
               if: ${{ failure() }}
               uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
@@ -641,7 +757,10 @@ jobs:
                         "ref": "${{ github.ref }}",
                         "jobName": "upload-s3",
                         "packageName": "posthog-js",
-                        "packageVersion": "${{ needs.build-s3-artifacts.outputs.committed-version }}",
+                        "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
+                        "workflowRunUrl": "${{ steps.release-failure-metadata.outputs.run_url }}",
+                        "workflowJobUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
+                        "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
                         "region": "${{ matrix.region.name }}",
                         "bucket": "${{ matrix.region.bucket }}"
                       }
@@ -654,7 +773,7 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to upload posthog-js v${{ needs.build-s3-artifacts.outputs.committed-version }} dist to ${{ matrix.region.bucket }}! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+                  message: '❌ Failed to upload ${{ steps.release-failure-metadata.outputs.package_ref }} dist to ${{ matrix.region.bucket }}! <${{ steps.release-failure-metadata.outputs.job_url }}|View failed job>'
                   emoji_reaction: 'x'
 
     notify-released:
@@ -697,6 +816,39 @@ jobs:
             needs.upload-s3.result == 'failure' &&
             needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
+            - name: Resolve failed S3 upload job links
+              id: failed-s3-upload-jobs
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PACKAGE_VERSION: ${{ needs.build-s3-artifacts.outputs.committed-version }}
+              run: |
+                  set -euo pipefail
+
+                  run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  mapfile -t links < <(
+                      gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" \
+                          --jq '.jobs[] | select(.name | startswith("Upload posthog-js dist to S3 (")) | select(.conclusion == "failure") | "<\(.html_url)|\(.name)>"' 2>/dev/null || true
+                  )
+
+                  if [ ${#links[@]} -eq 0 ]; then
+                      links=("<$run_url|View workflow run>")
+                  fi
+
+                  job_links="${links[0]}"
+                  for ((i = 1; i < ${#links[@]}; i++)); do
+                      job_links+=", ${links[$i]}"
+                  done
+
+                  package_ref="posthog-js"
+                  if [ -n "$PACKAGE_VERSION" ]; then
+                      package_ref="posthog-js@v$PACKAGE_VERSION"
+                  fi
+
+                  {
+                      echo "job_links=$job_links"
+                      echo "package_ref=$package_ref"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Notify Slack - Partial Release
               continue-on-error: true # Slack failure shouldn't mark release as failed
               uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
@@ -704,5 +856,5 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '⚠️ npm packages released, but S3 publish failed — posthog-js v${{ needs.build-s3-artifacts.outputs.committed-version }} immutable assets and/or major-version or top-level aliases need attention. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+                  message: '⚠️ npm packages released, but S3 publish failed — ${{ steps.failed-s3-upload-jobs.outputs.package_ref }} immutable assets and/or major-version or top-level aliases need attention. Failed job(s): ${{ steps.failed-s3-upload-jobs.outputs.job_links }}'
                   emoji_reaction: 'warning'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: 'Release'
 
 permissions:
     contents: read
-    actions: read
 
 on:
     push:
@@ -64,7 +63,6 @@ jobs:
         environment: 'NPM Release' # This will require an approval from a maintainer, they are notified in Slack above
         permissions:
             contents: read
-            actions: read
         outputs:
             commit-hash: ${{ steps.commit-version-bump.outputs.commit-hash }}
             # posthog-js SDK version after `pnpm bump`. Downstream jobs use this
@@ -149,20 +147,11 @@ jobs:
               id: release-failure-metadata
               if: ${{ failure() }}
               env:
-                  GH_TOKEN: ${{ github.token }}
-                  JOB_NAME: Bump versions and commit to main
                   PACKAGE_VERSION: ${{ steps.get-version.outputs.version }}
               run: |
                   set -euo pipefail
 
-                  job_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
-                      resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
-                      if [ -n "$resolved_job_url" ]; then
-                          job_url="$resolved_job_url"
-                      fi
-                  fi
-
+                  action_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   package_version="$PACKAGE_VERSION"
                   if [ -z "$package_version" ] && [ -f packages/browser/package.json ] && [ -n "$(git status --porcelain -- packages/browser/package.json)" ]; then
                       package_version=$(jq -r '.version // empty' packages/browser/package.json)
@@ -174,7 +163,7 @@ jobs:
                   fi
 
                   {
-                      echo "job_url=$job_url"
+                      echo "action_url=$action_url"
                       echo "package_version=$package_version"
                       echo "package_ref=$package_ref"
                   } >> "$GITHUB_OUTPUT"
@@ -193,7 +182,7 @@ jobs:
                         "jobName": "version-bump",
                         "packageName": "posthog-js",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
+                        "actionUrl": "${{ steps.release-failure-metadata.outputs.action_url }}"
                       }
 
             - name: Notify Slack - Failed
@@ -203,7 +192,7 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to bump versions for `${{ steps.release-failure-metadata.outputs.package_ref }}`! <${{ steps.release-failure-metadata.outputs.job_url }}|View failed job>'
+                  message: '❌ Failed to bump versions for `${{ steps.release-failure-metadata.outputs.package_ref }}`! <${{ steps.release-failure-metadata.outputs.action_url }}|View workflow run>'
                   emoji_reaction: 'x'
 
     notify-rejected:
@@ -376,22 +365,13 @@ jobs:
               id: release-failure-metadata
               if: ${{ failure() }}
               env:
-                  GH_TOKEN: ${{ github.token }}
-                  JOB_NAME: Publish packages (${{ matrix.package.name }})
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
                   PACKAGE_PATH: ${{ steps.get-package-path.outputs.path }}
               run: |
                   set -euo pipefail
 
-                  job_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
-                      resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
-                      if [ -n "$resolved_job_url" ]; then
-                          job_url="$resolved_job_url"
-                      fi
-                  fi
-
+                  action_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   package_version="$PACKAGE_VERSION"
                   if [ -z "$package_version" ] && [ -n "$PACKAGE_PATH" ] && [ -f "$PACKAGE_PATH/package.json" ]; then
                       package_version=$(jq -r '.version // empty' "$PACKAGE_PATH/package.json")
@@ -403,7 +383,7 @@ jobs:
                   fi
 
                   {
-                      echo "job_url=$job_url"
+                      echo "action_url=$action_url"
                       echo "package_version=$package_version"
                       echo "package_ref=$package_ref"
                   } >> "$GITHUB_OUTPUT"
@@ -422,7 +402,7 @@ jobs:
                         "jobName": "publish",
                         "packageName": "${{ matrix.package.name }}",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}"
+                        "actionUrl": "${{ steps.release-failure-metadata.outputs.action_url }}"
                       }
 
             - name: Notify Slack - Failed
@@ -433,7 +413,7 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to release `${{ steps.release-failure-metadata.outputs.package_ref }}`! <${{ steps.release-failure-metadata.outputs.job_url }}|View failed job>'
+                  message: '❌ Failed to release `${{ steps.release-failure-metadata.outputs.package_ref }}`! <${{ steps.release-failure-metadata.outputs.action_url }}|View workflow run>'
                   emoji_reaction: 'x'
 
     build-s3-artifacts:
@@ -634,7 +614,6 @@ jobs:
         environment: 'S3 Upload' # For OIDC credential scoping only — no required reviewers (single approval at NPM Release)
         permissions:
             contents: read
-            actions: read
             id-token: write
         strategy:
             fail-fast: false
@@ -709,27 +688,18 @@ jobs:
               id: release-failure-metadata
               if: ${{ failure() }}
               env:
-                  GH_TOKEN: ${{ github.token }}
-                  JOB_NAME: Upload posthog-js dist to S3 (${{ matrix.region.name }})
                   PACKAGE_VERSION: ${{ needs.build-s3-artifacts.outputs.committed-version }}
               run: |
                   set -euo pipefail
 
-                  job_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  if jobs_json=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" 2>/dev/null); then
-                      resolved_job_url=$(jq -r --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | .html_url' <<< "$jobs_json" | head -n 1)
-                      if [ -n "$resolved_job_url" ]; then
-                          job_url="$resolved_job_url"
-                      fi
-                  fi
-
+                  action_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   package_ref="posthog-js"
                   if [ -n "$PACKAGE_VERSION" ]; then
                       package_ref="posthog-js@v$PACKAGE_VERSION"
                   fi
 
                   {
-                      echo "job_url=$job_url"
+                      echo "action_url=$action_url"
                       echo "package_version=$PACKAGE_VERSION"
                       echo "package_ref=$package_ref"
                   } >> "$GITHUB_OUTPUT"
@@ -748,7 +718,7 @@ jobs:
                         "jobName": "upload-s3",
                         "packageName": "posthog-js",
                         "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version }}",
-                        "actionUrl": "${{ steps.release-failure-metadata.outputs.job_url }}",
+                        "actionUrl": "${{ steps.release-failure-metadata.outputs.action_url }}",
                         "region": "${{ matrix.region.name }}",
                         "bucket": "${{ matrix.region.bucket }}"
                       }
@@ -761,7 +731,7 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to upload ${{ steps.release-failure-metadata.outputs.package_ref }} dist to ${{ matrix.region.bucket }}! <${{ steps.release-failure-metadata.outputs.job_url }}|View failed job>'
+                  message: '❌ Failed to upload ${{ steps.release-failure-metadata.outputs.package_ref }} dist to ${{ matrix.region.bucket }}! <${{ steps.release-failure-metadata.outputs.action_url }}|View workflow run>'
                   emoji_reaction: 'x'
 
     notify-released:
@@ -804,35 +774,21 @@ jobs:
             needs.upload-s3.result == 'failure' &&
             needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
-            - name: Resolve failed S3 upload job links
-              id: failed-s3-upload-jobs
+            - name: Resolve partial release metadata
+              id: partial-release-metadata
               env:
-                  GH_TOKEN: ${{ github.token }}
                   PACKAGE_VERSION: ${{ needs.build-s3-artifacts.outputs.committed-version }}
               run: |
                   set -euo pipefail
 
-                  mapfile -t links < <(
-                      gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" \
-                          --jq '.jobs[] | select(.name | startswith("Upload posthog-js dist to S3 (")) | select(.conclusion == "failure") | "<\(.html_url)|\(.name)>"' 2>/dev/null || true
-                  )
-
-                  if [ ${#links[@]} -eq 0 ]; then
-                      links=("failed S3 job link unavailable")
-                  fi
-
-                  job_links="${links[0]}"
-                  for ((i = 1; i < ${#links[@]}; i++)); do
-                      job_links+=", ${links[$i]}"
-                  done
-
+                  action_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   package_ref="posthog-js"
                   if [ -n "$PACKAGE_VERSION" ]; then
                       package_ref="posthog-js@v$PACKAGE_VERSION"
                   fi
 
                   {
-                      echo "job_links=$job_links"
+                      echo "action_url=$action_url"
                       echo "package_ref=$package_ref"
                   } >> "$GITHUB_OUTPUT"
 
@@ -843,5 +799,5 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '⚠️ npm packages released, but S3 publish failed — ${{ steps.failed-s3-upload-jobs.outputs.package_ref }} immutable assets and/or major-version or top-level aliases need attention. Failed job(s): ${{ steps.failed-s3-upload-jobs.outputs.job_links }}'
+                  message: '⚠️ npm packages released, but S3 publish failed — ${{ steps.partial-release-metadata.outputs.package_ref }} immutable assets and/or major-version or top-level aliases need attention. <${{ steps.partial-release-metadata.outputs.action_url }}|View workflow run>'
                   emoji_reaction: 'warning'


### PR DESCRIPTION
## Problem

Release failure notifications did not always include the SDK version, and failure links could be too generic or missing from downstream alerts. That made it harder to identify which release/version failed and where to inspect logs.

## Changes

- Resolve failure metadata before release failure notifications/events, including package version and the workflow run URL.
- Update release Slack failure messages to include `package@vversion` when available and link to the failed workflow run.
- Include the workflow run URL in PostHog failure events as `actionUrl` so downstream Slack alerts can link to the relevant release run.
- Update partial S3 failure Slack messages to include the posthog-js version and workflow run link without querying GitHub job metadata.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was created with pi. The workflow YAML was updated to pass version and workflow run URL details through direct Slack messages and PostHog failure events. Validation performed: parsed the modified workflow YAML successfully.
