### PR TITLE
fix(ai): declare inclusive cache token reporting for OpenAI-compatible providers

### DIFF
--- a/.changeset/fix-openai-wrapper-cache-reporting-convention.md
+++ b/.changeset/fix-openai-wrapper-cache-reporting-convention.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+fix(ai): declare `$ai_cache_reporting_exclusive: false` on OpenAI wrapper events so ingestion no longer double-bills cached input tokens for Claude models served through OpenAI-compatible hosts (e.g. OpenRouter)

--- a/.changeset/fix-openai-wrapper-cache-reporting-convention.md
+++ b/.changeset/fix-openai-wrapper-cache-reporting-convention.md
@@ -2,4 +2,4 @@
 '@posthog/ai': patch
 ---
 
-fix(ai): declare `$ai_cache_reporting_exclusive: false` on OpenAI wrapper events so ingestion no longer double-bills cached input tokens for Claude models served through OpenAI-compatible hosts (e.g. OpenRouter)
+fix(ai): declare `$ai_cache_reporting_exclusive: false` on OpenAI wrapper events so ingestion no longer double-bills cached input tokens for Claude models served through OpenAI-compatible hosts (e.g. OpenRouter). The flag stays unset when callers pass their own input or cache token counts through `posthogProperties`, so existing passthrough workarounds keep reporting correctly.

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -8,7 +8,7 @@ import {
   withPrivacyMode,
   formatOpenAIResponsesInput,
 } from '../utils'
-import { captureAiGeneration } from '../captureAiGeneration'
+import { captureAiGeneration } from './capture'
 import type { APIPromise } from 'openai'
 import type { Stream } from 'openai/streaming'
 import type { ParsedResponse } from 'openai/resources/responses/responses'

--- a/packages/ai/src/openai/capture.ts
+++ b/packages/ai/src/openai/capture.ts
@@ -1,0 +1,21 @@
+import { PostHog } from 'posthog-node'
+import { captureAiGeneration as baseCaptureAiGeneration, CaptureAiGenerationOptions } from '../captureAiGeneration'
+
+/**
+ * OpenAI-compatible usage reports `prompt_tokens` INCLUSIVE of cached tokens
+ * (`prompt_tokens_details.cached_tokens` is a subset of it), unlike Anthropic's
+ * exclusive convention. Ingestion auto-classifies Claude-shaped models as
+ * exclusive regardless of provider, so events for Claude served through
+ * OpenAI-compatible hosts (e.g. OpenRouter) would get cache reads billed twice.
+ * Declaring the convention on every event from this wrapper lets ingestion
+ * normalize correctly (see PostHog/posthog#49252); for non-Claude models the
+ * flag is a no-op. Callers can still override it via posthogProperties.
+ */
+export const captureAiGeneration = (client: PostHog, options: CaptureAiGenerationOptions): Promise<void> =>
+  baseCaptureAiGeneration(client, {
+    ...options,
+    properties: {
+      $ai_cache_reporting_exclusive: false,
+      ...options.properties,
+    },
+  })

--- a/packages/ai/src/openai/capture.ts
+++ b/packages/ai/src/openai/capture.ts
@@ -2,6 +2,17 @@ import { PostHog } from 'posthog-node'
 import { captureAiGeneration as baseCaptureAiGeneration, CaptureAiGenerationOptions } from '../captureAiGeneration'
 
 /**
+ * The declared convention only describes the wrapper's own usage numbers, so
+ * when the caller passes any of these through posthogProperties the wrapper no
+ * longer knows the convention of the reported counts (callers working around
+ * the double-billing already pass exclusive ones) and must not declare it.
+ * Output/reasoning token overrides don't affect the input/cache relationship,
+ * so they don't suppress the declaration. Subset of the input/cache keys in
+ * `TOKEN_PROPERTY_KEYS` (../utils.ts) — keep in sync if that taxonomy grows.
+ */
+const INPUT_OR_CACHE_TOKEN_KEYS = ['$ai_input_tokens', '$ai_cache_read_input_tokens', '$ai_cache_creation_input_tokens']
+
+/**
  * OpenAI-compatible usage reports `prompt_tokens` INCLUSIVE of cached tokens
  * (`prompt_tokens_details.cached_tokens` is a subset of it), unlike Anthropic's
  * exclusive convention. Ingestion auto-classifies Claude-shaped models as
@@ -9,13 +20,23 @@ import { captureAiGeneration as baseCaptureAiGeneration, CaptureAiGenerationOpti
  * OpenAI-compatible hosts (e.g. OpenRouter) would get cache reads billed twice.
  * Declaring the convention on every event from this wrapper lets ingestion
  * normalize correctly (see PostHog/posthog#49252); for non-Claude models the
- * flag is a no-op. Callers can still override it via posthogProperties.
+ * flag is a no-op. Callers can still override it via posthogProperties, and
+ * when they pass through input or cache token counts themselves the flag stays
+ * unset unless they declare it explicitly.
  */
