### PR TITLE
ci: update PostHog Watcher action

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -30,7 +30,7 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@520090eef3045d78794fb25e1cedaeb83fd6c342
+              uses: PostHog/posthog-watcher-action@94aefbfa2471384d5d41cddacbbf684b6be171d5
               with:
                   mode: enqueue
                   trigger-drain-workflow: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -42,7 +42,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@520090eef3045d78794fb25e1cedaeb83fd6c342
+              uses: PostHog/posthog-watcher-action@94aefbfa2471384d5d41cddacbbf684b6be171d5
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep
@@ -57,3 +57,4 @@ jobs:
                   fix-pr-review-team: PostHog/team-client-libraries
                   approve-project-resources: 'true'
                   state-enabled: 'true'
+                  pi-session-sharing: 'true'

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -48,7 +48,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@520090eef3045d78794fb25e1cedaeb83fd6c342
+              uses: PostHog/posthog-watcher-action@94aefbfa2471384d5d41cddacbbf684b6be171d5
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -61,6 +61,7 @@ jobs:
                   fix-pr-review-team: PostHog/team-client-libraries
                   approve-project-resources: 'true'
                   state-enabled: 'true'
+                  pi-session-sharing: 'true'
 
     process-issue:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs['issue-number'] != '' }}
@@ -79,7 +80,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@520090eef3045d78794fb25e1cedaeb83fd6c342
+              uses: PostHog/posthog-watcher-action@94aefbfa2471384d5d41cddacbbf684b6be171d5
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}
@@ -93,3 +94,4 @@ jobs:
                   fix-pr-review-team: PostHog/team-client-libraries
                   approve-project-resources: 'true'
                   state-enabled: 'true'
+                  pi-session-sharing: 'true'


### PR DESCRIPTION
## Problem

The PostHog Watcher workflows were pinned to an older action SHA, so they could not use the newly merged opt-in Pi session sharing feature from PostHog/posthog-watcher-action#7.

## Changes

- Updated all `PostHog/posthog-watcher-action` workflow usages to the latest `main` SHA: `94aefbfa2471384d5d41cddacbbf684b6be171d5`.
- Enabled `pi-session-sharing: 'true'` for watcher jobs that run Pi (`sweep`, `drain-queue`, and `process-issue`).
- Left enqueue unchanged apart from the SHA update because it only queues events and does not run Pi.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi updated the watcher workflow configuration in a dedicated git worktree. The action SHA was resolved from `PostHog/posthog-watcher-action` `main` after PR #7 was merged, and session sharing was enabled only on workflow steps that invoke Pi.

Verification: parsed the edited workflow YAML files with Ruby's YAML parser.
