### PR TITLE
fix(ai): capture OpenAI service_tier in $ai_model_parameters for accurate cost tracking

### DIFF
--- a/.changeset/ai-openai-service-tier-model-params.md
+++ b/.changeset/ai-openai-service-tier-model-params.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+fix(ai): capture OpenAI `service_tier` in `$ai_model_parameters` so PostHog can correctly attribute costs for flex and priority tier requests

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -126,6 +126,7 @@ export const getModelParams = (
     'language',
     'response_format',
     'timestamp_granularities',
+    'service_tier',
   ] as const
 
   for (const key of paramKeys) {

--- a/packages/ai/tests/utils.test.ts
+++ b/packages/ai/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { toContentString, getTokensSource } from '../src/utils'
+import { toContentString, getTokensSource, getModelParams } from '../src/utils'
 
 describe('getTokensSource', () => {
   it.each([
@@ -199,5 +199,29 @@ describe('toContentString', () => {
       const result = toContentString(input)
       expect(result).toBe('[object Object]') // Falls back to String()
     })
+  })
+})
+
+describe('getModelParams', () => {
+  it('returns empty object for null params', () => {
+    expect(getModelParams(null)).toEqual({})
+  })
+
+  it('includes service_tier when provided', () => {
+    const params = { model: 'gpt-4o', service_tier: 'flex' } as any
+    expect(getModelParams(params)).toEqual({ service_tier: 'flex' })
+  })
+
+  it('includes service_tier alongside other model params', () => {
+    const params = { model: 'gpt-4o', temperature: 0.7, service_tier: 'priority' } as any
+    const result = getModelParams(params)
+    expect(result.service_tier).toBe('priority')
+    expect(result.temperature).toBe(0.7)
+  })
+
+  it('omits service_tier when not provided', () => {
+    const params = { model: 'gpt-4o', temperature: 0.5 } as any
+    const result = getModelParams(params)
+    expect(result).not.toHaveProperty('service_tier')
   })
 })

--- a/packages/ai/tests/utils.test.ts
+++ b/packages/ai/tests/utils.test.ts
@@ -207,16 +207,17 @@ describe('getModelParams', () => {
     expect(getModelParams(null)).toEqual({})
   })
 
-  it('includes service_tier when provided', () => {
-    const params = { model: 'gpt-4o', service_tier: 'flex' } as any
-    expect(getModelParams(params)).toEqual({ service_tier: 'flex' })
-  })
-
-  it('includes service_tier alongside other model params', () => {
-    const params = { model: 'gpt-4o', temperature: 0.7, service_tier: 'priority' } as any
+  it.each([
+    ['flex', { temperature: undefined }],
+    ['auto', { temperature: undefined }],
+    ['priority', { temperature: 0.7 }],
+  ])('includes service_tier "%s" alongside other model params', (service_tier, extra) => {
+    const params = { model: 'gpt-4o', service_tier, ...extra } as any
     const result = getModelParams(params)
-    expect(result.service_tier).toBe('priority')
-    expect(result.temperature).toBe(0.7)
+    expect(result.service_tier).toBe(service_tier)
+    if (extra.temperature !== undefined) {
+      expect(result.temperature).toBe(extra.temperature)
+    }
   })
 
   it('omits service_tier when not provided', () => {


### PR DESCRIPTION
## What

Fixes PostHog/posthog#72429.

OpenAI's `service_tier` parameter (`flex`, `auto`, `priority`) affects the price of a request (e.g. `flex` is half the standard price), but it was not being captured in the event — so PostHog's backend had no way to apply the correct multiplier when calculating `$ai_total_cost_usd`.

## How

`getModelParams` in `src/utils.ts` extracts OpenAI request parameters into `$ai_model_parameters`. Added `service_tier` to the list of extracted keys so it flows through to the event automatically.

## Testing

Added 4 unit tests to `tests/utils.test.ts` covering:
- `service_tier` is included when set (`flex`, `priority`)
- `service_tier` is omitted when not provided
- `service_tier` is captured alongside other params (e.g. `temperature`)
- null params return `{}`

All existing tests continue to pass.