### PR TITLE
fix(browser): drop redundant ver/compression params from capture URL

### DIFF
--- a/.changeset/drop-capture-url-ver-compression.md
+++ b/.changeset/drop-capture-url-ver-compression.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: remove redundant `ver` and gzip `compression` query params from capture requests. `$lib_version` is already included in the event payload, and gzip is self-describing via its magic-byte header, so neither is required for ingestion — dropping them simplifies the request URL. Non-gzip codecs (base64) still send the `compression` hint, which non-legacy endpoints such as session replay require.

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -100,7 +100,7 @@ describe('request', () => {
             )
             expect(mockedXHR.open).toHaveBeenCalledWith(
                 'GET',
-                'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45',
+                'https://any.posthog-instance.com/?_=1700000000000',
                 true
             )
 
@@ -429,14 +429,7 @@ describe('request', () => {
         describe('keepalive with fetch and large bodies can cause some browsers to reject network calls', () => {
             it.each([
                 ['always keepalive with small json POST', 'POST', 'small', undefined, true, ''],
-                [
-                    'always keepalive with small gzip POST',
-                    'POST',
-                    'small',
-                    Compression.GZipJS,
-                    true,
-                    '&compression=gzip-js',
-                ],
+                ['always keepalive with small gzip POST', 'POST', 'small', Compression.GZipJS, true, ''],
                 [
                     'always keepalive with small base64 POST',
                     'POST',
@@ -445,16 +438,9 @@ describe('request', () => {
                     true,
                     '&compression=base64',
                 ],
-                ['never keepalive with GET', 'GET', undefined, Compression.GZipJS, false, '&compression=gzip-js'],
+                ['never keepalive with GET', 'GET', undefined, Compression.GZipJS, false, ''],
                 ['never keepalive with large JSON POST', 'POST', veryLargeBodyData, undefined, false, ''],
-                [
-                    'never keepalive with large GZIP POST',
-                    'POST',
-                    veryLargeBodyData,
-                    Compression.GZipJS,
-                    false,
-                    '&compression=gzip-js',
-                ],
+                ['never keepalive with large GZIP POST', 'POST', veryLargeBodyData, Compression.GZipJS, false, ''],
                 [
                     'never keepalive with large base64 POST',
                     'POST',
@@ -655,7 +641,7 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
-                    'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45',
+                    'https://any.posthog-instance.com/?_=1700000000000',
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
@@ -681,7 +667,7 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
-                    'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45&compression=base64',
+                    'https://any.posthog-instance.com/?_=1700000000000&compression=base64',
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
@@ -707,7 +693,7 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
-                    'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45&compression=gzip-js',
+                    'https://any.posthog-instance.com/?_=1700000000000',
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
@@ -845,7 +831,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
 
@@ -866,7 +852,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
 
             mockedIsolatedFetch.mockClear()
@@ -885,7 +871,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
 
@@ -931,7 +917,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
     })

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -1,7 +1,7 @@
 import { each, find } from './utils'
 import Config from './config'
 import { Compression, RequestWithOptions, RequestResponse } from './types'
-import { formDataToQuery, getQueryParam } from './utils/request-utils'
+import { formDataToQuery } from './utils/request-utils'
 
 import { logger } from './utils/logger'
 import { AbortController, CompressionStream, fetch, navigator, XMLHttpRequest } from './utils/globals'
@@ -34,22 +34,6 @@ const SIXTY_FOUR_KILOBYTES = 64 * 1024
 */
 const KEEP_ALIVE_THRESHOLD = SIXTY_FOUR_KILOBYTES * 0.8
 let nativeAsyncGzipDisabled = false
-
-const removeURLParam = (url: string, param: string): string => {
-    const [urlWithoutHash, hash] = url.split('#')
-    const [baseUrl, search] = urlWithoutHash.split('?')
-
-    if (!search) {
-        return url
-    }
-
-    const updatedSearch = search
-        .split('&')
-        .filter((pair) => pair.split('=')[0] !== param)
-        .join('&')
-
-    return `${baseUrl}${updatedSearch ? `?${updatedSearch}` : ''}${hash ? `#${hash}` : ''}`
-}
 
 type EncodedBody = {
     contentType: string
@@ -144,7 +128,7 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
 const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest => {
     const fallbackToUncompressed = (): EncodedRequest => {
         return {
-            url: removeURLParam(options.url, 'compression'),
+            url: options.url,
             encodedBody: encodePostData({
                 ...options,
                 compression: undefined,
@@ -157,7 +141,7 @@ const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest =
     try {
         encodedBody = encodePostData(options)
     } catch (error) {
-        if (isGzipRequest(options.compression, getQueryParam(options.url, 'compression'))) {
+        if (isGzipRequest(options.compression)) {
             logger.error('Failed to gzip request body, sending uncompressed payload', error)
             return fallbackToUncompressed()
         }
@@ -165,11 +149,7 @@ const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest =
         throw error
     }
 
-    if (
-        !encodedBody ||
-        !isGzipRequest(options.compression, getQueryParam(options.url, 'compression')) ||
-        isGzipData(encodedBody.body)
-    ) {
+    if (!encodedBody || !isGzipRequest(options.compression) || isGzipData(encodedBody.body)) {
         return { url: options.url, encodedBody }
     }
 
@@ -391,8 +371,11 @@ const _sendBeacon = (options: RequestWithOptions) => {
 const buildRequestURL = (url: string, compression?: RequestWithOptions['compression']): string => {
     return extendURLParams(url, {
         _: new Date().getTime().toString(),
-        ver: Config.JS_SDK_VERSION,
-        compression,
+        // Gzip is self-describing via its magic-byte header, so the capture endpoint detects it
+        // (and base64, on legacy paths) without this hint — sending `compression` for gzip is
+        // redundant. Omit it for gzip (the default) to keep the URL minimal; non-gzip codecs
+        // (base64) still need the hint on non-legacy endpoints such as session replay.
+        ...(compression && compression !== Compression.GZipJS ? { compression } : {}),
     })
 }
 


### PR DESCRIPTION
The capture endpoint already recovers both without the query params: $lib_version is in the event payload, and gzip is self-describing via its magic-byte header (the endpoint sniffs it, plus base64 on legacy paths). Dropping them from the URL removes data that isn't needed and keeps the request simpler. Base64 still sends the compression hint, which non-legacy endpoints such as session replay require.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>