### PR TITLE
feat: add posthog-js/customizations subpath entry point

### DIFF
--- a/.changeset/customizations-subpath-entrypoint.md
+++ b/.changeset/customizations-subpath-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"posthog-js": minor
+---
+
+feat(web): add a `posthog-js/customizations` subpath entry point exposing the optional customizations (`setAllPersonProfilePropertiesAsPersonPropertiesForFlags`, the `before-send` sampling helpers, and the redux/kea loggers) as a proper ES module with bundled types, replacing the internal `posthog-js/lib/src/customizations` deep import. Also fixes the TypeScript definitions so `setAllPersonProfilePropertiesAsPersonPropertiesForFlags` accepts the instance passed to the `loaded` callback (the documented usage), and the `loaded` callback's instance type now includes `config`.

--- a/packages/browser/customizations/package.json
+++ b/packages/browser/customizations/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "posthog-js-customizations",
+    "version": "1.0.0",
+    "private": true,
+    "description": "Subpath entry point exposing the optional posthog-js customizations (setAllPersonProfilePropertiesAsPersonPropertiesForFlags, before-send helpers, redux/kea loggers). ESM-only; consumed by bundlers via the `module` field.",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/PostHog/posthog-js",
+        "directory": "packages/browser/customizations"
+    },
+    "main": "../dist/customizations.js",
+    "module": "../dist/customizations.js",
+    "types": "../dist/customizations.d.ts"
+}

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -56,6 +56,7 @@
         "react/package.json",
         "react/surveys/package.json",
         "react/slim/package.json",
+        "customizations/package.json",
         "rrweb/package.json",
         "rrweb-types/package.json",
         "rrweb-plugin-console-record/package.json"

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -2897,7 +2897,7 @@
       "name": "PostHogInterface",
       "properties": [],
       "path": "lib/src/types.d.ts",
