### PR TITLE
fix(core): keep UUIDv7 valid by sanitizing generator inputs

### DIFF
--- a/.changeset/uuidv7-fallback-uuidv4.md
+++ b/.changeset/uuidv7-fallback-uuidv4.md
@@ -1,5 +1,0 @@
----
-'@posthog/core': patch
----
-
-Fall back to UUIDv4 when the UUIDv7 generator throws. `V7Generator` validates its timestamp and random fields and throws `RangeError: invalid field value` when `Date.now()` or `Math.random()` misbehaves (legacy `Date` polyfills, broken RNG/clock on some Android devices). Since every SDK call funnels through `uuidv7()` via session/anonymous id generation, that throw previously crashed the host app; the v4 generator performs no field validation and never reads the clock, so id generation now degrades gracefully instead.

--- a/.changeset/uuidv7-fallback-uuidv4.md
+++ b/.changeset/uuidv7-fallback-uuidv4.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Fall back to UUIDv4 when the UUIDv7 generator throws. `V7Generator` validates its timestamp and random fields and throws `RangeError: invalid field value` when `Date.now()` or `Math.random()` misbehaves (legacy `Date` polyfills, broken RNG/clock on some Android devices). Since every SDK call funnels through `uuidv7()` via session/anonymous id generation, that throw previously crashed the host app; the v4 generator performs no field validation and never reads the clock, so id generation now degrades gracefully instead.

--- a/.changeset/uuidv7-sanitize-inputs.md
+++ b/.changeset/uuidv7-sanitize-inputs.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Sanitize the UUIDv7 generator's inputs so it never throws and always returns a valid **v7** id. `V7Generator` validates its timestamp and random fields and throws `RangeError` when `Date.now()` or `Math.random()` misbehaves (legacy `Date` polyfills — see #710 — or a broken RNG/clock on some Android devices). Because every SDK call funnels through `uuidv7()` via session/anonymous id generation, that throw previously crashed the host app. The clock is now clamped into the 48-bit range and the RNG output is coerced with ToUint32 (`>>> 0`) before the fields are assembled, so generation degrades gracefully while preserving the v7 version that session tracking and id bootstrapping rely on. Healthy environments are byte-for-byte unaffected.

--- a/packages/core/src/__tests__/uuidv7.spec.ts
+++ b/packages/core/src/__tests__/uuidv7.spec.ts
@@ -8,21 +8,18 @@ describe('uuidv7', () => {
     expect(uuidv7()).toMatch(UUID_V7_REGEX)
   })
 
-  it('falls back to a UUIDv4 string when the v7 generator throws', () => {
+  it('falls back to a UUIDv4 string when the v7 generator throws, then recovers', () => {
     // Out-of-spec Math.random() implementations (broken device RNGs, or pages
     // where another script clobbers Math.random — see #710 for the Date.now()
     // equivalent) produce out-of-range field values, making
     // V7Generator.generate() throw `RangeError: invalid field value`.
     const spy = jest.spyOn(Math, 'random').mockReturnValue(1) // spec says [0, 1)
     try {
-      expect(() => uuidv7()).not.toThrow()
       expect(uuidv7()).toMatch(UUID_V4_REGEX)
     } finally {
       spy.mockRestore()
     }
-  })
-
-  it('generates v7 ids again once the environment recovers', () => {
+    // the generator is not left in a broken state once the environment recovers
     expect(uuidv7()).toMatch(UUID_V7_REGEX)
   })
 })

