### PR TITLE
feat(ai): report OpenAI Agents tracing processor errors

### DIFF
--- a/.changeset/quiet-falcons-report.md
+++ b/.changeset/quiet-falcons-report.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': minor
+---
+
+Add optional error callback support to the OpenAI Agents tracing processor.

--- a/packages/ai/src/openai-agents/index.ts
+++ b/packages/ai/src/openai-agents/index.ts
@@ -2,7 +2,7 @@ import { PostHogTracingProcessor } from './processor'
 import type { PostHogTracingProcessorOptions } from './processor'
 
 export { PostHogTracingProcessor } from './processor'
-export type { PostHogTracingProcessorOptions, DistinctIdResolver } from './processor'
+export type { PostHogTracingProcessorOptions, DistinctIdResolver, TracingProcessorErrorHandler } from './processor'
 
 export type InstrumentOptions = PostHogTracingProcessorOptions
 

--- a/packages/ai/src/openai-agents/index.ts
+++ b/packages/ai/src/openai-agents/index.ts
@@ -2,7 +2,12 @@ import { PostHogTracingProcessor } from './processor'
 import type { PostHogTracingProcessorOptions } from './processor'
 
 export { PostHogTracingProcessor } from './processor'
-export type { PostHogTracingProcessorOptions, DistinctIdResolver, TracingProcessorErrorHandler } from './processor'
+export type {
+  PostHogTracingProcessorOptions,
+  DistinctIdResolver,
+  TracingProcessorErrorContext,
+  TracingProcessorErrorHandler,
+} from './processor'
 
 export type InstrumentOptions = PostHogTracingProcessorOptions
 

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -43,34 +43,62 @@ function normalizeInputRoles(input: unknown): unknown {
   })
 }
 