-      "example": "\"config\" | \"init\""
+      "example": "Omit<BasePostHogInterface, 'config' | 'init' | 'set_config'> & {\n    config: PostHogConfig;\n    set_config(config: Partial<PostHogConfig>): void;\n}"
     },
     {
       "id": "ProductTour",

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -404,6 +404,10 @@ const typeTargets = entrypoints
     .map((file) => {
         const source = `./lib/src/entrypoints/${file.replace('.ts', '.d.ts')}`
         const isExtensionBundles = file === 'extension-bundles.es.ts'
+        // customizations types must reference the main module for the PostHog class —
+        // an inlined duplicate would be nominally incompatible with the consumer's
+        // `posthog` instance (same private-fields problem as extension-bundles).
+        const isCustomizations = file === 'customizations.es.ts'
         const inlineExternalTypes = inlineExternalTypesEntries.has(file)
         const rewriteRrdomAlias = rewriteRrdomNodeTypeAlias(file)
         /** @type {import('rollup').RollupOptions} */
@@ -413,6 +417,7 @@ const typeTargets = entrypoints
             // their own copies — classes with private fields are nominally typed, so
             // duplicate declarations across .d.ts files are incompatible.
             ...(isExtensionBundles ? { external: [/module\.slim/] } : {}),
+            ...(isCustomizations ? { external: [/posthog-core$/] } : {}),
             output: [
                 {
                     dir: path.resolve('./dist'),
@@ -433,6 +438,18 @@ const typeTargets = entrypoints
                               name: 'fix-dts-external-paths',
                               renderChunk(code) {
                                   return code.replace(/\.\/module\.slim\.es(?=['"])/g, './module.slim')
+                              },
+                          },
+                      ]
+                    : []),
+                ...(isCustomizations
+                    ? [
+                          {
+                              name: 'fix-customizations-dts-external-paths',
+                              renderChunk(code) {
+                                  // the external posthog-core import keeps its source-relative
+                                  // path; point it at dist/module.d.ts instead
+                                  return code.replace(/['"](?:\.\.\/)+posthog-core['"]/g, "'./module'")
                               },
                           },
                       ]

--- a/packages/browser/src/__tests__/entrypoints/customizations.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/customizations.test.ts
@@ -1,0 +1,25 @@
+import { assignableWindow } from '../../utils/globals'
+
+describe('customizations entrypoints', () => {
+    beforeEach(() => {
+        jest.resetModules()
+        delete assignableWindow.posthogCustomizations
+    })
+
+    it('exports setAllPersonProfilePropertiesAsPersonPropertiesForFlags from the module entrypoint', async () => {
+        // backs the `posthog-js/customizations` subpath — the importable alternative
+        // to the internal `posthog-js/lib/src/customizations` path, which is CJS-only
+        // and unresolvable under native ESM / Node16 module resolution
+        const entry = await import('../../entrypoints/customizations.es')
+
+        expect(typeof entry.setAllPersonProfilePropertiesAsPersonPropertiesForFlags).toBe('function')
+    })
+
+    it('publishes customizations on window.posthogCustomizations from the script entrypoint', async () => {
+        await import('../../entrypoints/customizations.full')
+
+        expect(
+            typeof assignableWindow.posthogCustomizations?.setAllPersonProfilePropertiesAsPersonPropertiesForFlags
+        ).toBe('function')
+    })
+})

--- a/packages/browser/src/__tests__/entrypoints/customizations.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/customizations.test.ts
@@ -1,4 +1,19 @@
 import { assignableWindow } from '../../utils/globals'
+import type { PostHogConfig } from '../../types'
+import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from '../../customizations'
+
+// everything the `src/customizations` barrel exports — keep in sync with customizations/index.ts
+const EXPECTED_EXPORTS = [
+    'setAllPersonProfilePropertiesAsPersonPropertiesForFlags',
+    'sampleByDistinctId',
+    'sampleBySessionId',
+    'sampleByEvent',
+    'printAndDropEverything',
+    'posthogReduxLogger',
+    'posthogKeaLogger',
+    'sessionRecordingLoggerForPostHogInstance',
+    'browserConsoleLogger',
+]
 
 describe('customizations entrypoints', () => {
     beforeEach(() => {
@@ -6,20 +21,35 @@ describe('customizations entrypoints', () => {
         delete assignableWindow.posthogCustomizations
     })
 
-    it('exports setAllPersonProfilePropertiesAsPersonPropertiesForFlags from the module entrypoint', async () => {
+    it('exports all customizations from the module entrypoint', async () => {
         // backs the `posthog-js/customizations` subpath — the importable alternative
         // to the internal `posthog-js/lib/src/customizations` path, which is CJS-only
         // and unresolvable under native ESM / Node16 module resolution
         const entry = await import('../../entrypoints/customizations.es')
 
-        expect(typeof entry.setAllPersonProfilePropertiesAsPersonPropertiesForFlags).toBe('function')
+        for (const name of EXPECTED_EXPORTS) {
+            expect(typeof (entry as Record<string, unknown>)[name]).toBe('function')
+        }
     })
 
-    it('publishes customizations on window.posthogCustomizations from the script entrypoint', async () => {
+    it('publishes all customizations on window.posthogCustomizations from the script entrypoint', async () => {
         await import('../../entrypoints/customizations.full')
 
-        expect(
-            typeof assignableWindow.posthogCustomizations?.setAllPersonProfilePropertiesAsPersonPropertiesForFlags
-        ).toBe('function')
+        for (const name of EXPECTED_EXPORTS) {
+            expect(typeof assignableWindow.posthogCustomizations?.[name]).toBe('function')
+        }
+    })
+
+    it('setAllPersonProfilePropertiesAsPersonPropertiesForFlags accepts the instance passed to `loaded`', () => {
+        // compile-time regression for the documented usage
+        // (https://posthog.com/docs/feature-flags/property-overrides): the `loaded`
+        // callback receives a `PostHogInterface`, not the concrete `PostHog` class
+        const config: Partial<PostHogConfig> = {
+            loaded: (posthog) => {
+                setAllPersonProfilePropertiesAsPersonPropertiesForFlags(posthog)
+            },
+        }
+
+        expect(config.loaded).toBeDefined()
     })
 })

--- a/packages/browser/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags.ts
+++ b/packages/browser/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags.ts
@@ -1,4 +1,4 @@
-import { PostHog } from '../posthog-core'
+import type { PostHogConfig, PostHogInterface } from '../types'
 import {
     CAMPAIGN_PARAMS,
     getCampaignParams,
@@ -9,7 +9,23 @@ import {
 import { each, extend } from '../utils'
 import { includes } from '@posthog/core'
 
-export const setAllPersonProfilePropertiesAsPersonPropertiesForFlags = (posthog: PostHog): void => {
+// only the members the function reads — typed structurally (not as the PostHog
+// class) so it accepts both the singleton and the instance handed to the `loaded`
+// callback, where the docs recommend calling it. Picking scalar config keys keeps
+// nominal class types (config.__extensionClasses) out of the signature, which
+// would otherwise be incompatible across the lib/ and dist/ declaration copies.
+type PostHogWithFlags = Pick<PostHogInterface, 'setPersonPropertiesForFlags'> & {
+    config: Pick<
+        PostHogConfig,
+        | 'mask_personal_data_properties'
+        | 'custom_personal_data_properties'
+        | 'detect_google_search_app'
+        | 'disable_capture_url_hashes'
+        | 'custom_campaign_params'
+    >
+}
+
+export const setAllPersonProfilePropertiesAsPersonPropertiesForFlags = (posthog: PostHogWithFlags): void => {
     const allProperties = extend(
         {},
         getEventProperties(

--- a/packages/browser/src/entrypoints/customizations.es.ts
+++ b/packages/browser/src/entrypoints/customizations.es.ts
@@ -1,0 +1,5 @@
+// ES module entrypoint backing the `posthog-js/customizations` subpath, so
+// consumers can import customizations without reaching into the tsc build
+// output (`posthog-js/lib/src/customizations`), which is CJS-only and does not
+// resolve under native ESM or Node16 module resolution.
+export * from '../customizations'

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -143,7 +143,12 @@ import type {
  * This guarantees we'll be able to use `PostHogConfig` as implemented in the browser/src/posthog-core.ts file
  * using the proper `loaded` function signature.
  */
-export type PostHogInterface = Omit<BasePostHogInterface, 'config' | 'init'>
+export type PostHogInterface = Omit<BasePostHogInterface, 'config' | 'init' | 'set_config'> & {
+    // re-declared (rather than kept from the base interface) so they use the
+    // browser-specific `PostHogConfig` below, matching the class implementation
+    config: PostHogConfig
+    set_config(config: Partial<PostHogConfig>): void
+}
 
 /*
  * Specify that `loaded` should be using the PostHog instance type


### PR DESCRIPTION
## Problem

`setAllPersonProfilePropertiesAsPersonPropertiesForFlags` (and the other optional customizations) are not exported from any public entrypoint of `posthog-js`. Today the only ways to reach them are:

- `import { … } from 'posthog-js/lib/src/customizations'` — a deep import into the internal tsc build output. Works under CJS/bundler resolution, but fails with `ERR_UNSUPPORTED_DIR_IMPORT` under native Node ESM and doesn't resolve under TypeScript `node16`/`nodenext`. This is the path the docs and the nextjs playground currently use.
- The `customizations.full.js` script bundle, which only assigns `window.posthogCustomizations` (its `.d.ts` is `export {}`).

## Fix

Follows the existing `rrweb/` subpath pattern:

- **`src/entrypoints/customizations.es.ts`** — new ES module entrypoint re-exporting `src/customizations`; the existing rollup machinery emits `dist/customizations.js` + `dist/customizations.d.ts`.
- **`customizations/package.json`** — subpath stub pointing `main`/`module`/`types` at those dist files (added to the `files` list), so consumers write:
  ```ts
  import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/customizations'
  ```
- **`rollup.config.mjs`** — marks `posthog-core` as external in the customizations d.ts and rewrites the import to `./module`. Without this the d.ts inlines a duplicate `PostHog` class, and since classes with private fields are nominally typed, consumers couldn't pass their `posthog` instance (same problem already solved for `extension-bundles`).

## Test

`src/__tests__/entrypoints/customizations.test.ts` asserts the function is importable from the module entrypoint and still published on `window.posthogCustomizations` by the script entrypoint. The first assertion fails on main (module doesn't exist) and passes with this change.

Verified end-to-end with a packed tarball in a scratch consumer project:
- `tsc --strict` (moduleResolution `bundler`) typechecks passing the `posthog-js` default instance into the function imported from `posthog-js/customizations`
- both `require('posthog-js/customizations')` and ESM import of the dist bundle resolve the function at runtime
- `turbo build --filter=posthog-js`, lint, prettier, and existing customizations tests pass

## Notes

Like the `rrweb/` subpath, this resolves via legacy `main`/`module` fields — bare Node ESM still can't resolve the subpath because the package has no `exports` map (adding one would break every existing `posthog-js/lib/...` deep import, including the documented one). Docs and `playground/nextjs` can be updated to the new import path as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)