### PR TITLE
ci(upgrade): post accurate alert when the upgrade PR fails (not "Failed to release")

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -178,5 +178,5 @@ jobs:
                   payload: |
                       {
                         "channel": "${{ vars.SLACK_ALERTS_POSTHOG_JS_CHANNEL_ID || 'C07HTMN9X47' }}",
-                        "text": ":warning: Could not open the PostHog upgrade PR for `${{ github.event.inputs.package_name }}@${{ github.event.inputs.package_version }}` — the release itself succeeded. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                        "text": ":warning: The PostHog/posthog upgrade for `${{ github.event.inputs.package_name }}@${{ github.event.inputs.package_version }}` failed — the release itself succeeded. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
                       }

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -143,19 +143,23 @@ jobs:
               run: |
                   gh pr edit "$PR_NUMBER" --repo PostHog/posthog --add-reviewer PostHog/client-libraries-approvers --add-reviewer PostHog/team-client-libraries
 
-            # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
+            # This job runs after posthog-js is already published; it only opens the
+            # dependency-bump PR in the PostHog/posthog monorepo. A failure here means
+            # the upgrade PR could not be opened, not that the release failed, so it
+            # emits its own event rather than the release-failure one.
+            # CDP function: https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Send failure event to PostHog
               if: ${{ failure() }}
               uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
               with:
                   posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
