### PR TITLE
test(node): make local polling tests deterministic

### DIFF
--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -6182,15 +6182,14 @@ describe('ETag support for local evaluation polling', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    // Wait for initial load
-    await waitForPromises()
+    // Wait deterministically for the constructor-started load to finish.
+    await posthog.reloadFeatureFlags()
 
     // First call should not have If-None-Match header
     expect(fetchCalls[0].options.headers['If-None-Match']).toBeUndefined()
 
     // Trigger a reload
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
 
     // Second call should have If-None-Match header with the ETag
     expect(fetchCalls[1].options.headers['If-None-Match']).toBe('"abc123"')
@@ -6248,26 +6247,23 @@ describe('ETag support for local evaluation polling', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    // Wait for initial load
-    await waitForPromises()
+    // Wait deterministically for the constructor-started load to finish.
+    await posthog.reloadFeatureFlags()
 
     // First call should not have If-None-Match header
     expect(fetchCalls[0].options.headers['If-None-Match']).toBeUndefined()
 
-    // Verify flags were loaded
-    const flag1 = await posthog.getFeatureFlag('test-flag', 'user-1', { sendFeatureFlagEvents: false })
-    expect(flag1).toBe(true)
+    // Verify flags were loaded locally
+    expect((posthog as any).featureFlagsPoller.featureFlagsByKey['test-flag']?.active).toBe(true)
 
     // Trigger a reload (should get 304)
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
 
     // Verify the request that triggered 304 included the If-None-Match header
     expect(fetchCalls[1].options.headers['If-None-Match']).toBe('"test-etag"')
 
-    // Verify flags are still available after 304
-    const flag2 = await posthog.getFeatureFlag('test-flag', 'user-1', { sendFeatureFlagEvents: false })
-    expect(flag2).toBe(true)
+    // Verify flags are still available locally after 304
+    expect((posthog as any).featureFlagsPoller.featureFlagsByKey['test-flag']?.active).toBe(true)
 
     // Verify fetch was called twice
     expect(mockFetch).toHaveBeenCalledTimes(2)
@@ -6305,19 +6301,18 @@ describe('ETag support for local evaluation polling', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    // Wait deterministically for the constructor-started load to finish.
+    await posthog.reloadFeatureFlags()
 
     // First call - no ETag
     expect(fetchCalls[0].options.headers['If-None-Match']).toBeUndefined()
 
     // Second call
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
     expect(fetchCalls[1].options.headers['If-None-Match']).toBe('"etag-v1"')
 
     // Third call
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
     expect(fetchCalls[2].options.headers['If-None-Match']).toBe('"etag-v2"')
   })
 
@@ -6354,16 +6349,15 @@ describe('ETag support for local evaluation polling', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    // Wait deterministically for the constructor-started load to finish.
+    await posthog.reloadFeatureFlags()
 
     // Second call should have the ETag from first response
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
     expect(fetchCalls[1].options.headers['If-None-Match']).toBe('"initial-etag"')
 
     // Third call should not have ETag (server stopped sending it)
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
     expect(fetchCalls[2].options.headers['If-None-Match']).toBeUndefined()
   })
 
@@ -6415,19 +6409,17 @@ describe('ETag support for local evaluation polling', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    // Wait deterministically for the constructor-started load to finish.
+    await posthog.reloadFeatureFlags()
 
     // Multiple 304 responses should not cause any issues
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
 
     expect(mockFetch).toHaveBeenCalledTimes(3)
 
-    // Flags should still work
-    const flag = await posthog.getFeatureFlag('test-flag', 'user-1')
-    expect(flag).toBe(true)
+    // Flags should still work locally
+    expect((posthog as any).featureFlagsPoller.featureFlagsByKey['test-flag']?.active).toBe(true)
   })
 
   it('updates ETag when server sends new ETag with 304 response', async () => {
@@ -6481,19 +6473,18 @@ describe('ETag support for local evaluation polling', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    // Wait deterministically for the constructor-started load to finish.
+    await posthog.reloadFeatureFlags()
 
     // First call has no ETag
     expect(fetchCalls[0].options.headers['If-None-Match']).toBeUndefined()
 
     // Second call uses initial ETag
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
     expect(fetchCalls[1].options.headers['If-None-Match']).toBe('"etag-v1"')
 
     // Third call should use the updated ETag from the 304 response
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
     expect(fetchCalls[2].options.headers['If-None-Match']).toBe('"etag-v2"')
   })
 })
