### PR TITLE
fix(browser): only send _ cache-buster on GET requests

### DIFF
--- a/.changeset/drop-capture-url-cachebuster.md
+++ b/.changeset/drop-capture-url-cachebuster.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: only append the `_` cache-buster query param to GET requests. It exists to bust browser caches for GETs, but our data-collection requests are POSTs (which browsers don't cache), so it's unnecessary there. Skipping it on POSTs simplifies the request URL.

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -438,7 +438,7 @@ describe('request', () => {
                     true,
                     '&compression=base64',
                 ],
-                ['never keepalive with GET', 'GET', undefined, Compression.GZipJS, false, ''],
+                ['never keepalive with GET', 'GET', undefined, Compression.GZipJS, false, '&_=1700000000000'],
                 ['never keepalive with large JSON POST', 'POST', veryLargeBodyData, undefined, false, ''],
                 ['never keepalive with large GZIP POST', 'POST', veryLargeBodyData, Compression.GZipJS, false, ''],
                 [
@@ -470,7 +470,7 @@ describe('request', () => {
                         })
                     )
                     expect(mockedFetch).toHaveBeenCalledWith(
-                        `https://any.posthog-instance.com?ver=1.23.45&_=1700000000000${expectedURLParams}`,
+                        `https://any.posthog-instance.com?ver=1.23.45${expectedURLParams}`,
                         expect.objectContaining({
                             headers: new Headers(),
                             keepalive: expectedKeepAlive,
@@ -641,7 +641,7 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
-                    'https://any.posthog-instance.com/?_=1700000000000',
+                    'https://any.posthog-instance.com/',
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
@@ -667,7 +667,7 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
-                    'https://any.posthog-instance.com/?_=1700000000000&compression=base64',
+                    'https://any.posthog-instance.com/?compression=base64',
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
@@ -693,7 +693,7 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
-                    'https://any.posthog-instance.com/?_=1700000000000',
+                    'https://any.posthog-instance.com/',
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -368,15 +368,24 @@ const _sendBeacon = (options: RequestWithOptions) => {
     }
 }
 
-const buildRequestURL = (url: string, compression?: RequestWithOptions['compression']): string => {
-    return extendURLParams(url, {
-        _: new Date().getTime().toString(),
-        // Gzip is self-describing via its magic-byte header, so the capture endpoint detects it
-        // (and base64, on legacy paths) without this hint — sending `compression` for gzip is
-        // redundant. Omit it for gzip (the default) to keep the URL minimal; non-gzip codecs
-        // (base64) still need the hint on non-legacy endpoints such as session replay.
-        ...(compression && compression !== Compression.GZipJS ? { compression } : {}),
-    })
+const buildRequestURL = (
+    url: string,
+    method: RequestWithOptions['method'],
+    compression?: RequestWithOptions['compression']
+): string => {
+    const params: Record<string, string> = {}
+    // The cache-buster only matters for GET requests; POSTs aren't cached, so skip it there.
+    if (method !== 'POST') {
+        params._ = new Date().getTime().toString()
+    }
+    // Gzip is self-describing via its magic-byte header, so the capture endpoint detects it
+    // (and base64, on legacy paths) without this hint — sending `compression` for gzip is
+    // redundant. Omit it for gzip (the default) to keep the URL minimal; non-gzip codecs
+    // (base64) still need the hint on non-legacy endpoints such as session replay.
+    if (compression && compression !== Compression.GZipJS) {
+        params.compression = compression
+    }
+    return Object.keys(params).length ? extendURLParams(url, params) : url
 }
 
 const AVAILABLE_TRANSPORTS: {
@@ -412,7 +421,7 @@ export const request = (_options: RequestWithOptions) => {
     const options: RequestWithEncodedBody = { ..._options }
     options.timeout = options.timeout || 60000
 
-    options.url = buildRequestURL(options.url, options.compression)
+    options.url = buildRequestURL(options.url, options.method, options.compression)
 
     const transport = options.transport ?? 'fetch'
 
@@ -448,7 +457,7 @@ export const request = (_options: RequestWithOptions) => {
                     transportMethod({
                         ...options,
                         compression: undefined,
-                        url: buildRequestURL(_options.url, undefined),
+                        url: buildRequestURL(_options.url, _options.method, undefined),
                     })
                     return
                 }


### PR DESCRIPTION
The `_` timestamp param was appended to every request to bust browser caches, but that only matters for GET requests — our data-collection requests are POSTs, which browsers don't cache. Skipping it on POSTs simplifies the request URL.