### PR TITLE
fix(ai): prevent unhandled rejection crashing host process on mid-stream provider errors

### DIFF
--- a/.changeset/quiet-streams-stay-alive.md
+++ b/.changeset/quiet-streams-stay-alive.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+fix: prevent unhandled promise rejection from crashing the host process when a streamed provider response errors mid-flight (OpenAI, Azure OpenAI, Anthropic wrappers)

--- a/packages/ai/src/anthropic/index.ts
+++ b/packages/ai/src/anthropic/index.ts
@@ -267,7 +267,10 @@ export class WrappedMessages extends AnthropicOriginal.Messages {
               })
               throw error
             }
-          })()
+          })().catch(() => {
+            // Swallow: analytics must never crash the host process. The caller
+            // already receives this error via their own tee of the stream.
+          })
 
           // Return the other stream to the user
           return stream2

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -276,7 +276,10 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
               })
               throw error
             }
-          })()
+          })().catch(() => {
+            // Swallow: analytics must never crash the host process. The caller
+            // already receives this error via their own tee of the stream.
+          })
 
           // Return the other stream to the user
           return stream2
@@ -471,7 +474,10 @@ export class WrappedResponses extends AzureOpenAI.Responses {
               })
               throw error
             }
-          })()
+          })().catch(() => {
+            // Swallow: analytics must never crash the host process. The caller
+            // already receives this error via their own tee of the stream.
+          })
 
           return stream2
         }

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -361,7 +361,10 @@ export class WrappedCompletions extends Completions {
               })
               throw error
             }
-          })()
+          })().catch(() => {
+            // Swallow: analytics must never crash the host process. The caller
+            // already receives this error via their own tee of the stream.
+          })
 
           // Return the other stream to the user
           return stream2
@@ -595,7 +598,10 @@ export class WrappedResponses extends Responses {
               })
               throw error
             }
-          })()
+          })().catch(() => {
+            // Swallow: analytics must never crash the host process. The caller
+            // already receives this error via their own tee of the stream.
+          })
 
           return stream2
         }
@@ -968,7 +974,10 @@ export class WrappedTranscriptions extends Transcriptions {
               })
               throw error
             }
-          })()
+          })().catch(() => {
+            // Swallow: analytics must never crash the host process. The caller
+            // already receives this error via their own tee of the stream.
+          })
 
           return stream2
         }

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -2,6 +2,7 @@ import { PostHog } from 'posthog-node'
 import PostHogAnthropic, { WrappedMessages } from '../src/anthropic'
 import AnthropicOriginal from '@anthropic-ai/sdk'
 import { version } from '../package.json'
