### PR TITLE
fix(next): route Pages Router server bundles to the server barrel

### DIFF
--- a/.changeset/proud-camels-shake.md
+++ b/.changeset/proud-camels-shake.md
@@ -2,4 +2,4 @@
 '@posthog/next': patch
 ---
 
-Fix `@posthog/next/pages` so Pages Router server bundles resolve the server entrypoint instead of the client barrel. Next.js resolves these bundles with the `node` export condition rather than `react-server`; previously, that fell through to `default`, leaving the server API undefined in `getServerSideProps`. The `node` condition now points to the server barrel, and that import path no longer pulls in `server-only`, which throws outside React Server builds.
+Fix `@posthog/next/pages` in Pages Router server bundles so server APIs like `getServerSideProps` resolve correctly instead of importing the client entrypoint.

--- a/.changeset/proud-camels-shake.md
+++ b/.changeset/proud-camels-shake.md
@@ -1,0 +1,5 @@
+---
+'@posthog/next': patch
+---
+
+Fix `@posthog/next/pages` resolving to the client barrel in Pages Router server bundles. Server code resolves the `node` export condition (not `react-server`), which previously fell through to `default` — leaving the server API undefined inside `getServerSideProps`. The `node` condition now routes to the server barrel, and the modules it reaches no longer import `server-only` (whose non-react-server build throws at import time).

--- a/.changeset/proud-camels-shake.md
+++ b/.changeset/proud-camels-shake.md
@@ -2,4 +2,4 @@
 '@posthog/next': patch
 ---
 
-Fix `@posthog/next/pages` resolving to the client barrel in Pages Router server bundles. Server code resolves the `node` export condition (not `react-server`), which previously fell through to `default` — leaving the server API undefined inside `getServerSideProps`. The `node` condition now routes to the server barrel, and the modules it reaches no longer import `server-only` (whose non-react-server build throws at import time).
+Fix `@posthog/next/pages` so Pages Router server bundles resolve the server entrypoint instead of the client barrel. Next.js resolves these bundles with the `node` export condition rather than `react-server`; previously, that fell through to `default`, leaving the server API undefined in `getServerSideProps`. The `node` condition now points to the server barrel, and that import path no longer pulls in `server-only`, which throws outside React Server builds.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -41,6 +41,7 @@
             "worker": "./dist/pages.edge.js",
             "browser": "./dist/pages.client.js",
             "react-server": "./dist/pages.js",
+            "node": "./dist/pages.js",
             "default": "./dist/pages.client.js"
         }
     },

--- a/packages/next/src/middleware/postHogMiddleware.ts
+++ b/packages/next/src/middleware/postHogMiddleware.ts
@@ -1,5 +1,3 @@
-import 'server-only'
-
 import { NextResponse } from 'next/server.js'
 import type { NextRequest } from 'next/server.js'
 import { getPostHogCookieName, readPostHogCookie, serializePostHogCookie, isOptedOut } from '../shared/cookie.js'

--- a/packages/next/src/pages.client.ts
+++ b/packages/next/src/pages.client.ts
@@ -1,7 +1,3 @@
-// Client-runtime barrel for the `./pages` subpath. Resolved by Next.js's
-// `browser` exports condition. Excludes `getPostHog`, `getServerSidePostHog`,
-// and `postHogMiddleware`, which import `server-only` or `posthog-node` and
-// must not be reachable from a client bundle.
 export { PostHogProvider } from './pages/PostHogProvider.js'
 export { PostHogPageView } from './pages/PostHogPageView.js'
 export { DEFAULT_INGEST_PATH } from './shared/constants.js'

--- a/packages/next/src/server/getPostHog.ts
+++ b/packages/next/src/server/getPostHog.ts
@@ -1,5 +1,3 @@
-import 'server-only'
-
 import { isFunction } from '@posthog/core'
 import type { PostHogOptions, IPostHog } from 'posthog-node'
 import { cookies, headers } from 'next/headers.js'