-                  event: 'posthog-js-github-release-workflow-failure'
+                  event: 'posthog-js-github-upgrade-pr-failure'
                   properties: >-
                       {
                         "commitSha": "${{ github.sha }}",
                         "jobStatus": "${{ job.status }}",
                         "ref": "${{ github.ref }}",
-                        "repository": "Posthog/posthog",
+                        "repository": "PostHog/posthog",
                         "packageName": "${{ github.event.inputs.package_name }}",
                         "packageVersion": "${{ github.event.inputs.package_version }}",
                         "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -178,5 +178,5 @@ jobs:
                   payload: |
                       {
                         "channel": "${{ vars.SLACK_ALERTS_POSTHOG_JS_CHANNEL_ID || 'C07HTMN9X47' }}",
-                        "text": ":warning: The PostHog/posthog upgrade for `${{ github.event.inputs.package_name }}@${{ github.event.inputs.package_version }}` failed — the release itself succeeded. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                        "text": ":warning: The PostHog/posthog dependency bump for `${{ github.event.inputs.package_name }}@${{ github.event.inputs.package_version }}` failed — this is the downstream monorepo upgrade, not the posthog-js release. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
                       }

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -143,6 +143,7 @@ jobs:
               run: |
                   gh pr edit "$PR_NUMBER" --repo PostHog/posthog --add-reviewer PostHog/client-libraries-approvers --add-reviewer PostHog/team-client-libraries
 
+            # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Send failure event to PostHog
               if: ${{ failure() }}
               continue-on-error: true

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -143,19 +143,12 @@ jobs:
               run: |
                   gh pr edit "$PR_NUMBER" --repo PostHog/posthog --add-reviewer PostHog/client-libraries-approvers --add-reviewer PostHog/team-client-libraries
 
-            # This job runs after posthog-js is already published; it only opens the
-            # dependency-bump PR in the PostHog/posthog monorepo. A failure here means
-            # the upgrade PR could not be opened, not that the release failed. It records
-            # its own analytics event and posts an accurate alert rather than a
-            # "Failed to release" one.
             - name: Send failure event to PostHog
               if: ${{ failure() }}
               continue-on-error: true
               uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
               with:
                   posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
-                  # Distinct from release.yml's event name so the release-failure CDP
-                  # alert does not fire for an upgrade-PR failure.
                   event: 'posthog-js-github-upgrade-pr-failure'
                   properties: >-
                       {
@@ -170,7 +163,6 @@ jobs:
 
             - name: Notify Slack that the upgrade PR failed
               if: ${{ failure() }}
-              # #alerts-posthog-js; override with a repo var when one exists.
               uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
               with:
                   method: chat.postMessage

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -146,21 +146,23 @@ jobs:
             # This job runs after posthog-js is already published; it only opens the
             # dependency-bump PR in the PostHog/posthog monorepo. A failure here means
             # the upgrade PR could not be opened, not that the release failed, so it
-            # emits its own event rather than the release-failure one.
-            # CDP function: https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
-            - name: Send failure event to PostHog
+            # posts an accurate alert rather than a "Failed to release" one.
+            - name: Notify Slack that the upgrade PR failed
               if: ${{ failure() }}
-              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
-              with:
-                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
-                  event: 'posthog-js-github-upgrade-pr-failure'
-                  properties: >-
-                      {
-                        "commitSha": "${{ github.sha }}",
-                        "jobStatus": "${{ job.status }}",
-                        "ref": "${{ github.ref }}",
-                        "repository": "PostHog/posthog",
-                        "packageName": "${{ github.event.inputs.package_name }}",
-                        "packageVersion": "${{ github.event.inputs.package_version }}",
-                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                      }
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  # #alerts-posthog-js; override with a repo var when one exists.
+                  SLACK_CHANNEL_ID: ${{ vars.SLACK_ALERTS_POSTHOG_JS_CHANNEL_ID || 'C07HTMN9X47' }}
+                  PACKAGE_NAME: ${{ github.event.inputs.package_name }}
+                  PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
+                  RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  text=":warning: Could not open the PostHog upgrade PR for \`${PACKAGE_NAME}@${PACKAGE_VERSION}\` — the release itself succeeded. <${RUN_URL}|View workflow run>"
+                  response=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+                    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+                    -H 'Content-type: application/json; charset=utf-8' \
+                    -d "$(jq -n --arg channel "$SLACK_CHANNEL_ID" --arg text "$text" '{channel: $channel, text: $text}')")
+                  if [ "$(echo "$response" | jq -r '.ok')" != "true" ]; then
+                      echo "Slack notification failed: $response"
+                      exit 1
+                  fi

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -170,20 +170,13 @@ jobs:
 
             - name: Notify Slack that the upgrade PR failed
               if: ${{ failure() }}
-              env:
-                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
-                  # #alerts-posthog-js; override with a repo var when one exists.
-                  SLACK_CHANNEL_ID: ${{ vars.SLACK_ALERTS_POSTHOG_JS_CHANNEL_ID || 'C07HTMN9X47' }}
-                  PACKAGE_NAME: ${{ github.event.inputs.package_name }}
-                  PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
-                  RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-              run: |
-                  text=":warning: Could not open the PostHog upgrade PR for \`${PACKAGE_NAME}@${PACKAGE_VERSION}\` — the release itself succeeded. <${RUN_URL}|View workflow run>"
-                  response=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
-                    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-                    -H 'Content-type: application/json; charset=utf-8' \
-                    -d "$(jq -n --arg channel "$SLACK_CHANNEL_ID" --arg text "$text" '{channel: $channel, text: $text}')")
-                  if [ "$(echo "$response" | jq -r '.ok')" != "true" ]; then
-                      echo "Slack notification failed: $response"
-                      exit 1
-                  fi
+              # #alerts-posthog-js; override with a repo var when one exists.
+              uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  payload: |
+                      {
+                        "channel": "${{ vars.SLACK_ALERTS_POSTHOG_JS_CHANNEL_ID || 'C07HTMN9X47' }}",
+                        "text": ":warning: Could not open the PostHog upgrade PR for `${{ github.event.inputs.package_name }}@${{ github.event.inputs.package_version }}` — the release itself succeeded. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                      }

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -145,8 +145,29 @@ jobs:
 
             # This job runs after posthog-js is already published; it only opens the
             # dependency-bump PR in the PostHog/posthog monorepo. A failure here means
-            # the upgrade PR could not be opened, not that the release failed, so it
-            # posts an accurate alert rather than a "Failed to release" one.
+            # the upgrade PR could not be opened, not that the release failed. It records
+            # its own analytics event and posts an accurate alert rather than a
+            # "Failed to release" one.
+            - name: Send failure event to PostHog
+              if: ${{ failure() }}
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  # Distinct from release.yml's event name so the release-failure CDP
+                  # alert does not fire for an upgrade-PR failure.
+                  event: 'posthog-js-github-upgrade-pr-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "${{ job.status }}",
+                        "ref": "${{ github.ref }}",
+                        "repository": "PostHog/posthog",
+                        "packageName": "${{ github.event.inputs.package_name }}",
+                        "packageVersion": "${{ github.event.inputs.package_version }}",
+                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                      }
+
             - name: Notify Slack that the upgrade PR failed
               if: ${{ failure() }}
               env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,7 @@ jobs:
                   fi
 
             - name: Publish ${{ matrix.package.name }} to NPM
