### PR TITLE
perf(next): dedupe getDistinctId resolution per request

### DIFF
--- a/.changeset/tidy-flies-guess.md
+++ b/.changeset/tidy-flies-guess.md
@@ -1,0 +1,5 @@
+---
+'@posthog/next': patch
+---
+
+Dedupe `getDistinctId` resolution per request in the App Router: repeated `getPostHog()` calls within one request (e.g. across a layout and its pages) now share a single resolver invocation, keyed on the request's `headers()` instance.

--- a/packages/next/src/server/createPostHog.ts
+++ b/packages/next/src/server/createPostHog.ts
@@ -14,10 +14,13 @@ export interface CreatePostHogConfig {
      * session/device/window linkage stays client-provided. Return nullish to
      * fall back to the client identity.
      *
-     * Runs once per `getPostHog()` call. In App Router it may call
-     * request-scoped auth helpers directly; in Pages Router
-     * (`@posthog/next/pages`) it receives the `GetServerSidePropsContext`
-     * passed to `getPostHog(ctx)`. Skipped for opted-out users.
+     * Runs in request scope and may call `cookies()`/`headers()` or auth
+     * helpers that do. In the App Router it runs at most once per request:
+     * repeated `getPostHog()` calls share a single resolution. In the Pages
+     * Router (`@posthog/next/pages`) it runs once per `getPostHog(ctx)` call
+     * and receives that `GetServerSidePropsContext`. Skipped for opted-out
+     * users. Errors are logged and treated as no identity; Next.js
+     * control-flow errors propagate normally.
      */
     getDistinctId?: PostHogDistinctIdResolver
 }

--- a/packages/next/src/server/getPostHog.ts
+++ b/packages/next/src/server/getPostHog.ts
@@ -28,6 +28,38 @@ export function withRequestContext(client: IPostHog, contextData: Parameters<IPo
     }) as IPostHog
 }
 
