### PR TITLE
fix(react-native): repeating surveys show again when a new iteration starts

### DIFF
--- a/.changeset/shared-survey-state.md
+++ b/.changeset/shared-survey-state.md
@@ -3,4 +3,4 @@
 'posthog-js': patch
 ---
 
-chore: survey seen-key and repeat-activation helpers now live in @posthog/core, shared by the web and React Native SDKs. No behavior change.
+chore: survey seen-key and repeat-activation helpers now live in @posthog/core, shared by the web and React Native SDKs. Core's survey enums are now const-object literal unions (matching the web SDK's existing pattern), so the same values type-check across both SDKs. No behavior change.

--- a/.changeset/shared-survey-state.md
+++ b/.changeset/shared-survey-state.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+---
+
+chore: survey seen-key and repeat-activation helpers now live in @posthog/core, shared by the web and React Native SDKs. No behavior change.

--- a/.changeset/shared-survey-state.md
+++ b/.changeset/shared-survey-state.md
@@ -3,4 +3,4 @@
 'posthog-js': patch
 ---
 
-chore: survey seen-key and repeat-activation helpers now live in @posthog/core, shared by the web and React Native SDKs. Core's survey enums are now const-object literal unions (matching the web SDK's existing pattern), so the same values type-check across both SDKs. No behavior change.
+chore: survey seen-key and repeat-activation helpers now live in @posthog/core, shared by the web and React Native SDKs. Core's survey enums are now const-object literal unions (matching the web SDK's existing pattern), so the same values type-check across both SDKs. No behavior change. Type-level note: enum members no longer work as standalone type annotations (e.g. `SurveyType.Popover` as a type); use the exported union types instead. Runtime values are unchanged.

--- a/.changeset/tidy-hogs-repeat.md
+++ b/.changeset/tidy-hogs-repeat.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+fix: repeating surveys now show again when a new iteration starts. The local seen state is keyed by survey iteration (matching the web SDK), so a survey scheduled to repeat no longer stays hidden on a device after the first response.

--- a/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
@@ -4,7 +4,6 @@ import {
     doesSurveyUrlMatch,
     getFontFamily,
     getSurveySeen,
-    hasEvents,
     hasWaitPeriodPassed,
     sendSurveyEvent,
 } from '../../extensions/surveys/surveys-extension-utils'
@@ -265,49 +264,6 @@ describe('getSurveySeen', () => {
             localStorage.setItem(`${SURVEY_SEEN_PREFIX}${surveyWithZeroIteration.id}`, 'true')
             expect(getSurveySeen(surveyWithZeroIteration)).toBe(true)
         })
-    })
-})
-
-describe('hasEvents', () => {
-    it('should return false when survey has no conditions', () => {
-        const survey = {
-            conditions: undefined,
-        } as Pick<Survey, 'conditions'>
-        expect(hasEvents(survey)).toBe(false)
-    })
-
-    it('should return false when survey has no events', () => {
-        const survey = {
-            conditions: {
-                events: undefined,
-                actions: { values: [] },
-            },
-        } as Pick<Survey, 'conditions'>
-        expect(hasEvents(survey)).toBe(false)
-    })
-
-    it('should return false when survey has empty events values', () => {
-        const survey = {
-            conditions: {
-                events: {
-                    values: [],
-                },
-                actions: { values: [] },
-            },
-        } as Pick<Survey, 'conditions'>
-        expect(hasEvents(survey)).toBe(false)
-    })
-
-    it('should return true when survey has events values', () => {
-        const survey = {
-            conditions: {
-                events: {
-                    values: [{ name: 'event1' }, { name: 'event2' }],
-                },
-                actions: { values: [] },
-            },
-        } as Pick<Survey, 'conditions'>
-        expect(hasEvents(survey)).toBe(true)
     })
 })
 

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -8,7 +8,6 @@ import {
     SurveyEventProperties,
     SurveyPosition,
     SurveyQuestion,
-    SurveySchedule,
     SurveyType,
     SurveyWidgetType,
 } from '../../posthog-surveys-types'
@@ -22,7 +21,14 @@ import {
     SURVEY_IN_PROGRESS_PREFIX,
 } from '../../utils/survey-utils'
 import { isNullish, type SurveyResponses } from '@posthog/core'
-import { buildSurveyResponseProperties, getSurveyResponseKey, surveyHasResponses } from '@posthog/core/surveys'
+import {
+    buildSurveyResponseProperties,
+    canSurveyActivateRepeatedly,
+    doesSurveyActivateByEvent,
+    getSurveyResponseKey,
+    getSurveyStorageKey,
+    surveyHasResponses,
+} from '@posthog/core/surveys'
 
 import { propertyComparisons } from '../../utils/property-utils'
 import { getTargetingUrl } from '../../utils/url-targeting-utils'
