### PR TITLE
ci: skip heavy CI for non-impacting changes

### DIFF
--- a/.github/actions/changed-files-classifier/action.yaml
+++ b/.github/actions/changed-files-classifier/action.yaml
@@ -1,0 +1,297 @@
+name: Changed files classifier
+
+description: Classifies PR changed files so required CI jobs can skip heavyweight setup safely.
+
+inputs:
+  github-token:
+    description: Token used to read pull request files.
+    required: true
+
+outputs:
+  changed_files:
+    description: Newline-delimited changed files considered by the classifier.
+    value: ${{ steps.classify.outputs.changed_files }}
+  reason:
+    description: Classification or fail-open reason.
+    value: ${{ steps.classify.outputs.reason }}
+  skip_heavy:
+    description: true when no heavyweight SDK CI category is affected.
+    value: ${{ steps.classify.outputs.skip_heavy }}
+  run_sdk_ci:
+    description: Run broad SDK unit/functional checks.
+    value: ${{ steps.classify.outputs.run_sdk_ci }}
+  run_browser_ci:
+    description: Run browser build/test checks.
+    value: ${{ steps.classify.outputs.run_browser_ci }}
+  run_node_ci:
+    description: Run Node-specific checks.
+    value: ${{ steps.classify.outputs.run_node_ci }}
+  run_rrweb_ci:
+    description: Run rrweb checks.
+    value: ${{ steps.classify.outputs.run_rrweb_ci }}
+  run_lint_ci:
+    description: Run package lint checks.
+    value: ${{ steps.classify.outputs.run_lint_ci }}
+  run_playground_lint:
+    description: Run playground lint checks.
+    value: ${{ steps.classify.outputs.run_playground_lint }}
+  run_package_ci:
+    description: Run package tarball checks.
+    value: ${{ steps.classify.outputs.run_package_ci }}
+  run_references_ci:
+    description: Run public API reference checks.
+    value: ${{ steps.classify.outputs.run_references_ci }}
+  run_typescript_ci:
+    description: Run TypeScript compatibility checks.
+    value: ${{ steps.classify.outputs.run_typescript_ci }}
+
+runs:
+  using: composite
+  steps:
+    - name: Classify changed files
+      id: classify
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        set_output() {
+          local key="$1"
+          local value="$2"
+          if [[ "$value" == *$'\n'* ]]; then
+            {
+              echo "$key<<EOF"
+              printf '%s\n' "$value"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "$key=$value" >> "$GITHUB_OUTPUT"
+          fi
+        }
+
+        emit() {
+          local reason="$1"
+          local changed_files="$2"
+          local run_sdk_ci="$3"
+          local run_browser_ci="$4"
+          local run_node_ci="$5"
+          local run_rrweb_ci="$6"
+          local run_lint_ci="$7"
+          local run_playground_lint="$8"
+          local run_package_ci="$9"
+          local run_references_ci="${10}"
+          local run_typescript_ci="${11}"
+
+          local skip_heavy="false"
+          if [[ "$run_sdk_ci" == "false" && "$run_browser_ci" == "false" && "$run_node_ci" == "false" && "$run_rrweb_ci" == "false" && "$run_lint_ci" == "false" && "$run_playground_lint" == "false" && "$run_package_ci" == "false" && "$run_references_ci" == "false" && "$run_typescript_ci" == "false" ]]; then
+            skip_heavy="true"
+          fi
+
+          set_output changed_files "$changed_files"
+          set_output reason "$reason"
+          set_output skip_heavy "$skip_heavy"
+          set_output run_sdk_ci "$run_sdk_ci"
+          set_output run_browser_ci "$run_browser_ci"
+          set_output run_node_ci "$run_node_ci"
+          set_output run_rrweb_ci "$run_rrweb_ci"
+          set_output run_lint_ci "$run_lint_ci"
+          set_output run_playground_lint "$run_playground_lint"
+          set_output run_package_ci "$run_package_ci"
+          set_output run_references_ci "$run_references_ci"
+          set_output run_typescript_ci "$run_typescript_ci"
+
+          echo "Changed-file classifier: $reason"
+          if [[ -n "$changed_files" ]]; then
+            echo "Changed files:"
+            printf '%s\n' "$changed_files"
+          fi
+          echo "run_sdk_ci=$run_sdk_ci"
+          echo "run_browser_ci=$run_browser_ci"
+          echo "run_node_ci=$run_node_ci"
+          echo "run_rrweb_ci=$run_rrweb_ci"
+          echo "run_lint_ci=$run_lint_ci"
+          echo "run_playground_lint=$run_playground_lint"
+          echo "run_package_ci=$run_package_ci"
+          echo "run_references_ci=$run_references_ci"
+          echo "run_typescript_ci=$run_typescript_ci"
+          echo "skip_heavy=$skip_heavy"
+        }
+
+        fail_open() {
+          emit "$1" "${2:-}" true true true true true true true true true
+        }
+
+        mark_all() {
+          run_sdk_ci=true
+          run_browser_ci=true
+          run_node_ci=true
+          run_rrweb_ci=true
+          run_lint_ci=true
+          run_playground_lint=true
+          run_package_ci=true
+          run_references_ci=true
+          run_typescript_ci=true
+        }
+
+        mark_browser() {
+          run_sdk_ci=true
+          run_browser_ci=true
+          run_lint_ci=true
+          run_package_ci=true
+          run_references_ci=true
+          run_typescript_ci=true
+        }
+
+        mark_node() {
+          run_sdk_ci=true
+          run_node_ci=true
+          run_lint_ci=true
+          run_package_ci=true
+          run_references_ci=true
+          run_typescript_ci=true
+        }
+
+        mark_package() {
+          run_sdk_ci=true
+          run_lint_ci=true
+          run_package_ci=true
+          run_references_ci=true
+          run_typescript_ci=true
+        }
+
+        if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" && "${GITHUB_EVENT_NAME:-}" != "pull_request_target" ]]; then
+          fail_open "fail-open: ${GITHUB_EVENT_NAME:-unknown} event runs full CI"
+          exit 0
+        fi
+
+        if [[ -z "${GH_TOKEN:-}" ]]; then
+          fail_open "fail-open: missing GitHub token"
+          exit 0
+        fi
+
+        if [[ -z "${GITHUB_EVENT_PATH:-}" || ! -f "${GITHUB_EVENT_PATH}" ]]; then
+          fail_open "fail-open: missing GitHub event payload"
+          exit 0
+        fi
+
+        pr_number="$(jq -r '.pull_request.number // empty' "${GITHUB_EVENT_PATH}" 2>/dev/null || true)"
+        if [[ -z "$pr_number" ]]; then
+          fail_open "fail-open: missing pull request number"
+          exit 0
+        fi
+
+        files_tmp="$(mktemp)"
+        for page in $(seq 1 30); do
+          response_tmp="$(mktemp)"
+          status="$({ curl --silent --show-error --location \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --output "$response_tmp" \
+            --write-out "%{http_code}" \
+            "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100&page=${page}"; } || true)"
+
+          if [[ "$status" != "200" ]]; then
+            fail_open "fail-open: pull request files API returned HTTP ${status}" "$(cat "$files_tmp" 2>/dev/null || true)"
+            exit 0
+          fi
+
+          count="$(jq 'length' "$response_tmp" 2>/dev/null || echo "")"
+          if [[ ! "$count" =~ ^[0-9]+$ ]]; then
+            fail_open "fail-open: could not parse pull request files API response" "$(cat "$files_tmp" 2>/dev/null || true)"
+            exit 0
+          fi
+
+          jq -r '.[].filename' "$response_tmp" >> "$files_tmp"
+
+          if [[ "$count" -lt 100 ]]; then
+            break
+          fi
+
+          if [[ "$page" -eq 30 ]]; then
+            fail_open "fail-open: pull request has too many changed files to classify safely" "$(cat "$files_tmp" 2>/dev/null || true)"
+            exit 0
+          fi
+        done
+
+        changed_files="$(sort -u "$files_tmp")"
+        if [[ -z "$changed_files" ]]; then
+          fail_open "fail-open: no changed files returned by pull request files API"
+          exit 0
+        fi
+
+        run_sdk_ci=false
+        run_browser_ci=false
+        run_node_ci=false
+        run_rrweb_ci=false
+        run_lint_ci=false
+        run_playground_lint=false
+        run_package_ci=false
+        run_references_ci=false
+        run_typescript_ci=false
+        reason="classified"
+
+        while IFS= read -r file; do
+          [[ -z "$file" ]] && continue
+
+          case "$file" in
+            .github/actions/*|.github/workflows/library-ci.yml|.github/workflows/integration.yml|.github/workflows/es-check.yml|.github/workflows/minimum-version-ts-check.yaml|.github/workflows/testcafe.yml|.github/workflows/bundled-size.yaml)
+              mark_all
+              reason="fail-open: main CI workflow/action changed"
+              break
+              ;;
+            .github/workflows/release.yml|.github/workflows/posthog-upgrade.yml|.changeset/*.md|docs/*|docs/**/*|*.md|**/*.md|packages/*/CHANGELOG.md|packages/*/references/*|packages/*/references/**/*)
+              ;;
+            package.json|pnpm-lock.yaml|pnpm-workspace.yaml|turbo.json|.npmrc|.nvmrc|tsconfig*.json|.eslintrc*|eslint.config.*|.prettierrc*|jest*|jest.*|babel*|babel.*|rollup*|rollup.*|vite*|vite.*|rslib*|rslib.*|playwright*|playwright.*|testcafe*|testcafe.*)
+              mark_all
+              ;;
+            packages/core/*|packages/core/**/*)
+              mark_browser
+              mark_node
+              ;;
+            packages/browser/*|packages/browser/**/*)
+              mark_browser
+              ;;
+            packages/node/*|packages/node/**/*)
+              mark_node
+              ;;
+            packages/rrweb/*|packages/rrweb/**/*)
+              run_sdk_ci=true
+              run_rrweb_ci=true
+              run_lint_ci=true
+              run_package_ci=true
+              run_typescript_ci=true
+              ;;
+            packages/types/*|packages/types/**/*)
+              mark_package
+              run_browser_ci=true
+              run_node_ci=true
+              ;;
+            packages/*|packages/**/*)
+              mark_package
+              ;;
+            tooling/*|tooling/**/*|scripts/*|scripts/**/*|compliance/*|compliance/**/*)
+              mark_all
+              ;;
+            examples/*|examples/**/*)
+              run_lint_ci=true
+              run_package_ci=true
+              ;;
+            playground/*|playground/**/*)
+              run_playground_lint=true
+              ;;
+            .github/workflows/*)
+              mark_all
+              reason="fail-open: unclassified workflow changed"
+              break
+              ;;
+            *)
+              mark_all
+              reason="fail-open: unclassified path changed (${file})"
+              break
+              ;;
+          esac
+        done <<< "$changed_files"
+
+        emit "$reason" "$changed_files" "$run_sdk_ci" "$run_browser_ci" "$run_node_ci" "$run_rrweb_ci" "$run_lint_ci" "$run_playground_lint" "$run_package_ci" "$run_references_ci" "$run_typescript_ci"

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -18,7 +18,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_browser_ci != 'true'
+        run: echo "Skipping bundled-size checks because changed files do not affect browser bundles."
+
       - name: Setup pnpm and Node.js
+        if: steps.changes.outputs.run_browser_ci == 'true'
         uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
         with:
           # TODO: pnpm/setup does not read .nvmrc yet; keep this in sync with .nvmrc.
@@ -28,12 +38,15 @@ jobs:
           install: false
 
       - name: Install dependencies
+        if: steps.changes.outputs.run_browser_ci == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build project
+        if: steps.changes.outputs.run_browser_ci == 'true'
         run: pnpm build
 
       - name: Upload bundle size visualization
+        if: steps.changes.outputs.run_browser_ci == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: viz-upload
         with:
@@ -41,11 +54,11 @@ jobs:
           path: packages/browser/bundle-stats-array.html
 
       - name: Skip PR comments for fork PR
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        if: ${{ steps.changes.outputs.run_browser_ci == 'true' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: echo "Skipping bundled-size PR comments for fork PRs because GitHub tokens are read-only."
 
       - name: Find artifact link comment if it exists
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.changes.outputs.run_browser_ci == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # pin v4.0.0
         id: fc
         with:
@@ -54,7 +67,7 @@ jobs:
           body-includes: Download bundle size visualization
 
       - name: Create or update artifact link comment
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.changes.outputs.run_browser_ci == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # pin v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -64,7 +77,7 @@ jobs:
           edit-mode: replace
 
       - uses: preactjs/compressed-size-action@946a292cd35bd1088e0d7eb92b69d1a8d5b5d76a # pin v2.8.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.changes.outputs.run_browser_ci == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           compression: "none"
           strip-hash: '-(\w{8})\.'

--- a/.github/workflows/es-check.yml
+++ b/.github/workflows/es-check.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   ssr:
     name: Build and check ES5/ES6 support
@@ -17,12 +21,24 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_browser_ci != 'true'
+        run: echo "Skipping ES5/ES6 support checks because changed files do not affect browser bundles."
+
       - uses: ./.github/actions/setup
+        if: steps.changes.outputs.run_browser_ci == 'true'
         with:
           build: true
 
       - name: Run es-check to check if our ie11 bundle is ES5 compatible
+        if: steps.changes.outputs.run_browser_ci == 'true'
         run: npx es-check@7.2.1 es5 packages/browser/dist/array.full.es5.js
 
       - name: Run es-check to check if our main bundle is ES6 compatible
+        if: steps.changes.outputs.run_browser_ci == 'true'
         run: npx es-check@7.2.1 es6 packages/browser/dist/array.full.js

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,7 @@ env:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -50,28 +51,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/changed-files-classifier
         if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' }}
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.changes.outputs.run_browser_ci != 'true' }}
+        run: echo "Skipping ${{ matrix.tests.name }} integration tests because changed files do not affect browser checks."
+
+      - uses: ./.github/actions/setup
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.changes.outputs.run_browser_ci == 'true' }}
         with:
           build: false
 
       - uses: ./.github/actions/is-affected
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.changes.outputs.run_browser_ci == 'true' }}
         id: is-affected
         with:
           package-name: posthog-js
 
       - name: Build packages
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
       - name: Install Playwright Browsers
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         run: pnpm exec playwright install ${{ matrix.tests.install }} --with-deps --only-shell
         working-directory: packages/browser
 
       - name: Run ${{ matrix.tests.name }} test
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   unit:
@@ -20,10 +21,21 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_sdk_ci != 'true'
+        run: echo "Skipping unit tests because changed files do not affect SDK tests."
+
       - name: Setup environment
+        if: steps.changes.outputs.run_sdk_ci == 'true'
         uses: ./.github/actions/setup
 
       - run: pnpm test:unit
+        if: steps.changes.outputs.run_sdk_ci == 'true'
 
   edge-runtime:
     name: Node edge runtime tests
@@ -31,10 +43,21 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_node_ci != 'true'
+        run: echo "Skipping Node edge runtime tests because changed files do not affect Node runtime checks."
+
       - name: Setup environment
+        if: steps.changes.outputs.run_node_ci == 'true'
         uses: ./.github/actions/setup
 
       - name: Node edge runtime tests
+        if: steps.changes.outputs.run_node_ci == 'true'
         run: pnpm --filter=posthog-node test:edge-compat
 
   integration:
@@ -45,32 +68,43 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_browser_ci != 'true'
+        run: echo "Skipping Playwright E2E tests because changed files do not affect browser checks."
+
       - name: Setup environment
+        if: steps.changes.outputs.run_browser_ci == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
       - uses: ./.github/actions/is-affected
+        if: steps.changes.outputs.run_browser_ci == 'true'
         id: is-affected
         with:
           package-name: posthog-js
 
       - name: Build package
         run: pnpm build
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true'
 
       - name: Install Playwright Browsers
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true'
         run: pnpm exec playwright install --with-deps
         working-directory: packages/browser
 
       - name: Run Playwright tests
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true'
         run: pnpm exec playwright test --workers=5
         working-directory: packages/browser
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ !cancelled() && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-report
           path: packages/browser/playwright-report/
@@ -88,28 +122,39 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_browser_ci != 'true'
+        run: echo "Skipping backward compatibility tests because changed files do not affect browser checks."
+
       - name: Setup environment
+        if: steps.changes.outputs.run_browser_ci == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
       - uses: ./.github/actions/is-affected
+        if: steps.changes.outputs.run_browser_ci == 'true'
         id: is-affected
         with:
           package-name: posthog-js
 
       - name: Build package
         run: pnpm build
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true'
 
       - name: Install Playwright Browsers
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true'
         run: pnpm exec playwright install --with-deps chromium
         working-directory: packages/browser
 
       - name: Run backward compatibility tests
         id: compat-tests
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true'
         continue-on-error: true
         run: |
           pnpm exec playwright test --config playwright.config.compat.ts --project chromium-compat --workers=5 --reporter=json > compat-results.json 2>&1 || true
@@ -117,7 +162,7 @@ jobs:
         working-directory: packages/browser
 
       - name: Process compat test results
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true'
         id: process-results
         working-directory: packages/browser
         run: |
@@ -201,7 +246,7 @@ jobs:
             </details>
 
       - name: Delete compat comment if tests pass
-        if: ${{ steps.process-results.outputs.has_failures == 'false' && steps.is-affected.outputs.is-affected == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.process-results.outputs.has_failures == 'false' && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-passing-comment
         with:
@@ -223,7 +268,7 @@ jobs:
             })
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ !cancelled() && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-compat-report
           path: packages/browser/playwright-report/
@@ -234,46 +279,60 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_sdk_ci != 'true'
+        run: echo "Skipping functional tests because changed files do not affect SDK tests."
       - name: Setup environment
+        if: steps.changes.outputs.run_sdk_ci == 'true'
         uses: ./.github/actions/setup
       - run: pnpm test:functional
+        if: steps.changes.outputs.run_sdk_ci == 'true'
 
   rrweb:
     name: rrweb tests
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_rrweb_ci != 'true'
+        run: echo "Skipping rrweb tests because changed files do not affect rrweb packages."
+
       - name: Setup environment
+        if: steps.changes.outputs.run_rrweb_ci == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
-      - name: Check if rrweb packages changed
-        id: changed
-        run: |
-          CHANGED=$(git diff --name-only origin/main...HEAD | grep -c '^packages/rrweb/' || true)
-          echo "rrweb-changed=$([[ $CHANGED -gt 0 ]] && echo true || echo false)" >> $GITHUB_OUTPUT
-
       - name: Build rrweb packages
-        if: steps.changed.outputs.rrweb-changed == 'true'
+        if: steps.changes.outputs.run_rrweb_ci == 'true'
         run: pnpm turbo run build --filter='./packages/rrweb/**' --concurrency=1
 
       - name: Install Chrome for Puppeteer
-        if: steps.changed.outputs.rrweb-changed == 'true'
+        if: steps.changes.outputs.run_rrweb_ci == 'true'
         run: pnpm --filter @posthog/rrweb exec puppeteer browsers install chrome
 
       - name: Run rrweb tests
-        if: steps.changed.outputs.rrweb-changed == 'true'
+        if: steps.changes.outputs.run_rrweb_ci == 'true'
         run: xvfb-run --server-args="-screen 0 1920x1080x24" pnpm turbo run test --filter='./packages/rrweb/**'
 
       - name: Upload diff images on failure
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        if: failure() && steps.changed.outputs.rrweb-changed == 'true'
+        if: failure() && steps.changes.outputs.run_rrweb_ci == 'true'
         with:
           name: rrweb-image-diff
           path: packages/rrweb/**/__image_snapshots__/__diff_output__/*.png
@@ -284,11 +343,20 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_lint_ci != 'true'
+        run: echo "Skipping package lint because changed files do not affect linted package files."
       - name: Setup environment
+        if: steps.changes.outputs.run_lint_ci == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
       - name: Lint all packages
+        if: steps.changes.outputs.run_lint_ci == 'true'
         run: pnpm lint
 
   lint-playground:
@@ -296,11 +364,20 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_playground_lint != 'true'
+        run: echo "Skipping playground lint because changed files do not affect playground files."
       - name: Setup environment
+        if: steps.changes.outputs.run_playground_lint == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
       - name: Lint playground files
+        if: steps.changes.outputs.run_playground_lint == 'true'
         run: pnpm lint:playground
 
   package:
@@ -309,23 +386,37 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_package_ci != 'true'
+        run: echo "Skipping package tarball checks because changed files do not affect packages or packaged examples."
+
       - name: Setup environment
+        if: steps.changes.outputs.run_package_ci == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
       - name: Build package tarballs
+        if: steps.changes.outputs.run_package_ci == 'true'
         run: pnpm package
 
       - name: Smoke test package tarballs
+        if: steps.changes.outputs.run_package_ci == 'true'
         run: pnpm check:package-tarballs
 
       # Replaces Vercel preview deploy validation for @posthog/next.
       - name: Install Next.js App Router example dependencies from local tarballs
+        if: steps.changes.outputs.run_package_ci == 'true'
         run: pnpm install --lockfile=false
         working-directory: examples/example-next-app-router
 
       - name: Build Next.js App Router example
+        if: steps.changes.outputs.run_package_ci == 'true'
         run: pnpm build
         working-directory: examples/example-next-app-router
         env:
@@ -334,10 +425,12 @@ jobs:
           NEXT_PUBLIC_POSTHOG_HOST: https://us.i.posthog.com
 
       - name: Install Next.js config example dependencies from local tarballs
+        if: steps.changes.outputs.run_package_ci == 'true'
         run: pnpm install --lockfile=false
         working-directory: examples/example-nextjs
 
       - name: Build Next.js config example
+        if: steps.changes.outputs.run_package_ci == 'true'
         run: pnpm build
         working-directory: examples/example-nextjs
         env:
@@ -352,17 +445,29 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_browser_ci != 'true'
+        run: echo "Skipping mangled property check because changed files do not affect browser builds."
+
       - name: Setup environment
+        if: steps.changes.outputs.run_browser_ci == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
       - name: Build posthog-js
+        if: steps.changes.outputs.run_browser_ci == 'true'
         run: pnpm exec turbo --filter=posthog-js build
         env:
           WRITE_MANGLED_PROPERTIES: 1
 
       - run: git diff --exit-code # fail if e.g. the mangled properties list has changed, see rollup.config.js
+        if: steps.changes.outputs.run_browser_ci == 'true'
 
   generate-references:
     # Runs the same api-extractor pipeline the release workflow uses to bump
@@ -373,14 +478,25 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_references_ci != 'true'
+        run: echo "Skipping public API reference checks because changed files do not affect public APIs."
       - name: Setup environment
+        if: steps.changes.outputs.run_references_ci == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
       - name: Generate public API references
+        if: steps.changes.outputs.run_references_ci == 'true'
         run: pnpm generate-references
 
       - name: Check public API references
+        if: steps.changes.outputs.run_references_ci == 'true'
         run: pnpm check:public-api

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   unit:
     name: Check minimum TS version
@@ -30,18 +34,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/changed-files-classifier
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: steps.changes.outputs.run_typescript_ci != 'true'
+        run: echo "Skipping minimum TypeScript version check because changed files do not affect package types or build configuration."
+
       - uses: ./.github/actions/setup
+        if: steps.changes.outputs.run_typescript_ci == 'true'
         with:
           node_version: ${{ matrix.node-version }}
           build: true
 
       # once its built we can see if we can use it on the forced version
       - name: Override TypeScript version
+        if: steps.changes.outputs.run_typescript_ci == 'true'
         env:
           TS_VERSION: ${{ matrix.typescript-version.version }}
         run: yq -i '.catalog.typescript = strenv(TS_VERSION)' pnpm-workspace.yaml && pnpm install --no-frozen-lockfile
 
       - name: Test TypeScript Import
+        if: steps.changes.outputs.run_typescript_ci == 'true'
         run: |
           rm ci-ts-file.js || true
           pnpm exec tsc --version

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   browsers:
     name: Test on ${{ matrix.name }}
@@ -40,27 +44,37 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/changed-files-classifier
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        id: changes
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Skip heavy CI
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.run_browser_ci != 'true' }}
+        run: echo "Skipping ${{ matrix.name }} TestCafe tests because changed files do not affect browser checks."
+
+      - uses: ./.github/actions/setup
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.run_browser_ci == 'true' }}
         with:
           build: false
 
       - uses: ./.github/actions/is-affected
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.run_browser_ci == 'true' }}
         id: is-affected
         with:
           package-name: posthog-js
 
       - name: Build packages
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
       - name: Serve static files
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         run: python -m http.server 8080 &
 
       - name: Run ${{ matrix.name }} test
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         timeout-minutes: 10
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -98,7 +112,7 @@ jobs:
         working-directory: packages/browser
 
       - name: Check ${{ matrix.name }} events
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.changes.outputs.run_browser_ci == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         run: pnpm check-testcafe-results
         working-directory: packages/browser


### PR DESCRIPTION
## Problem
CI currently runs expensive SDK build/test/package jobs for PRs that only touch release automation, docs, or other non-runtime files. Required checks still need to appear, so workflow-level path skipping is unsafe.

## Changes
- Add a reusable changed-files classifier action for CI impact detection.
- Make required JS CI jobs start and bail out successfully before expensive setup when a PR only changes non-impacting files.
- Preserve required check names while guarding heavyweight package, browser, TypeScript, and bundle/test steps.
- Keep full CI for pushes, unknown files, CI workflow changes, and SDK/package source/build changes.

## Checklist
- [x] CI changes only
- [x] Required checks preserved with successful no-op paths
- [x] Classifier fails open for unknown or risky cases
