### PR TITLE
fix: support suppressing React Native feature flag events

### DIFF
--- a/.changeset/khaki-days-buy.md
+++ b/.changeset/khaki-days-buy.md
@@ -1,0 +1,6 @@
+---
+'posthog-react-native': patch
+'@posthog/core': patch
+---
+
+Add per-call sendEvent option support to React Native feature flag helpers.

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -1064,15 +1064,11 @@ describe('PostHog Feature Flags v4', () => {
           expect(mocks.fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('should NOT send event from getFeatureFlag when sendEvent: false', async () => {
-          expect(posthog.getFeatureFlag('feature-1', { sendEvent: false })).toEqual(true)
-          await waitForPromises()
-          // Only the flags fetch call, no event capture
-          expect(mocks.fetch).toHaveBeenCalledTimes(1)
-        })
-
-        it('should NOT send event from isFeatureEnabled when sendEvent: false', async () => {
-          expect(posthog.isFeatureEnabled('feature-1', { sendEvent: false })).toEqual(true)
+        it.each([
+          ['getFeatureFlag', () => posthog.getFeatureFlag('feature-1', { sendEvent: false })],
+          ['isFeatureEnabled', () => posthog.isFeatureEnabled('feature-1', { sendEvent: false })],
+        ] as const)('should NOT send event from %s when sendEvent: false', async (_, callFn) => {
+          expect(callFn()).toEqual(true)
           await waitForPromises()
           // Only the flags fetch call, no event capture
           expect(mocks.fetch).toHaveBeenCalledTimes(1)

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -1064,6 +1064,20 @@ describe('PostHog Feature Flags v4', () => {
           expect(mocks.fetch).toHaveBeenCalledTimes(1)
         })
 
+        it('should NOT send event from getFeatureFlag when sendEvent: false', async () => {
+          expect(posthog.getFeatureFlag('feature-1', { sendEvent: false })).toEqual(true)
+          await waitForPromises()
+          // Only the flags fetch call, no event capture
+          expect(mocks.fetch).toHaveBeenCalledTimes(1)
+        })
+
+        it('should NOT send event from isFeatureEnabled when sendEvent: false', async () => {
+          expect(posthog.isFeatureEnabled('feature-1', { sendEvent: false })).toEqual(true)
+          await waitForPromises()
+          // Only the flags fetch call, no event capture
+          expect(mocks.fetch).toHaveBeenCalledTimes(1)
+        })
+
         it('should NOT send duplicate events for the same flag key', async () => {
           posthog.getFeatureFlagResult('feature-1')
           await waitForPromises()

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -1060,8 +1060,11 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     }
   }
 
-  getFeatureFlag(key: string): FeatureFlagValue | undefined {
-    const result = this._getFeatureFlagResult(key, { missingFlagBehavior: 'getFeatureFlag' })
+  getFeatureFlag(key: string, options?: FeatureFlagResultOptions): FeatureFlagValue | undefined {
+    const result = this._getFeatureFlagResult(key, {
+      missingFlagBehavior: 'getFeatureFlag',
+      sendEvent: options?.sendEvent,
+    })
     return result?.variant ?? result?.enabled
   }
 
@@ -1129,8 +1132,8 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     }
   }
 
-  isFeatureEnabled(key: string): boolean | undefined {
-    const response = this.getFeatureFlag(key)
+  isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean | undefined {
+    const response = this.getFeatureFlag(key, options)
     if (response === undefined) {
       return undefined
     }

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -428,6 +428,12 @@
               "isOptional": false,
               "type": "string",
               "name": "key"
+            },
+            {
+              "description": "Optional per-call settings",
+              "isOptional": true,
+              "type": "FeatureFlagResultOptions",
+              "name": "options"
             }
           ],
           "returnType": {
@@ -739,6 +745,12 @@
               "isOptional": false,
               "type": "string",
               "name": "key"
+            },
+            {
+              "description": "Optional per-call settings",
+              "isOptional": true,
+              "type": "FeatureFlagResultOptions",
+              "name": "options"
             }
           ],
           "returnType": {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -22,6 +22,7 @@ import {
   patchFetchForTracingHeaders,
   safeSetTimeout,
   FeatureFlagValue,
+  FeatureFlagResultOptions,
   ErrorTracking as CoreErrorTracking,
 } from '@posthog/core'
 import { Properties } from '@posthog/types'
@@ -956,10 +957,11 @@ export class PostHog extends PostHogCore {
    * @public
    *
    * @param key The feature flag key
+   * @param options Optional lookup settings
    * @returns True if enabled, false if disabled, undefined if not loaded
    */
-  isFeatureEnabled(key: string): boolean | undefined {
-    return super.isFeatureEnabled(key)
+  isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean | undefined {
+    return super.isFeatureEnabled(key, options)
   }
 
   /**
@@ -979,10 +981,11 @@ export class PostHog extends PostHogCore {
    * @public
    *
    * @param key The feature flag key
+   * @param options Optional lookup settings
    * @returns The feature flag value or undefined if not loaded
    */
-  getFeatureFlag(key: string): boolean | string | undefined {
-    return super.getFeatureFlag(key)
+  getFeatureFlag(key: string, options?: FeatureFlagResultOptions): boolean | string | undefined {
+    return super.getFeatureFlag(key, options)
   }
 
   /**

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -957,7 +957,7 @@ export class PostHog extends PostHogCore {
    * @public
    *
    * @param key The feature flag key
-   * @param options Optional lookup settings
+   * @param options Optional per-call settings
    * @returns True if enabled, false if disabled, undefined if not loaded
    */
   isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean | undefined {
@@ -981,7 +981,7 @@ export class PostHog extends PostHogCore {
    * @public
    *
    * @param key The feature flag key
-   * @param options Optional lookup settings
+   * @param options Optional per-call settings
    * @returns The feature flag value or undefined if not loaded
    */
   getFeatureFlag(key: string, options?: FeatureFlagResultOptions): boolean | string | undefined {

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -2531,4 +2531,40 @@ describe('Feature flag error tracking', () => {
     // $feature_flag_error should not be present
     expect(featureFlagEvent.properties.$feature_flag_error).toBeUndefined()
   })
+
+  it('should not send $feature_flag_called from getFeatureFlag when sendEvent is false', async () => {
+    ;(globalThis as any).window.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url.includes('/flags/')) {
+        return Promise.resolve({
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              flags: {
+                'my-flag': {
+                  key: 'my-flag',
+                  enabled: true,
+                  variant: undefined,
+                  reason: undefined,
+                  metadata: { id: 1, version: 1, payload: undefined, description: undefined },
+                },
+              },
+              errorsWhileComputingFlags: false,
+              requestId: 'test-request-id',
+              evaluatedAt: Date.now(),
+            }),
+        })
+      }
+      return Promise.resolve({ status: 200, json: () => Promise.resolve({ status: 'ok' }) })
+    })
+
+    await posthog.reloadFeatureFlagsAsync()
+
+    expect(posthog.getFeatureFlag('my-flag', { sendEvent: false })).toBe(true)
+
+    await posthog.flush()
+
+    const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
+    const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
+    expect(captureCall).toBeUndefined()
+  })
 })

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -2532,7 +2532,10 @@ describe('Feature flag error tracking', () => {
     expect(featureFlagEvent.properties.$feature_flag_error).toBeUndefined()
   })
 
-  it('should not send $feature_flag_called from getFeatureFlag when sendEvent is false', async () => {
+  it.each([
+    ['getFeatureFlag', (client: PostHog) => client.getFeatureFlag('my-flag', { sendEvent: false })],
+    ['isFeatureEnabled', (client: PostHog) => client.isFeatureEnabled('my-flag', { sendEvent: false })],
+  ] as const)('should not send $feature_flag_called from %s when sendEvent is false', async (_, callFn) => {
     ;(globalThis as any).window.fetch = jest.fn().mockImplementation((url: string) => {
       if (url.includes('/flags/')) {
         return Promise.resolve({
@@ -2559,7 +2562,7 @@ describe('Feature flag error tracking', () => {
 
     await posthog.reloadFeatureFlagsAsync()
 
-    expect(posthog.getFeatureFlag('my-flag', { sendEvent: false })).toBe(true)
+    expect(callFn(posthog)).toBe(true)
 
     await posthog.flush()
 


### PR DESCRIPTION
## Problem

React Native exposes `getFeatureFlag()` and `isFeatureEnabled()`, but those helpers did not support per-call suppression of `$feature_flag_called` events. Users could only pass `{ sendEvent: false }` through `getFeatureFlagResult()`.

Fixes #3929.

## Changes

- Updated `@posthog/core` so `getFeatureFlag()` and `isFeatureEnabled()` accept `FeatureFlagResultOptions`.
- Updated `posthog-react-native` to pass those options through its public `getFeatureFlag()` and `isFeatureEnabled()` methods.
- Added tests covering `{ sendEvent: false }` for feature flag helper calls.
- Added a changeset for `@posthog/core` and `posthog-react-native`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size