### PR TITLE
fix: Retry flags requests on 502 and 504

### DIFF
--- a/.changeset/tall-walls-retry.md
+++ b/.changeset/tall-walls-retry.md
@@ -1,0 +1,7 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+'posthog-node': patch
+---
+
+Retry `/flags` requests that receive HTTP 502 or 504 responses.

--- a/.changeset/tall-walls-retry.md
+++ b/.changeset/tall-walls-retry.md
@@ -1,7 +1,5 @@
 ---
 '@posthog/core': patch
-'posthog-js': patch
-'posthog-node': patch
 ---
 
 Retry `/flags` requests that receive HTTP 502 or 504 responses.

--- a/.changeset/tall-walls-retry.md
+++ b/.changeset/tall-walls-retry.md
@@ -1,5 +1,10 @@
 ---
 '@posthog/core': patch
+'posthog-node': patch
+'posthog-js-lite': patch
+'posthog-react-native': patch
+'@posthog/next': patch
+'@posthog/nuxt': patch
 ---
 
-Retry `/flags` requests that receive HTTP 502 or 504 responses.
+Retry `/flags` requests that receive HTTP 502 or 504 responses across SDKs that use the shared core flags client.

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -1251,6 +1251,54 @@ describe('PostHog Feature Flags v4', () => {
         expect(mocks.fetch).toHaveBeenCalledTimes(1)
       })
 
+      it.each([502, 504])('should retry HTTP %i responses and return the successful flags response', async (status) => {
+        let flagsRequestCount = 0
+        ;[posthog, mocks] = createTestClient(
+          'TEST_API_KEY',
+          { flushAt: 1, fetchRetryCount: 2, fetchRetryDelay: 1 },
+          (_mocks) => {
+            _mocks.fetch.mockImplementation((url) => {
+              if (url.includes('/flags/')) {
+                flagsRequestCount++
+                if (flagsRequestCount < 2) {
+                  return Promise.resolve({
+                    status,
+                    text: () => Promise.resolve('error'),
+                    json: () => Promise.resolve({ error: 'error' }),
+                  })
+                }
+                return Promise.resolve({
+                  status: 200,
+                  text: () => Promise.resolve('ok'),
+                  json: () =>
+                    Promise.resolve({
+                      flags: createMockFeatureFlags(),
+                      requestId: 'retry-success',
+                      evaluatedAt: 1640995200000,
+                    }),
+                })
+              }
+              return Promise.resolve({
+                status: 200,
+                text: () => Promise.resolve('ok'),
+                json: () => Promise.resolve({ status: 'ok' }),
+              })
+            })
+          }
+        )
+
+        const resultPromise = posthog.getFlags('distinct-id')
+        await waitForPromises()
+        await jest.advanceTimersByTimeAsync(1)
+        const result = await resultPromise
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.response.featureFlags).toEqual(expectedFeatureFlagResponses)
+        }
+        expect(mocks.fetch).toHaveBeenCalledTimes(2)
+      })
+
       it('should not retry when featureFlagsRequestMaxRetries is 0', async () => {
         ;[posthog, mocks] = createTestClient(
           'TEST_API_KEY',

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -1299,6 +1299,40 @@ describe('PostHog Feature Flags v4', () => {
         expect(mocks.fetch).toHaveBeenCalledTimes(2)
       })
 
+      it.each([502, 504])('should return api_error after exhausting retries for HTTP %i responses', async (status) => {
+        ;[posthog, mocks] = createTestClient(
+          'TEST_API_KEY',
+          { flushAt: 1, fetchRetryCount: 2, fetchRetryDelay: 1, featureFlagsRequestMaxRetries: 2 },
+          (_mocks) => {
+            _mocks.fetch.mockImplementation((url) => {
+              if (url.includes('/flags/')) {
+                return Promise.resolve({
+                  status,
+                  text: () => Promise.resolve('error'),
+                  json: () => Promise.resolve({ error: 'error' }),
+                })
+              }
+              return Promise.resolve({
+                status: 200,
+                text: () => Promise.resolve('ok'),
+                json: () => Promise.resolve({ status: 'ok' }),
+              })
+            })
+          }
+        )
+
+        const resultPromise = posthog.getFlags('distinct-id')
+        await waitForPromises()
+        await jest.advanceTimersByTimeAsync(1)
+        await jest.advanceTimersByTimeAsync(1)
+
+        await expect(resultPromise).resolves.toEqual({
+          success: false,
+          error: { type: 'api_error', statusCode: status },
+        })
+        expect(mocks.fetch).toHaveBeenCalledTimes(3)
+      })
+
       it('should not retry when featureFlagsRequestMaxRetries is 0', async () => {
         ;[posthog, mocks] = createTestClient(
           'TEST_API_KEY',

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -113,7 +113,13 @@ export function isPostHogFetchNetworkError(err: unknown): err is PostHogFetchNet
   return err instanceof PostHogFetchNetworkError
 }
 
-function isRetryableFlagsFetchError(err: unknown): err is PostHogFetchNetworkError {
+function isRetryableFlagsFetchError(
+  err: unknown
+): err is PostHogFetchNetworkError | (PostHogFetchHttpError & { status: 502 | 504 }) {
+  if (err instanceof PostHogFetchHttpError) {
+    return err.status === 502 || err.status === 504
+  }
+
   if (!(err instanceof PostHogFetchNetworkError)) {
     return false
   }
@@ -616,7 +622,7 @@ export abstract class PostHogCoreStateless {
 
     this._logger.info('Flags URL', url)
 
-    // Retry only network/transport/timeout failures for /flags. HTTP/API status errors are surfaced immediately.
+    // Retry only network/transport/timeout failures and selected gateway HTTP errors for /flags.
     return this.fetchWithRetry(
       url,
       fetchOptions,


### PR DESCRIPTION
## Problem

The shared `/flags` request path retried transient network errors, but did not retry gateway HTTP responses. The SDK test harness now covers 502/504 followed by success and expects the second `/flags` attempt to return the flag result.

## Changes

- Allow `/flags` retry logic to retry HTTP 502 and 504 responses, while preserving the existing network retry behavior and ECONNREFUSED exclusion.
- Keep other HTTP statuses such as 408/429/500/503 non-retryable for `/flags`.
- Add focused core feature flag tests for 502 and 504 retry-to-success behavior.
- Add a changeset for `@posthog/core`, `posthog-js`, and `posthog-node`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

Also affects the shared `@posthog/core` package.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a changeset file

## Validation

```sh
pnpm --filter @posthog/core test:unit -- posthog.featureflags.spec.ts --runInBand
pnpm --filter @posthog/core lint
pnpm --filter @posthog/types build && pnpm --filter @posthog/core build
```

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by an AI coding agent from a human-directed request. The change is intentionally limited to shared core `/flags` retry classification: 502 and 504 are now retried through `featureFlagsRequestMaxRetries`; other HTTP statuses retain existing non-retry behavior.