-export const captureAiGeneration = (client: PostHog, options: CaptureAiGenerationOptions): Promise<void> =>
-  baseCaptureAiGeneration(client, {
+export const captureAiGeneration = (client: PostHog, options: CaptureAiGenerationOptions): Promise<void> => {
+  const props = options.properties
+  // Own-property check, matching how getTokensSource detects passthrough and
+  // how the properties spread actually copies values into the event.
+  const callerReportsTokens =
+    props !== undefined && INPUT_OR_CACHE_TOKEN_KEYS.some((key) => Object.prototype.hasOwnProperty.call(props, key))
+  return baseCaptureAiGeneration(client, {
     ...options,
-    properties: {
-      $ai_cache_reporting_exclusive: false,
-      ...options.properties,
-    },
+    properties: callerReportsTokens
+      ? props
+      : {
+          $ai_cache_reporting_exclusive: false,
+          ...props,
+        },
   })
+}

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -10,7 +10,7 @@ import {
   calculateWebSearchCount,
   getModelParams,
 } from '../utils'
-import { captureAiGeneration } from '../captureAiGeneration'
+import { captureAiGeneration } from './capture'
 import type { APIPromise } from 'openai'
 import type { Stream } from 'openai/streaming'
 import type { ParsedResponse } from 'openai/resources/responses/responses'

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -861,3 +861,70 @@ describe('PostHogAzureOpenAI - streaming error safety', () => {
     expect(unhandledRejections).toEqual([])
   })
 })
