### PR TITLE
feat(surveys): support dark mode appearance

### DIFF
--- a/.changeset/survey-dark-mode-appearance.md
+++ b/.changeset/survey-dark-mode-appearance.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+---
+
+Add survey dark mode appearance support for web surveys.

--- a/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
@@ -691,47 +691,30 @@ describe('addSurveyCSSVariablesToElement', () => {
             })
         }
 
-        it('uses darkModeAppearance when color scheme is dark', () => {
-            addSurveyCSSVariablesToElement(element, SurveyType.Popover, {
-                backgroundColor: '#ffffff',
-                textColor: '#111111',
-                darkModeColorScheme: 'dark',
-                darkModeAppearance: {
-                    backgroundColor: '#111827',
-                    textColor: '#f9fafb',
-                },
-            })
+        it.each([
+            ['dark', 'dark', false, '#111827', '#f9fafb'],
+            ['system dark preference', undefined, true, '#111827', '#f9fafb'],
+            ['explicit system dark preference', 'system', true, '#111827', '#f9fafb'],
+            ['light', 'light', true, '#ffffff', '#111111'],
+        ] as const)(
+            'uses %s color scheme appearance',
+            (_label, darkModeColorScheme, prefersDarkMode, expectedBackgroundColor, expectedTextColor) => {
+                mockPrefersDarkMode(prefersDarkMode)
 
-            expect(element.style.getPropertyValue('--ph-survey-background-color')).toBe('#111827')
-            expect(element.style.getPropertyValue('--ph-survey-text-primary-color')).toBe('#f9fafb')
-        })
+                addSurveyCSSVariablesToElement(element, SurveyType.Popover, {
+                    backgroundColor: '#ffffff',
+                    textColor: '#111111',
+                    darkModeColorScheme,
+                    darkModeAppearance: {
+                        backgroundColor: '#111827',
+                        textColor: '#f9fafb',
+                    },
+                })
 
-        it('uses system preference when color scheme is not explicitly light or dark', () => {
-            mockPrefersDarkMode(true)
-
-            addSurveyCSSVariablesToElement(element, SurveyType.Popover, {
-                backgroundColor: '#ffffff',
-                darkModeAppearance: {
-                    backgroundColor: '#111827',
-                },
-            })
-
-            expect(element.style.getPropertyValue('--ph-survey-background-color')).toBe('#111827')
-        })
-
-        it('keeps light appearance when color scheme is light', () => {
-            mockPrefersDarkMode(true)
-
-            addSurveyCSSVariablesToElement(element, SurveyType.Popover, {
-                backgroundColor: '#ffffff',
-                darkModeColorScheme: 'light',
-                darkModeAppearance: {
-                    backgroundColor: '#111827',
-                },
-            })
-
-            expect(element.style.getPropertyValue('--ph-survey-background-color')).toBe('#ffffff')
-        })
+                expect(element.style.getPropertyValue('--ph-survey-background-color')).toBe(expectedBackgroundColor)
+                expect(element.style.getPropertyValue('--ph-survey-text-primary-color')).toBe(expectedTextColor)
+            }
+        )
 
         it('returns the original appearance when no dark mode appearance is configured', () => {
             const appearance = { backgroundColor: '#ffffff' }

--- a/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
@@ -3,6 +3,7 @@ import {
     canActivateRepeatedly,
     doesSurveyUrlMatch,
     getFontFamily,
+    getSurveyAppearanceForColorScheme,
     getSurveySeen,
     hasEvents,
     hasWaitPeriodPassed,
@@ -670,6 +671,72 @@ describe('addSurveyCSSVariablesToElement', () => {
             expect(element.style.getPropertyValue('--ph-survey-rating-active-text-color')).toBe('#020617')
             // Inactive rating uses inputTextColor
             expect(element.style.getPropertyValue('--ph-survey-rating-text-color')).toBe('#ff0000')
+        })
+    })
+
+    describe('dark mode appearance', () => {
+        const mockPrefersDarkMode = (matches: boolean): void => {
+            Object.defineProperty(window, 'matchMedia', {
+                writable: true,
+                value: jest.fn().mockImplementation((query) => ({
+                    matches,
+                    media: query,
+                    onchange: null,
+                    addListener: jest.fn(),
+                    removeListener: jest.fn(),
+                    addEventListener: jest.fn(),
+                    removeEventListener: jest.fn(),
+                    dispatchEvent: jest.fn(),
+                })),
+            })
+        }
+
+        it('uses darkModeAppearance when color scheme is dark', () => {
+            addSurveyCSSVariablesToElement(element, SurveyType.Popover, {
+                backgroundColor: '#ffffff',
+                textColor: '#111111',
+                darkModeColorScheme: 'dark',
+                darkModeAppearance: {
+                    backgroundColor: '#111827',
+                    textColor: '#f9fafb',
+                },
+            })
+
+            expect(element.style.getPropertyValue('--ph-survey-background-color')).toBe('#111827')
+            expect(element.style.getPropertyValue('--ph-survey-text-primary-color')).toBe('#f9fafb')
+        })
+
+        it('uses system preference when color scheme is not explicitly light or dark', () => {
+            mockPrefersDarkMode(true)
+
+            addSurveyCSSVariablesToElement(element, SurveyType.Popover, {
+                backgroundColor: '#ffffff',
+                darkModeAppearance: {
+                    backgroundColor: '#111827',
+                },
+            })
+
+            expect(element.style.getPropertyValue('--ph-survey-background-color')).toBe('#111827')
+        })
+
+        it('keeps light appearance when color scheme is light', () => {
+            mockPrefersDarkMode(true)
+
+            addSurveyCSSVariablesToElement(element, SurveyType.Popover, {
+                backgroundColor: '#ffffff',
+                darkModeColorScheme: 'light',
+                darkModeAppearance: {
+                    backgroundColor: '#111827',
+                },
+            })
+
+            expect(element.style.getPropertyValue('--ph-survey-background-color')).toBe('#ffffff')
+        })
+
+        it('returns the original appearance when no dark mode appearance is configured', () => {
+            const appearance = { backgroundColor: '#ffffff' }
+
+            expect(getSurveyAppearanceForColorScheme(appearance)).toBe(appearance)
         })
     })
 })

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -91,17 +91,32 @@ const BOTTOM_BORDER_SURVEY_POSITIONS: SurveyPosition[] = [
     SurveyPosition.Right,
 ]
 
