### PR TITLE
fix(core): honor caller-supplied feature-flag props over cached values

### DIFF
--- a/.changeset/feature-flag-prop-precedence.md
+++ b/.changeset/feature-flag-prop-precedence.md
@@ -1,6 +1,5 @@
 ---
 "@posthog/core": patch
-"posthog-react-native": patch
 ---
 
 fix(core): feature-flag properties (`$feature/*` and `$active_feature_flags`) passed explicitly to `capture()` now take precedence over the SDK's cached flag values, matching posthog-js (web) and posthog-android

--- a/.changeset/feature-flag-prop-precedence.md
+++ b/.changeset/feature-flag-prop-precedence.md
@@ -1,5 +1,7 @@
 ---
 "@posthog/core": patch
+"posthog-react-native": patch
+"posthog-js-lite": patch
 ---
 
-fix(core): feature-flag properties (`$feature/*` and `$active_feature_flags`) passed explicitly to `capture()` now take precedence over the SDK's cached flag values, matching posthog-js (web) and posthog-android
+fix: feature-flag properties (`$feature/*` and `$active_feature_flags`) passed explicitly to `capture()` now take precedence over the SDK's cached flag values, matching posthog-js (web) and posthog-android

--- a/.changeset/feature-flag-prop-precedence.md
+++ b/.changeset/feature-flag-prop-precedence.md
@@ -1,0 +1,6 @@
+---
+"@posthog/core": patch
+"posthog-react-native": patch
+---
+
+fix(core): feature-flag properties (`$feature/*` and `$active_feature_flags`) passed explicitly to `capture()` now take precedence over the SDK's cached flag values, matching posthog-js (web) and posthog-android

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -900,6 +900,28 @@ describe('PostHog Feature Flags v4', () => {
         })
       })
 