+              id: publish
               if: steps.preflight.outputs.should-publish == 'true'
               env:
                   NPM_CONFIG_PROVENANCE: true
@@ -338,6 +339,10 @@ jobs:
                       else
                           exit $status
                       fi
+                  else
+                      # published=true only when this run did the publish, so
+                      # downstream one-shot steps run exactly once across a race.
+                      echo "published=true" >> "$GITHUB_OUTPUT"
                   fi
 
             - name: Tag repository with package_name and package_version
@@ -381,7 +386,7 @@ jobs:
             ########################################################
             ############## posthog-js auto-update ##################
             - name: Dispatch posthog upgrade for posthog-js
-              if: matrix.package.name == 'posthog-js' && steps.preflight.outputs.should-publish == 'true'
+              if: matrix.package.name == 'posthog-js' && steps.publish.outputs.published == 'true'
               env:
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,45 +303,92 @@ jobs:
               if: steps.check-package-version.outputs.is-new-version == 'true'
               run: pnpm install --frozen-lockfile && pnpm build
 
-            - name: Publish ${{ matrix.package.name }} to NPM
+            # A concurrent release run (main gets a push per merge, plus one per
+            # `[version bump]` commit) can publish this exact version during the
+            # install/build above. Re-check the registry right before publishing so
+            # an already-published version short-circuits the publish/tag/release
+            # tail as a no-op instead of erroring on npm's republish rejection.
+            - name: Check registry before publishing
+              id: preflight
               if: steps.check-package-version.outputs.is-new-version == 'true'
+              env:
+                  PACKAGE_NAME: ${{ matrix.package.name }}
+                  PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
               run: |
-                  pnpm publish --filter=${{ matrix.package.name }} --access public --no-git-checks
+                  if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+                      echo "$PACKAGE_NAME@$PACKAGE_VERSION is already on npm; skipping publish."
+                      echo "should-publish=false" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "should-publish=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Publish ${{ matrix.package.name }} to NPM
+              if: steps.preflight.outputs.should-publish == 'true'
               env:
                   NPM_CONFIG_PROVENANCE: true
+                  PACKAGE_NAME: ${{ matrix.package.name }}
+                  PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
+              run: |
+                  set +e
+                  pnpm publish --filter="$PACKAGE_NAME" --access public --no-git-checks
+                  status=$?
+                  set -e
+                  if [ $status -ne 0 ]; then
+                      # A concurrent run can publish this exact version in the seconds
+                      # between the preflight check and here; npm rejects the republish
+                      # with a 403. The version being on the registry is the desired end
+                      # state, so treat that specific case as success.
+                      if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+                          echo "$PACKAGE_NAME@$PACKAGE_VERSION already exists on npm after a concurrent publish; treating as success."
+                      else
+                          exit $status
+                      fi
+                  fi
 
             - name: Tag repository with package_name and package_version
-              if: steps.check-package-version.outputs.is-new-version == 'true'
+              if: steps.preflight.outputs.should-publish == 'true'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
               run: |
-                  gh api "repos/${{ github.repository }}/git/refs" \
-                    -f "ref=refs/tags/$PACKAGE_NAME@$COMMITTED_VERSION" \
-                    -f "sha=$(git rev-parse HEAD)"
+                  # A concurrent run that publishes first also creates this tag, so
+                  # skip when it already exists rather than failing on a 422.
+                  if gh api "repos/${{ github.repository }}/git/refs/tags/$PACKAGE_NAME@$COMMITTED_VERSION" >/dev/null 2>&1; then
+                      echo "Tag $PACKAGE_NAME@$COMMITTED_VERSION already exists; skipping."
+                  else
+                      gh api "repos/${{ github.repository }}/git/refs" \
+                        -f "ref=refs/tags/$PACKAGE_NAME@$COMMITTED_VERSION" \
+                        -f "sha=$(git rev-parse HEAD)"
+                  fi
 
             - name: Create GitHub release