+function safeString(value: unknown): string {
+  try {
+    return String(value)
+  } catch {
+    return Object.prototype.toString.call(value)
+  }
+}
+
 function ensureSerializable(obj: unknown): unknown {
   if (obj === null || obj === undefined) {
     return obj
   }
   try {
-    JSON.stringify(obj)
-    return obj
+    const serializedValue = JSON.stringify(obj)
+    return serializedValue === undefined ? safeString(obj) : obj
   } catch {
-    return String(obj)
+    return safeString(obj)
+  }
+}
+
+function stringifyForSizeCheck(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  const serializableValue = ensureSerializable(value)
+  if (serializableValue === null || serializableValue === undefined) {
+    return null
+  }
+  if (typeof serializableValue === 'string') {
+    return serializableValue
+  }
+
+  try {
+    return JSON.stringify(serializableValue) ?? safeString(serializableValue)
+  } catch {
+    return safeString(serializableValue)
   }
 }
 
 function exceedsMaxOutputSize(value: unknown): boolean {
-  if (value === null || value === undefined) {
-    return false
-  }
-
-  const serializedValue = typeof value === 'string' ? value : (JSON.stringify(value) ?? String(value))
-  return new TextEncoder().encode(serializedValue).length > MAX_OUTPUT_SIZE
+  const serializedValue = stringifyForSizeCheck(value)
+  return serializedValue === null ? false : new TextEncoder().encode(serializedValue).length > MAX_OUTPUT_SIZE
 }
 
 function parseIsoTimestamp(isoStr: string | null | undefined): number | null {
-  if (!isoStr) {
+  if (typeof isoStr !== 'string' || isoStr.trim() === '') {
     return null
   }
 
   const ts = new Date(isoStr).getTime()
-  return isNaN(ts) ? null : ts / 1000
+  return Number.isFinite(ts) ? ts / 1000 : null
 }
 
 interface TraceMetadata {

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -60,24 +60,17 @@ function exceedsMaxOutputSize(value: unknown): boolean {
     return false
   }
 
-  try {
-    const serializedValue = typeof value === 'string' ? value : JSON.stringify(value)
-    return new TextEncoder().encode(serializedValue).length > MAX_OUTPUT_SIZE
-  } catch {
-    return false
-  }
+  const serializedValue = typeof value === 'string' ? value : (JSON.stringify(value) ?? String(value))
+  return new TextEncoder().encode(serializedValue).length > MAX_OUTPUT_SIZE
 }
 
 function parseIsoTimestamp(isoStr: string | null | undefined): number | null {
   if (!isoStr) {
     return null
   }
-  try {
-    const ts = new Date(isoStr).getTime()
-    return isNaN(ts) ? null : ts / 1000
-  } catch {
-    return null
-  }
+
+  const ts = new Date(isoStr).getTime()
+  return isNaN(ts) ? null : ts / 1000
 }
 
 interface TraceMetadata {
@@ -89,6 +82,7 @@ interface TraceMetadata {
 }
 
 export type DistinctIdResolver = string | ((trace: Trace) => string | null | undefined)
+export type TracingProcessorErrorHandler = (error: unknown, context: string) => void
 
 export interface PostHogTracingProcessorOptions {
   client: PostHog
@@ -96,6 +90,7 @@ export interface PostHogTracingProcessorOptions {
   privacyMode?: boolean
   groups?: Record<string, any>
   properties?: Record<string, any>
+  onError?: TracingProcessorErrorHandler
 }
 
 /**
@@ -122,6 +117,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
   private _privacyMode: boolean
   private _groups: Record<string, any>
   private _properties: Record<string, any>
+  private _onError: TracingProcessorErrorHandler | undefined
 
   private _spanStartTimes: Map<string, number> = new Map()
   private _traceMetadata: Map<string, TraceMetadata> = new Map()
@@ -133,6 +129,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
     this._privacyMode = options.privacyMode ?? false
     this._groups = options.groups ?? {}
     this._properties = options.properties ?? {}
+    this._onError = options.onError
   }
 
   private _getDistinctId(trace: Trace | null): string | undefined {
@@ -178,6 +175,10 @@ export class PostHogTracingProcessor implements TracingProcessor {
     }
   }
 
+  private _handleError(error: unknown, context: string): void {
+    this._onError?.(error, context)
+  }
+
   private _captureEvent(event: string, properties: Record<string, any>, distinctId?: string): void {
     try {
       if (!this._client?.capture) {
@@ -197,8 +198,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
       }
 
       this._client.capture(eventMessage)
-    } catch {
-      // Silently ignore capture errors
+    } catch (error) {
+      this._handleError(error, 'capture')
     }
   }
 
@@ -274,8 +275,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
         distinctId,
         startTime: Date.now() / 1000,
       })
-    } catch {
-      // Silently ignore errors
+    } catch (error) {
+      this._handleError(error, 'onTraceStart')
     }
   }
 
@@ -320,8 +321,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
       }
 
       this._captureEvent('$ai_trace', properties, distinctId ?? traceId)
-    } catch {
-      // Silently ignore errors
+    } catch (error) {
+      this._handleError(error, 'onTraceEnd')
     }
   }
 
@@ -329,8 +330,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
     try {
       this._evictStaleEntries()
       this._spanStartTimes.set(span.spanId, Date.now() / 1000)
-    } catch {
-      // Silently ignore errors
+    } catch (error) {
+      this._handleError(error, 'onSpanStart')
     }
   }
 
@@ -404,8 +405,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
           this._handleGenericSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
           break
       }
-    } catch {
-      // Silently ignore errors
+    } catch (error) {
+      this._handleError(error, 'onSpanEnd')
     }
   }
 
@@ -417,8 +418,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
       if (typeof this._client?.flush === 'function') {
         await this._client.flush()
       }
-    } catch {
-      // Silently ignore errors
+    } catch (error) {
+      this._handleError(error, 'shutdown')
     }
   }
 
@@ -427,8 +428,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
       if (typeof this._client?.flush === 'function') {
         await this._client.flush()
       }
-    } catch {
-      // Silently ignore errors
+    } catch (error) {
+      this._handleError(error, 'forceFlush')
     }
   }
 

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -17,7 +17,7 @@ import type {
   SpeechGroupSpanData,
   MCPListToolsSpanData,
 } from '@openai/agents-core'
-import { MAX_OUTPUT_SIZE, truncate, withPrivacyMode } from '../utils'
+import { MAX_OUTPUT_SIZE, toContentString, truncate, utf8ByteLength, withPrivacyMode } from '../utils'
 import { version } from '../../package.json'
 import { warnIfPostHogAiGateway } from '../gatewayWarning'
 
@@ -43,9 +43,9 @@ function normalizeInputRoles(input: unknown): unknown {
   })
 }
 
-function safeString(value: unknown): string {
+function safeContentString(value: unknown): string {
   try {
-    return String(value)
+    return toContentString(value)
   } catch {
     return Object.prototype.toString.call(value)
   }
@@ -57,9 +57,9 @@ function ensureSerializable(obj: unknown): unknown {
   }
   try {
     const serializedValue = JSON.stringify(obj)
-    return serializedValue === undefined ? safeString(obj) : obj
+    return serializedValue === undefined ? safeContentString(obj) : obj
   } catch {
-    return safeString(obj)
+    return safeContentString(obj)
   }
 }
 
@@ -72,24 +72,15 @@ function stringifyForSizeCheck(value: unknown): string | null {
     return value
   }
 
-  const serializableValue = ensureSerializable(value)
-  if (serializableValue === null || serializableValue === undefined) {
-    return null
-  }
-  if (typeof serializableValue === 'string') {
-    return serializableValue
-  }
-
   try {
-    return JSON.stringify(serializableValue) ?? safeString(serializableValue)
+    return JSON.stringify(value) ?? safeContentString(value)
   } catch {
-    return safeString(serializableValue)
+    return safeContentString(value)
   }
 }
 
-function exceedsMaxOutputSize(value: unknown): boolean {
-  const serializedValue = stringifyForSizeCheck(value)
-  return serializedValue === null ? false : new TextEncoder().encode(serializedValue).length > MAX_OUTPUT_SIZE
+function exceedsMaxOutputSize(serializedValue: string | null): boolean {
+  return serializedValue === null ? false : utf8ByteLength(serializedValue) > MAX_OUTPUT_SIZE
 }
 
 function parseIsoTimestamp(isoStr: string | null | undefined): number | null {
@@ -110,7 +101,15 @@ interface TraceMetadata {
 }
 
 export type DistinctIdResolver = string | ((trace: Trace) => string | null | undefined)
-export type TracingProcessorErrorHandler = (error: unknown, context: string) => void
+export type TracingProcessorErrorContext =
+  | 'capture'
+  | 'onTraceStart'
+  | 'onTraceEnd'
+  | 'onSpanStart'
+  | 'onSpanEnd'
+  | 'shutdown'
+  | 'forceFlush'
+export type TracingProcessorErrorHandler = (error: unknown, context: TracingProcessorErrorContext) => void
 
 export interface PostHogTracingProcessorOptions {
   client: PostHog
@@ -181,7 +180,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
 
   private _prepareCapturedValue(value: unknown): unknown {
     const serializableValue = ensureSerializable(value)
-    const boundedValue = exceedsMaxOutputSize(serializableValue) ? truncate(serializableValue) : serializableValue
+    const serializedValue = stringifyForSizeCheck(serializableValue)
+    const boundedValue = exceedsMaxOutputSize(serializedValue) ? truncate(serializedValue) : serializableValue
     return this._withPrivacyMode(boundedValue)
   }
 
@@ -203,7 +203,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
     }
   }
 
-  private _handleError(error: unknown, context: string): void {
+  private _handleError(error: unknown, context: TracingProcessorErrorContext): void {
     try {
       this._onError?.(error, context)
     } catch (handlerError) {

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -176,7 +176,12 @@ export class PostHogTracingProcessor implements TracingProcessor {
   }
 
   private _handleError(error: unknown, context: string): void {
-    this._onError?.(error, context)
+    try {
+      this._onError?.(error, context)
+    } catch (handlerError) {
+      // Preserve the tracing processor's non-throwing contract even if the error handler fails.
+      void handlerError
+    }
   }
 
   private _captureEvent(event: string, properties: Record<string, any>, distinctId?: string): void {

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -586,6 +586,25 @@ describe('PostHogTracingProcessor', () => {
       expect(call.properties.$ai_span_type).toBe('custom')
       expect(call.properties.$ai_custom_data).toEqual({ query: 'SELECT * FROM users', rows: 100 })
     })
+
+    it('stringifies custom span data when JSON serialization fails', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'custom',
+          name: 'unserializable_payload',
+          data: {
+            toJSON() {
+              throw new Error('Cannot serialize')
+            },
+          },
+        },
+      })
+
+      await expect(processor.onSpanEnd(span as any)).resolves.toBeUndefined()
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_custom_data).toBe('[object Object]')
+    })
   })
 
   describe('response spans', () => {
@@ -952,6 +971,20 @@ describe('PostHogTracingProcessor', () => {
 
       const call = mockClient.capture.mock.calls[0][0]
       expect(call.properties.$ai_latency).toBeCloseTo(2.0, 1)
+    })
+
+    it('ignores invalid runtime timestamp values', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        startedAt: Symbol('invalid') as any,
+        endedAt: '2024-01-01T00:00:02.000Z',
+      })
+
+      // Don't call onSpanStart to skip recording start time
+      await expect(processor.onSpanEnd(span as any)).resolves.toBeUndefined()
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_latency).toBe(0)
     })
   })
 

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -885,6 +885,25 @@ describe('PostHogTracingProcessor', () => {
       expect(onError).toHaveBeenCalledWith(captureError, 'capture')
     })
 
+    it('does not throw when onError throws', async () => {
+      mockClient.capture.mockImplementation(() => {
+        throw new Error('capture failed')
+      })
+      const onError = jest.fn(() => {
+        throw new Error('onError failed')
+      })
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+        onError,
+      })
+
+      await expect(proc.onSpanEnd(createMockSpan() as any)).resolves.toBeUndefined()
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith(expect.any(Error), 'capture')
+    })
+
     it('reports flush failures through onError without throwing', async () => {
       const flushError = new Error('flush failed')
       mockClient.flush.mockRejectedValueOnce(flushError)

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -867,6 +867,37 @@ describe('PostHogTracingProcessor', () => {
       const call = mockClient.capture.mock.calls[0][0]
       expect(call.properties.$ai_error_type).toBe(expectedType)
     })
+
+    it('reports capture failures through onError without throwing', async () => {
+      const captureError = new Error('capture failed')
+      mockClient.capture.mockImplementation(() => {
+        throw captureError
+      })
+      const onError = jest.fn()
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+        onError,
+      })
+
+      await expect(proc.onSpanEnd(createMockSpan() as any)).resolves.toBeUndefined()
+
+      expect(onError).toHaveBeenCalledWith(captureError, 'capture')
+    })
+
+    it('reports flush failures through onError without throwing', async () => {
+      const flushError = new Error('flush failed')
+      mockClient.flush.mockRejectedValueOnce(flushError)
+      const onError = jest.fn()
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        onError,
+      })
+
+      await expect(proc.forceFlush()).resolves.toBeUndefined()
+
+      expect(onError).toHaveBeenCalledWith(flushError, 'forceFlush')
+    })
   })
 
   describe('latency calculation', () => {


### PR DESCRIPTION
## Problem

The OpenAI Agents tracing processor intentionally avoids throwing from tracing lifecycle hooks, but failures were fully silent. That made capture and flush issues hard to observe and also left defensive-code scan findings around swallowed errors.

## Changes

- Add an optional `onError(error, context)` callback to `PostHogTracingProcessorOptions`.
- Type the error callback context with an exported `TracingProcessorErrorContext` union.
- Route capture, trace/span lifecycle, shutdown, and force flush failures through `onError` while preserving the existing non-throwing behavior.
- Guard the `onError` callback itself so a throwing handler cannot break the processor's non-throwing contract.
- Harden timestamp parsing against invalid runtime values and harden captured-value size checks against JSON serialization failures.
- Reuse shared AI utility helpers for content stringification and UTF-8 byte length checks.
- Export the tracing processor error handler/context types from the OpenAI Agents entrypoint.
- Add tests covering capture, flush, throwing-handler, invalid timestamp, and unserializable payload handling.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A pi coding agent ran `slop-scan`, selected the OpenAI Agents tracing processor as a useful low-noise hotspot, and made a focused change to keep the processor's non-throwing behavior while exposing failures through an optional callback. Reviewer feedback and follow-up hardening were addressed by guarding the callback, typing the context, reusing shared utilities, avoiding double serialization preparation, and handling invalid runtime timestamps/serialization edge cases. Validation run: `pnpm --filter=@posthog/ai test:unit -- openai-agents.test.ts --runInBand`, `pnpm --filter=@posthog/ai lint`, `git diff --check`, and `slop-scan scan packages/ai/src/openai-agents --lint`.