@@ -574,17 +580,13 @@ export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
 }
 
 export const hasEvents = (survey: Pick<Survey, 'conditions'>): boolean => {
-    return survey.conditions?.events?.values?.length != undefined && survey.conditions?.events?.values?.length > 0
+    return doesSurveyActivateByEvent(survey)
 }
 
 export const canActivateRepeatedly = (
     survey: Pick<Survey, 'schedule' | 'conditions' | 'id' | 'current_iteration'>
 ): boolean => {
-    return (
-        !!(survey.conditions?.events?.repeatedActivation && hasEvents(survey)) ||
-        survey.schedule === SurveySchedule.Always ||
-        isSurveyInProgress(survey)
-    )
+    return canSurveyActivateRepeatedly(survey) || isSurveyInProgress(survey)
 }
 
 /**
@@ -701,11 +703,7 @@ interface InProgressSurveyState {
 }
 
 const getInProgressSurveyStateKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
-    let key = `${SURVEY_IN_PROGRESS_PREFIX}${survey.id}`
-    if (survey.current_iteration && survey.current_iteration > 0) {
-        key = `${SURVEY_IN_PROGRESS_PREFIX}${survey.id}_${survey.current_iteration}`
-    }
-    return key
+    return getSurveyStorageKey(SURVEY_IN_PROGRESS_PREFIX, survey)
 }
 
 export const setInProgressSurveyState = (

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../posthog-surveys-types'
 import { document as _document, window as _window } from '../../utils/globals'
 import {
-    doesSurveyActivateByEvent,
     getSurveyInteractionProperty,
     getSurveySeenKey,
     getSurveyAbandonedKey,
@@ -577,10 +576,6 @@ export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
     }
 
     return reverseIfUnshuffled(survey.questions, shuffle(survey.questions))
-}
-
-export const hasEvents = (survey: Pick<Survey, 'conditions'>): boolean => {
-    return doesSurveyActivateByEvent(survey)
 }
 
 export const canActivateRepeatedly = (

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -13,9 +13,11 @@ import {
 } from '../../posthog-surveys-types'
 import { document as _document, window as _window } from '../../utils/globals'
 import {
+    doesSurveyActivateByEvent,
     getSurveyInteractionProperty,
     getSurveySeenKey,
     getSurveyAbandonedKey,
+    getSurveyStorageKey,
     SURVEY_LOGGER as logger,
     setSurveySeenOnLocalStorage,
     SURVEY_IN_PROGRESS_PREFIX,
@@ -24,9 +26,7 @@ import { isNullish, type SurveyResponses } from '@posthog/core'
 import {
     buildSurveyResponseProperties,
     canSurveyActivateRepeatedly,
-    doesSurveyActivateByEvent,
     getSurveyResponseKey,
-    getSurveyStorageKey,
     surveyHasResponses,
 } from '@posthog/core/surveys'
 

--- a/packages/browser/src/utils/survey-event-receiver.ts
+++ b/packages/browser/src/utils/survey-event-receiver.ts
@@ -1,17 +1,10 @@
+import { canSurveyActivateRepeatedly } from '@posthog/core/surveys'
 import { SURVEYS_ACTIVATED } from '../constants'
-import { Survey, SurveyEventName, SurveySchedule } from '../posthog-surveys-types'
+import { Survey, SurveyEventName } from '../posthog-surveys-types'
 import { PostHog } from '../posthog-core'
 import { SURVEY_LOGGER as logger } from './survey-utils'
 import { ActivationOutcome, EventReceiver } from './event-receiver'
 import { createLogger } from './logger'
-
-// A survey is "repeatable" when it shows on every captured trigger: an "always" schedule, or the
-// "Show every time the event is captured" option. Config-only (no dependency on the lazy-loaded
-// surveys extension) so it stays out of the core bundle.
-function isRepeatableSurvey(survey: Survey): boolean {
-    const hasEvents = (survey.conditions?.events?.values?.length ?? 0) > 0
-    return survey.schedule === SurveySchedule.Always || !!(survey.conditions?.events?.repeatedActivation && hasEvents)
-}
 
 export class SurveyEventReceiver extends EventReceiver<Survey> {
     constructor(instance: PostHog) {
@@ -57,7 +50,7 @@ export class SurveyEventReceiver extends EventReceiver<Survey> {
         // A repeatable survey (or one we can't resolve yet) shows once per trigger, so it's consumed
         // when shown. A non-repeatable survey is instead promoted to persistence on shown — so it
         // survives a reload — and only consumed once the user dismisses or answers it.
-        const consumedOnShown = !survey || isRepeatableSurvey(survey)
+        const consumedOnShown = !survey || canSurveyActivateRepeatedly(survey)
         if (consumedOnShown) {
             return event === SurveyEventName.SHOWN ? 'consume' : 'ignore'
         }

--- a/packages/browser/src/utils/survey-utils.ts
+++ b/packages/browser/src/utils/survey-utils.ts
@@ -1,16 +1,14 @@
+import { getSurveyStorageKey } from '@posthog/core/surveys'
+
 import { DisplaySurveyOptions, Survey, SurveyType, DisplaySurveyType } from '../posthog-surveys-types'
 import { createLogger } from '../utils/logger'
 
-export { getSurveyInteractionProperty } from '@posthog/core/surveys'
+export { doesSurveyActivateByEvent, getSurveyInteractionProperty, getSurveyStorageKey } from '@posthog/core/surveys'
 
 export const SURVEY_LOGGER = createLogger('[Surveys]')
 
 export function isSurveyRunning(survey: Survey): boolean {
     return !!(survey.start_date && !survey.end_date)
-}
-
-export function doesSurveyActivateByEvent(survey: Pick<Survey, 'conditions'>): boolean {
-    return !!survey.conditions?.events?.values?.length
 }
 
 export function doesSurveyActivateByAction(survey: Pick<Survey, 'conditions'>): boolean {
@@ -20,14 +18,6 @@ export function doesSurveyActivateByAction(survey: Pick<Survey, 'conditions'>): 
 export const SURVEY_SEEN_PREFIX = 'seenSurvey_'
 export const SURVEY_IN_PROGRESS_PREFIX = 'inProgressSurvey_'
 export const SURVEY_ABANDONED_PREFIX = 'abandonedSurvey_'
-
-const getSurveyStorageKey = (prefix: string, survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
-    let key = `${prefix}${survey.id}`
-    if (survey.current_iteration && survey.current_iteration > 0) {
-        key = `${prefix}${survey.id}_${survey.current_iteration}`
-    }
-    return key
-}
 
 export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
     return getSurveyStorageKey(SURVEY_SEEN_PREFIX, survey)

--- a/packages/browser/src/utils/survey-utils.ts
+++ b/packages/browser/src/utils/survey-utils.ts
@@ -1,9 +1,9 @@
-import { getSurveyStorageKey } from '@posthog/core/surveys'
+import { getSurveyIterationKey } from '@posthog/core/surveys'
 
 import { DisplaySurveyOptions, Survey, SurveyType, DisplaySurveyType } from '../posthog-surveys-types'
 import { createLogger } from '../utils/logger'
 
-export { doesSurveyActivateByEvent, getSurveyInteractionProperty, getSurveyStorageKey } from '@posthog/core/surveys'
+export { doesSurveyActivateByEvent, getSurveyInteractionProperty } from '@posthog/core/surveys'
 
 export const SURVEY_LOGGER = createLogger('[Surveys]')
 
@@ -18,6 +18,12 @@ export function doesSurveyActivateByAction(survey: Pick<Survey, 'conditions'>): 
 export const SURVEY_SEEN_PREFIX = 'seenSurvey_'
 export const SURVEY_IN_PROGRESS_PREFIX = 'inProgressSurvey_'
 export const SURVEY_ABANDONED_PREFIX = 'abandonedSurvey_'
+
+// Prefix namespacing is a localStorage concern, so it stays in the browser package;
+// the iteration-qualified key itself is shared with the other SDKs via @posthog/core.
+export const getSurveyStorageKey = (prefix: string, survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
+    return `${prefix}${getSurveyIterationKey(survey)}`
+}
 
 export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
     return getSurveyStorageKey(SURVEY_SEEN_PREFIX, survey)

--- a/packages/core/src/surveys/activation.spec.ts
+++ b/packages/core/src/surveys/activation.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from '@jest/globals'
+import { SurveySchedule } from '../types'
+import { canSurveyActivateRepeatedly, doesSurveyActivateByEvent } from './activation'
+
+describe('doesSurveyActivateByEvent', () => {
+  const cases: [string, Parameters<typeof doesSurveyActivateByEvent>[0], boolean][] = [
+    ['non-empty event values', { conditions: { events: { values: [{ name: 'event' }] } } }, true],
+    ['empty event values', { conditions: { events: { values: [] } } }, false],
+    ['undefined conditions', { conditions: undefined }, false],
+    ['null conditions', { conditions: null }, false],
+    ['null events', { conditions: { events: null } }, false],
+  ]
+
+  it.each(cases)('%s returns %p', (_name, survey, expected) => {
+    expect(doesSurveyActivateByEvent(survey)).toBe(expected)
+  })
+})
+
+describe('canSurveyActivateRepeatedly', () => {
+  const cases: [string, Parameters<typeof canSurveyActivateRepeatedly>[0], boolean][] = [
+    ['always schedule without events', { schedule: SurveySchedule.Always }, true],
+    [
+      'events with repeated activation enabled',
+      {
+        schedule: SurveySchedule.Once,
+        conditions: { events: { repeatedActivation: true, values: [{ name: 'event' }] } },
+      },
+      true,
+    ],
+    [
+      'events with repeated activation disabled',
+      {
+        schedule: SurveySchedule.Once,
+        conditions: { events: { repeatedActivation: false, values: [{ name: 'event' }] } },
+      },
+      false,
+    ],
+    [
+      'events without repeated activation',
+      {
+        schedule: SurveySchedule.Once,
+        conditions: { events: { values: [{ name: 'event' }] } },
+      },
+      false,
+    ],
+    [
+      'repeated activation without event values',
+      {
+        schedule: SurveySchedule.Once,
+        conditions: { events: { repeatedActivation: true, values: [] } },
+      },
+      false,
+    ],
+    ['undefined schedule without events', { schedule: undefined }, false],
+    ['null schedule without events', { schedule: null }, false],
+  ]
+
+  it.each(cases)('%s returns %p', (_name, survey, expected) => {
+    expect(canSurveyActivateRepeatedly(survey)).toBe(expected)
+  })
+})

--- a/packages/core/src/surveys/activation.ts
+++ b/packages/core/src/surveys/activation.ts
@@ -1,29 +1,17 @@
 import { SurveySchedule } from '../types'
 
-type SurveyWithIteration = {
-  id: string
-  current_iteration?: number | null
-}
-
+// Structural type instead of Pick<Survey, 'schedule' | 'conditions'>: the browser SDK
+// has its own Survey type using literal unions where core uses enums, so picking from
+// core's Survey would reject browser values. The template-literal schedule type accepts
+// both while still rejecting arbitrary strings.
 type SurveyForRepeatActivation = {
-  schedule?: string | null
+  schedule?: `${SurveySchedule}` | null
   conditions?: {
     events?: {
       repeatedActivation?: boolean
       values?: { name: string }[]
     } | null
   } | null
-}
-
-/**
- * Storage key for per-survey display state (seen, in-progress, abandoned, ...).
- * Keyed by iteration so repeating surveys become visible again when a new iteration starts.
- */
-export function getSurveyStorageKey(prefix: string, survey: SurveyWithIteration): string {
-  if (survey.current_iteration && survey.current_iteration > 0) {
-    return `${prefix}${survey.id}_${survey.current_iteration}`
-  }
-  return `${prefix}${survey.id}`
 }
 
 export function doesSurveyActivateByEvent(survey: SurveyForRepeatActivation): boolean {

--- a/packages/core/src/surveys/activation.ts
+++ b/packages/core/src/surveys/activation.ts
@@ -1,11 +1,8 @@
-import { SurveySchedule } from '../types'
+import { Survey, SurveySchedule } from '../types'
 
-// Structural type instead of Pick<Survey, 'schedule' | 'conditions'>: the browser SDK
-// has its own Survey type using literal unions where core uses enums, so picking from
-// core's Survey would reject browser values. The template-literal schedule type accepts
-// both while still rejecting arbitrary strings.
-type SurveyForRepeatActivation = {
-  schedule?: `${SurveySchedule}` | null
+// conditions is narrowed to the fields these predicates actually read, so both SDKs'
+// Survey shapes (which still drift in nested condition types) satisfy it structurally.
+type SurveyForRepeatActivation = Pick<Survey, 'schedule'> & {
   conditions?: {
     events?: {
       repeatedActivation?: boolean

--- a/packages/core/src/surveys/events.ts
+++ b/packages/core/src/surveys/events.ts
@@ -1,3 +1,4 @@
+import { SurveyWithIteration } from './keys'
 import { SurveyResponses, SurveyResponseValue } from '../types'
 import { isArray, isNullish, isUndefined } from '../utils'
 
@@ -72,9 +73,4 @@ type SurveyQuestionForResponses = {
 
 type SurveyForResponses = {
   questions: SurveyQuestionForResponses[]
-}
-
-type SurveyWithIteration = {
-  id: string
-  current_iteration?: number | null
 }

--- a/packages/core/src/surveys/index.ts
+++ b/packages/core/src/surveys/index.ts
@@ -16,3 +16,4 @@ export {
   getLanguageFromStoredPersonProperties,
   normalizeLanguageCode,
 } from './translations'
+export { canSurveyActivateRepeatedly, doesSurveyActivateByEvent, getSurveyStorageKey } from './state'

--- a/packages/core/src/surveys/index.ts
+++ b/packages/core/src/surveys/index.ts
@@ -16,4 +16,5 @@ export {
   getLanguageFromStoredPersonProperties,
   normalizeLanguageCode,
 } from './translations'
-export { canSurveyActivateRepeatedly, doesSurveyActivateByEvent, getSurveyStorageKey } from './state'
+export { canSurveyActivateRepeatedly, doesSurveyActivateByEvent } from './activation'
+export { getSurveyIterationKey, type SurveyWithIteration } from './keys'

--- a/packages/core/src/surveys/index.ts
+++ b/packages/core/src/surveys/index.ts
@@ -17,4 +17,4 @@ export {
   normalizeLanguageCode,
 } from './translations'
 export { canSurveyActivateRepeatedly, doesSurveyActivateByEvent } from './activation'
-export { getSurveyIterationKey, type SurveyWithIteration } from './keys'
+export { getSurveyIterationKey, isSurveyKeyForSurvey, type SurveyWithIteration } from './keys'

--- a/packages/core/src/surveys/keys.spec.ts
+++ b/packages/core/src/surveys/keys.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@jest/globals'
+import { getSurveyIterationKey } from './keys'
+
+describe('getSurveyIterationKey', () => {
+  const cases: [number | null | undefined, string][] = [
+    [2, 'survey-1_2'],
+    [1, 'survey-1_1'],
+    [0, 'survey-1'],
+    [null, 'survey-1'],
+    [undefined, 'survey-1'],
+  ]
+
+  it.each(cases)('current_iteration %p produces key %p', (currentIteration, expected) => {
+    expect(getSurveyIterationKey({ id: 'survey-1', current_iteration: currentIteration })).toBe(expected)
+  })
+})

--- a/packages/core/src/surveys/keys.spec.ts
+++ b/packages/core/src/surveys/keys.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals'
-import { getSurveyIterationKey } from './keys'
+import { getSurveyIterationKey, isSurveyKeyForSurvey } from './keys'
 
 describe('getSurveyIterationKey', () => {
   const cases: [number | null | undefined, string][] = [
@@ -12,5 +12,18 @@ describe('getSurveyIterationKey', () => {
 
   it.each(cases)('current_iteration %p produces key %p', (currentIteration, expected) => {
     expect(getSurveyIterationKey({ id: 'survey-1', current_iteration: currentIteration })).toBe(expected)
+  })
+})
+
+describe('isSurveyKeyForSurvey', () => {
+  it.each([
+    ['bare id', 'abc', 'abc', true],
+    ['first iteration', 'abc_1', 'abc', true],
+    ['later iteration', 'abc_12', 'abc', true],
+    ['different survey id', 'def_1', 'abc', false],
+    ['prefix collision with bare id', 'abcd', 'abc', false],
+    ['prefix collision with iteration key', 'abcd_1', 'abc', false],
+  ])('%s: key %p for survey %p returns %p', (_name, key, surveyId, expected) => {
+    expect(isSurveyKeyForSurvey(key, surveyId)).toBe(expected)
   })
 })

--- a/packages/core/src/surveys/keys.ts
+++ b/packages/core/src/surveys/keys.ts
@@ -3,6 +3,14 @@ import { Survey } from '../types'
 export type SurveyWithIteration = Pick<Survey, 'id' | 'current_iteration'>
 
 /**
+ * True when a stored display-state key belongs to the given survey: its bare id
+ * or any iteration-qualified `id_n` key.
+ */
+export function isSurveyKeyForSurvey(key: string, surveyId: string): boolean {
+  return key === surveyId || key.startsWith(`${surveyId}_`)
+}
+
+/**
  * Iteration-qualified survey identifier ('id' or 'id_iteration'), used to key
  * per-survey display state (seen, in-progress, ...). Keying by iteration lets a
  * repeating survey become visible again when a new iteration starts.

--- a/packages/core/src/surveys/keys.ts
+++ b/packages/core/src/surveys/keys.ts
@@ -1,0 +1,15 @@
+import { Survey } from '../types'
+
+export type SurveyWithIteration = Pick<Survey, 'id' | 'current_iteration'>
+
+/**
+ * Iteration-qualified survey identifier ('id' or 'id_iteration'), used to key
+ * per-survey display state (seen, in-progress, ...). Keying by iteration lets a
+ * repeating survey become visible again when a new iteration starts.
+ */
+export function getSurveyIterationKey(survey: SurveyWithIteration): string {
+  if (survey.current_iteration && survey.current_iteration > 0) {
+    return `${survey.id}_${survey.current_iteration}`
+  }
+  return survey.id
+}

--- a/packages/core/src/surveys/state.ts
+++ b/packages/core/src/surveys/state.ts
@@ -1,0 +1,43 @@
+import { SurveySchedule } from '../types'
+
+type SurveyWithIteration = {
+  id: string
+  current_iteration?: number | null
+}
+
+type SurveyForRepeatActivation = {
+  schedule?: string | null
+  conditions?: {
+    events?: {
+      repeatedActivation?: boolean
+      values?: { name: string }[]
+    } | null
+  } | null
+}
+
+/**
+ * Storage key for per-survey display state (seen, in-progress, abandoned, ...).
+ * Keyed by iteration so repeating surveys become visible again when a new iteration starts.
+ */
+export function getSurveyStorageKey(prefix: string, survey: SurveyWithIteration): string {
+  if (survey.current_iteration && survey.current_iteration > 0) {
+    return `${prefix}${survey.id}_${survey.current_iteration}`
+  }
+  return `${prefix}${survey.id}`
+}
+
+export function doesSurveyActivateByEvent(survey: SurveyForRepeatActivation): boolean {
+  return !!survey.conditions?.events?.values?.length
+}
+
+/**
+ * Platform-independent part of "can this survey show again after being seen":
+ * event-repeated activation or an 'always' schedule. SDKs may OR in
+ * platform-specific state (e.g. the web SDK's in-progress partial responses).
+ */
+export function canSurveyActivateRepeatedly(survey: SurveyForRepeatActivation): boolean {
+  return (
+    (doesSurveyActivateByEvent(survey) && !!survey.conditions?.events?.repeatedActivation) ||
+    survey.schedule === SurveySchedule.Always
+  )
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -848,8 +848,8 @@ export type Survey = {
   }
   start_date?: string
   end_date?: string
-  current_iteration?: number
-  current_iteration_start_date?: string
+  current_iteration?: number | null
+  current_iteration_start_date?: string | null
   schedule?: SurveySchedule
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -628,43 +628,49 @@ export type SurveyAppearance = {
   widgetColor?: string
 }
 
-export enum SurveyPosition {
-  TopLeft = 'top_left',
-  TopCenter = 'top_center',
-  TopRight = 'top_right',
-  MiddleLeft = 'middle_left',
-  MiddleCenter = 'middle_center',
-  MiddleRight = 'middle_right',
-  Left = 'left',
-  Right = 'right',
-  Center = 'center',
-}
+export const SurveyPosition = {
+  TopLeft: 'top_left',
+  TopCenter: 'top_center',
+  TopRight: 'top_right',
+  MiddleLeft: 'middle_left',
+  MiddleCenter: 'middle_center',
+  MiddleRight: 'middle_right',
+  Left: 'left',
+  Right: 'right',
+  Center: 'center',
+} as const
+export type SurveyPosition = (typeof SurveyPosition)[keyof typeof SurveyPosition]
 
-export enum SurveyWidgetType {
-  Button = 'button',
-  Tab = 'tab',
-  Selector = 'selector',
-}
+export const SurveyWidgetType = {
+  Button: 'button',
+  Tab: 'tab',
+  Selector: 'selector',
+} as const
+export type SurveyWidgetType = (typeof SurveyWidgetType)[keyof typeof SurveyWidgetType]
 
-export enum SurveyType {
-  Popover = 'popover',
-  API = 'api',
-  Widget = 'widget',
-  ExternalSurvey = 'external_survey',
-}
+export const SurveyType = {
+  Popover: 'popover',
+  API: 'api',
+  Widget: 'widget',
+  ExternalSurvey: 'external_survey',
+} as const
+export type SurveyType = (typeof SurveyType)[keyof typeof SurveyType]
 
 export type SurveyQuestion = BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion
 
-export enum SurveyQuestionDescriptionContentType {
-  Html = 'html',
-  Text = 'text',
-}
+export const SurveyQuestionDescriptionContentType = {
+  Html: 'html',
+  Text: 'text',
+} as const
+export type SurveyQuestionDescriptionContentType =
+  (typeof SurveyQuestionDescriptionContentType)[keyof typeof SurveyQuestionDescriptionContentType]
 
 // Survey validation types
-export enum SurveyValidationType {
-  MinLength = 'min_length',
-  MaxLength = 'max_length',
-}
+export const SurveyValidationType = {
+  MinLength: 'min_length',
+  MaxLength: 'max_length',
+} as const
+export type SurveyValidationType = (typeof SurveyValidationType)[keyof typeof SurveyValidationType]
 
 export interface SurveyValidationRule {
   type: SurveyValidationType
@@ -705,16 +711,16 @@ type SurveyQuestionBase = {
 }
 
 export type BasicSurveyQuestion = SurveyQuestionBase & {
-  type: SurveyQuestionType.Open
+  type: typeof SurveyQuestionType.Open
 }
 
 export type LinkSurveyQuestion = SurveyQuestionBase & {
-  type: SurveyQuestionType.Link
+  type: typeof SurveyQuestionType.Link
   link?: string | null
 }
 
 export type RatingSurveyQuestion = SurveyQuestionBase & {
-  type: SurveyQuestionType.Rating
+  type: typeof SurveyQuestionType.Rating
   display: SurveyRatingDisplay
   scale: 2 | 3 | 5 | 7 | 10
   lowerBoundLabel: string
@@ -722,49 +728,52 @@ export type RatingSurveyQuestion = SurveyQuestionBase & {
   skipSubmitButton?: boolean
 }
 
-export enum SurveyRatingDisplay {
-  Number = 'number',
-  Emoji = 'emoji',
-}
+export const SurveyRatingDisplay = {
+  Number: 'number',
+  Emoji: 'emoji',
+} as const
+export type SurveyRatingDisplay = (typeof SurveyRatingDisplay)[keyof typeof SurveyRatingDisplay]
 
 export type MultipleSurveyQuestion = SurveyQuestionBase & {
-  type: SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice
+  type: typeof SurveyQuestionType.SingleChoice | typeof SurveyQuestionType.MultipleChoice
   choices: string[]
   hasOpenChoice?: boolean
   shuffleOptions?: boolean
   skipSubmitButton?: boolean
 }
 
-export enum SurveyQuestionType {
-  Open = 'open',
-  MultipleChoice = 'multiple_choice',
-  SingleChoice = 'single_choice',
-  Rating = 'rating',
-  Link = 'link',
-}
+export const SurveyQuestionType = {
+  Open: 'open',
+  MultipleChoice: 'multiple_choice',
+  SingleChoice: 'single_choice',
+  Rating: 'rating',
+  Link: 'link',
+} as const
+export type SurveyQuestionType = (typeof SurveyQuestionType)[keyof typeof SurveyQuestionType]
 
-export enum SurveyQuestionBranchingType {
-  NextQuestion = 'next_question',
-  End = 'end',
-  ResponseBased = 'response_based',
-  SpecificQuestion = 'specific_question',
-}
+export const SurveyQuestionBranchingType = {
+  NextQuestion: 'next_question',
+  End: 'end',
+  ResponseBased: 'response_based',
+  SpecificQuestion: 'specific_question',
+} as const
+export type SurveyQuestionBranchingType = (typeof SurveyQuestionBranchingType)[keyof typeof SurveyQuestionBranchingType]
 
 export type NextQuestionBranching = {
-  type: SurveyQuestionBranchingType.NextQuestion
+  type: typeof SurveyQuestionBranchingType.NextQuestion
 }
 
 export type EndBranching = {
-  type: SurveyQuestionBranchingType.End
+  type: typeof SurveyQuestionBranchingType.End
 }
 
 export type ResponseBasedBranching = {
-  type: SurveyQuestionBranchingType.ResponseBased
+  type: typeof SurveyQuestionBranchingType.ResponseBased
   responseValues: Record<string, any>
 }
 
 export type SpecificQuestionBranching = {
-  type: SurveyQuestionBranchingType.SpecificQuestion
+  type: typeof SurveyQuestionBranchingType.SpecificQuestion
   index: number
 }
 
@@ -778,20 +787,22 @@ export type SurveyResponses = Record<string, SurveyResponseValue>
 
 export type SurveyCallback = (surveys: Survey[]) => void
 
-export enum SurveyMatchType {
-  Regex = 'regex',
-  NotRegex = 'not_regex',
-  Exact = 'exact',
-  IsNot = 'is_not',
-  Icontains = 'icontains',
-  NotIcontains = 'not_icontains',
-}
+export const SurveyMatchType = {
+  Regex: 'regex',
+  NotRegex: 'not_regex',
+  Exact: 'exact',
+  IsNot: 'is_not',
+  Icontains: 'icontains',
+  NotIcontains: 'not_icontains',
+} as const
+export type SurveyMatchType = (typeof SurveyMatchType)[keyof typeof SurveyMatchType]
 
-export enum SurveySchedule {
-  Once = 'once',
-  Recurring = 'recurring',
-  Always = 'always',
-}
+export const SurveySchedule = {
+  Once: 'once',
+  Recurring: 'recurring',
+  Always: 'always',
+} as const
+export type SurveySchedule = (typeof SurveySchedule)[keyof typeof SurveySchedule]
 
 export type SurveyElement = {
   text?: string
@@ -850,7 +861,7 @@ export type Survey = {
   end_date?: string
   current_iteration?: number | null
   current_iteration_start_date?: string | null
-  schedule?: SurveySchedule
+  schedule?: SurveySchedule | null
 }
 
 export type SurveyActionType = {
@@ -860,11 +871,12 @@ export type SurveyActionType = {
 }
 
 /** Sync with plugin-server/src/types.ts */
-export enum ActionStepStringMatching {
-  Contains = 'contains',
-  Exact = 'exact',
-  Regex = 'regex',
-}
+export const ActionStepStringMatching = {
+  Contains: 'contains',
+  Exact: 'exact',
+  Regex: 'regex',
+} as const
+export type ActionStepStringMatching = (typeof ActionStepStringMatching)[keyof typeof ActionStepStringMatching]
 
 export type ActionStepType = {
   event?: string

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -1559,21 +1559,9 @@
     {
       "id": "ActionStepStringMatching",
       "name": "ActionStepStringMatching",
-      "properties": [
-        {
-          "type": "\"contains\"",
-          "name": "Contains"
-        },
-        {
-          "type": "\"exact\"",
-          "name": "Exact"
-        },
-        {
-          "type": "\"regex\"",
-          "name": "Regex"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof ActionStepStringMatching)[keyof typeof ActionStepStringMatching]"
     },
     {
       "id": "ActionStepType",
@@ -1620,7 +1608,7 @@
       "name": "BasicSurveyQuestion",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Open;\n}"
+      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Open;\n}"
     },
     {
       "id": "BeforeSendFn_2",
@@ -1728,7 +1716,7 @@
       "name": "EndBranching",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    type: SurveyQuestionBranchingType.End;\n}"
+      "example": "{\n    type: typeof SurveyQuestionBranchingType.End;\n}"
     },
     {
       "id": "ErrorEventLike",
@@ -2059,7 +2047,7 @@
       "name": "LinkSurveyQuestion",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Link;\n    link?: string | null;\n}"
+      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Link;\n    link?: string | null;\n}"
     },
     {
       "id": "Logger",
@@ -2119,14 +2107,14 @@
       "name": "MultipleSurveyQuestion",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice;\n    choices: string[];\n    hasOpenChoice?: boolean;\n    shuffleOptions?: boolean;\n    skipSubmitButton?: boolean;\n}"
+      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.SingleChoice | typeof SurveyQuestionType.MultipleChoice;\n    choices: string[];\n    hasOpenChoice?: boolean;\n    shuffleOptions?: boolean;\n    skipSubmitButton?: boolean;\n}"
     },
     {
       "id": "NextQuestionBranching",
       "name": "NextQuestionBranching",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    type: SurveyQuestionBranchingType.NextQuestion;\n}"
+      "example": "{\n    type: typeof SurveyQuestionBranchingType.NextQuestion;\n}"
     },
     {
       "id": "ObjectLike",
@@ -2480,7 +2468,7 @@
       "name": "RatingSurveyQuestion",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Rating;\n    display: SurveyRatingDisplay;\n    scale: 2 | 3 | 5 | 7 | 10;\n    lowerBoundLabel: string;\n    upperBoundLabel: string;\n    skipSubmitButton?: boolean;\n}"
+      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Rating;\n    display: SurveyRatingDisplay;\n    scale: 2 | 3 | 5 | 7 | 10;\n    lowerBoundLabel: string;\n    upperBoundLabel: string;\n    skipSubmitButton?: boolean;\n}"
     },
     {
       "id": "RejectionLike",
@@ -2501,7 +2489,7 @@
       "name": "ResponseBasedBranching",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    type: SurveyQuestionBranchingType.ResponseBased;\n    responseValues: Record<string, any>;\n}"
+      "example": "{\n    type: typeof SurveyQuestionBranchingType.ResponseBased;\n    responseValues: Record<string, any>;\n}"
     },
     {
       "id": "RetriableOptions",
@@ -2562,7 +2550,7 @@
       "name": "SpecificQuestionBranching",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    type: SurveyQuestionBranchingType.SpecificQuestion;\n    index: number;\n}"
+      "example": "{\n    type: typeof SurveyQuestionBranchingType.SpecificQuestion;\n    index: number;\n}"
     },
     {
       "id": "StackFrame",
@@ -2657,7 +2645,7 @@
       "name": "Survey",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    id: string;\n    name: string;\n    description?: string;\n    type: SurveyType;\n    translations?: Record<string, SurveyTranslation>;\n    feature_flag_keys?: {\n        key: string;\n        value?: string;\n    }[];\n    linked_flag_key?: string;\n    targeting_flag_key?: string;\n    internal_targeting_flag_key?: string;\n    questions: SurveyQuestion[];\n    appearance?: SurveyAppearance;\n    conditions?: {\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: SurveyMatchType;\n        events?: {\n            repeatedActivation?: boolean;\n            values?: {\n                name: string;\n            }[];\n        };\n        actions?: {\n            values: SurveyActionType[];\n        };\n        deviceTypes?: string[];\n        deviceTypesMatchType?: SurveyMatchType;\n        linkedFlagVariant?: string;\n    };\n    start_date?: string;\n    end_date?: string;\n    current_iteration?: number;\n    current_iteration_start_date?: string;\n    schedule?: SurveySchedule;\n}"
+      "example": "{\n    id: string;\n    name: string;\n    description?: string;\n    type: SurveyType;\n    translations?: Record<string, SurveyTranslation>;\n    feature_flag_keys?: {\n        key: string;\n        value?: string;\n    }[];\n    linked_flag_key?: string;\n    targeting_flag_key?: string;\n    internal_targeting_flag_key?: string;\n    questions: SurveyQuestion[];\n    appearance?: SurveyAppearance;\n    conditions?: {\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: SurveyMatchType;\n        events?: {\n            repeatedActivation?: boolean;\n            values?: {\n                name: string;\n            }[];\n        };\n        actions?: {\n            values: SurveyActionType[];\n        };\n        deviceTypes?: string[];\n        deviceTypesMatchType?: SurveyMatchType;\n        linkedFlagVariant?: string;\n    };\n    start_date?: string;\n    end_date?: string;\n    current_iteration?: number | null;\n    current_iteration_start_date?: string | null;\n    schedule?: SurveySchedule | null;\n}"
     },
     {
       "id": "SurveyActionType",
@@ -2676,76 +2664,16 @@
     {
       "id": "SurveyMatchType",
       "name": "SurveyMatchType",
-      "properties": [
-        {
-          "type": "\"exact\"",
-          "name": "Exact"
-        },
-        {
-          "type": "\"icontains\"",
-          "name": "Icontains"
-        },
-        {
-          "type": "\"is_not\"",
-          "name": "IsNot"
-        },
-        {
-          "type": "\"not_icontains\"",
-          "name": "NotIcontains"
-        },
-        {
-          "type": "\"not_regex\"",
-          "name": "NotRegex"
-        },
-        {
-          "type": "\"regex\"",
-          "name": "Regex"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyMatchType)[keyof typeof SurveyMatchType]"
     },
     {
       "id": "SurveyPosition",
       "name": "SurveyPosition",
-      "properties": [
-        {
-          "type": "\"center\"",
-          "name": "Center"
-        },
-        {
-          "type": "\"left\"",
-          "name": "Left"
-        },
-        {
-          "type": "\"middle_center\"",
-          "name": "MiddleCenter"
-        },
-        {
-          "type": "\"middle_left\"",
-          "name": "MiddleLeft"
-        },
-        {
-          "type": "\"middle_right\"",
-          "name": "MiddleRight"
-        },
-        {
-          "type": "\"right\"",
-          "name": "Right"
-        },
-        {
-          "type": "\"top_center\"",
-          "name": "TopCenter"
-        },
-        {
-          "type": "\"top_left\"",
-          "name": "TopLeft"
-        },
-        {
-          "type": "\"top_right\"",
-          "name": "TopRight"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyPosition)[keyof typeof SurveyPosition]"
     },
     {
       "id": "SurveyQuestion",
@@ -2764,40 +2692,16 @@
     {
       "id": "SurveyQuestionBranchingType",
       "name": "SurveyQuestionBranchingType",
-      "properties": [
-        {
-          "type": "\"end\"",
-          "name": "End"
-        },
-        {
-          "type": "\"next_question\"",
-          "name": "NextQuestion"
-        },
-        {
-          "type": "\"response_based\"",
-          "name": "ResponseBased"
-        },
-        {
-          "type": "\"specific_question\"",
-          "name": "SpecificQuestion"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyQuestionBranchingType)[keyof typeof SurveyQuestionBranchingType]"
     },
     {
       "id": "SurveyQuestionDescriptionContentType",
       "name": "SurveyQuestionDescriptionContentType",
-      "properties": [
-        {
-          "type": "\"html\"",
-          "name": "Html"
-        },
-        {
-          "type": "\"text\"",
-          "name": "Text"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyQuestionDescriptionContentType)[keyof typeof SurveyQuestionDescriptionContentType]"
     },
     {
       "id": "SurveyQuestionTranslation",
@@ -2837,44 +2741,16 @@
     {
       "id": "SurveyQuestionType",
       "name": "SurveyQuestionType",
-      "properties": [
-        {
-          "type": "\"link\"",
-          "name": "Link"
-        },
-        {
-          "type": "\"multiple_choice\"",
-          "name": "MultipleChoice"
-        },
-        {
-          "type": "\"open\"",
-          "name": "Open"
-        },
-        {
-          "type": "\"rating\"",
-          "name": "Rating"
-        },
-        {
-          "type": "\"single_choice\"",
-          "name": "SingleChoice"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyQuestionType)[keyof typeof SurveyQuestionType]"
     },
     {
       "id": "SurveyRatingDisplay",
       "name": "SurveyRatingDisplay",
-      "properties": [
-        {
-          "type": "\"emoji\"",
-          "name": "Emoji"
-        },
-        {
-          "type": "\"number\"",
-          "name": "Number"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyRatingDisplay)[keyof typeof SurveyRatingDisplay]"
     },
     {
       "id": "SurveyResponse",
@@ -2886,21 +2762,9 @@
     {
       "id": "SurveySchedule",
       "name": "SurveySchedule",
-      "properties": [
-        {
-          "type": "\"always\"",
-          "name": "Always"
-        },
-        {
-          "type": "\"once\"",
-          "name": "Once"
-        },
-        {
-          "type": "\"recurring\"",
-          "name": "Recurring"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveySchedule)[keyof typeof SurveySchedule]"
     },
     {
       "id": "SurveyTranslation",
@@ -2936,25 +2800,9 @@
     {
       "id": "SurveyType",
       "name": "SurveyType",
-      "properties": [
-        {
-          "type": "\"api\"",
-          "name": "API"
-        },
-        {
-          "type": "\"external_survey\"",
-          "name": "ExternalSurvey"
-        },
-        {
-          "type": "\"popover\"",
-          "name": "Popover"
-        },
-        {
-          "type": "\"widget\"",
-          "name": "Widget"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyType)[keyof typeof SurveyType]"
     },
     {
       "id": "SurveyValidationRule",
@@ -2978,36 +2826,16 @@
     {
       "id": "SurveyValidationType",
       "name": "SurveyValidationType",
-      "properties": [
-        {
-          "type": "\"max_length\"",
-          "name": "MaxLength"
-        },
-        {
-          "type": "\"min_length\"",
-          "name": "MinLength"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyValidationType)[keyof typeof SurveyValidationType]"
     },
     {
       "id": "SurveyWidgetType",
       "name": "SurveyWidgetType",
-      "properties": [
-        {
-          "type": "\"button\"",
-          "name": "Button"
-        },
-        {
-          "type": "\"selector\"",
-          "name": "Selector"
-        },
-        {
-          "type": "\"tab\"",
-          "name": "Tab"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyWidgetType)[keyof typeof SurveyWidgetType]"
     },
     {
       "id": "UnsetPersonPropertiesMessage",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2075,21 +2075,9 @@
     {
       "id": "ActionStepStringMatching",
       "name": "ActionStepStringMatching",
-      "properties": [
-        {
-          "type": "\"contains\"",
-          "name": "Contains"
-        },
-        {
-          "type": "\"exact\"",
-          "name": "Exact"
-        },
-        {
-          "type": "\"regex\"",
-          "name": "Regex"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof ActionStepStringMatching)[keyof typeof ActionStepStringMatching]"
     },
     {
       "id": "ActionStepType",
@@ -2146,7 +2134,7 @@
       "name": "BasicSurveyQuestion",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Open;\n}"
+      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Open;\n}"
     },
     {
       "id": "BeforeSendFn",
@@ -2216,7 +2204,7 @@
       "name": "EndBranching",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    type: SurveyQuestionBranchingType.End;\n}"
+      "example": "{\n    type: typeof SurveyQuestionBranchingType.End;\n}"
     },
     {
       "id": "ErrorEventLike",
@@ -2488,7 +2476,7 @@
       "name": "LinkSurveyQuestion",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Link;\n    link?: string | null;\n}"
+      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Link;\n    link?: string | null;\n}"
     },
     {
       "id": "Logger",
@@ -2532,14 +2520,14 @@
       "name": "MultipleSurveyQuestion",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice;\n    choices: string[];\n    hasOpenChoice?: boolean;\n    shuffleOptions?: boolean;\n    skipSubmitButton?: boolean;\n}"
+      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.SingleChoice | typeof SurveyQuestionType.MultipleChoice;\n    choices: string[];\n    hasOpenChoice?: boolean;\n    shuffleOptions?: boolean;\n    skipSubmitButton?: boolean;\n}"
     },
     {
       "id": "NextQuestionBranching",
       "name": "NextQuestionBranching",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    type: SurveyQuestionBranchingType.NextQuestion;\n}"
+      "example": "{\n    type: typeof SurveyQuestionBranchingType.NextQuestion;\n}"
     },
     {
       "id": "ObjectLike",
@@ -3179,7 +3167,7 @@
       "name": "RatingSurveyQuestion",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Rating;\n    display: SurveyRatingDisplay;\n    scale: 2 | 3 | 5 | 7 | 10;\n    lowerBoundLabel: string;\n    upperBoundLabel: string;\n    skipSubmitButton?: boolean;\n}"
+      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Rating;\n    display: SurveyRatingDisplay;\n    scale: 2 | 3 | 5 | 7 | 10;\n    lowerBoundLabel: string;\n    upperBoundLabel: string;\n    skipSubmitButton?: boolean;\n}"
     },
     {
       "id": "RejectionLike",
@@ -3200,7 +3188,7 @@
       "name": "ResponseBasedBranching",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    type: SurveyQuestionBranchingType.ResponseBased;\n    responseValues: Record<string, any>;\n}"
+      "example": "{\n    type: typeof SurveyQuestionBranchingType.ResponseBased;\n    responseValues: Record<string, any>;\n}"
     },
     {
       "id": "RetriableOptions",
@@ -3240,7 +3228,7 @@
       "name": "SpecificQuestionBranching",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    type: SurveyQuestionBranchingType.SpecificQuestion;\n    index: number;\n}"
+      "example": "{\n    type: typeof SurveyQuestionBranchingType.SpecificQuestion;\n    index: number;\n}"
     },
     {
       "id": "StackFrame",
@@ -3335,7 +3323,7 @@
       "name": "Survey",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    id: string;\n    name: string;\n    description?: string;\n    type: SurveyType;\n    translations?: Record<string, SurveyTranslation>;\n    feature_flag_keys?: {\n        key: string;\n        value?: string;\n    }[];\n    linked_flag_key?: string;\n    targeting_flag_key?: string;\n    internal_targeting_flag_key?: string;\n    questions: SurveyQuestion[];\n    appearance?: SurveyAppearance;\n    conditions?: {\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: SurveyMatchType;\n        events?: {\n            repeatedActivation?: boolean;\n            values?: {\n                name: string;\n            }[];\n        };\n        actions?: {\n            values: SurveyActionType[];\n        };\n        deviceTypes?: string[];\n        deviceTypesMatchType?: SurveyMatchType;\n        linkedFlagVariant?: string;\n    };\n    start_date?: string;\n    end_date?: string;\n    current_iteration?: number;\n    current_iteration_start_date?: string;\n    schedule?: SurveySchedule;\n}"
+      "example": "{\n    id: string;\n    name: string;\n    description?: string;\n    type: SurveyType;\n    translations?: Record<string, SurveyTranslation>;\n    feature_flag_keys?: {\n        key: string;\n        value?: string;\n    }[];\n    linked_flag_key?: string;\n    targeting_flag_key?: string;\n    internal_targeting_flag_key?: string;\n    questions: SurveyQuestion[];\n    appearance?: SurveyAppearance;\n    conditions?: {\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: SurveyMatchType;\n        events?: {\n            repeatedActivation?: boolean;\n            values?: {\n                name: string;\n            }[];\n        };\n        actions?: {\n            values: SurveyActionType[];\n        };\n        deviceTypes?: string[];\n        deviceTypesMatchType?: SurveyMatchType;\n        linkedFlagVariant?: string;\n    };\n    start_date?: string;\n    end_date?: string;\n    current_iteration?: number | null;\n    current_iteration_start_date?: string | null;\n    schedule?: SurveySchedule | null;\n}"
     },
     {
       "id": "SurveyActionType",
@@ -3361,33 +3349,9 @@
     {
       "id": "SurveyMatchType",
       "name": "SurveyMatchType",
-      "properties": [
-        {
-          "type": "\"exact\"",
-          "name": "Exact"
-        },
-        {
-          "type": "\"icontains\"",
-          "name": "Icontains"
-        },
-        {
-          "type": "\"is_not\"",
-          "name": "IsNot"
-        },
-        {
-          "type": "\"not_icontains\"",
-          "name": "NotIcontains"
-        },
-        {
-          "type": "\"not_regex\"",
-          "name": "NotRegex"
-        },
-        {
-          "type": "\"regex\"",
-          "name": "Regex"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyMatchType)[keyof typeof SurveyMatchType]"
     },
     {
       "id": "SurveyModalProps",
@@ -3399,45 +3363,9 @@
     {
       "id": "SurveyPosition",
       "name": "SurveyPosition",
-      "properties": [
-        {
-          "type": "\"center\"",
-          "name": "Center"
-        },
-        {
-          "type": "\"left\"",
-          "name": "Left"
-        },
-        {
-          "type": "\"middle_center\"",
-          "name": "MiddleCenter"
-        },
-        {
-          "type": "\"middle_left\"",
-          "name": "MiddleLeft"
-        },
-        {
-          "type": "\"middle_right\"",
-          "name": "MiddleRight"
-        },
-        {
-          "type": "\"right\"",
-          "name": "Right"
-        },
-        {
-          "type": "\"top_center\"",
-          "name": "TopCenter"
-        },
-        {
-          "type": "\"top_left\"",
-          "name": "TopLeft"
-        },
-        {
-          "type": "\"top_right\"",
-          "name": "TopRight"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyPosition)[keyof typeof SurveyPosition]"
     },
     {
       "id": "SurveyQuestion",
@@ -3456,40 +3384,16 @@
     {
       "id": "SurveyQuestionBranchingType",
       "name": "SurveyQuestionBranchingType",
-      "properties": [
-        {
-          "type": "\"end\"",
-          "name": "End"
-        },
-        {
-          "type": "\"next_question\"",
-          "name": "NextQuestion"
-        },
-        {
-          "type": "\"response_based\"",
-          "name": "ResponseBased"
-        },
-        {
-          "type": "\"specific_question\"",
-          "name": "SpecificQuestion"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyQuestionBranchingType)[keyof typeof SurveyQuestionBranchingType]"
     },
     {
       "id": "SurveyQuestionDescriptionContentType",
       "name": "SurveyQuestionDescriptionContentType",
-      "properties": [
-        {
-          "type": "\"html\"",
-          "name": "Html"
-        },
-        {
-          "type": "\"text\"",
-          "name": "Text"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyQuestionDescriptionContentType)[keyof typeof SurveyQuestionDescriptionContentType]"
     },
     {
       "id": "SurveyQuestionTranslation",
@@ -3529,44 +3433,16 @@
     {
       "id": "SurveyQuestionType",
       "name": "SurveyQuestionType",
-      "properties": [
-        {
-          "type": "\"link\"",
-          "name": "Link"
-        },
-        {
-          "type": "\"multiple_choice\"",
-          "name": "MultipleChoice"
-        },
-        {
-          "type": "\"open\"",
-          "name": "Open"
-        },
-        {
-          "type": "\"rating\"",
-          "name": "Rating"
-        },
-        {
-          "type": "\"single_choice\"",
-          "name": "SingleChoice"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyQuestionType)[keyof typeof SurveyQuestionType]"
     },
     {
       "id": "SurveyRatingDisplay",
       "name": "SurveyRatingDisplay",
-      "properties": [
-        {
-          "type": "\"emoji\"",
-          "name": "Emoji"
-        },
-        {
-          "type": "\"number\"",
-          "name": "Number"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyRatingDisplay)[keyof typeof SurveyRatingDisplay]"
     },
     {
       "id": "SurveyResponse",
@@ -3592,21 +3468,9 @@
     {
       "id": "SurveySchedule",
       "name": "SurveySchedule",
-      "properties": [
-        {
-          "type": "\"always\"",
-          "name": "Always"
-        },
-        {
-          "type": "\"once\"",
-          "name": "Once"
-        },
-        {
-          "type": "\"recurring\"",
-          "name": "Recurring"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveySchedule)[keyof typeof SurveySchedule]"
     },
     {
       "id": "SurveyTranslation",
@@ -3642,25 +3506,9 @@
     {
       "id": "SurveyType",
       "name": "SurveyType",
-      "properties": [
-        {
-          "type": "\"api\"",
-          "name": "API"
-        },
-        {
-          "type": "\"external_survey\"",
-          "name": "ExternalSurvey"
-        },
-        {
-          "type": "\"popover\"",
-          "name": "Popover"
-        },
-        {
-          "type": "\"widget\"",
-          "name": "Widget"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyType)[keyof typeof SurveyType]"
     },
     {
       "id": "SurveyValidationRule",
@@ -3684,36 +3532,16 @@
     {
       "id": "SurveyValidationType",
       "name": "SurveyValidationType",
-      "properties": [
-        {
-          "type": "\"max_length\"",
-          "name": "MaxLength"
-        },
-        {
-          "type": "\"min_length\"",
-          "name": "MinLength"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyValidationType)[keyof typeof SurveyValidationType]"
     },
     {
       "id": "SurveyWidgetType",
       "name": "SurveyWidgetType",
-      "properties": [
-        {
-          "type": "\"button\"",
-          "name": "Button"
-        },
-        {
-          "type": "\"selector\"",
-          "name": "Selector"
-        },
-        {
-          "type": "\"tab\"",
-          "name": "Tab"
-        }
-      ],
-      "path": "../core/src/types.ts"
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "(typeof SurveyWidgetType)[keyof typeof SurveyWidgetType]"
     }
   ],
   "categories": [

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -6,7 +6,12 @@ import { getActiveMatchingSurveys } from './getActiveMatchingSurveys'
 import { useSurveyStorage } from './useSurveyStorage'
 import { useActivatedSurveys } from './useActivatedSurveys'
 import { SurveyModal } from './components/SurveyModal'
-import { defaultSurveyAppearance, getContrastingTextColor, SurveyAppearanceTheme } from './surveys-utils'
+import {
+  defaultSurveyAppearance,
+  getContrastingTextColor,
+  getSurveySeenKey,
+  SurveyAppearanceTheme,
+} from './surveys-utils'
 import { Survey, SurveyAppearance, SurveyType, type SurveyResponses } from '@posthog/core'
 import { usePostHog } from '../hooks/usePostHog'
 import { useFeatureFlags } from '../hooks/useFeatureFlags'
@@ -169,7 +174,7 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
         setLastSeenSurveyDate(new Date())
       },
       onClose: (submitted: boolean, responses: SurveyResponses) => {
-        setSeenSurvey(activeSurvey.id)
+        setSeenSurvey(getSurveySeenKey(activeSurvey))
         setActiveSurvey(undefined)
         if (!submitted) {
           dismissedSurveyEvent(translatedActiveSurvey.survey, responses, posthog, translatedActiveSurvey.language)

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -6,12 +6,7 @@ import { getActiveMatchingSurveys } from './getActiveMatchingSurveys'
 import { useSurveyStorage } from './useSurveyStorage'
 import { useActivatedSurveys } from './useActivatedSurveys'
 import { SurveyModal } from './components/SurveyModal'
-import {
-  defaultSurveyAppearance,
-  getContrastingTextColor,
-  getSurveySeenKey,
-  SurveyAppearanceTheme,
-} from './surveys-utils'
+import { defaultSurveyAppearance, getContrastingTextColor, SurveyAppearanceTheme } from './surveys-utils'
 import { Survey, SurveyAppearance, SurveyType, type SurveyResponses } from '@posthog/core'
 import { usePostHog } from '../hooks/usePostHog'
 import { useFeatureFlags } from '../hooks/useFeatureFlags'
@@ -174,7 +169,7 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
         setLastSeenSurveyDate(new Date())
       },
       onClose: (submitted: boolean, responses: SurveyResponses) => {
-        setSeenSurvey(getSurveySeenKey(activeSurvey))
+        setSeenSurvey(activeSurvey)
         setActiveSurvey(undefined)
         if (!submitted) {
           dismissedSurveyEvent(translatedActiveSurvey.survey, responses, posthog, translatedActiveSurvey.language)

--- a/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
+++ b/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
@@ -1,4 +1,4 @@
-import { canActivateRepeatedly, hasEvents, surveyValidationMap } from './surveys-utils'
+import { canActivateRepeatedly, getSurveySeenKey, hasEvents, surveyValidationMap } from './surveys-utils'
 import { currentDeviceType } from '../native-deps'
 import { FeatureFlagValue, Survey, SurveyMatchType } from '@posthog/core'
 
@@ -40,7 +40,7 @@ export function getActiveMatchingSurveys(
       return false
     }
 
-    if (seenSurveys.includes(survey.id) && !canActivateRepeatedly(survey)) {
+    if (seenSurveys.includes(getSurveySeenKey(survey)) && !canActivateRepeatedly(survey)) {
       return false
     }
 

--- a/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
+++ b/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
@@ -1,4 +1,5 @@
-import { canActivateRepeatedly, getSurveySeenKey, hasEvents, surveyValidationMap } from './surveys-utils'
+import { canSurveyActivateRepeatedly, doesSurveyActivateByEvent, getSurveyIterationKey } from '@posthog/core/surveys'
+import { surveyValidationMap } from './surveys-utils'
 import { currentDeviceType } from '../native-deps'
 import { FeatureFlagValue, Survey, SurveyMatchType } from '@posthog/core'
 
@@ -40,7 +41,7 @@ export function getActiveMatchingSurveys(
       return false
     }
 
-    if (seenSurveys.includes(getSurveySeenKey(survey)) && !canActivateRepeatedly(survey)) {
+    if (seenSurveys.includes(getSurveyIterationKey(survey)) && !canSurveyActivateRepeatedly(survey)) {
       return false
     }
 
@@ -84,10 +85,10 @@ export function getActiveMatchingSurveys(
 
     const targetingFlagCheck = isSurveyFlagEnabled(survey.targeting_flag_key, flags)
 
-    const eventBasedTargetingFlagCheck = hasEvents(survey) ? activatedSurveys.has(survey.id) : true
+    const eventBasedTargetingFlagCheck = doesSurveyActivateByEvent(survey) ? activatedSurveys.has(survey.id) : true
 
     const internalTargetingFlagCheck =
-      survey.internal_targeting_flag_key && !canActivateRepeatedly(survey)
+      survey.internal_targeting_flag_key && !canSurveyActivateRepeatedly(survey)
         ? isSurveyFlagEnabled(survey.internal_targeting_flag_key, flags)
         : true
     const flagsCheck = survey.feature_flag_keys?.length

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -11,7 +11,6 @@ import {
   SurveyQuestionDescriptionContentType,
   SurveyMatchType,
 } from '@posthog/core'
-import { canSurveyActivateRepeatedly, doesSurveyActivateByEvent, getSurveyStorageKey } from '@posthog/core/surveys'
 
 // Extended operator type to include numeric operators not in core SurveyMatchType
 export type PropertyOperator = SurveyMatchType | 'gt' | 'lt'
@@ -214,23 +213,9 @@ export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
   // return reverseIfUnshuffled(survey.questions, shuffle(survey.questions))
 }
 
-export const hasEvents = (survey: Survey): boolean => {
-  return doesSurveyActivateByEvent(survey)
-}
-
 // export const hasActions = (survey: Survey): boolean => {
 //   return survey.conditions?.actions?.values.length !== undefined && survey.conditions.actions.values.length > 0
 // }
-
-export const canActivateRepeatedly = (survey: Survey): boolean => {
-  return canSurveyActivateRepeatedly(survey)
-}
-
-// Keying by iteration (shared with the web SDK) lets a repeating survey show again
-// on this device when a new iteration starts. No prefix: keys live in a dedicated list.
-export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
-  return getSurveyStorageKey('', survey)
-}
 
 /**
  * Use the Fisher-yates algorithm to shuffle this array

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -10,8 +10,8 @@ import {
   SurveyPosition,
   SurveyQuestionDescriptionContentType,
   SurveyMatchType,
-  SurveySchedule,
 } from '@posthog/core'
+import { canSurveyActivateRepeatedly, doesSurveyActivateByEvent, getSurveyStorageKey } from '@posthog/core/surveys'
 
 // Extended operator type to include numeric operators not in core SurveyMatchType
 export type PropertyOperator = SurveyMatchType | 'gt' | 'lt'
@@ -215,7 +215,7 @@ export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
 }
 
 export const hasEvents = (survey: Survey): boolean => {
-  return survey.conditions?.events?.values !== undefined && survey.conditions.events.values.length > 0
+  return doesSurveyActivateByEvent(survey)
 }
 
 // export const hasActions = (survey: Survey): boolean => {
@@ -223,18 +223,13 @@ export const hasEvents = (survey: Survey): boolean => {
 // }
 
 export const canActivateRepeatedly = (survey: Survey): boolean => {
-  return (
-    !!(survey.conditions?.events?.repeatedActivation && hasEvents(survey)) || survey.schedule === SurveySchedule.Always
-  )
+  return canSurveyActivateRepeatedly(survey)
 }
 
-// Mirrors the web SDK's seen-key logic: keying by iteration lets a repeating survey
-// show again on this device when a new iteration starts.
+// Keying by iteration (shared with the web SDK) lets a repeating survey show again
+// on this device when a new iteration starts. No prefix: keys live in a dedicated list.
 export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
-  if (survey.current_iteration && survey.current_iteration > 0) {
-    return `${survey.id}_${survey.current_iteration}`
-  }
-  return survey.id
+  return getSurveyStorageKey('', survey)
 }
 
 /**

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -228,6 +228,15 @@ export const canActivateRepeatedly = (survey: Survey): boolean => {
   )
 }
 
+// Mirrors the web SDK's seen-key logic: keying by iteration lets a repeating survey
+// show again on this device when a new iteration starts.
+export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
+  if (survey.current_iteration && survey.current_iteration > 0) {
+    return `${survey.id}_${survey.current_iteration}`
+  }
+  return survey.id
+}
+
 /**
  * Use the Fisher-yates algorithm to shuffle this array
  * https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -213,10 +213,6 @@ export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
   // return reverseIfUnshuffled(survey.questions, shuffle(survey.questions))
 }
 
-// export const hasActions = (survey: Survey): boolean => {
-//   return survey.conditions?.actions?.values.length !== undefined && survey.conditions.actions.values.length > 0
-// }
-
 /**
  * Use the Fisher-yates algorithm to shuffle this array
  * https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle

--- a/packages/react-native/src/surveys/useActivatedSurveys.ts
+++ b/packages/react-native/src/surveys/useActivatedSurveys.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 
-import { hasEvents, matchPropertyFilters, PropertyFilters, SurveyEventWithFilters } from './surveys-utils'
+import { doesSurveyActivateByEvent } from '@posthog/core/surveys'
+import { matchPropertyFilters, PropertyFilters, SurveyEventWithFilters } from './surveys-utils'
 import { Survey } from '@posthog/core'
 import { PostHog } from '../posthog-rn'
 
@@ -16,7 +17,7 @@ export function useActivatedSurveys(posthog: PostHog, surveys: Survey[]): Readon
 
   const eventMap = useMemo(() => {
     const newEventMap = new Map<string, EventSurveyConfig[]>()
-    for (const survey of surveys.filter(hasEvents)) {
+    for (const survey of surveys.filter(doesSurveyActivateByEvent)) {
       for (const event of (survey.conditions?.events?.values ?? []) as SurveyEventWithFilters[]) {
         const configs = newEventMap.get(event.name) ?? []
         configs.push({

--- a/packages/react-native/src/surveys/useSurveyStorage.ts
+++ b/packages/react-native/src/surveys/useSurveyStorage.ts
@@ -1,13 +1,27 @@
 import { PostHogPersistedProperty } from '@posthog/core'
+import { getSurveyIterationKey, SurveyWithIteration } from '@posthog/core/surveys'
 import { useCallback, useEffect, useState } from 'react'
 import { usePostHog } from '../hooks/usePostHog'
 
 type SurveyStorage = {
+  // Iteration-qualified keys (getSurveyIterationKey) so repeating surveys re-show when a new iteration starts
   seenSurveys: string[]
-  // Keys come from getSurveySeenKey — survey ID, iteration-suffixed for repeating surveys
-  setSeenSurvey: (surveyKey: string) => void
+  setSeenSurvey: (survey: SurveyWithIteration) => void
   lastSeenSurveyDate: Date | undefined
   setLastSeenSurveyDate: (date: Date) => void
+}
+
+// To keep storage bounded, only keep the last 20 seen surveys
+const MAX_SEEN_SURVEYS = 20
+
+// One slot per survey: stale keys from earlier iterations (or the pre-iteration bare id)
+// can never match again and would otherwise evict other surveys' seen state.
+export function updateSeenSurveys(current: string[], survey: SurveyWithIteration): string[] {
+  const surveyKey = getSurveyIterationKey(survey)
+  return [surveyKey, ...current.filter((key) => key !== survey.id && !key.startsWith(`${survey.id}_`))].slice(
+    0,
+    MAX_SEEN_SURVEYS
+  )
 }
 
 export function useSurveyStorage(): SurveyStorage {
@@ -35,14 +49,10 @@ export function useSurveyStorage(): SurveyStorage {
   return {
     seenSurveys,
     setSeenSurvey: useCallback(
-      (surveyKey: string) => {
+      (survey: SurveyWithIteration) => {
         setSeenSurveys((current) => {
-          // To keep storage bounded, only keep the last 20 seen surveys
-          const newValue = [surveyKey, ...current.filter((key) => key !== surveyKey)]
-          posthogStorage.setPersistedProperty(
-            PostHogPersistedProperty.SurveysSeen,
-            JSON.stringify(newValue.slice(0, 20))
-          )
+          const newValue = updateSeenSurveys(current, survey)
+          posthogStorage.setPersistedProperty(PostHogPersistedProperty.SurveysSeen, JSON.stringify(newValue))
           return newValue
         })
       },

--- a/packages/react-native/src/surveys/useSurveyStorage.ts
+++ b/packages/react-native/src/surveys/useSurveyStorage.ts
@@ -1,5 +1,5 @@
 import { PostHogPersistedProperty } from '@posthog/core'
-import { getSurveyIterationKey, SurveyWithIteration } from '@posthog/core/surveys'
+import { getSurveyIterationKey, isSurveyKeyForSurvey, SurveyWithIteration } from '@posthog/core/surveys'
 import { useCallback, useEffect, useState } from 'react'
 import { usePostHog } from '../hooks/usePostHog'
 
@@ -18,10 +18,7 @@ const MAX_SEEN_SURVEYS = 20
 // can never match again and would otherwise evict other surveys' seen state.
 export function updateSeenSurveys(current: string[], survey: SurveyWithIteration): string[] {
   const surveyKey = getSurveyIterationKey(survey)
-  return [surveyKey, ...current.filter((key) => key !== survey.id && !key.startsWith(`${survey.id}_`))].slice(
-    0,
-    MAX_SEEN_SURVEYS
-  )
+  return [surveyKey, ...current.filter((key) => !isSurveyKeyForSurvey(key, survey.id))].slice(0, MAX_SEEN_SURVEYS)
 }
 
 export function useSurveyStorage(): SurveyStorage {
@@ -39,8 +36,8 @@ export function useSurveyStorage(): SurveyStorage {
       const serialisedSeenSurveys = posthogStorage.getPersistedProperty(PostHogPersistedProperty.SurveysSeen)
       if (typeof serialisedSeenSurveys === 'string') {
         const parsedSeenSurveys: unknown = JSON.parse(serialisedSeenSurveys)
-        if (Array.isArray(parsedSeenSurveys) && typeof parsedSeenSurveys[0] === 'string') {
-          setSeenSurveys(parsedSeenSurveys)
+        if (Array.isArray(parsedSeenSurveys)) {
+          setSeenSurveys(parsedSeenSurveys.filter((key): key is string => typeof key === 'string'))
         }
       }
     })

--- a/packages/react-native/src/surveys/useSurveyStorage.ts
+++ b/packages/react-native/src/surveys/useSurveyStorage.ts
@@ -4,7 +4,8 @@ import { usePostHog } from '../hooks/usePostHog'
 
 type SurveyStorage = {
   seenSurveys: string[]
-  setSeenSurvey: (surveyId: string) => void
+  // Keys come from getSurveySeenKey — survey ID, iteration-suffixed for repeating surveys
+  setSeenSurvey: (surveyKey: string) => void
   lastSeenSurveyDate: Date | undefined
   setLastSeenSurveyDate: (date: Date) => void
 }
@@ -34,10 +35,10 @@ export function useSurveyStorage(): SurveyStorage {
   return {
     seenSurveys,
     setSeenSurvey: useCallback(
-      (surveyId: string) => {
+      (surveyKey: string) => {
         setSeenSurveys((current) => {
           // To keep storage bounded, only keep the last 20 seen surveys
-          const newValue = [surveyId, ...current.filter((id) => id !== surveyId)]
+          const newValue = [surveyKey, ...current.filter((key) => key !== surveyKey)]
           posthogStorage.setPersistedProperty(
             PostHogPersistedProperty.SurveysSeen,
             JSON.stringify(newValue.slice(0, 20))

--- a/packages/react-native/test/getActiveMatchingSurveys.spec.ts
+++ b/packages/react-native/test/getActiveMatchingSurveys.spec.ts
@@ -355,7 +355,11 @@ describe('getActiveMatchingSurveys', () => {
       expect(result).toHaveLength(0)
     })
 
-    it('should include repeating surveys seen in a previous iteration', () => {
+    it.each([
+      ['seen in a previous iteration', 'repeating-survey_1', 1],
+      ['already seen in the current iteration', 'repeating-survey_2', 0],
+      ['seen before it became repeating (bare id key)', 'repeating-survey', 1],
+    ])('repeating survey %s -> %s shown', (_name, seenKey, expectedLength) => {
       const surveys = [
         createMockSurvey({
           id: 'repeating-survey',
@@ -364,24 +368,9 @@ describe('getActiveMatchingSurveys', () => {
         }),
       ]
 
-      const result = getActiveMatchingSurveys(surveys, mockFlags, ['repeating-survey_1'], mockActivatedSurveys)
+      const result = getActiveMatchingSurveys(surveys, mockFlags, [seenKey], mockActivatedSurveys)
 
-      expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('repeating-survey')
-    })
-
-    it('should exclude repeating surveys already seen in the current iteration', () => {
-      const surveys = [
-        createMockSurvey({
-          id: 'repeating-survey',
-          schedule: SurveySchedule.Recurring,
-          current_iteration: 2,
-        }),
-      ]
-
-      const result = getActiveMatchingSurveys(surveys, mockFlags, ['repeating-survey_2'], mockActivatedSurveys)
-
-      expect(result).toHaveLength(0)
+      expect(result).toHaveLength(expectedLength)
     })
   })
 

--- a/packages/react-native/test/getActiveMatchingSurveys.spec.ts
+++ b/packages/react-native/test/getActiveMatchingSurveys.spec.ts
@@ -354,6 +354,35 @@ describe('getActiveMatchingSurveys', () => {
 
       expect(result).toHaveLength(0)
     })
+
+    it('should include repeating surveys seen in a previous iteration', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'repeating-survey',
+          schedule: SurveySchedule.Recurring,
+          current_iteration: 2,
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, ['repeating-survey_1'], mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('repeating-survey')
+    })
+
+    it('should exclude repeating surveys already seen in the current iteration', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'repeating-survey',
+          schedule: SurveySchedule.Recurring,
+          current_iteration: 2,
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, ['repeating-survey_2'], mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
   })
 
   describe('Linked flag filtering', () => {

--- a/packages/react-native/test/useSurveyStorage.spec.ts
+++ b/packages/react-native/test/useSurveyStorage.spec.ts
@@ -1,4 +1,10 @@
-import { updateSeenSurveys } from '../src/surveys/useSurveyStorage'
+/** @jest-environment jsdom */
+import { PostHogPersistedProperty } from '@posthog/core'
+import { act, renderHook } from '@testing-library/react'
+import React from 'react'
+import { PostHogContext } from '../src/PostHogContext'
+import type { PostHog } from '../src/posthog-rn'
+import { updateSeenSurveys, useSurveyStorage } from '../src/surveys/useSurveyStorage'
 
 describe('updateSeenSurveys', () => {
   it.each([
@@ -36,5 +42,38 @@ describe('updateSeenSurveys', () => {
     expect(result).toHaveLength(20)
     expect(result[0]).toBe('new-survey')
     expect(result).not.toContain('survey-19')
+  })
+})
+
+describe('useSurveyStorage', () => {
+  it('drops non-string persisted entries before updating seen surveys', async () => {
+    jest.useRealTimers()
+    try {
+      const ready = Promise.resolve()
+      const mockPostHog = {
+        ready: jest.fn(() => ready),
+        getPersistedProperty: jest.fn((property) =>
+          property === PostHogPersistedProperty.SurveysSeen
+            ? JSON.stringify(['survey-a', 42, null, 'survey-b'])
+            : undefined
+        ),
+        setPersistedProperty: jest.fn(),
+      } as unknown as PostHog
+      const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(PostHogContext.Provider, { value: { client: mockPostHog } }, children)
+
+      const { result } = renderHook(() => useSurveyStorage(), { wrapper })
+      await act(async () => {
+        await ready
+      })
+
+      expect(result.current.seenSurveys).toEqual(['survey-a', 'survey-b'])
+      expect(() => {
+        act(() => result.current.setSeenSurvey({ id: 'survey-c', current_iteration: 1 }))
+      }).not.toThrow()
+      expect(result.current.seenSurveys).toEqual(['survey-c_1', 'survey-a', 'survey-b'])
+    } finally {
+      jest.useFakeTimers()
+    }
   })
 })

--- a/packages/react-native/test/useSurveyStorage.spec.ts
+++ b/packages/react-native/test/useSurveyStorage.spec.ts
@@ -1,0 +1,40 @@
+import { updateSeenSurveys } from '../src/surveys/useSurveyStorage'
+
+describe('updateSeenSurveys', () => {
+  it.each([
+    [
+      'replaces the pre-iteration bare id',
+      ['survey-1', 'other'],
+      { id: 'survey-1', current_iteration: 2 },
+      ['survey-1_2', 'other'],
+    ],
+    [
+      'replaces a previous iteration key',
+      ['survey-1_1', 'other'],
+      { id: 'survey-1', current_iteration: 2 },
+      ['survey-1_2', 'other'],
+    ],
+    [
+      'dedupes the current key',
+      ['survey-1_2', 'other'],
+      { id: 'survey-1', current_iteration: 2 },
+      ['survey-1_2', 'other'],
+    ],
+    [
+      'leaves other surveys untouched',
+      ['survey-10_1'],
+      { id: 'survey-1', current_iteration: 2 },
+      ['survey-1_2', 'survey-10_1'],
+    ],
+  ])('%s', (_name, current, survey, expected) => {
+    expect(updateSeenSurveys(current, survey)).toEqual(expected)
+  })
+
+  it('caps the list at 20 entries, evicting the oldest', () => {
+    const current = Array.from({ length: 20 }, (_, i) => `survey-${i}`)
+    const result = updateSeenSurveys(current, { id: 'new-survey', current_iteration: null })
+    expect(result).toHaveLength(20)
+    expect(result[0]).toBe('new-survey')
+    expect(result).not.toContain('survey-19')
+  })
+})


### PR DESCRIPTION
## Problem

Repeating surveys ("Repeat on a schedule") never repeat on React Native. The local seen-state is keyed by bare survey ID, so once a user answers or dismisses a survey on a device it stays hidden forever, even after the backend opens the next iteration. Web, iOS, and Android all key seen-state by iteration.

The bug existed because RN and web each maintain their own copy of this logic, and the copies drifted. Sharing it was blocked by a type mismatch: core uses TS enums, the browser package deliberately uses const-object literal unions, and TS enums don't accept equal string literals.

Found while auditing repeating-survey behavior across SDKs ([Slack thread](https://posthog.slack.com/archives/C07QD3LT8U9/p1783335567251989?thread_ts=1783335567.251989&cid=C07QD3LT8U9)). Companion PRs: [posthog#68735](https://github.com/PostHog/posthog/pull/68735) (backend), [posthog.com#18200](https://github.com/PostHog/posthog.com/pull/18200) (docs).

## Changes

1. **Fix: RN seen-state is now iteration-aware.** `id_iteration` when `current_iteration > 0`, bare ID otherwise, matching the other SDKs. Applied on both the read path (`getActiveMatchingSurveys`) and the write path (survey close/dismiss). Marking a survey seen also purges its stale keys from earlier iterations, so each survey holds exactly one slot in the bounded 20-entry list. Backward compatible: previously stored bare IDs simply stop matching a repeating survey's key, which correctly makes it eligible again. We deliberately do NOT migrate legacy bare IDs to the current iteration key: the old SDK never re-showed a survey after one answer, so a legacy bare ID almost always represents an answer from an old iteration — migrating it would wrongly suppress the current iteration for those users and delay this fix by a full cycle. The cost of not migrating is bounded to a one-time re-show for the rare user who answered the still-current iteration right before upgrading.

2. **The shared logic now lives in `@posthog/core/surveys`** (following the existing pattern there): `getSurveyIterationKey`, `doesSurveyActivateByEvent`, and `canSurveyActivateRepeatedly`. Web keeps its localStorage prefixes and its in-progress check as thin local layers; RN imports the core names directly. This is what prevents the two SDKs from drifting apart again.

3. **Core's survey enums are now const-object literal unions**, the pattern the browser package already uses. This removes the type mismatch that forced hand-rolled parameter types in shared helpers: they now use `Pick<Survey, ...>` from core's `Survey`, whose `current_iteration`/`schedule` are also nullable now, matching the API. Value usage (`SurveySchedule.Always`) and type annotations are unchanged for all consumers; runtime output is identical.

Deliberately **not** in this PR: unifying the browser's `posthog-surveys-types.ts` onto core's types. That's public API with real field drift and a known declaration-output landmine (#698), so it's a follow-up PR. This PR removes the blocker for it.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] posthog-react-native
- [x] @posthog/core

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Changesets added (all patch): `tidy-hogs-repeat.md` (RN fix), `shared-survey-state.md` (core/web refactor)

## How did you test this code?

- New RN cases in `getActiveMatchingSurveys.spec.ts`: seen in a previous iteration → shows again; seen in the current iteration → stays hidden; bare pre-iteration key → shows again. The first fails against the old code.
- New `useSurveyStorage.spec.ts`: seen-list keeps one slot per survey and caps at 20 (guards the eviction edge).
- New core `keys.spec.ts`: `getSurveyIterationKey` for iterations 2/1/0/null/undefined, one canonical suite instead of per-SDK copies.
- Refactor and enum conversion covered by existing suites: core 703, RN 497 (full suites), browser surveys 307. Production-file typechecks clean in all three packages.
- Not done: manual device test on RN.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) directed by Lucas, from a cross-repo audit of repeating-survey behavior. Iterated through a multi-agent review swarm (13 low-severity findings, all addressed, including the seen-list eviction edge) and Greptile comments (test parameterization, direct key coverage). The enum-to-const-object conversion was chosen over template-literal type workarounds to fix the sharing blocker at the root; full browser type unification was scoped out to a follow-up on purpose.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