-              if: steps.check-package-version.outputs.is-new-version == 'true'
+              if: steps.preflight.outputs.should-publish == 'true'
               working-directory: ${{ steps.get-package-path.outputs.path }}
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
               run: |
-                  # read from the first until the second header in the changelog file
-                  # this assumes the formatting of the file
-                  # and that this workflow is always running for the most recent entry in the file
-                  LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
-                  gh release create "$PACKAGE_NAME@$COMMITTED_VERSION" \
-                    --target main \
-                    --title "$PACKAGE_NAME@$COMMITTED_VERSION" \
-                    --notes "$LAST_CHANGELOG_ENTRY"
+                  # A concurrent run that publishes first also creates this release, so
+                  # skip when it already exists rather than failing.
+                  if gh release view "$PACKAGE_NAME@$COMMITTED_VERSION" >/dev/null 2>&1; then
+                      echo "Release $PACKAGE_NAME@$COMMITTED_VERSION already exists; skipping."
+                  else
+                      # read from the first until the second header in the changelog file
+                      # this assumes the formatting of the file
+                      # and that this workflow is always running for the most recent entry in the file
+                      LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
+                      gh release create "$PACKAGE_NAME@$COMMITTED_VERSION" \
+                        --target main \
+                        --title "$PACKAGE_NAME@$COMMITTED_VERSION" \
+                        --notes "$LAST_CHANGELOG_ENTRY"
+                  fi
 
             ########################################################
             ############## posthog-js auto-update ##################
             - name: Dispatch posthog upgrade for posthog-js
-              if: matrix.package.name == 'posthog-js' && steps.check-package-version.outputs.is-new-version == 'true'
+              if: matrix.package.name == 'posthog-js' && steps.preflight.outputs.should-publish == 'true'
               env:
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,11 +303,8 @@ jobs:
               if: steps.check-package-version.outputs.is-new-version == 'true'
               run: pnpm install --frozen-lockfile && pnpm build
 
-            # A concurrent release run (main gets a push per merge, plus one per
-            # `[version bump]` commit) can publish this exact version during the
-            # install/build above. Re-check the registry right before publishing so
-            # an already-published version short-circuits the publish/tag/release
-            # tail as a no-op instead of erroring on npm's republish rejection.
+            # Re-check the registry after the build: a concurrent run may have
+            # already published this version, making the publish tail a no-op.
             - name: Check registry before publishing
               id: preflight
               if: steps.check-package-version.outputs.is-new-version == 'true'
@@ -334,10 +331,8 @@ jobs:
                   status=$?
                   set -e
                   if [ $status -ne 0 ]; then
-                      # A concurrent run can publish this exact version in the seconds
-                      # between the preflight check and here; npm rejects the republish
-                      # with a 403. The version being on the registry is the desired end
-                      # state, so treat that specific case as success.
+                      # A concurrent publish of the same version returns a 403; the
+                      # version being on the registry is the desired end state.
                       if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version >/dev/null 2>&1; then
                           echo "$PACKAGE_NAME@$PACKAGE_VERSION already exists on npm after a concurrent publish; treating as success."
                       else
@@ -352,8 +347,7 @@ jobs:
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
               run: |
-                  # A concurrent run that publishes first also creates this tag, so
-                  # skip when it already exists rather than failing on a 422.
+                  # Skip when a concurrent run already created the tag.
                   if gh api "repos/${{ github.repository }}/git/refs/tags/$PACKAGE_NAME@$COMMITTED_VERSION" >/dev/null 2>&1; then
                       echo "Tag $PACKAGE_NAME@$COMMITTED_VERSION already exists; skipping."
                   else
@@ -370,8 +364,7 @@ jobs:
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
               run: |
-                  # A concurrent run that publishes first also creates this release, so
-                  # skip when it already exists rather than failing.
+                  # Skip when a concurrent run already created the release.
                   if gh release view "$PACKAGE_NAME@$COMMITTED_VERSION" >/dev/null 2>&1; then
                       echo "Release $PACKAGE_NAME@$COMMITTED_VERSION already exists; skipping."
                   else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,90 +303,45 @@ jobs:
               if: steps.check-package-version.outputs.is-new-version == 'true'
               run: pnpm install --frozen-lockfile && pnpm build
 
