### PR TITLE
chore: update PostHog watcher action

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -30,7 +30,7 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@94aefbfa2471384d5d41cddacbbf684b6be171d5
+              uses: PostHog/posthog-watcher-action@4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d
               with:
                   mode: enqueue
                   trigger-drain-workflow: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -42,7 +42,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@94aefbfa2471384d5d41cddacbbf684b6be171d5
+              uses: PostHog/posthog-watcher-action@4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -48,7 +48,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@94aefbfa2471384d5d41cddacbbf684b6be171d5
+              uses: PostHog/posthog-watcher-action@4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -80,7 +80,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@94aefbfa2471384d5d41cddacbbf684b6be171d5
+              uses: PostHog/posthog-watcher-action@4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}


### PR DESCRIPTION
## Problem

The PostHog watcher workflows pin `PostHog/posthog-watcher-action` to a specific commit SHA. They should be kept current with the latest upstream action commit.

## Changes

Updated all `PostHog/posthog-watcher-action` workflow references from `94aefbfa2471384d5d41cddacbbf684b6be171d5` to `4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d`.

Verified with:

```bash
rg -n "PostHog/posthog-watcher-action@" .github/workflows
rg -n "PostHog/posthog-watcher-action@" .github/workflows | grep -v "4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d" || true
git diff --check
```

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi updated the pinned PostHog watcher action references across the workflow files and verified that all references now point to the same latest upstream SHA. This is a workflow-only dependency update, so no SDK changeset was added.
