### PR TITLE
fix(autocapture): guard getComputedStyle against cross-realm elements

### DIFF
--- a/.changeset/gentle-owls-hide.md
+++ b/.changeset/gentle-owls-hide.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Prevent uncaught `getComputedStyle` crashes in heatmaps and autocapture when the event target is a cross-realm element (e.g. from an iframe or synthetic event)

--- a/packages/browser/playwright/mocked/heatmaps.spec.ts
+++ b/packages/browser/playwright/mocked/heatmaps.spec.ts
@@ -94,6 +94,41 @@ test.describe('Heatmaps', () => {
         expect(rageclickEvents.length).toBeGreaterThan(0)
     })
 
+    test('does not crash when getComputedStyle throws for the event target', async ({ page, context }) => {
+        await start(startOptions, page, context)
+
+        await page.resetCapturedEvents()
+
+        const pageErrors: string[] = []
+        page.on('pageerror', (error) => pageErrors.push(error.message))
+
+        await page.evaluate(() => {
+            const el = document.createElement('div')
+            el.id = 'cross-realm-target'
+            document.body.appendChild(el)
+
+            const original = window.getComputedStyle.bind(window)
+            window.getComputedStyle = ((element: Element, pseudoElt?: string | null) => {
+                if (element === el) {
+                    throw new TypeError(
+                        "Argument 1 ('element') to Window.getComputedStyle must be an instance of Element"
+                    )
+                }
+                return original(element, pseudoElt)
+            }) as typeof window.getComputedStyle
+
+            el.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 5, clientY: 5 }))
+            el.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 5, clientY: 5 }))
+        })
+
+        await pollUntilEventCaptured(page, '$$heatmap')
+
+        expect(pageErrors).toEqual([])
+
+        const heatmapEvents = (await page.capturedEvents()).filter((event) => event.event === '$$heatmap')
+        expect(heatmapEvents.length).toBeGreaterThanOrEqual(1)
+    })
+
     test('does not capture events when heatmaps are disabled', async ({ page, context }) => {
         await start(
             {

--- a/packages/browser/src/__tests__/autocapture-utils.test.ts
+++ b/packages/browser/src/__tests__/autocapture-utils.test.ts
@@ -23,6 +23,7 @@ import { AutocaptureConfig, PostHogConfig } from '../types'
 describe(`Autocapture utility functions`, () => {
     afterEach(() => {
         document!.getElementsByTagName('html')[0].innerHTML = ''
+        jest.restoreAllMocks()
     })
 
     describe(`getSafeText`, () => {
@@ -209,6 +210,18 @@ describe(`Autocapture utility functions`, () => {
             expect(shouldCaptureDomEvent(null as unknown as Element, makeMouseEvent({}))).toBe(false)
             expect(shouldCaptureDomEvent(undefined as unknown as Element, makeMouseEvent({}))).toBe(false)
             expect(shouldCaptureDomEvent(`div` as unknown as Element, makeMouseEvent({}))).toBe(false)
+        })
+
+        it(`does not throw when getComputedStyle throws for a cross-realm element`, () => {
+            jest.spyOn(window, 'getComputedStyle').mockImplementation(() => {
+                throw new TypeError("Argument 1 ('element') to Window.getComputedStyle must be an instance of Element")
+            })
+
+            const el = document!.createElement(`div`)
+            const parent = document!.createElement(`div`)
+            parent.appendChild(el)
+
+            expect(() => shouldCaptureDomEvent(el, makeMouseEvent({}))).not.toThrow()
         })
 
         it(`should NOT capture "click" events on <form> elements`, () => {

--- a/packages/browser/src/__tests__/heatmaps.test.ts
+++ b/packages/browser/src/__tests__/heatmaps.test.ts
@@ -113,6 +113,22 @@ describe('heatmaps', () => {
         expect(posthog.heatmaps!.getAndClearBuffer()).toBeDefined()
     })
 
+    it('does not crash when getComputedStyle throws for a cross-realm element', async () => {
+        jest.spyOn(window, 'getComputedStyle').mockImplementation(() => {
+            throw new TypeError("Argument 1 ('element') to Window.getComputedStyle must be an instance of Element")
+        })
+
+        const el = document.createElement('div')
+        document.body.appendChild(el)
+
+        expect(() => posthog.heatmaps?.['_onClick']?.(createMockMouseEvent({ target: el }))).not.toThrow()
+
+        jest.advanceTimersByTime(posthog.heatmaps!.flushIntervalMilliseconds + 1)
+
+        expect(beforeSendMock).toBeCalledTimes(1)
+        expect(beforeSendMock.mock.lastCall[0].properties.$heatmap_data['http://replaced/'][0].target_fixed).toBe(false)
+    })
+
     it('should handle empty mouse moves', async () => {
         posthog.heatmaps?.['_onMouseMove']?.(new Event('mousemove'))
 

--- a/packages/browser/src/__tests__/heatmaps.test.ts
+++ b/packages/browser/src/__tests__/heatmaps.test.ts
@@ -58,6 +58,10 @@ describe('heatmaps', () => {
         posthog.register({ $current_test_name: expect.getState().currentTestName })
     })
 
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
     it('should send generated heatmap data', async () => {
         posthog.heatmaps?.['_onClick']?.(createMockMouseEvent())
 
@@ -127,6 +131,25 @@ describe('heatmaps', () => {
 
         expect(beforeSendMock).toBeCalledTimes(1)
         expect(beforeSendMock.mock.lastCall[0].properties.$heatmap_data['http://replaced/'][0].target_fixed).toBe(false)
+    })
+
+    it('does not crash on mousemove when getComputedStyle throws for a cross-realm element', async () => {
+        jest.spyOn(window, 'getComputedStyle').mockImplementation(() => {
+            throw new TypeError("Argument 1 ('element') to Window.getComputedStyle must be an instance of Element")
+        })
+
+        const el = document.createElement('div')
+        document.body.appendChild(el)
+
+        posthog.heatmaps?.['_onMouseMove']?.(createMockMouseEvent({ target: el }))
+
+        expect(() => jest.advanceTimersByTime(posthog.heatmaps!.flushIntervalMilliseconds + 1)).not.toThrow()
+
+        expect(beforeSendMock).toBeCalledTimes(1)
+        expect(beforeSendMock.mock.lastCall[0].properties.$heatmap_data['http://replaced/'][0]).toMatchObject({
+            type: 'mousemove',
+            target_fixed: false,
+        })
     })
 
     it('should handle empty mouse moves', async () => {

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -324,10 +324,12 @@ const getElementAndParentsForElement = (el: Element, captureOnAnyElement: false 
         if (captureOnAnyElement || autocaptureCompatibleElements.indexOf(parentNode.tagName.toLowerCase()) > -1) {
             parentIsUsefulElement = true
         } else {
-            const compStyles = window.getComputedStyle(parentNode)
-            if (compStyles && compStyles.getPropertyValue('cursor') === 'pointer') {
-                parentIsUsefulElement = true
-            }
+            try {
+                const compStyles = window.getComputedStyle(parentNode)
+                if (compStyles && compStyles.getPropertyValue('cursor') === 'pointer') {
+                    parentIsUsefulElement = true
+                }
+            } catch {}
         }
 
         targetElementList.push(parentNode)
@@ -409,10 +411,12 @@ export function shouldCaptureDomEvent(
         return false
     }
 
-    const compStyles = window.getComputedStyle(el)
-    if (compStyles && compStyles.getPropertyValue('cursor') === 'pointer' && event.type === 'click') {
-        return true
-    }
+    try {
+        const compStyles = window.getComputedStyle(el)
+        if (compStyles && compStyles.getPropertyValue('cursor') === 'pointer' && event.type === 'click') {
+            return true
+        }
+    } catch {}
 
     const tag = el.tagName.toLowerCase()
     switch (tag) {

--- a/packages/browser/src/heatmaps.ts
+++ b/packages/browser/src/heatmaps.ts
@@ -33,7 +33,14 @@ function elementOrParentPositionMatches(el: Element | null, matches: string[], b
             return false
         }
 
-        if (includes(matches, window?.getComputedStyle(curEl).position)) {
+        let position: string | undefined
+        try {
+            position = (curEl.ownerDocument?.defaultView ?? window)?.getComputedStyle(curEl).position
+        } catch {
+            return false
+        }
+
+        if (includes(matches, position)) {
             return true
         }
 


### PR DESCRIPTION
Closes #1692

## Problem

posthog-js crashes with `TypeError: Argument 1 ('element') to Window.getComputedStyle must be an instance of Element` on real user sessions (reported on WebKit/Apple Mail and Firefox). It surfaces as an uncaught error from the heatmaps mousemove handler and can also fire from autocapture.

The existing `isElementNode` guard only checks `nodeType === 1`, but a cross-realm element (from an iframe, a detached document, or a synthetic event like the ones rxdb dispatches) has `nodeType === 1` yet is **not** `instanceof` the current window's `Element`. `getComputedStyle` does a realm brand-check, so it throws even though the node looks like an element.

## Changes

- `heatmaps.ts` — `elementOrParentPositionMatches` now resolves the style via the element's own realm (`ownerDocument.defaultView`) and wraps the call in `try/catch`, returning `false` (treated as non-fixed) if it throws.
- `autocapture-utils.ts` — wrapped the two `getComputedStyle` pointer-cursor checks (event target + its parents) so the same cross-realm input can't escape the click/change handlers.
- Tests:
  - `heatmaps.test.ts` — click + mousemove regression tests that force `getComputedStyle` to throw.
  - `autocapture-utils.test.ts` — regression test for the autocapture guards.
  - `playwright/mocked/heatmaps.spec.ts` — real-browser regression across **WebKit / Firefox / Chromium**.

Left `element-inference.ts` alone (already inside a `try/catch`) and `product-tours-utils.ts` alone (its element always comes from a same-realm `querySelector`, so the throw isn't reachable).

## Verification

Verified in real browsers, including **WebKit** (the browser from the original report):

| Browser  | Fixed bundle | Pre-fix bundle |
| -------- | ------------ | -------------- |
| WebKit   | ✅ pass      | ❌ fails (crash breaks capture) |
| Firefox  | ✅ pass      | — |
| Chromium | ✅ pass      | ❌ fails (crash breaks capture) |

The Playwright test forces `getComputedStyle` to throw the exact `TypeError` on a mousemove/click target and asserts there is no uncaught `pageerror` and that heatmap data is still captured. Reverting the source fix makes the same test fail, confirming it is a genuine regression guard.

Unit tests: `heatmaps.test.ts` + `autocapture-utils.test.ts` = 248 passing.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Investigated issue #1692 with Claude Code, tracing the crash from the Sentry stacktrace to `getComputedStyle` in heatmaps/autocapture.
- Root cause: cross-realm elements pass the `nodeType === 1` guard but fail `getComputedStyle`'s realm check. Chose the codebase's existing inline `try/catch` idiom over a shared helper to match surrounding style.
- Scoped hardening to the two call sites that receive arbitrary event targets; deliberately skipped sites that are already guarded or only see same-realm elements.
- Ran a pre-PR review loop (fresh-context reviewer + greptile). Added the mousemove and autocapture regression tests and the spy restore in response to their feedback.
- Verified with jest (248 pass) and Playwright across WebKit/Firefox/Chromium, including a before/after check proving the browser test reproduces the crash without the fix.