-            # Re-check the registry after the build: a concurrent run may have
-            # already published this version, making the publish tail a no-op.
-            - name: Check registry before publishing
-              id: preflight
-              if: steps.check-package-version.outputs.is-new-version == 'true'
-              env:
-                  PACKAGE_NAME: ${{ matrix.package.name }}
-                  PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
-              run: |
-                  if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version >/dev/null 2>&1; then
-                      echo "$PACKAGE_NAME@$PACKAGE_VERSION is already on npm; skipping publish."
-                      echo "should-publish=false" >> "$GITHUB_OUTPUT"
-                  else
-                      echo "should-publish=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Publish ${{ matrix.package.name }} to NPM
-              id: publish
-              if: steps.preflight.outputs.should-publish == 'true'
+              if: steps.check-package-version.outputs.is-new-version == 'true'
+              run: |
+                  pnpm publish --filter=${{ matrix.package.name }} --access public --no-git-checks
               env:
                   NPM_CONFIG_PROVENANCE: true
-                  PACKAGE_NAME: ${{ matrix.package.name }}
-                  PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
-              run: |
-                  set +e
-                  pnpm publish --filter="$PACKAGE_NAME" --access public --no-git-checks
-                  status=$?
-                  set -e
-                  if [ $status -ne 0 ]; then
-                      # A concurrent publish of the same version returns a 403; the
-                      # version being on the registry is the desired end state.
-                      if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version >/dev/null 2>&1; then
-                          echo "$PACKAGE_NAME@$PACKAGE_VERSION already exists on npm after a concurrent publish; treating as success."
-                      else
-                          exit $status
-                      fi
-                  else
-                      # published=true only when this run did the publish, so
-                      # downstream one-shot steps run exactly once across a race.
-                      echo "published=true" >> "$GITHUB_OUTPUT"
-                  fi
 
             - name: Tag repository with package_name and package_version
-              if: steps.preflight.outputs.should-publish == 'true'
+              if: steps.check-package-version.outputs.is-new-version == 'true'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
               run: |
-                  # Skip when a concurrent run already created the tag.
-                  if gh api "repos/${{ github.repository }}/git/refs/tags/$PACKAGE_NAME@$COMMITTED_VERSION" >/dev/null 2>&1; then
-                      echo "Tag $PACKAGE_NAME@$COMMITTED_VERSION already exists; skipping."
-                  else
-                      gh api "repos/${{ github.repository }}/git/refs" \
-                        -f "ref=refs/tags/$PACKAGE_NAME@$COMMITTED_VERSION" \
-                        -f "sha=$(git rev-parse HEAD)"
-                  fi
+                  gh api "repos/${{ github.repository }}/git/refs" \
+                    -f "ref=refs/tags/$PACKAGE_NAME@$COMMITTED_VERSION" \
+                    -f "sha=$(git rev-parse HEAD)"
 
             - name: Create GitHub release
-              if: steps.preflight.outputs.should-publish == 'true'
+              if: steps.check-package-version.outputs.is-new-version == 'true'
               working-directory: ${{ steps.get-package-path.outputs.path }}
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
               run: |
-                  # Skip when a concurrent run already created the release.
-                  if gh release view "$PACKAGE_NAME@$COMMITTED_VERSION" >/dev/null 2>&1; then
-                      echo "Release $PACKAGE_NAME@$COMMITTED_VERSION already exists; skipping."
-                  else
-                      # read from the first until the second header in the changelog file
-                      # this assumes the formatting of the file
-                      # and that this workflow is always running for the most recent entry in the file
-                      LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
-                      gh release create "$PACKAGE_NAME@$COMMITTED_VERSION" \
-                        --target main \
-                        --title "$PACKAGE_NAME@$COMMITTED_VERSION" \
-                        --notes "$LAST_CHANGELOG_ENTRY"
-                  fi
+                  # read from the first until the second header in the changelog file
+                  # this assumes the formatting of the file
+                  # and that this workflow is always running for the most recent entry in the file
+                  LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
+                  gh release create "$PACKAGE_NAME@$COMMITTED_VERSION" \
+                    --target main \
+                    --title "$PACKAGE_NAME@$COMMITTED_VERSION" \
+                    --notes "$LAST_CHANGELOG_ENTRY"
 
             ########################################################
             ############## posthog-js auto-update ##################
             - name: Dispatch posthog upgrade for posthog-js