--- a/packages/next/tests/packaging.test.ts
+++ b/packages/next/tests/packaging.test.ts
@@ -24,6 +24,7 @@ interface SubpathExports {
     worker?: string
     browser?: string
     'react-server'?: string
+    node?: string
     default?: string
 }
 interface PackageJson {
@@ -50,6 +51,7 @@ describe('package.json#exports routing', () => {
         expect(pages.edge).toBe('./dist/pages.edge.js')
         expect(pages.worker).toBe('./dist/pages.edge.js')
         expect(pages['react-server']).toBe('./dist/pages.js')
+        expect(pages.node).toBe('./dist/pages.js')
         expect(pages.default).toBe('./dist/pages.client.js')
     })
 
@@ -143,9 +145,9 @@ describeIfBuilt('Transitive import closure of each built barrel', () => {
     // in. If they stop doing so, the server-side API has likely lost the
     // intended functionality (e.g. a re-export was accidentally dropped).
     it.each([
-        ['pages.js', { 'server-only': true, 'posthog-node': true, 'posthog-node/edge': false }],
+        ['pages.js', { 'server-only': false, 'posthog-node': true, 'posthog-node/edge': false }],
         ['index.js', { 'server-only': true, 'posthog-node': true, 'posthog-node/edge': false }],
-        ['pages.edge.js', { 'server-only': true, 'posthog-node': false, 'posthog-node/edge': false }],
+        ['pages.edge.js', { 'server-only': false, 'posthog-node': false, 'posthog-node/edge': false }],
         ['server.edge.js', { 'server-only': false, 'posthog-node': true, 'posthog-node/edge': false }],
     ])('server/edge barrel %s keeps the expected bare imports', (file, expected) => {
         const imports = bareImportsReachableFrom(path.join(DIST_DIR, file))


### PR DESCRIPTION
## Problem

`@posthog/next/pages` resolves to the **client barrel** in Pages Router server bundles, so `getServerSidePostHog` is silently `undefined` inside `getServerSideProps`. Pages Router server code resolves the `node` export condition (not `react-server`, which only applies to App Router RSC bundles), and the `./pages` exports map had no `node` entry — resolution fell through to `default`, which points at the client barrel.

Reproduced with a real `next build` + `next start` Pages Router app installing the packed tarball: the module resolved to `pages.client.js` and exposed only `DEFAULT_INGEST_PATH`, `PostHogPageView`, `PostHogProvider`.

## Changes

- Add `"node": "./dist/pages.js"` to the `./pages` export conditions so Pages Router server bundles get the server barrel.
- Remove `import 'server-only'` from the modules that barrel reaches (`getPostHog.ts`, `postHogMiddleware.ts`) — `server-only`'s non-react-server build is a top-level `throw`, so it must not be in a Pages node graph. Client bundles remain protected by the exports map (`browser`/`default` → client barrels), which `packaging.test.ts` now enforces: `pages.js` and `pages.edge.js` must not reach `server-only`, and the client barrel closures must not reach `server-only`/`posthog-node`.
- `packaging.test.ts` also asserts the new `node` routing and that `default` stays last.

Verified end-to-end with the repro app: `getServerSidePostHog` resolves and runs inside `getServerSideProps`, while App Router route handlers and `instrumentation.ts` (which resolve `react-server`) are unchanged.

Note: the root `.` entry intentionally keeps no `node` condition — App Router client components are SSR'd in a plain node context where the client barrel is the correct resolution. A consequence is that Next 15.5+ node-runtime middleware importing `postHogMiddleware` from `@posthog/next` still gets the client barrel; edge middleware (the default) is unaffected.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). The bug surfaced while writing docs for the Pages Router server API; verified by building a minimal Pages Router app against the packed tarball, probing which barrel each context (getServerSideProps, App Router route handler, instrumentation.ts) actually resolves.
- Key decision: fix at the exports-map level (`node` condition) rather than restructuring barrels, and encode the invariants in `packaging.test.ts` so the split can't silently regress. `server-only` removal is limited to modules reachable from the pages server barrel; `onRequestError.ts` keeps it since `index.js` is only served under `react-server`.
- Related: PostHog/posthog-js#4091 (createPostHog) stacks on this branch.