+
+describe('PostHogAzureOpenAI - cache token reporting convention', () => {
+  // Deliberately not `conditionalTest`: azure.ts routes captures through the
+  // OpenAI capture helper, and with the credential-gated suite above skipped
+  // in CI (no AZURE_OPENAI_API_KEY), a gated test would never catch the Azure
+  // path bypassing the declaration. Everything here is mocked.
+  test.each([
+    { behavior: 'declares inclusive reporting by default', posthogProperties: undefined, expectedFlag: false },
+    {
+      behavior: 'lets user-provided posthogProperties override the declaration',
+      posthogProperties: { $ai_cache_reporting_exclusive: true },
+      expectedFlag: true,
+    },
+  ])('$behavior', async ({ posthogProperties, expectedFlag }) => {
+    const mockPostHogClient = new (PostHog as any)()
+    const client = new PostHogAzureOpenAI({
+      apiKey: 'mock-azure-key',
+      posthog: mockPostHogClient as any,
+    })
+
+    const ChatMock: any = openaiModule.Chat
+    const originalCreate = (ChatMock.Completions as any).prototype.create
+    ;(ChatMock.Completions as any).prototype.create = jest.fn().mockResolvedValue({
+      id: 'chatcmpl-cache-convention',
+      model: 'gpt-4',
+      object: 'chat.completion',
+      created: 1234567890,
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'stop',
+          message: {
+            role: 'assistant',
+            content: 'Hello!',
+            refusal: null,
+          },
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 32611,
+        completion_tokens: 561,
+        total_tokens: 33172,
+        prompt_tokens_details: {
+          cached_tokens: 27929,
+        },
+      },
+    })
+
+    await client.chat.completions.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+      posthogDistinctId: 'test-id',
+      posthogProperties,
+    })
+
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { properties } = captureArgs[0]
+
+    expect(properties['$ai_provider']).toBe('azure')
+    expect(properties['$ai_input_tokens']).toBe(32611)
+    expect(properties['$ai_cache_read_input_tokens']).toBe(27929)
+    expect(properties['$ai_cache_reporting_exclusive']).toBe(expectedFlag)
+    ;(ChatMock.Completions as any).prototype.create = originalCreate
+  })
+})

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -658,45 +658,79 @@ describe('PostHogOpenAI - Jest test suite', () => {
   // The cache-reporting tests below are fully mocked (no API calls), so they
   // run unconditionally instead of using `conditionalTest`.
   test.each([
-    { behavior: 'declares inclusive reporting by default', posthogProperties: undefined, expectedFlag: false },
+    {
+      behavior: 'declares inclusive reporting by default',
+      posthogProperties: undefined,
+      expectedFlag: false,
+      expectedInputTokens: 32611,
+    },
     {
       behavior: 'lets user-provided posthogProperties override the declaration',
       posthogProperties: { $ai_cache_reporting_exclusive: true },
       expectedFlag: true,
+      expectedInputTokens: 32611,
     },
-  ])('cache token reporting convention $behavior (#3615)', async ({ posthogProperties, expectedFlag }) => {
-    // OpenAI-convention usage reports prompt_tokens INCLUSIVE of cached tokens.
-    // Ingestion classifies claude* models as Anthropic-convention (exclusive)
-    // and would price the 27,929 cached tokens twice unless the event declares
-    // the convention via $ai_cache_reporting_exclusive: false. Numbers taken
-    // from the #3615 report (Claude via OpenRouter).
-    mockOpenAiChatResponse.model = 'anthropic/claude-sonnet-4.6'
-    mockOpenAiChatResponse.usage = {
-      prompt_tokens: 32611,
-      completion_tokens: 561,
-      total_tokens: 33172,
-      prompt_tokens_details: {
-        cached_tokens: 27929,
+    {
+      // Callers working around the double-billing already pass exclusive
+      // counts through posthogProperties (here 4,682 = 32,611 − 27,929);
+      // declaring `false` on those events would make ingestion subtract the
+      // cache again and report −23,247 uncached tokens.
+      behavior: 'stays unset when posthogProperties passes through token counts',
+      posthogProperties: { $ai_input_tokens: 4682, $ai_cache_read_input_tokens: 27929 },
+      expectedFlag: undefined,
+      expectedInputTokens: 4682,
+    },
+    {
+      behavior: 'keeps an explicit declaration alongside passed-through token counts',
+      posthogProperties: {
+        $ai_input_tokens: 4682,
+        $ai_cache_read_input_tokens: 27929,
+        $ai_cache_reporting_exclusive: true,
       },
+      expectedFlag: true,
+      expectedInputTokens: 4682,
+    },
+  ])(
+    'cache token reporting convention $behavior (#3615)',
+    async ({ posthogProperties, expectedFlag, expectedInputTokens }) => {
+      // OpenAI-convention usage reports prompt_tokens INCLUSIVE of cached tokens.
+      // Ingestion classifies claude* models as Anthropic-convention (exclusive)
+      // and would price the 27,929 cached tokens twice unless the event declares
+      // the convention via $ai_cache_reporting_exclusive: false. Numbers taken
+      // from the #3615 report (Claude via OpenRouter).
+      mockOpenAiChatResponse.model = 'anthropic/claude-sonnet-4.6'
+      mockOpenAiChatResponse.usage = {
+        prompt_tokens: 32611,
+        completion_tokens: 561,
+        total_tokens: 33172,
+        prompt_tokens_details: {
+          cached_tokens: 27929,
+        },
+      }
+
+      await client.chat.completions.create({
+        model: 'anthropic/claude-sonnet-4.6',
+        messages: [{ role: 'user', content: 'Hello' }],
+        posthogDistinctId: 'test-id',
+        posthogProperties,
+      })
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { properties } = captureArgs[0]
+
+      // Token counts stay raw either way (OpenAI convention, consistent with
+      // $ai_usage) unless the caller passes their own through…
+      expect(properties['$ai_input_tokens']).toBe(expectedInputTokens)
+      expect(properties['$ai_cache_read_input_tokens']).toBe(27929)
+      // …only the declared convention changes, so ingestion subtracts instead of double-billing.
+      if (expectedFlag === undefined) {
+        expect(properties).not.toHaveProperty('$ai_cache_reporting_exclusive')
+      } else {
+        expect(properties['$ai_cache_reporting_exclusive']).toBe(expectedFlag)
+      }
     }
-
-    await client.chat.completions.create({
-      model: 'anthropic/claude-sonnet-4.6',
-      messages: [{ role: 'user', content: 'Hello' }],
-      posthogDistinctId: 'test-id',
-      posthogProperties,
-    })
-
-    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureArgs[0]
-
-    // Token counts stay raw either way (OpenAI convention, consistent with $ai_usage)…
-    expect(properties['$ai_input_tokens']).toBe(32611)
-    expect(properties['$ai_cache_read_input_tokens']).toBe(27929)
-    // …only the declared convention changes, so ingestion subtracts instead of double-billing.
-    expect(properties['$ai_cache_reporting_exclusive']).toBe(expectedFlag)
-  })
+  )
 
   test('declares inclusive cache token reporting on streaming completions', async () => {
     const stream = (await client.chat.completions.create({

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -732,6 +732,37 @@ describe('PostHogOpenAI - Jest test suite', () => {
     }
   )
 
+  // Each key must suppress the declaration on its own, not only alongside
+  // $ai_input_tokens — partial overrides are valid passthrough too.
+  test.each(['$ai_input_tokens', '$ai_cache_read_input_tokens', '$ai_cache_creation_input_tokens'])(
+    'passthrough of %s alone keeps the reporting declaration unset (#3615)',
+    async (tokenKey) => {
+      mockOpenAiChatResponse.model = 'anthropic/claude-sonnet-4.6'
+      mockOpenAiChatResponse.usage = {
+        prompt_tokens: 32611,
+        completion_tokens: 561,
+        total_tokens: 33172,
+        prompt_tokens_details: {
+          cached_tokens: 27929,
+        },
+      }
+
+      await client.chat.completions.create({
+        model: 'anthropic/claude-sonnet-4.6',
+        messages: [{ role: 'user', content: 'Hello' }],
+        posthogDistinctId: 'test-id',
+        posthogProperties: { [tokenKey]: 1234 },
+      })
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { properties } = captureArgs[0]
+
+      expect(properties[tokenKey]).toBe(1234)
+      expect(properties).not.toHaveProperty('$ai_cache_reporting_exclusive')
+    }
+  )
+
   test('declares inclusive cache token reporting on streaming completions', async () => {
     const stream = (await client.chat.completions.create({
       model: 'gpt-4',

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -655,6 +655,73 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(properties['$ai_cache_read_input_tokens']).toBe(5)
   })
 
+  // The cache-reporting tests below are fully mocked (no API calls), so they
+  // run unconditionally instead of using `conditionalTest`.
+  test('declares inclusive cache token reporting so ingestion does not double-bill Claude via OpenAI-compatible hosts (#3615)', async () => {
+    // OpenAI-convention usage reports prompt_tokens INCLUSIVE of cached tokens.
+    // Ingestion classifies claude* models as Anthropic-convention (exclusive)
+    // and would price the 27,929 cached tokens twice unless the event declares
+    // the convention via $ai_cache_reporting_exclusive: false. Numbers taken
+    // from the #3615 report (Claude via OpenRouter).
+    mockOpenAiChatResponse.model = 'anthropic/claude-sonnet-4.6'
+    mockOpenAiChatResponse.usage = {
+      prompt_tokens: 32611,
+      completion_tokens: 561,
+      total_tokens: 33172,
+      prompt_tokens_details: {
+        cached_tokens: 27929,
+      },
+    }
+
+    await client.chat.completions.create({
+      model: 'anthropic/claude-sonnet-4.6',
+      messages: [{ role: 'user', content: 'Hello' }],
+      posthogDistinctId: 'test-id',
+    })
+
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { properties } = captureArgs[0]
+
+    // Token counts stay raw (OpenAI convention, consistent with $ai_usage)…
+    expect(properties['$ai_input_tokens']).toBe(32611)
+    expect(properties['$ai_cache_read_input_tokens']).toBe(27929)
+    // …and the event declares the convention so ingestion subtracts instead of double-billing.
+    expect(properties['$ai_cache_reporting_exclusive']).toBe(false)
+  })
+
+  test('declares inclusive cache token reporting on streaming completions', async () => {
+    const stream = (await client.chat.completions.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+      stream: true,
+      posthogDistinctId: 'test-id',
+    })) as unknown as AsyncIterable<ChatCompletionChunk>
+
+    // Consume the stream to trigger the monitoring capture
+    for await (const _chunk of stream) {
+      // no-op
+    }
+    await flushPromises()
+
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    expect(captureArgs[0].properties['$ai_cache_reporting_exclusive']).toBe(false)
+  })
+
+  test('user-provided posthogProperties can override the cache reporting declaration', async () => {
+    await client.chat.completions.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+      posthogDistinctId: 'test-id',
+      posthogProperties: { $ai_cache_reporting_exclusive: true },
+    })
+
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    expect(captureArgs[0].properties['$ai_cache_reporting_exclusive']).toBe(true)
+  })
+
   // New test: ensure captureImmediate is used when flag is set
   conditionalTest('captureImmediate flag', async () => {
     await client.chat.completions.create({

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -657,7 +657,14 @@ describe('PostHogOpenAI - Jest test suite', () => {
 
   // The cache-reporting tests below are fully mocked (no API calls), so they
   // run unconditionally instead of using `conditionalTest`.
-  test('declares inclusive cache token reporting so ingestion does not double-bill Claude via OpenAI-compatible hosts (#3615)', async () => {
+  test.each([
+    { behavior: 'declares inclusive reporting by default', posthogProperties: undefined, expectedFlag: false },
+    {
+      behavior: 'lets user-provided posthogProperties override the declaration',
+      posthogProperties: { $ai_cache_reporting_exclusive: true },
+      expectedFlag: true,
+    },
+  ])('cache token reporting convention $behavior (#3615)', async ({ posthogProperties, expectedFlag }) => {
     // OpenAI-convention usage reports prompt_tokens INCLUSIVE of cached tokens.
     // Ingestion classifies claude* models as Anthropic-convention (exclusive)
     // and would price the 27,929 cached tokens twice unless the event declares
@@ -677,17 +684,18 @@ describe('PostHogOpenAI - Jest test suite', () => {
       model: 'anthropic/claude-sonnet-4.6',
       messages: [{ role: 'user', content: 'Hello' }],
       posthogDistinctId: 'test-id',
+      posthogProperties,
     })
 
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
     const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
     const { properties } = captureArgs[0]
 
-    // Token counts stay raw (OpenAI convention, consistent with $ai_usage)…
+    // Token counts stay raw either way (OpenAI convention, consistent with $ai_usage)…
     expect(properties['$ai_input_tokens']).toBe(32611)
     expect(properties['$ai_cache_read_input_tokens']).toBe(27929)
-    // …and the event declares the convention so ingestion subtracts instead of double-billing.
-    expect(properties['$ai_cache_reporting_exclusive']).toBe(false)
+    // …only the declared convention changes, so ingestion subtracts instead of double-billing.
+    expect(properties['$ai_cache_reporting_exclusive']).toBe(expectedFlag)
   })
 
   test('declares inclusive cache token reporting on streaming completions', async () => {
@@ -707,19 +715,6 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
     const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
     expect(captureArgs[0].properties['$ai_cache_reporting_exclusive']).toBe(false)
-  })
-
-  test('user-provided posthogProperties can override the cache reporting declaration', async () => {
-    await client.chat.completions.create({
-      model: 'gpt-4',
-      messages: [{ role: 'user', content: 'Hello' }],
-      posthogDistinctId: 'test-id',
-      posthogProperties: { $ai_cache_reporting_exclusive: true },
-    })
-
-    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    expect(captureArgs[0].properties['$ai_cache_reporting_exclusive']).toBe(true)
   })
 
   // New test: ensure captureImmediate is used when flag is set


### PR DESCRIPTION
## Problem

Fixes #3615

Tracking Claude generations through OpenAI-compatible hosts (e.g. OpenRouter) reports ~3.4x inflated costs. This wrapper forwards OpenAI-convention usage — `prompt_tokens` (32,611) already *includes* cached tokens, and `prompt_tokens_details.cached_tokens` (27,929) is forwarded separately. Ingestion classifies any `claude*`/`anthropic*` model as Anthropic-convention (*exclusive*) and prices input at full rate *plus* cache reads: 32,611 × $3/M + 27,929 × $0.30/M = **$0.1062117** — exactly the `$ai_input_cost_usd` reported in the issue. The cached tokens are billed twice.

## Changes

- New thin seam `packages/ai/src/openai/capture.ts`: every capture from the OpenAI wrapper (chat ± streaming, Responses API, embeddings, Azure) now declares the documented property **`$ai_cache_reporting_exclusive: false`**. Ingestion honors the explicit flag (PostHog/posthog#49252) and performs the subtraction itself.
- `openai/index.ts` + `openai/azure.ts` switch one import each to the seam — covering all ~30 call sites; user-supplied `posthogProperties` can still override the flag.
- 3 regression tests (issue numbers as fixtures; streaming path; user override). They use plain `test()` rather than this file's `conditionalTest` because they are fully mocked and CI doesn't set `OPENAI_API_KEY` — gated tests would never run.

**Why not client-side subtraction (as #3433 did for the Vercel path):** subtraction needs Claude-model detection in the SDK (fragile across model-id formats like `us.anthropic.claude-…`), could double-subtract if ingestion later extends its inclusive-detection, and makes `$ai_input_tokens` diverge from the raw `$ai_usage`. The flag declares provenance — which only the SDK knows — and leaves token semantics untouched. Happy to switch to the subtraction approach if you prefer consistency with #3433. (The AI triage on the issue sketched the subtraction variant; it analyzed only this repo and couldn't see the ingestion-side flag.)

**Notes for reviewers:**
- Expected residual: even with correct accounting, totals land ~10% below OpenRouter's billed amount (route-specific pricing; cache *writes* have no field in OpenAI-shape usage). This PR fixes the double-billing, not reseller invoice parity — `costOverride` remains the path to exact parity.
- Same neighborhood, out of scope: `openai-agents/processor.ts` maps usage independently and may deserve the same declaration — happy to file a follow-up. Vercel/LangChain/Anthropic paths already handle Claude cache tokens.
- Self-hosted ingestion older than PostHog/posthog#49252 (03/2026) ignores the flag.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size
- [x] Ran changeset generation (`.changeset/fix-openai-wrapper-cache-reporting-convention.md`)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @DerGeraetK

- Built with Claude Code. Root cause verified against ingestion source (`nodejs/src/ingestion/pipelines/ai/costs/input-costs.ts`) and reproduced arithmetically to 7 decimals from the issue's event values. An adversarial review pass challenged the diagnosis (alternative hypotheses: mispriced cache rate, model-name mismatch, missing `cached_tokens` — all refuted) and flipped the fix choice from client-side subtraction to convention declaration.
- Verified locally: jest for the openai suite (12 passed incl. the 3 new regression tests, `capture.ts` at 100% coverage) and eslint on the touched files. Full root build/lint/test runs in CI — the local Windows environment has pre-existing native-binding issues unrelated to this change.
- Agent-authored code, human-reviewed and directed; no self-merge.