+/**
+ * Dedupes server identity resolution per request. Next's request store reuses
+ * the same read-only headers object for repeated `headers()` calls, so a
+ * WeakMap keyed on it scopes the cache to the request and lets entries be
+ * garbage-collected with it. This is the same mechanism used by the Flags
+ * SDK's `dedupe()` helper; React's `cache()` is a no-op outside RSC render and
+ * unavailable under the `react >= 18` peer range.
+ *
+ * Results are keyed per resolver so factories with different resolvers don't
+ * share identities. Rejections are cached too, ensuring a rethrown Next.js
+ * control-flow error is rethrown on every call in the request.
+ */
+const resolverResultsByRequest = new WeakMap<object, Map<PostHogDistinctIdResolver, Promise<string | undefined>>>()
+
+function resolveServerDistinctIdOncePerRequest(
+    headerStore: object,
+    getDistinctId: PostHogDistinctIdResolver
+): Promise<string | undefined> {
+    let byResolver = resolverResultsByRequest.get(headerStore)
+    if (!byResolver) {
+        byResolver = new Map()
+        resolverResultsByRequest.set(headerStore, byResolver)
+    }
+
+    let result = byResolver.get(getDistinctId)
+    if (!result) {
+        result = resolveServerDistinctId(getDistinctId)
+        byResolver.set(getDistinctId, result)
+    }
+    return result
+}
+
 export async function getRequestScopedPostHog(
     apiKey?: string,
     options?: Partial<PostHogOptions>,
@@ -54,7 +86,7 @@ export async function getRequestScopedPostHog(
     const contextData = buildContextData(tracing, state)
 
     if (getDistinctId) {
-        const serverDistinctId = await resolveServerDistinctId(getDistinctId)
+        const serverDistinctId = await resolveServerDistinctIdOncePerRequest(headerStore, getDistinctId)
         if (serverDistinctId) {
             contextData.distinctId = serverDistinctId
         }

--- a/packages/next/src/shared/identity.ts
+++ b/packages/next/src/shared/identity.ts
@@ -13,12 +13,13 @@ export function generateAnonymousId(): string {
  * Resolves the distinct id of the user making the current request, from a
  * server-side source of truth (e.g. the app's auth session).
  *
- * Called once per `getPostHog()` call, so it may
- * read request-scoped state such as `cookies()` / `headers()` or auth helpers
- * like next-auth's `auth()`. When `getPostHog(ctx)` is called with a
- * `GetServerSidePropsContext` (Pages Router), the resolver receives it so Pages Router auth helpers (e.g.
- * `getServerSession(ctx.req, ctx.res, ...)`) can be used; in App Router it is
- * `undefined`. Return `null`/`undefined` when there is no authenticated user
+ * In App Router/no-arg `getPostHog()`, called at most once per request with
+ * `undefined` context, so it may read request-scoped state such as
+ * `cookies()` / `headers()` or auth helpers like next-auth's `auth()`. In
+ * Pages Router/`getPostHog(ctx)`, called once per call with the provided
+ * `GetServerSidePropsContext`, so Pages Router auth helpers (e.g.
+ * `getServerSession(ctx.req, ctx.res, ...)`) can be used. Return
+ * `null`/`undefined` when there is no authenticated user
  * to fall back to the client-provided identity (PostHog cookie / tracing
  * headers).
  */

--- a/packages/next/tests/createPostHog.test.ts
+++ b/packages/next/tests/createPostHog.test.ts
@@ -297,7 +297,7 @@ describe('createPostHog', () => {
             warnSpy.mockRestore()
         })
 
-        it('calls the resolver once per getPostHog call', async () => {
+        it('does not re-run the resolver per captured event', async () => {
             const getDistinctId = jest.fn(() => 'server-user')
 
             const { getPostHog } = createPostHog({ apiKey: 'phc_test123', getDistinctId })
@@ -306,6 +306,33 @@ describe('createPostHog', () => {
             client.capture({ event: 'two' })
 
             expect(getDistinctId).toHaveBeenCalledTimes(1)
+        })
+
+        it('resolves identity once per request across multiple getPostHog() calls', async () => {
+            const getDistinctId = jest.fn(() => 'server-user')
+
+            const { getPostHog } = createPostHog({ apiKey: 'phc_test123', getDistinctId })
+            const client1 = await getPostHog()
+            const client2 = await getPostHog()
+            client1.capture({ event: 'one' })
+            client2.capture({ event: 'two' })
+
+            expect(getDistinctId).toHaveBeenCalledTimes(1)
+            expect(mockWithContext).toHaveBeenCalledWith(
+                expect.objectContaining({ distinctId: 'server-user' }),
+                expect.any(Function)
+            )
+        })
+
+        it('resolves identity again for a new request', async () => {
+            const getDistinctId = jest.fn(() => 'server-user')
+
+            const { getPostHog } = createPostHog({ apiKey: 'phc_test123', getDistinctId })
+            await getPostHog()
+            ;(headers as jest.Mock).mockResolvedValue(createMockHeaders({}))
+            await getPostHog()
+
+            expect(getDistinctId).toHaveBeenCalledTimes(2)
         })
 
         it('keeps identities separate across interleaved requests on the shared client', async () => {

--- a/packages/next/tests/createPostHog.test.ts
+++ b/packages/next/tests/createPostHog.test.ts
@@ -324,6 +324,40 @@ describe('createPostHog', () => {
             )
         })
 
+        it('shares an in-flight resolver promise for concurrent getPostHog() calls in the same request', async () => {
+            let resolveDistinctId!: (distinctId: string) => void
+            const distinctIdPromise = new Promise<string>((resolve) => {
+                resolveDistinctId = resolve
+            })
+            let markResolverStarted!: () => void
+            const resolverStarted = new Promise<void>((resolve) => {
+                markResolverStarted = resolve
+            })
+            const getDistinctId = jest.fn(() => {
+                markResolverStarted()
+                return distinctIdPromise
+            })
+
+            // The headers() mock resolves the same store object for the whole
+            // test, mirroring how Next returns one headers instance per request.
+            const { getPostHog } = createPostHog({ apiKey: 'phc_test123', getDistinctId })
+            const clientsPromise = Promise.all([getPostHog(), getPostHog()])
+
+            await resolverStarted
+            expect(getDistinctId).toHaveBeenCalledTimes(1)
+
+            resolveDistinctId('server-user')
+            const [client1, client2] = await clientsPromise
+            client1.capture({ event: 'one' })
+            client2.capture({ event: 'two' })
+
+            expect(getDistinctId).toHaveBeenCalledTimes(1)
+            expect(mockWithContext).toHaveBeenCalledWith(
+                expect.objectContaining({ distinctId: 'server-user' }),
+                expect.any(Function)
+            )
+        })
+
         it('resolves identity again for a new request', async () => {
             const getDistinctId = jest.fn(() => 'server-user')
 


### PR DESCRIPTION
## Problem

With `createPostHog({ getDistinctId })`, the resolver runs on every `getPostHog()` call. An App Router tree where a layout, a page, and several server components each call `getPostHog()` runs the resolver N times per request — N session-store lookups per render for resolvers that do their own I/O.

React's `cache()` isn't a fix the SDK can rely on: it's a no-op outside RSC render (route handlers, server actions) and isn't reliably exported under the `react >= 18` peer range.

## Changes

Memoize the resolution in a `WeakMap` keyed on the request's `headers()` instance — Next returns the same object for the whole request, so the cache is request-scoped by construction and entries are garbage-collected with the request. This is the same mechanism as the Vercel Flags SDK's `dedupe()` helper ("a middleware-friendly version of `React.cache`").

- Keyed per resolver function, so multiple `createPostHog()` factories stay independent.
- Rejections are cached deliberately: a rethrown `redirect()` must rethrow on every call within the request.
- The Pages Router path (`getPostHog(ctx)`) is unchanged — no `headers()` there, and `getServerSideProps` typically resolves once per request anyway.
- JSDoc updated: the resolver now documents "at most once per request" instead of advising users to wrap resolvers in React `cache()`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). The per-request `headers()`-keyed WeakMap approach comes from a verified research pass over Vercel's Flags SDK (`dedupe()` in `flags/next`), chosen over React `cache()` for the reasons above.
- The inefficiency was originally flagged by a multi-agent code review of #4091 and deferred; the human asked for it as its own PR.