-              if: matrix.package.name == 'posthog-js' && steps.publish.outputs.published == 'true'
+              if: matrix.package.name == 'posthog-js' && steps.check-package-version.outputs.is-new-version == 'true'
               env:
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}


### PR DESCRIPTION
## Problem

The `🚨 Failed to release posthog-js@X 🚨` alerts in **#alerts-posthog-js** are misleading: the release actually **succeeds**. They fire from the downstream **PostHog Upgrade** workflow (`posthog-upgrade.yml`), which runs *after* publish to open a dependency-bump PR in the `PostHog/posthog` monorepo.

Worked example — `posthog-js@1.396.4` (2026-07-01):
- Release run [`28531105556`](https://github.com/PostHog/posthog-js/actions/runs/28531105556) published to npm + tagged + created the GitHub release at 17:03:12; its failure-notification steps were **skipped**. ✅
- PostHog Upgrade run [`28534364662`](https://github.com/PostHog/posthog-js/actions/runs/28534364662) failed at 17:04:05 in its `pnpm i` step:
  ```
  ERR_PNPM_EXOTIC_SUBDEP  Exotic dependency "uWebSockets.js" (resolved via url) is not allowed
  in subdependencies when blockExoticSubdeps is enabled
    ...while installing the dependencies of ultimate-express@2.0.9
  ```
- Both `release.yml` and `posthog-upgrade.yml` emitted the **same** `posthog-js-github-release-workflow-failure` event, and the CDP function ([project 11213](https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe)) renders any of them as "Failed to release."

`concurrency: group: release` serializes releases, so there is **no** concurrent-publish race — an earlier revision of this PR chased that wrong diagnosis and has been reverted (thanks to the reviewer who flagged it).

## Changes

Scoped to `posthog-upgrade.yml`; `release.yml` is untouched (genuine release failures still alert exactly as before):

- The failure event is renamed to a distinct **`posthog-js-github-upgrade-pr-failure`**, so the release-failure CDP alert no longer fires for an upgrade failure. It's kept (best-effort) so upgrade-failure analytics are preserved.
- A new step posts an **accurate alert** to #alerts-posthog-js via `slackapi/slack-github-action` (the same pinned action the org's `slack-thread-reply` wraps):
  > ⚠️ The PostHog/posthog dependency bump for `posthog-js@X` failed — this is the downstream monorepo upgrade, not the posthog-js release.

The `posthog-js-github-release-workflow-failure` event is **not lost** — `release.yml` still emits it for real release failures.

**Assumption to confirm before merge:** the `SLACK_CLIENT_LIBRARIES_BOT_TOKEN` bot must be a member of **#alerts-posthog-js** (`C07HTMN9X47`) for `chat.postMessage` to succeed. The channel can be overridden with a `SLACK_ALERTS_POSTHOG_JS_CHANNEL_ID` repo var.

## Follow-up (separate, out of scope)

The recurring trigger is the `ultimate-express@2.0.9` → `uWebSockets.js` exotic subdep blocked by `blockExoticSubdeps` in `PostHog/posthog`; the upgrade `pnpm i` keeps failing until that's resolved. This PR only fixes the misleading alert, not the underlying install failure.

## Release info Sub-libraries affected

### Libraries affected

CI-only change — no library code changes, no version bump, no changeset.

## Checklist

- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Anna directed this while investigating a false `Failed to release posthog-js@1.396.4` alert.

Claude Code first diagnosed a concurrent-publish race and proposed idempotent publish/tag/release guards; a reviewer pushed back (releases are concurrency-1). Re-investigation via the Actions API found the true source — the PostHog Upgrade run failing at `pnpm i` and emitting the shared release-failure event. The idempotency commits were reverted and the branch repurposed. Iterations settled on: a distinct event name (stops the false CDP alert without losing the release event, which `release.yml` still emits) plus a direct, accurate Slack alert (self-contained, no CDP dependency, no alerting gap). Not manually tested — workflow behavior is only observable on a real release, and Slack bot channel membership still needs confirming.