+      it('should let caller-supplied feature flag properties override cached values', async () => {
+        posthog.capture('test-event', {
+          '$feature/feature-1': 'server-value',
+          $active_feature_flags: ['server-flag'],
+        })
+
+        await waitForPromises()
+
+        expect(parseBody(mocks.fetch.mock.calls[1])).toMatchObject({
+          batch: [
+            {
+              event: 'test-event',
+              properties: {
+                '$feature/feature-1': 'server-value',
+                $active_feature_flags: ['server-flag'],
+                '$feature/feature-2': true,
+              },
+            },
+          ],
+        })
+      })
+
       it('should override flags', () => {
         posthog.overrideFeatureFlag({
           'feature-2': false,

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -900,9 +900,13 @@ describe('PostHog Feature Flags v4', () => {
         })
       })
 
-      it('should let caller-supplied feature flag properties override cached values', async () => {
+      it.each([
+        ['a string variant', 'server-value'],
+        ['boolean false (client-side disable)', false],
+        ['null', null],
+      ])('lets a caller-supplied $feature/* value (%s) override the cached value', async (_case, overrideValue) => {
         posthog.capture('test-event', {
-          '$feature/feature-1': 'server-value',
+          '$feature/feature-1': overrideValue,
           $active_feature_flags: ['server-flag'],
         })
 
@@ -913,7 +917,7 @@ describe('PostHog Feature Flags v4', () => {
             {
               event: 'test-event',
               properties: {
-                '$feature/feature-1': 'server-value',
+                '$feature/feature-1': overrideValue,
                 $active_feature_flags: ['server-flag'],
                 '$feature/feature-2': true,
               },

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -83,9 +83,7 @@ class PostHogFetchNetworkError extends Error {
 export const maybeAdd = (key: string, value: JsonType | undefined): Record<string, JsonType> =>
   value !== undefined ? { [key]: value } : {}
 
-// Caller-supplied feature-flag properties (`$feature/*` and `$active_feature_flags`) take
-// precedence over the cached values the SDK injects, so an explicit value passed to `capture()`
-// is honoured (e.g. server-evaluated flags on exposure events).
+// Caller-supplied `$feature/*` and `$active_feature_flags` win over the SDK's cached flag values.
 export const applyCallerFeatureFlagOverrides = (
   target: PostHogEventProperties,
   callerProperties: PostHogEventProperties

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -83,6 +83,20 @@ class PostHogFetchNetworkError extends Error {
 export const maybeAdd = (key: string, value: JsonType | undefined): Record<string, JsonType> =>
   value !== undefined ? { [key]: value } : {}
 
+// Caller-supplied feature-flag properties (`$feature/*` and `$active_feature_flags`) take
+// precedence over the cached values the SDK injects, so an explicit value passed to `capture()`
+// is honoured (e.g. server-evaluated flags on exposure events).
+export const applyCallerFeatureFlagOverrides = (
+  target: PostHogEventProperties,
+  callerProperties: PostHogEventProperties
+): void => {
+  for (const key of Object.keys(callerProperties)) {
+    if (key.startsWith('$feature/') || key === '$active_feature_flags') {
+      target[key] = callerProperties[key]
+    }
+  }
+}
+
 export async function logFlushError(err: any): Promise<void> {
   if (err instanceof PostHogFetchHttpError) {
     let text = ''
@@ -378,13 +392,16 @@ export abstract class PostHogCoreStateless {
     event: string
     properties?: PostHogEventProperties
   }): PostHogEventProperties {
+    const userProperties = payload.properties || {}
+    const properties: PostHogEventProperties = {
+      ...userProperties,
+      ...this.getCommonEventProperties(), // Common PH props
+    }
+    applyCallerFeatureFlagOverrides(properties, userProperties)
     return {
       distinct_id: payload.distinct_id,
       event: payload.event,
-      properties: {
-        ...(payload.properties || {}),
-        ...this.getCommonEventProperties(), // Common PH props
-      },
+      properties,
     }
   }
 

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -34,7 +34,12 @@ import {
   updateFlagValue,
 } from './featureFlagUtils'
 import { Compression, FeatureFlagError, PostHogPersistedProperty } from './types'
-import { maybeAdd, PostHogCoreStateless, QuotaLimitedFeature } from './posthog-core-stateless'
+import {
+  applyCallerFeatureFlagOverrides,
+  maybeAdd,
+  PostHogCoreStateless,
+  QuotaLimitedFeature,
+} from './posthog-core-stateless'
 import { uuidv7 } from './vendor/uuidv7'
 import { isEmptyObject, isNullish, getPersonPropertiesHash, isObject, isArray, isString, getEventUuid } from './utils'
 import { EventHint } from './error-tracking'
@@ -220,13 +225,16 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   }
 
   private enrichProperties(properties?: PostHogEventProperties): PostHogEventProperties {
-    return {
+    const userProperties = properties || {}
+    const enriched: PostHogEventProperties = {
       ...this.props, // Persisted properties first
       ...this.sessionProps, // Followed by session properties
-      ...(properties || {}), // Followed by user specified properties
+      ...userProperties, // Followed by user specified properties
       ...this.getCommonEventProperties(), // Followed by FF props
       $session_id: this.getSessionId(),
     }
+    applyCallerFeatureFlagOverrides(enriched, userProperties)
+    return enriched
   }
 
   /**


### PR DESCRIPTION
## Problem

When you pass a `$feature/<flag>` property explicitly to `capture()`, the shared core drops it in favor of its own cached flag value. This blocks passing server-evaluated flag values onto client exposure events (e.g. paywall screen views) as a safety net for when the client's cached flags are stale or a server-side person property changed evaluation.

The flag properties are injected in two places, each spreading `getCommonEventProperties()` **after** the caller's properties, so the cached value wins on collision:

- `PostHogCore.enrichProperties()` (`packages/core/src/posthog-core.ts`)
- `PostHogCoreStateless.buildPayload()` (`packages/core/src/posthog-core-stateless.ts`) — the final, authoritative merge

This also made the SDKs inconsistent. Precedence of an explicit `$feature/foo` passed to `capture()`:

| SDK | Behavior |
| --- | --- |
| posthog-js (web) | caller wins |
| posthog-android | caller wins |
| posthog-ios | caller wins ([posthog-ios#690](https://github.com/PostHog/posthog-ios/pull/690)) |
| **posthog-react-native / `@posthog/core`** | **SDK-cached wins** (this PR flips it to caller wins) |
| posthog-flutter | delegates to native |

## Changes

Added a shared `applyCallerFeatureFlagOverrides()` helper in `@posthog/core` and applied it at both injection sites so caller-supplied `$feature/*` and `$active_feature_flags` win over the cached values. All other property precedence is unchanged. `PostHogCoreStateless` (used by posthog-node) has no cached flag props to override, so this is a no-op there.

Added a regression test in `posthog.featureflags.spec.ts` asserting an explicit `$feature/*` and `$active_feature_flags` survive into the sent event over the loaded flags.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Anna directed this work with Claude Code following a customer (Portola) escalation about server/client feature-flag values, alongside the sibling iOS fix ([posthog-ios#690](https://github.com/PostHog/posthog-ios/pull/690)). The agent traced the precedence across all PostHog SDKs (web, iOS, Android, React Native core, Flutter) and found the target behavior "caller wins" already shipped in web and Android, so this aligns RN rather than inventing new behavior.

The non-obvious part: flags are injected twice (`enrichProperties` then `buildPayload`), so the override had to be applied at both sites — the deeper `buildPayload` is the authoritative one. Scope was deliberately limited to `$feature/*` and `$active_feature_flags`. Verified locally: full `@posthog/core` suite (690 tests) passes and eslint is clean.