### PR TITLE
fix: stop duplicating distinct_id in flags person properties

### DIFF
--- a/.changeset/quiet-wolves-fix.md
+++ b/.changeset/quiet-wolves-fix.md
@@ -1,0 +1,5 @@
+---
+"posthog-node": patch
+---
+
+Stop duplicating `distinct_id` inside `/flags` person properties.

--- a/.github/workflows/sdk-compliance-tests-browser.yml
+++ b/.github/workflows/sdk-compliance-tests-browser.yml
@@ -24,10 +24,10 @@ permissions:
 
 jobs:
   test-browser-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: compliance/browser/Dockerfile
       adapter-context: .
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"
       sdk-type: client
       report-name: browser-sdk-compliance-report

--- a/.github/workflows/sdk-compliance-tests-node.yml
+++ b/.github/workflows/sdk-compliance-tests-node.yml
@@ -24,9 +24,9 @@ permissions:
 
 jobs:
   test-node-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: compliance/node/Dockerfile
       adapter-context: .
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"
       report-name: node-sdk-compliance-report

--- a/compliance/browser/docker-compose.yml
+++ b/compliance/browser/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "client", "--debug"]
     networks:
       - test-network

--- a/compliance/node/docker-compose.yml
+++ b/compliance/node/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
     networks:
       - test-network

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -772,7 +772,6 @@ describe('local evaluation', () => {
           distinct_id: 'some-distinct-id_outside_rollout?',
           groups: {},
           person_properties: {
-            distinct_id: 'some-distinct-id_outside_rollout?',
             region: 'USA',
             email: 'a@b.com',
           },
@@ -795,7 +794,7 @@ describe('local evaluation', () => {
           token: 'TEST_API_KEY',
           distinct_id: 'some-distinct-id',
           groups: {},
-          person_properties: { distinct_id: 'some-distinct-id', doesnt_matter: '1' },
+          person_properties: { doesnt_matter: '1' },
           group_properties: {},
           geoip_disable: true,
           flag_keys_to_evaluate: ['complex-flag'],

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -93,6 +93,39 @@ describe('local evaluation', () => {
     expect(mockedFetch).toHaveBeenCalledWith(...anyLocalEvalCall)
   })
 
+  it('locally evaluates person distinct_id conditions without sending it in remote person properties', async () => {
+    const flags = {
+      flags: [
+        {
+          id: 1,
+          name: 'Distinct ID Feature',
+          key: 'distinct-id-flag',
+          active: true,
+          filters: {
+            groups: [
+              {
+                properties: [{ key: 'distinct_id', type: 'person', value: 'some-distinct-id', operator: 'exact' }],
+                rollout_percentage: 100,
+              },
+            ],
+          },
+        },
+      ],
+    }
+    mockedFetch.mockImplementation(apiImplementation({ localFlags: flags }))
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      strictLocalEvaluation: true,
+      ...posthogImmediateResolveOptions,
+    })
+
+    expect(await posthog.getFeatureFlag('distinct-id-flag', 'some-distinct-id')).toEqual(true)
+    expect(mockedFetch).toHaveBeenCalledWith(...anyLocalEvalCall)
+    expect(mockedFetch).not.toHaveBeenCalledWith(...anyFlagsCall)
+  })
+
   describe('early exit', () => {
     // First group's properties match but its rollout (0%) excludes everyone; the second group
     // would otherwise match. Mirrors the server-side `OutOfRolloutBound` short-circuit.

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -2890,7 +2890,7 @@ describe('PostHog Node.js', () => {
       )
     })
 
-    it('should add default person & group properties for feature flags', async () => {
+    it('should forward person properties and add default group properties for feature flags', async () => {
       await posthog.getFeatureFlag('random_key', 'some_id', {
         groups: { company: 'id:5', instance: 'app.posthog.com' },
         personProperties: { x1: 'y1' },
@@ -2906,7 +2906,6 @@ describe('PostHog Node.js', () => {
             distinct_id: 'some_id',
             groups: { company: 'id:5', instance: 'app.posthog.com' },
             person_properties: {
-              distinct_id: 'some_id',
               x1: 'y1',
             },
             group_properties: {
@@ -2966,9 +2965,7 @@ describe('PostHog Node.js', () => {
             token: 'TEST_API_KEY',
             distinct_id: 'some_id',
             groups: {},
-            person_properties: {
-              distinct_id: 'some_id',
-            },
+            person_properties: {},
             group_properties: {},
             geoip_disable: true,
           }),
@@ -2990,9 +2987,7 @@ describe('PostHog Node.js', () => {
             token: 'TEST_API_KEY',
             distinct_id: 'some_id',
             groups: { company: 'id:5' },
-            person_properties: {
-              distinct_id: 'some_id',
-            },
+            person_properties: {},
             group_properties: { company: { $group_key: 'id:5' } },
             geoip_disable: true,
           }),
@@ -3010,9 +3005,7 @@ describe('PostHog Node.js', () => {
             token: 'TEST_API_KEY',
             distinct_id: 'some_id',
             groups: {},
-            person_properties: {
-              distinct_id: 'some_id',
-            },
+            person_properties: {},
             group_properties: {},
             geoip_disable: true,
             flag_keys_to_evaluate: ['random_key'],
@@ -3032,9 +3025,7 @@ describe('PostHog Node.js', () => {
             token: 'TEST_API_KEY',
             distinct_id: 'some_id',
             groups: {},
-            person_properties: {
-              distinct_id: 'some_id',
-            },
+            person_properties: {},
             group_properties: {},
             geoip_disable: true,
             flag_keys_to_evaluate: ['random_key'],

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2458,7 +2458,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     personProperties?: Record<string, string>,
     groupProperties?: Record<string, Record<string, string>>
   ): { allPersonProperties: Record<string, string>; allGroupProperties: Record<string, Record<string, string>> } {
-    const allPersonProperties = { distinct_id: distinctId, ...(personProperties || {}) }
+    const allPersonProperties = { ...(personProperties || {}) }
 
     const allGroupProperties: Record<string, Record<string, string>> = {}
     if (groups) {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1002,7 +1002,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     const evaluationContext = this.createFeatureFlagEvaluationContext(
       distinctId,
       groups,
-      personProperties,
+      this.personPropertiesForLocalEvaluation(distinctId, personProperties),
       groupProperties
     )
 
@@ -1060,8 +1060,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       const flagsResponse = await super.getFeatureFlagDetailsStateless(
         evaluationContext.distinctId,
         evaluationContext.groups,
-        evaluationContext.personProperties,
-        evaluationContext.groupProperties,
+        personProperties,
+        groupProperties,
         disableGeoip,
         [key]
       )
@@ -1627,7 +1627,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     const evaluationContext = this.createFeatureFlagEvaluationContext(
       resolvedDistinctId,
       groups,
-      personProperties,
+      this.personPropertiesForLocalEvaluation(resolvedDistinctId, personProperties),
       groupProperties
     )
 
@@ -1651,8 +1651,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       const remoteEvaluationResult = await super.getFeatureFlagsAndPayloadsStateless(
         evaluationContext.distinctId,
         evaluationContext.groups,
-        evaluationContext.personProperties,
-        evaluationContext.groupProperties,
+        personProperties,
+        groupProperties,
         disableGeoip,
         flagKeys
       )
@@ -1794,7 +1794,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     const evaluationContext = this.createFeatureFlagEvaluationContext(
       resolvedDistinctId,
       groups,
-      personProperties,
+      this.personPropertiesForLocalEvaluation(resolvedDistinctId, personProperties),
       groupProperties
     )
 
@@ -1839,8 +1839,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       const details = await super.getFeatureFlagDetailsStateless(
         evaluationContext.distinctId,
         evaluationContext.groups,
-        evaluationContext.personProperties,
-        evaluationContext.groupProperties,
+        personProperties,
+        groupProperties,
         disableGeoip,
         flagKeys
       )
@@ -2471,6 +2471,13 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
 
     return { allPersonProperties, allGroupProperties }
+  }
+
+  private personPropertiesForLocalEvaluation(
+    distinctId: string,
+    personProperties?: Record<string, any>
+  ): Record<string, any> {
+    return { distinct_id: distinctId, ...(personProperties || {}) }
   }
 
   private createFeatureFlagEvaluationContext(


### PR DESCRIPTION
## Problem

`/flags` requests already send `distinct_id` at the top level. The Node client also automatically copied that value into `personProperties.distinct_id`, causing duplicated identity data in the request payload.

## Changes

- Stop auto-merging `distinctId` into Node `/flags` `personProperties`.
- Keep caller-provided `personProperties` unchanged, including explicit `distinct_id` overrides.
- Update Node feature flag tests to expect only top-level automatic `distinct_id`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This was implemented with pi in dedicated git worktrees. I changed the /flags request construction so SDKs keep the top-level distinct_id while no longer auto-copying it into person_properties; explicit caller-provided person_properties['distinct_id'] values are still preserved where covered.

Tested with `pnpm --filter posthog-node test:unit -- feature-flags.spec.ts posthog-node.spec.ts`.
