### PR TITLE
fix: skip update_referrer_info when user has registered custom $referrer

### DIFF
--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1352,17 +1352,16 @@ export class PostHog implements PostHogInterface {
             this.sessionPersistence.update_campaign_params()
         }
         if (this.config.save_referrer) {
-            // posthog.register() writes to this.persistence (regular persistence).
-            // update_referrer_info() writes to this.sessionPersistence, which is
-            // merged AFTER persistence in calculateEventProperties — so session values
-            // silently win for shared keys.  Skip the SDK update when the user has
-            // explicitly registered a custom $referrer or $referring_domain via
-            // posthog.register(), so their value is not overwritten on every pageview
-            // (e.g. in SPA-in-iframe scenarios where document.referrer is the iframe
-            // origin rather than the embedding page).
+            // Always update session referrer so fresh page loads reflect document.referrer.
+            // Then restore any value the user has explicitly registered via posthog.register()
+            // on a per-property basis, so a custom $referrer doesn't suppress an auto-detected
+            // $referring_domain (and vice-versa).
+            this.sessionPersistence.update_referrer_info()
             const persistenceProps = this.persistence.props
-            if (!('$referrer' in persistenceProps) && !('$referring_domain' in persistenceProps)) {
-                this.sessionPersistence.update_referrer_info()
+            for (const key of ['$referrer', '$referring_domain'] as const) {
+                if (key in persistenceProps) {
+                    this.sessionPersistence.register({ [key]: persistenceProps[key] })
+                }
             }
         }
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1352,7 +1352,18 @@ export class PostHog implements PostHogInterface {
             this.sessionPersistence.update_campaign_params()
         }
         if (this.config.save_referrer) {
-            this.sessionPersistence.update_referrer_info()
+            // posthog.register() writes to this.persistence (regular persistence).
+            // update_referrer_info() writes to this.sessionPersistence, which is
+            // merged AFTER persistence in calculateEventProperties — so session values
+            // silently win for shared keys.  Skip the SDK update when the user has
+            // explicitly registered a custom $referrer or $referring_domain via
+            // posthog.register(), so their value is not overwritten on every pageview
+            // (e.g. in SPA-in-iframe scenarios where document.referrer is the iframe
+            // origin rather than the embedding page).
+            const persistenceProps = this.persistence.props
+            if (!('$referrer' in persistenceProps) && !('$referring_domain' in persistenceProps)) {
+                this.sessionPersistence.update_referrer_info()
+            }
         }
 
         if (this.config.save_campaign_params || this.config.save_referrer) {


### PR DESCRIPTION
Closes PostHog/posthog-js#4208

## Problem

`posthog.register({ $referrer: '...', $referring_domain: '...' })` registers properties in `this.persistence`. However, on every `posthog.capture('$pageview')`, `update_referrer_info()` writes `document.referrer` to `this.sessionPersistence`.

In `calculateEventProperties`, the merge order is:

```ts
properties = extend(
    {},
    infoProperties,
    this.persistence.properties(),
    this.sessionPersistence.properties(),   // ← wins for shared keys
    properties
)
```

Because `sessionPersistence` is merged **after** `persistence`, the SDK-set `$referrer` (from `document.referrer`) silently overwrites the user-registered value on every pageview. This breaks SPAs embedded as iframes, where `document.referrer` is the iframe's own origin rather than the embedding page's domain.

## Fix

Before calling `update_referrer_info()`, check whether `$referrer` or `$referring_domain` already exists in `this.persistence.props`. If the user has explicitly registered custom values, skip the automatic update so the user-set values survive.

This is a targeted guard at the call site and requires no changes to `PostHogPersistence`.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| No manual `register()` call | `document.referrer` set on every pageview ✓ | unchanged ✓ |
| User called `posthog.register({ $referrer })` | `document.referrer` overwrites on every pageview ✗ | user value preserved ✓ |
| User called `posthog.unregister('$referrer')` | `document.referrer` overwrites ✓ | `document.referrer` used ✓ |