### PR TITLE
chore: update posthog watcher action

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -30,7 +30,7 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@92f333b9e509f45fb03cbc27dc788e6d9fa5290f
+              uses: PostHog/posthog-watcher-action@66668349cf7569a534d518ec70bd3f9afb8932ab
               with:
                   mode: enqueue
                   trigger-drain-workflow: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -42,7 +42,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@92f333b9e509f45fb03cbc27dc788e6d9fa5290f
+              uses: PostHog/posthog-watcher-action@66668349cf7569a534d518ec70bd3f9afb8932ab
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep
@@ -54,5 +54,6 @@ jobs:
                   allow-security-ai: 'true'
                   max-repair-attempts: '3'
                   max-pi-calls: '16'
+                  fix-pr-review-team: PostHog/team-client-libraries
                   approve-project-resources: 'true'
                   state-enabled: 'true'

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -48,7 +48,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@92f333b9e509f45fb03cbc27dc788e6d9fa5290f
+              uses: PostHog/posthog-watcher-action@66668349cf7569a534d518ec70bd3f9afb8932ab
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -58,6 +58,7 @@ jobs:
                   allow-security-ai: 'true'
                   max-repair-attempts: '3'
                   max-pi-calls: '16'
+                  fix-pr-review-team: PostHog/team-client-libraries
                   approve-project-resources: 'true'
                   state-enabled: 'true'
 
@@ -78,7 +79,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@92f333b9e509f45fb03cbc27dc788e6d9fa5290f
+              uses: PostHog/posthog-watcher-action@66668349cf7569a534d518ec70bd3f9afb8932ab
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}
@@ -89,5 +90,6 @@ jobs:
                   allow-security-ai: 'true'
                   max-repair-attempts: '3'
                   max-pi-calls: '16'
+                  fix-pr-review-team: PostHog/team-client-libraries
                   approve-project-resources: 'true'
                   state-enabled: 'true'


### PR DESCRIPTION
## Problem

The PostHog watcher workflows are pinned to an older `PostHog/posthog-watcher-action` commit. The latest watcher action release makes fix PR review teams configurable and no longer defaults to requesting `PostHog/team-client-libraries`.

## Changes

- Updated all watcher workflow action pins to `PostHog/posthog-watcher-action@66668349cf7569a534d518ec70bd3f9afb8932ab`, which includes PostHog/posthog-watcher-action#3.
- Configured `fix-pr-review-team: PostHog/team-client-libraries` for sweep, queue drain, and manual issue processing jobs so generated watcher fix PRs still request the client libraries team.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared by pi in a dedicated git worktree. I checked the merged watcher action PR and used the current `main` commit SHA for the action pin. Because the updated watcher action no longer has a default fix PR review team, the client libraries team is configured explicitly on the jobs that can create watcher fix PRs.

Verification: parsed the updated watcher workflow YAML files and confirmed the previous watcher action SHA is no longer referenced in those workflows.