@@ -6504,7 +6495,9 @@ describe('error handling and backoff', () => {
   jest.useFakeTimers()
 
   afterEach(async () => {
-    await posthog.shutdown()
+    jest.useRealTimers()
+    await posthog.shutdown(100).catch(() => undefined)
+    jest.useFakeTimers()
   })
 
   /**
@@ -6553,16 +6546,13 @@ describe('error handling and backoff', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    await posthog.reloadFeatureFlags()
     expect(mockFetch.callCount).toBe(1)
 
     // On-demand fetches should be blocked during backoff
-    await posthog.getFeatureFlag('test-flag', 'user-1')
-    await waitForPromises()
-    await posthog.getFeatureFlag('test-flag', 'user-2')
-    await waitForPromises()
-    await posthog.getFeatureFlag('test-flag', 'user-3')
-    await waitForPromises()
+    await posthog.getFeatureFlag('test-flag', 'user-1', { onlyEvaluateLocally: true })
+    await posthog.getFeatureFlag('test-flag', 'user-2', { onlyEvaluateLocally: true })
+    await posthog.getFeatureFlag('test-flag', 'user-3', { onlyEvaluateLocally: true })
 
     expect(mockFetch.callCount).toBe(1)
   })
@@ -6578,14 +6568,12 @@ describe('error handling and backoff', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    await posthog.reloadFeatureFlags()
     expect(mockFetch.callCount).toBe(1)
 
     // On-demand fetches should be blocked during backoff
-    await posthog.getFeatureFlag('test-flag', 'user-1')
-    await waitForPromises()
-    await posthog.getFeatureFlag('test-flag', 'user-2')
-    await waitForPromises()
+    await posthog.getFeatureFlag('test-flag', 'user-1', { onlyEvaluateLocally: true })
+    await posthog.getFeatureFlag('test-flag', 'user-2', { onlyEvaluateLocally: true })
 
     expect(mockFetch.callCount).toBe(1)
   })
@@ -6601,14 +6589,12 @@ describe('error handling and backoff', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    await posthog.reloadFeatureFlags()
     expect(mockFetch.callCount).toBe(1)
 
     // On-demand fetches should be blocked during backoff
-    await posthog.getFeatureFlag('test-flag', 'user-1')
-    await waitForPromises()
-    await posthog.getFeatureFlag('test-flag', 'user-2')
-    await waitForPromises()
+    await posthog.getFeatureFlag('test-flag', 'user-1', { onlyEvaluateLocally: true })
+    await posthog.getFeatureFlag('test-flag', 'user-2', { onlyEvaluateLocally: true })
 
     expect(mockFetch.callCount).toBe(1)
   })
@@ -6651,12 +6637,11 @@ describe('error handling and backoff', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    // Wait for initial fetch with a short delay
-    await new Promise((r) => setTimeout(r, 50))
+    await posthog.reloadFeatureFlags()
     expect(fetchCallCount).toBe(1)
 
     // On-demand fetch should be blocked during backoff
-    await posthog.getFeatureFlag('test-flag', 'user-1')
+    await posthog.getFeatureFlag('test-flag', 'user-1', { onlyEvaluateLocally: true })
     expect(fetchCallCount).toBe(1)
 
     // Advance mock time past the exponential backoff period
@@ -6664,7 +6649,7 @@ describe('error handling and backoff', () => {
     mockTime += 2001
 
     // Now on-demand fetch should be allowed (backoff expired based on Date.now())
-    await posthog.getFeatureFlag('test-flag', 'user-2')
+    await posthog.getFeatureFlag('test-flag', 'user-2', { onlyEvaluateLocally: true })
 
     // fetchCallCount should be 2 (on-demand fetch was allowed after backoff expired)
     expect(fetchCallCount).toBe(2)
@@ -6705,32 +6690,32 @@ describe('error handling and backoff', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await new Promise((r) => setTimeout(r, 50))
+    await posthog.reloadFeatureFlags()
     expect(fetchCallCount).toBe(1) // Initial fetch, backoff = 2s
 
     // Advance past 2s backoff, trigger second error
     mockTime += 2001
-    await posthog.getFeatureFlag('test', 'user')
+    await posthog.getFeatureFlag('test', 'user', { onlyEvaluateLocally: true })
     expect(fetchCallCount).toBe(2) // backoff now = 4s
 
     // 2s is NOT enough anymore
     mockTime += 2001
-    await posthog.getFeatureFlag('test', 'user')
+    await posthog.getFeatureFlag('test', 'user', { onlyEvaluateLocally: true })
     expect(fetchCallCount).toBe(2) // Still blocked
 
     // 4s total is enough
     mockTime += 2000
-    await posthog.getFeatureFlag('test', 'user')
+    await posthog.getFeatureFlag('test', 'user', { onlyEvaluateLocally: true })
     expect(fetchCallCount).toBe(3) // backoff now = 8s
 
     // 4s is NOT enough anymore
     mockTime += 4001
-    await posthog.getFeatureFlag('test', 'user')
+    await posthog.getFeatureFlag('test', 'user', { onlyEvaluateLocally: true })
     expect(fetchCallCount).toBe(3) // Still blocked
 
     // 8s total is enough
     mockTime += 4000
-    await posthog.getFeatureFlag('test', 'user')
+    await posthog.getFeatureFlag('test', 'user', { onlyEvaluateLocally: true })
     expect(fetchCallCount).toBe(4) // Exponential backoff verified!
 
     Date.now = originalDateNow
@@ -6783,17 +6768,15 @@ describe('error handling and backoff', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    await posthog.reloadFeatureFlags()
     expect(fetchCallCount).toBe(1) // Initial 401
 
     // Use reloadFeatureFlags to trigger a retry (uses forceReload=true, bypasses backoff)
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
     expect(fetchCallCount).toBe(2) // Retry succeeded with 200
 
     // Now on-demand fetch should work immediately (backoff cleared by 200 response)
-    await posthog.getFeatureFlag('test-flag', 'user-1')
-    await waitForPromises()
+    await posthog.getFeatureFlag('test-flag', 'user-1', { onlyEvaluateLocally: true })
 
     // The getFeatureFlag call should not trigger another fetch because
     // loadedSuccessfullyOnce is now true (flags loaded successfully)
@@ -6831,24 +6814,21 @@ describe('error handling and backoff', () => {
       ...posthogImmediateResolveOptions,
     })
 
-    await waitForPromises()
+    await posthog.reloadFeatureFlags()
     expect(fetchCallCount).toBe(1) // Initial fetch
 
     // On-demand fetch should be blocked
-    await posthog.getFeatureFlag('test-flag', 'user-1')
-    await waitForPromises()
+    await posthog.getFeatureFlag('test-flag', 'user-1', { onlyEvaluateLocally: true })
     expect(fetchCallCount).toBe(1) // Still blocked
 
     // reloadFeatureFlags uses forceReload=true internally, should bypass backoff
     await posthog.reloadFeatureFlags()
-    await waitForPromises()
 
     // reloadFeatureFlags should have bypassed backoff and made a new fetch
     expect(fetchCallCount).toBe(2)
 
     // On-demand fetch should still be blocked (new backoff started after 401)
-    await posthog.getFeatureFlag('test-flag', 'user-2')
-    await waitForPromises()
+    await posthog.getFeatureFlag('test-flag', 'user-2', { onlyEvaluateLocally: true })
     expect(fetchCallCount).toBe(2) // Still blocked
   })
 })


### PR DESCRIPTION
## Problem

The Node local-evaluation polling tests relied on `waitForPromises()`, which sleeps briefly and can be timing-sensitive. In CI, ETag and backoff cases in `feature-flags.spec.ts` timed out when constructor-started polling work or shutdown work did not complete before assertions continued.

Some tests also used the public feature-flag API to verify polling/cache behavior. That can do extra async work unrelated to the behavior under test, especially when local evaluation falls through to remote evaluation.

## Changes

- Await `posthog.reloadFeatureFlags()` to deterministically wait for constructor-started local-evaluation loads.
- Remove `waitForPromises()` sleeps from ETag and backoff tests where the reload promise is the actual synchronization point.
- Verify cached definitions directly from local poller state in ETag 304 tests.
- Force local-only feature-flag calls in backoff tests so they only exercise on-demand local-definition fetching and never remote fallback.
- Use real timers plus a short shutdown timeout during backoff test cleanup to avoid fake-timer-dependent teardown hangs.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was created with pi to split flaky test fixes out of an unrelated CI workflow PR. The chosen fix keeps production code unchanged and makes the tests await the actual feature-flag reload promise rather than relying on timer sleeps. The affected assertions now stay scoped to local polling/cache/backoff behavior.

Validation performed: `pnpm --filter posthog-node exec jest src/__tests__/feature-flags.spec.ts --runInBand`, repeated targeted ETag/backoff test runs, `pnpm --filter posthog-node exec jest src/__tests__/feature-flags.spec.ts -t "error handling and backoff" --runInBand --detectOpenHandles`, `pnpm --filter posthog-node lint`, and `pnpm --filter posthog-node test:unit`.