--- a/packages/core/src/__tests__/uuidv7.spec.ts
+++ b/packages/core/src/__tests__/uuidv7.spec.ts
@@ -1,25 +1,34 @@
 import { uuidv7 } from '../vendor/uuidv7'
 
 const UUID_V7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
 describe('uuidv7', () => {
   it('generates a valid UUIDv7 string', () => {
     expect(uuidv7()).toMatch(UUID_V7_REGEX)
   })
 
-  it('falls back to a UUIDv4 string when the v7 generator throws, then recovers', () => {
-    // Out-of-spec Math.random() implementations (broken device RNGs, or pages
-    // where another script clobbers Math.random — see #710 for the Date.now()
-    // equivalent) produce out-of-range field values, making
-    // V7Generator.generate() throw `RangeError: invalid field value`.
-    const spy = jest.spyOn(Math, 'random').mockReturnValue(1) // spec says [0, 1)
-    try {
-      expect(uuidv7()).toMatch(UUID_V4_REGEX)
-    } finally {
-      spy.mockRestore()
-    }
-    // the generator is not left in a broken state once the environment recovers
-    expect(uuidv7()).toMatch(UUID_V7_REGEX)
+  // A broken environment must never make id generation throw (it funnels every
+  // SDK call — session/anonymous ids, lifecycle captures — so a throw
+  // crash-loops the host app), and it must still yield a **v7** UUID: session
+  // tracking and id bootstrapping depend on the v7 version, so degrading to
+  // another version is not an acceptable fallback.
+  describe.each([
+    // Out-of-spec Math.random() (spec is [0, 1)); observed on real Android hardware.
+    ['Math.random() returns a value >= 1', () => jest.spyOn(Math, 'random').mockReturnValue(1)],
+    ['Math.random() returns NaN', () => jest.spyOn(Math, 'random').mockReturnValue(NaN)],
+    // Clobbered clock, e.g. a legacy Date polyfill on the host page (see #710).
+    ['Date.now() returns NaN', () => jest.spyOn(Date, 'now').mockReturnValue(NaN)],
+    ['Date.now() returns a non-48-bit value', () => jest.spyOn(Date, 'now').mockReturnValue(-1)],
+  ])('when %s', (_label, mock) => {
+    it('still returns a valid v7 UUID and does not throw, then recovers', () => {
+      const spy = mock()
+      try {
+        expect(uuidv7()).toMatch(UUID_V7_REGEX)
+      } finally {
+        spy.mockRestore()
+      }
+      // the generator is not left in a broken state once the environment recovers
+      expect(uuidv7()).toMatch(UUID_V7_REGEX)
+    })
   })
 })

--- a/packages/core/src/__tests__/uuidv7.spec.ts
+++ b/packages/core/src/__tests__/uuidv7.spec.ts
@@ -1,0 +1,28 @@
+import { uuidv7 } from '../vendor/uuidv7'
+
+const UUID_V7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('uuidv7', () => {
+  it('generates a valid UUIDv7 string', () => {
+    expect(uuidv7()).toMatch(UUID_V7_REGEX)
+  })
+
+  it('falls back to a UUIDv4 string when the v7 generator throws', () => {
+    // Out-of-spec Math.random() implementations (broken device RNGs, or pages
+    // where another script clobbers Math.random — see #710 for the Date.now()
+    // equivalent) produce out-of-range field values, making
+    // V7Generator.generate() throw `RangeError: invalid field value`.
+    const spy = jest.spyOn(Math, 'random').mockReturnValue(1) // spec says [0, 1)
+    try {
+      expect(() => uuidv7()).not.toThrow()
+      expect(uuidv7()).toMatch(UUID_V4_REGEX)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('generates v7 ids again once the environment recovers', () => {
+    expect(uuidv7()).toMatch(UUID_V7_REGEX)
+  })
+})

--- a/packages/core/src/vendor/uuidv7.ts
+++ b/packages/core/src/vendor/uuidv7.ts
@@ -286,7 +286,7 @@ export class V7Generator {
    * {@link generateOrResetCore} for the low-level primitive.
    */
   generate(): UUID {
-    return this.generateOrResetCore(Date.now(), 10_000);
+    return this.generateOrResetCore(clampUnixTsMs(Date.now()), 10_000);
   }
 
   /**
@@ -303,7 +303,7 @@ export class V7Generator {
    * {@link generateOrAbortCore} for the low-level primitive.
    */
   generateOrAbort(): UUID | undefined {
-    return this.generateOrAbortCore(Date.now(), 10_000);
+    return this.generateOrAbortCore(clampUnixTsMs(Date.now()), 10_000);
   }
 
   /**
@@ -429,10 +429,42 @@ const getDefaultRandom = (): { nextUint32(): number } => {
 //     };
 //   }
   return {
+    // Coerce the result with `>>> 0` (ToUint32) so a misbehaving `Math.random()`
+    // that returns NaN or a value outside [0, 1) — observed on real Android
+    // hardware — cannot yield an out-of-range field that makes fromFieldsV7
+    // throw `RangeError: invalid field value`. On a healthy RNG the expression
+    // is already a 32-bit unsigned integer, so this is a no-op and the output
+    // is byte-for-byte identical.
     nextUint32: (): number =>
-      Math.trunc(Math.random() * 0x1_0000) * 0x1_0000 +
-      Math.trunc(Math.random() * 0x1_0000),
+      (Math.trunc(Math.random() * 0x1_0000) * 0x1_0000 +
+        Math.trunc(Math.random() * 0x1_0000)) >>>
+      0,
   };
+};
+
+/**
+ * Clamps a millisecond timestamp into the 48-bit positive range accepted by
+ * {@link UUID.fromFieldsV7}. A broken or clobbered clock — e.g. a page whose
+ * `Date` is replaced by a legacy polyfill (see
+ * https://github.com/PostHog/posthog-js/issues/710) or a device whose system
+ * clock returns a nonsense value — can otherwise make `Date.now()` return a
+ * non-integer or out-of-range value that throws `RangeError` and fatals every
+ * SDK id generation. Clamping keeps the id a valid **v7** UUID (preserving the
+ * version that session tracking and id bootstrapping rely on) instead of
+ * degrading to another UUID version.
+ */
+const clampUnixTsMs = (unixTsMs: number): number => {
+  if (!Number.isFinite(unixTsMs)) {
+    return 1;
+  }
+  const truncated = Math.trunc(unixTsMs);
+  if (truncated < 1) {
+    return 1;
+  }
+  if (truncated > 0xffff_ffff_ffff) {
+    return 0xffff_ffff_ffff;
+  }
+  return truncated;
 };
 
 // /**
@@ -457,25 +489,20 @@ let defaultGenerator: V7Generator | undefined;
 /**
  * Generates a UUIDv7 string.
  *
- * Falls back to a UUIDv4 string if the v7 generator throws. `V7Generator`
- * validates its timestamp and random fields and throws `RangeError: invalid
- * field value` when `Date.now()` or `Math.random()` misbehaves — e.g. a page
+ * `V7Generator` validates its timestamp and random fields and throws
+ * `RangeError` when `Date.now()` or `Math.random()` misbehaves — e.g. a page
  * clobbered by a legacy `Date` polyfill (see
  * https://github.com/PostHog/posthog-js/issues/710) or a device with a broken
- * RNG/clock. The v4 generator performs no field validation and never reads
- * the clock, so it cannot throw; id generation should never crash the host
- * app.
+ * RNG/clock. Those inputs are sanitized at the source ({@link clampUnixTsMs}
+ * for the clock, ToUint32 coercion in {@link getDefaultRandom} for the RNG),
+ * so generation always yields a valid **v7** UUID and never throws — id
+ * generation cannot crash the host app, and the v7 version that session
+ * tracking and id bootstrapping depend on is preserved.
  *
  * @returns The 8-4-4-4-12 canonical hexadecimal string representation
  * ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx").
  */
-export const uuidv7 = (): string => {
-  try {
-    return uuidv7obj().toString();
-  } catch {
-    return uuidv4();
-  }
-};
+export const uuidv7 = (): string => uuidv7obj().toString();
 
 /** Generates a UUIDv7 object. */
 export const uuidv7obj = (): UUID =>

--- a/packages/core/src/vendor/uuidv7.ts
+++ b/packages/core/src/vendor/uuidv7.ts
@@ -457,10 +457,25 @@ let defaultGenerator: V7Generator | undefined;
 /**
  * Generates a UUIDv7 string.
  *
+ * Falls back to a UUIDv4 string if the v7 generator throws. `V7Generator`
+ * validates its timestamp and random fields and throws `RangeError: invalid
+ * field value` when `Date.now()` or `Math.random()` misbehaves — e.g. a page
+ * clobbered by a legacy `Date` polyfill (see
+ * https://github.com/PostHog/posthog-js/issues/710) or a device with a broken
+ * RNG/clock. The v4 generator performs no field validation and never reads
+ * the clock, so it cannot throw; id generation should never crash the host
+ * app.
+ *
  * @returns The 8-4-4-4-12 canonical hexadecimal string representation
  * ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx").
  */
-export const uuidv7 = (): string => uuidv7obj().toString();
+export const uuidv7 = (): string => {
+  try {
+    return uuidv7obj().toString();
+  } catch {
+    return uuidv4();
+  }
+};
 
 /** Generates a UUIDv7 object. */
 export const uuidv7obj = (): UUID =>


### PR DESCRIPTION
## Problem

`uuidv7()` in `@posthog/core` can throw `RangeError`. `V7Generator.generate()` reads `Date.now()` and `Math.random()` and feeds them to `UUID.fromFieldsV7(...)` / `generateOrAbortCore(...)`, both of which validate their fields — so any environment where the clock or RNG returns out-of-spec values makes id generation itself throw:

- a page where another script clobbers `Date` with a legacy polyfill — the case in #710 (datejs via clickfunnels) — trips the `` `unixTsMs` must be a 48-bit positive integer `` guard, and
- a device with a broken RNG (React Native's default generator always uses `Math.random()`, no buffered crypto) makes `nextUint32()` return an out-of-range value and trips `RangeError: invalid field value`. We've reproduced this in production on real Android hardware (OnePlus 8 Pro / Android 11, Xiaomi 13T Pro / Android 16).

The blast radius is much bigger than one lost id: every SDK call funnels through session/anonymous id generation (`getSessionId()` → `uuidv7()`, `getAnonymousId()` → `uuidv7()`), including SDK-internal captures such as `$app_opened`. A user-side `try/catch` around `posthog.capture(...)` cannot protect the lifecycle captures the SDK fires on its own, so on affected devices the app **crash-loops on every launch**. This was a recurring, measurable crash signature in our production Crashlytics data across multiple device models before we patched it locally.

## Fix

Sanitize the two untrusted inputs at the source so the generator can no longer throw **and still returns a valid v7 UUID** (superseding the earlier v4-fallback approach — see below):

- **Clock** — `clampUnixTsMs()` coerces `Date.now()` into the 48-bit positive range `fromFieldsV7` accepts (non-finite / `< 1` → `1`; `> 0xffff_ffff_ffff` → the max). Applied only at the two clock-reading entry points (`generate()`, `generateOrAbort()`); the low-level `generateOr*Core` primitives keep their documented throw-on-bad-input contract.
- **RNG** — `getDefaultRandom().nextUint32()` coerces its result with `>>> 0` (ToUint32), so a `Math.random()` that returns `NaN` or a value outside `[0, 1)` can't yield an out-of-range field. With a valid uint32 the counter-derived `randA`/`randB` fields are provably in range too, so `fromFieldsV7` never throws.

Both operations are **no-ops on healthy inputs** (an in-range integer clamps to itself; a valid uint32 is unchanged by `>>> 0`), so healthy environments are byte-for-byte identical.

## Why sanitize instead of falling back to v4 (previous approach)

The first version of this PR caught the throw and returned a `uuidv4()`. @pauldambra pointed out that PostHog relies on these ids being **v7** (session tracking, and `uuid7ToTimestampMs`-based id bootstrapping in `packages/browser`). Emitting a v4 would break that version invariant. Sanitizing the inputs keeps the id a real v7 while still never crashing — the equivalent graceful degradation without changing the UUID version. On a broken clock the embedded timestamp is meaningless either way, but the id stays a well-formed, monotonic-friendly v7 and the generator self-recovers once the environment does.

## Validation

- Ran the equivalent fallback as a `patch-package` patch in our production React Native app since mid-June 2026: the uuidv7 `RangeError` crash flavor disappeared from Crashlytics while event ingestion from those devices continued normally. This PR's sanitize-at-source patch targets the exact same crash surface and additionally preserves v7.
- Unit tests cover the healthy path plus four broken-environment cases (`Math.random()` ≥ 1, `Math.random()` = `NaN`, `Date.now()` = `NaN`, `Date.now()` out of 48-bit range): each yields a valid **v7** id, doesn't throw, and recovers.

## Checks

- `pnpm test:unit` (packages/core, uuidv7): 5 tests pass
- `pnpm lint` (packages/core): pass
- `pnpm build` (packages/core, after building workspace dep `@posthog/types`): pass

## Note on `packages/browser`

`packages/browser` has its own vendored copy of this file with a `uuid7ToTimestampMs` helper. This PR keeps the fix scoped to `@posthog/core`; happy to mirror the same input-sanitization there in a follow-up if you'd like.