+export const getSurveyAppearanceForColorScheme = (
+    appearance?: SurveyAppearance | null
+): SurveyAppearance | null | undefined => {
+    if (isNullish(appearance) || isNullish(appearance.darkModeAppearance)) {
+        return appearance
+    }
+
+    const shouldUseDarkMode =
+        appearance.darkModeColorScheme === 'dark' ||
+        (appearance.darkModeColorScheme !== 'light' && window?.matchMedia?.('(prefers-color-scheme: dark)').matches)
+
+    return shouldUseDarkMode ? { ...appearance, ...appearance.darkModeAppearance } : appearance
+}
+
 export const addSurveyCSSVariablesToElement = (
     element: HTMLElement,
     type: SurveyType,
     appearance?: SurveyAppearance | null
 ) => {
-    const effectiveAppearance = { ...defaultSurveyAppearance, ...appearance }
+    const resolvedAppearance = getSurveyAppearanceForColorScheme(appearance)
+    const effectiveAppearance = { ...defaultSurveyAppearance, ...resolvedAppearance }
     const hostStyle = element.style
 
     const surveyHasBottomBorder =
         !BOTTOM_BORDER_SURVEY_POSITIONS.includes(effectiveAppearance.position) ||
-        (type === SurveyType.Widget && appearance?.widgetType === SurveyWidgetType.Tab)
+        (type === SurveyType.Widget && resolvedAppearance?.widgetType === SurveyWidgetType.Tab)
 
     hostStyle.setProperty('--ph-survey-font-family', getFontFamily(effectiveAppearance.fontFamily))
     hostStyle.setProperty('--ph-survey-box-padding', effectiveAppearance.boxPadding)
@@ -125,7 +140,7 @@ export const addSurveyCSSVariablesToElement = (
     hostStyle.setProperty('--ph-survey-submit-button-color', effectiveAppearance.submitButtonColor)
     hostStyle.setProperty(
         '--ph-survey-submit-button-text-color',
-        appearance?.submitButtonTextColor || getContrastingTextColor(effectiveAppearance.submitButtonColor)
+        resolvedAppearance?.submitButtonTextColor || getContrastingTextColor(effectiveAppearance.submitButtonColor)
     )
     hostStyle.setProperty('--ph-survey-rating-bg-color', effectiveAppearance.ratingButtonColor)
     hostStyle.setProperty('--ph-survey-rating-active-bg-color', effectiveAppearance.ratingButtonActiveColor)
@@ -137,7 +152,7 @@ export const addSurveyCSSVariablesToElement = (
     // Primary text color: use override if provided, otherwise auto-calculate from background
     hostStyle.setProperty(
         '--ph-survey-text-primary-color',
-        appearance?.textColor || getContrastingTextColor(effectiveAppearance.backgroundColor)
+        resolvedAppearance?.textColor || getContrastingTextColor(effectiveAppearance.backgroundColor)
     )
     hostStyle.setProperty('--ph-survey-text-subtle-color', effectiveAppearance.textSubtleColor)
     hostStyle.setProperty('--ph-widget-color', effectiveAppearance.widgetColor)
@@ -146,14 +161,14 @@ export const addSurveyCSSVariablesToElement = (
 
     // Use user-provided inputBackground (or deprecated inputBackgroundColor for backwards compat)
     // Fallback to internal default, with slight adjustment for white backgrounds
-    const userInputBg = appearance?.inputBackground || appearance?.inputBackgroundColor
+    const userInputBg = resolvedAppearance?.inputBackground || resolvedAppearance?.inputBackgroundColor
     let inputBgColor = userInputBg || effectiveAppearance.inputBackground
     if (!userInputBg && effectiveAppearance.backgroundColor === 'white') {
         inputBgColor = '#f8f8f8'
     }
     hostStyle.setProperty('--ph-survey-input-background', inputBgColor)
     // Input text color applies to both text inputs and inactive rating buttons
-    const inputTextColor = appearance?.inputTextColor || getContrastingTextColor(inputBgColor)
+    const inputTextColor = resolvedAppearance?.inputTextColor || getContrastingTextColor(inputBgColor)
     hostStyle.setProperty('--ph-survey-input-text-color', inputTextColor)
     hostStyle.setProperty('--ph-survey-rating-text-color', inputTextColor)
     hostStyle.setProperty('--ph-survey-scrollbar-thumb-color', effectiveAppearance.scrollbarThumbColor)

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -100,7 +100,7 @@ export const getSurveyAppearanceForColorScheme = (
 
     const shouldUseDarkMode =
         appearance.darkModeColorScheme === 'dark' ||
-        (appearance.darkModeColorScheme !== 'light' && window?.matchMedia?.('(prefers-color-scheme: dark)').matches)
+        (appearance.darkModeColorScheme !== 'light' && window?.matchMedia?.('(prefers-color-scheme: dark)')?.matches)
 
     return shouldUseDarkMode ? { ...appearance, ...appearance.darkModeAppearance } : appearance
 }

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -30,7 +30,7 @@ export interface SurveyEventWithFilters {
 
 // Extends core SurveyAppearance with browser-specific fields
 // Omit 'position' from core because browser's SurveyPosition has additional values (e.g., NextToTrigger)
-export interface SurveyAppearance extends Omit<CoreSurveyAppearance, 'position' | 'widgetType'> {
+export interface SurveyAppearance extends Omit<CoreSurveyAppearance, 'position' | 'widgetType' | 'darkModeAppearance'> {
     // Browser-specific fields not in core
     /** @deprecated - not currently used */
     descriptionTextColor?: string
@@ -49,6 +49,8 @@ export interface SurveyAppearance extends Omit<CoreSurveyAppearance, 'position' 
     // Browser's SurveyPosition has more options than core (e.g., NextToTrigger)
     position?: SurveyPosition
     widgetType?: SurveyWidgetType
+    darkModeColorScheme?: 'light' | 'dark' | 'system'
+    darkModeAppearance?: Omit<SurveyAppearance, 'darkModeColorScheme' | 'darkModeAppearance'>
 }
 
 export type SurveyQuestion = BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -7,6 +7,7 @@
 import type { Properties, PropertyMatchType } from './types'
 import type {
     SurveyAppearance as CoreSurveyAppearance,
+    SurveyAppearanceColorScheme,
     SurveyQuestionTranslation,
     SurveyResponseValue as CoreSurveyResponseValue,
     SurveyTranslation,
@@ -49,7 +50,7 @@ export interface SurveyAppearance extends Omit<CoreSurveyAppearance, 'position' 
     // Browser's SurveyPosition has more options than core (e.g., NextToTrigger)
     position?: SurveyPosition
     widgetType?: SurveyWidgetType
-    darkModeColorScheme?: 'light' | 'dark' | 'system'
+    darkModeColorScheme?: SurveyAppearanceColorScheme
     darkModeAppearance?: Omit<SurveyAppearance, 'darkModeColorScheme' | 'darkModeAppearance'>
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -591,7 +591,9 @@ export type EvaluationReason = {
 }
 
 // survey types
-export type SurveyAppearance = {
+export type SurveyAppearanceColorScheme = 'light' | 'dark' | 'system'
+
+type SurveyAppearanceBase = {
   // keep in sync with frontend/src/types.ts -> SurveyAppearance
   backgroundColor?: string
   // Optional override for main survey text color. If not set, auto-calculated from backgroundColor.
@@ -626,6 +628,11 @@ export type SurveyAppearance = {
   widgetSelector?: string
   widgetLabel?: string
   widgetColor?: string
+}
+
+export type SurveyAppearance = SurveyAppearanceBase & {
+  darkModeColorScheme?: SurveyAppearanceColorScheme
+  darkModeAppearance?: SurveyAppearanceBase
 }
 
 export enum SurveyPosition {


### PR DESCRIPTION
## Problem

Surveys currently support a single appearance palette. This makes it difficult for apps to support dark mode without overriding survey colors locally.  #3522

## Changes

- Added dark mode appearance fields to the shared survey appearance type.
- Updated web survey rendering to resolve the effective appearance before applying CSS variables.
- Supports explicit `dark`, explicit `light`, and system-based dark mode behavior.
- Added unit coverage for dark mode appearance selection.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file