+import { collectUnhandledRejections } from './test-utils'
 
 // Type definitions
 interface MockAnthropicResponseOptions {
@@ -1162,5 +1163,59 @@ describe('PostHogAnthropic - $ai_base_url', () => {
 
     const { properties } = (ph.capture as jest.Mock).mock.calls[0][0]
     expect(properties['$ai_base_url']).toBe('https://gateway.posthog.com/anthropic')
+  })
+})
+
+describe('PostHogAnthropic - streaming error safety', () => {
+  let safetyMockPostHogClient: PostHog
+  let safetyClient: PostHogAnthropic
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    safetyMockPostHogClient = new (PostHog as any)()
+    safetyClient = new PostHogAnthropic({
+      apiKey: 'test-api-key',
+      posthog: safetyMockPostHogClient as any,
+    })
+  })
+
+  test('messages stream error is not rethrown unhandled', async () => {
+    const streamError = new Error('provider error injected into SSE stream')
+    const createErroringIterator = (): { [Symbol.asyncIterator](): AsyncIterator<unknown> } => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial' } }
+        throw streamError
+      },
+    })
+
+    const MessagesMock = AnthropicOriginal.Messages as jest.MockedClass<typeof AnthropicOriginal.Messages>
+    ;(MessagesMock.prototype.create as jest.Mock) = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        tee: jest.fn().mockReturnValue([createErroringIterator(), createErroringIterator()]),
+      })
+    )
+
+    const unhandledRejections = await collectUnhandledRejections(async () => {
+      const stream = await safetyClient.messages.create({
+        model: 'claude-3-5-sonnet-20240620',
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'Tell me about streaming' }],
+        stream: true,
+        posthogDistinctId: 'test-stream-error-user',
+      } as any)
+
+      // The caller's copy of the stream must still surface the error
+      await expect(async () => {
+        for await (const _chunk of stream as AsyncIterable<unknown>) {
+          // consume until the error
+        }
+      }).rejects.toThrow(streamError)
+    })
+
+    // The analytics error event is still captured
+    expect(safetyMockPostHogClient.capture).toHaveBeenCalledTimes(1)
+
+    // The detached analytics consumer must not crash the host process
+    expect(unhandledRejections).toEqual([])
   })
 })

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -1206,7 +1206,7 @@ describe('PostHogAnthropic - streaming error safety', () => {
 
       // The caller's copy of the stream must still surface the error
       await expect(async () => {
-        for await (const _chunk of stream as AsyncIterable<unknown>) {
+        for await (const _chunk of stream as unknown as AsyncIterable<unknown>) {
           // consume until the error
         }
       }).rejects.toThrow(streamError)

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -1,6 +1,7 @@
 import { PostHog } from 'posthog-node'
 import { PostHogAzureOpenAI } from '../src/openai/azure'
 import openaiModule from 'openai'
+import { collectUnhandledRejections } from './test-utils'
 
 let mockAzureEmbeddingResponse: any = {}
 
@@ -767,5 +768,96 @@ describe('PostHogAzureOpenAI - Embeddings test suite', () => {
     const posthogParams = Object.keys(actualParams).filter((key) => key.startsWith('posthog'))
     expect(posthogParams).toEqual([])
     ;(ChatMock.Completions as any).prototype.create = originalCreate
+  })
+})
+
+describe('PostHogAzureOpenAI - streaming error safety', () => {
+  let safetyMockPostHogClient: PostHog
+  let safetyClient: PostHogAzureOpenAI
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    safetyMockPostHogClient = new (PostHog as any)()
+    safetyClient = new PostHogAzureOpenAI({
+      apiKey: 'test-api-key',
+      posthog: safetyMockPostHogClient as any,
+    } as any)
+  })
+
+  const streamErrorCases: {
+    name: string
+    firstChunk: unknown
+    stubCreate: (impl: jest.Mock) => void
+    invoke: () => Promise<unknown>
+  }[] = [
+    {
+      name: 'chat completions',
+      firstChunk: {
+        id: 'chatcmpl-test',
+        model: 'gpt-4',
+        object: 'chat.completion.chunk',
+        created: 1,
+        choices: [{ index: 0, delta: { content: 'partial' }, finish_reason: null, logprobs: null }],
+      },
+      stubCreate: (impl) => {
+        ;((openaiModule as any).Chat.Completions as any).prototype.create = impl
+      },
+      invoke: () =>
+        safetyClient.chat.completions.create({
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Tell me about streaming' }],
+          stream: true,
+          posthogDistinctId: 'test-stream-error-user',
+        } as any),
+    },
+    {
+      name: 'responses',
+      firstChunk: { type: 'response.output_text.delta', delta: 'partial' },
+      stubCreate: (impl) => {
+        ;((openaiModule as any).Responses as any).prototype.create = impl
+      },
+      invoke: () =>
+        safetyClient.responses.create({
+          model: 'gpt-4',
+          input: 'Tell me about streaming',
+          stream: true,
+          posthogDistinctId: 'test-stream-error-user',
+        } as any),
+    },
+  ]
+
+  test.each(streamErrorCases)('$name stream error is not rethrown unhandled', async (streamErrorCase) => {
+    const streamError = new Error('provider error injected into SSE stream')
+    const createErroringIterator = (): { [Symbol.asyncIterator](): AsyncIterator<unknown> } => ({
+      async *[Symbol.asyncIterator]() {
+        yield streamErrorCase.firstChunk
+        throw streamError
+      },
+    })
+
+    streamErrorCase.stubCreate(
+      jest.fn().mockImplementation(() =>
+        Promise.resolve({
+          tee: jest.fn().mockReturnValue([createErroringIterator(), createErroringIterator()]),
+        })
+      )
+    )
+
+    const unhandledRejections = await collectUnhandledRejections(async () => {
+      const stream = await streamErrorCase.invoke()
+
+      // The caller's copy of the stream must still surface the error
+      await expect(async () => {
+        for await (const _chunk of stream as AsyncIterable<unknown>) {
+          // consume until the error
+        }
+      }).rejects.toThrow(streamError)
+    })
+
+    // The analytics error event is still captured
+    expect(safetyMockPostHogClient.capture).toHaveBeenCalledTimes(1)
+
+    // The detached analytics consumer must not crash the host process
+    expect(unhandledRejections).toEqual([])
   })
 })

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -906,6 +906,59 @@ describe('PostHogOpenAI - Jest test suite', () => {
       expect(properties['$ai_provider_metadata']).toEqual({ system_fingerprint: 'fp_stream_test' })
     })
 
+    test('does not emit an unhandled rejection when the stream errors mid-flight', async () => {
+      const streamError = new Error('provider error injected into SSE stream')
+      const createErroringIterator = (): MockAsyncIterator<ChatCompletionChunk> => ({
+        async *[Symbol.asyncIterator]() {
+          yield mockStreamChunks[0]
+          throw streamError
+        },
+      })
+
+      const ChatMock: any = openaiModule.Chat
+      ;(ChatMock.Completions as any).prototype.create = jest.fn().mockImplementation(() => {
+        const mockStream = {
+          tee: jest.fn().mockReturnValue([createErroringIterator(), createErroringIterator()]),
+        }
+        return createMockAPIPromise(mockStream)
+      })
+
+      const unhandledRejections: unknown[] = []
+      const onUnhandledRejection = (reason: unknown): void => {
+        unhandledRejections.push(reason)
+      }
+      process.on('unhandledRejection', onUnhandledRejection)
+
+      try {
+        const stream = await client.chat.completions.create({
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Tell me about streaming' }],
+          stream: true,
+          posthogDistinctId: 'test-stream-error-user',
+        })
+
+        // The caller's copy of the stream must still surface the error
+        await expect(async () => {
+          for await (const _chunk of stream) {
+            // consume until the error
+          }
+        }).rejects.toThrow(streamError)
+
+        // Let the internal analytics tee finish and any floating rejection surface
+        await flushPromises()
+        await new Promise((resolve) => setImmediate(resolve))
+        await new Promise((resolve) => setImmediate(resolve))
+
+        // The analytics error event is still captured
+        expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+
+        // The detached analytics consumer must not crash the host process
+        expect(unhandledRejections).toEqual([])
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection)
+      }
+    })
+
     conditionalTest('handles streaming with tool calls', async () => {
       // Create stream chunks with tool calls
       mockStreamChunks = createMockStreamChunks({

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -3,7 +3,7 @@ import PostHogOpenAI, { WrappedCompletions } from '../src/openai'
 import openaiModule from 'openai'
 import type { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat/completions'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
-import { flushPromises } from './test-utils'
+import { collectUnhandledRejections, flushPromises } from './test-utils'
 import { version } from '../package.json'
 
 // Test-specific helper interface for async iteration
@@ -906,57 +906,97 @@ describe('PostHogOpenAI - Jest test suite', () => {
       expect(properties['$ai_provider_metadata']).toEqual({ system_fingerprint: 'fp_stream_test' })
     })
 
-    test('does not emit an unhandled rejection when the stream errors mid-flight', async () => {
-      const streamError = new Error('provider error injected into SSE stream')
-      const createErroringIterator = (): MockAsyncIterator<ChatCompletionChunk> => ({
-        async *[Symbol.asyncIterator]() {
-          yield mockStreamChunks[0]
-          throw streamError
+    describe('mid-flight stream errors do not emit unhandled rejections', () => {
+      const streamErrorCases: {
+        name: string
+        firstChunk: unknown
+        stubCreate: (impl: jest.Mock) => void
+        invoke: () => Promise<unknown>
+      }[] = [
+        {
+          name: 'chat completions',
+          firstChunk: {
+            id: 'chatcmpl-test',
+            model: 'gpt-4',
+            object: 'chat.completion.chunk',
+            created: 1,
+            choices: [{ index: 0, delta: { content: 'partial' }, finish_reason: null, logprobs: null }],
+          },
+          stubCreate: (impl) => {
+            ;((openaiModule.Chat as any).Completions as any).prototype.create = impl
+          },
+          invoke: () =>
+            client.chat.completions.create({
+              model: 'gpt-4',
+              messages: [{ role: 'user', content: 'Tell me about streaming' }],
+              stream: true,
+              posthogDistinctId: 'test-stream-error-user',
+            }),
         },
-      })
+        {
+          name: 'responses',
+          firstChunk: { type: 'response.output_text.delta', delta: 'partial' },
+          stubCreate: (impl) => {
+            ;(openaiModule.Responses as any).prototype.create = impl
+          },
+          invoke: () =>
+            client.responses.create({
+              model: 'gpt-4',
+              input: 'Tell me about streaming',
+              stream: true,
+              posthogDistinctId: 'test-stream-error-user',
+            } as any),
+        },
+        {
+          name: 'audio transcriptions',
+          firstChunk: { type: 'transcript.text.delta', delta: 'partial' },
+          stubCreate: (impl) => {
+            ;((openaiModule as any).Audio.Transcriptions as any).prototype.create = impl
+          },
+          invoke: () =>
+            client.audio.transcriptions.create({
+              model: 'whisper-1',
+              file: new File(['audio'], 'audio.mp3'),
+              stream: true,
+              posthogDistinctId: 'test-stream-error-user',
+            } as any),
+        },
+      ]
 
-      const ChatMock: any = openaiModule.Chat
-      ;(ChatMock.Completions as any).prototype.create = jest.fn().mockImplementation(() => {
-        const mockStream = {
-          tee: jest.fn().mockReturnValue([createErroringIterator(), createErroringIterator()]),
-        }
-        return createMockAPIPromise(mockStream)
-      })
-
-      const unhandledRejections: unknown[] = []
-      const onUnhandledRejection = (reason: unknown): void => {
-        unhandledRejections.push(reason)
-      }
-      process.on('unhandledRejection', onUnhandledRejection)
-
-      try {
-        const stream = await client.chat.completions.create({
-          model: 'gpt-4',
-          messages: [{ role: 'user', content: 'Tell me about streaming' }],
-          stream: true,
-          posthogDistinctId: 'test-stream-error-user',
+      test.each(streamErrorCases)('$name stream error is not rethrown unhandled', async (streamErrorCase) => {
+        const streamError = new Error('provider error injected into SSE stream')
+        const createErroringIterator = (): MockAsyncIterator<unknown> => ({
+          async *[Symbol.asyncIterator]() {
+            yield streamErrorCase.firstChunk
+            throw streamError
+          },
         })
 
-        // The caller's copy of the stream must still surface the error
-        await expect(async () => {
-          for await (const _chunk of stream) {
-            // consume until the error
-          }
-        }).rejects.toThrow(streamError)
+        streamErrorCase.stubCreate(
+          jest.fn().mockImplementation(() =>
+            createMockAPIPromise({
+              tee: jest.fn().mockReturnValue([createErroringIterator(), createErroringIterator()]),
+            })
+          )
+        )
 
-        // Let the internal analytics tee finish and any floating rejection surface
-        await flushPromises()
-        await new Promise((resolve) => setImmediate(resolve))
-        await new Promise((resolve) => setImmediate(resolve))
+        const unhandledRejections = await collectUnhandledRejections(async () => {
+          const stream = await streamErrorCase.invoke()
+
+          // The caller's copy of the stream must still surface the error
+          await expect(async () => {
+            for await (const _chunk of stream as AsyncIterable<unknown>) {
+              // consume until the error
+            }
+          }).rejects.toThrow(streamError)
+        })
 
         // The analytics error event is still captured
         expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
 
         // The detached analytics consumer must not crash the host process
         expect(unhandledRejections).toEqual([])
-      } finally {
-        process.off('unhandledRejection', onUnhandledRejection)
-      }
+      })
     })
 
     conditionalTest('handles streaming with tool calls', async () => {

--- a/packages/ai/tests/test-utils.ts
+++ b/packages/ai/tests/test-utils.ts
@@ -23,3 +23,26 @@ export async function waitForAsyncOperations(): Promise<void> {
 export async function flushPromises(): Promise<void> {
   await new Promise(process.nextTick)
 }
+
+/**
+ * Runs `consume`, settles pending micro/macrotasks, and returns every
+ * `unhandledRejection` emitted while it ran. Used to assert that the detached
+ * analytics stream monitors never crash the host process when a provider
+ * stream errors mid-flight.
+ */
+export async function collectUnhandledRejections(consume: () => Promise<void>): Promise<unknown[]> {
+  const rejections: unknown[] = []
+  const listener = (reason: unknown): void => {
+    rejections.push(reason)
+  }
+  process.on('unhandledRejection', listener)
+  try {
+    await consume()
+    await flushPromises()
+    await new Promise((resolve) => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
+  } finally {
+    process.off('unhandledRejection', listener)
+  }
+  return rejections
+}


### PR DESCRIPTION
## Problem

The `@posthog/ai` streaming instrumentation can crash the entire host process.

The wrappers tee the provider stream and consume the analytics copy in a detached async IIFE:

```ts
const [stream1, stream2] = value.tee()
;(async () => {
  try {
    for await (const chunk of stream1) { /* accumulate */ }
    await captureAiGeneration(...)
  } catch (error) {
    await captureAiGeneration(..., { error })
    throw error   // rethrown into a promise nobody awaits or catches
  }
})()
return stream2
```

When the provider errors mid-stream (a rate limit injected into the SSE stream, a content-filter block like Gemini `PROHIBITED_CONTENT` via a gateway, a context-length rejection), **both** tees throw. The application catches the error on its own copy, but the analytics copy rethrows into a floating promise. That is a guaranteed unhandled rejection, which terminates the process on Node >= 15 and Bun defaults and drops every in-flight request.

We hit this in production three times in one hour via OpenRouter; each mid-stream provider error killed the server even though our application code caught the error. The crash stack always points at the raw stream iterator:

```
at iterator (node_modules/openai/core/streaming.mjs:46:39)
at processTicksAndRejections (native:7:39)
```

## Fix

Attach a `.catch()` to the detached monitor invocation at all six streaming tee sites (OpenAI chat completions + responses, Azure OpenAI chat completions + responses, Anthropic messages). The caller still receives the original error through their own tee, and the `$ai_generation` error event is still captured before the swallow.

This also hardens the success path: a failure inside `captureAiGeneration` after a successful stream would previously float unhandled the same way.

The Gemini wrapper is unaffected — its rethrows are in regular async methods that propagate to the caller.

## Test

Added a regression test that streams one chunk, then throws from the mocked tee iterators, and asserts:

- the caller's copy of the stream still rejects with the provider error,
- the analytics error event is still captured,
- no `unhandledRejection` is emitted on the process.

Red/green verified: the test fails on `main` (jest surfaces the floating rejection) and passes with this change. Full `packages/ai` jest suite: 367 passed, +1 from this PR, with the same six pre-existing env-dependent suite-level failures as clean `main`. `pnpm lint` clean.

Standalone reproduction outside jest (mock SSE endpoint injecting an error event, consumed via `.stream()` wrapped in try/catch): wrapped client exits 1 with the unhandled rejection despite the app-level catch firing; plain `openai` client under the identical scenario survives with exit 0.

fixes https://github.com/PostHog/posthog-js/issues/4074
