### PR TITLE
fix(browser): remove capture ver query param

### DIFF
--- a/.changeset/remove-capture-ver.md
+++ b/.changeset/remove-capture-ver.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Stop sending the deprecated `ver` query parameter to capture and session recording endpoints.

--- a/packages/browser/src/__tests__/extensions/replay/config.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/config.test.ts
@@ -107,21 +107,21 @@ describe('config', () => {
                 ],
                 [
                     {
-                        name: 'https://app.posthog.com/s/?ip=0&ver=123',
+                        name: 'https://app.posthog.com/s/?ver=123',
                     },
                     undefined,
                     undefined,
                 ],
                 [
                     {
-                        name: 'https://app.posthog.com/e/?ip=0&ver=123',
+                        name: 'https://app.posthog.com/e/?ver=123',
                     },
                     undefined,
                     undefined,
                 ],
                 [
                     {
-                        name: 'https://app.posthog.com/i/v0/e/?ip=0&ver=123',
+                        name: 'https://app.posthog.com/i/v0/e/?ver=123',
                     },
                     undefined,
                     undefined,
@@ -129,7 +129,7 @@ describe('config', () => {
                 [
                     {
                         // even an imaginary future world of rust session replay capture
-                        name: 'https://app.posthog.com/i/v0/s/?ip=0&ver=123',
+                        name: 'https://app.posthog.com/i/v0/s/?ver=123',
                     },
                     undefined,
                     undefined,
@@ -137,7 +137,7 @@ describe('config', () => {
                 [
                     {
                         // using a relative path as a reverse proxy api host
-                        name: 'https://app.posthog.com/ingest/s/?ip=0&ver=123',
+                        name: 'https://app.posthog.com/ingest/s/?ver=123',
                     },
                     undefined,
                     '/ingest',
@@ -145,7 +145,7 @@ describe('config', () => {
                 [
                     {
                         // using a reverse proxy with a path
-                        name: 'https://app.posthog.com/ingest/s/?ip=0&ver=123',
+                        name: 'https://app.posthog.com/ingest/s/?ver=123',
                     },
                     undefined,
                     'https://app.posthog.com/ingest',

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -195,6 +195,71 @@ describe('request', () => {
             )
         })
 
+        it.each(['/e/', '/s/', '/i/v0/e/', '/i/v0/s/'])('does not add ver to browser capture endpoint %s', (path) => {
+            request(
+                createRequest({
+                    url: `https://any.posthog-instance.com${path}`,
+                })
+            )
+
+            const requestedUrl = mockedFetch.mock.calls[0][0]
+            expect(requestedUrl).toContain('_=1700000000000')
+            expect(requestedUrl).not.toContain('ver=')
+        })
+
+        it('does not add ver to proxied capture endpoints', () => {
+            request(
+                createRequest({
+                    url: 'https://any.posthog-instance.com/ingest/s/',
+                })
+            )
+
+            const requestedUrl = mockedFetch.mock.calls[0][0]
+            expect(requestedUrl).toBe('https://any.posthog-instance.com/ingest/s/?_=1700000000000')
+        })
+
+        it('does not rely on String.prototype.endsWith for capture endpoint matching', () => {
+            const originalEndsWith = String.prototype.endsWith
+            // Simulate older browsers where String.prototype.endsWith is unavailable.
+            delete (String.prototype as any).endsWith
+
+            try {
+                request(
+                    createRequest({
+                        url: 'https://any.posthog-instance.com/e/',
+                    })
+                )
+
+                const requestedUrl = mockedFetch.mock.calls[0][0]
+                expect(requestedUrl).toBe('https://any.posthog-instance.com/e/?_=1700000000000')
+            } finally {
+                String.prototype.endsWith = originalEndsWith
+            }
+        })
+
+        it('removes existing ver from capture endpoints', () => {
+            request(
+                createRequest({
+                    url: 'https://any.posthog-instance.com/e/?ver=1.23.45&ip=0',
+                })
+            )
+
+            const requestedUrl = mockedFetch.mock.calls[0][0]
+            expect(requestedUrl).toBe('https://any.posthog-instance.com/e/?ip=0&_=1700000000000')
+        })
+
+        it('keeps ver on feature flag requests', () => {
+            request(
+                createRequest({
+                    url: 'https://any.posthog-instance.com/flags/?v=2',
+                })
+            )
+
+            expect(mockedFetch.mock.calls[0][0]).toBe(
+                'https://any.posthog-instance.com/flags/?v=2&_=1700000000000&ver=1.23.45'
+            )
+        })
+
         it('calls the callback handler when successful', async () => {
             request(createRequest())
             await flushPromises()

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -240,12 +240,12 @@ describe('request', () => {
         it('removes existing ver from capture endpoints', () => {
             request(
                 createRequest({
-                    url: 'https://any.posthog-instance.com/e/?ver=1.23.45&ip=0',
+                    url: 'https://any.posthog-instance.com/e/?ver=1.23.45&foo=bar',
                 })
             )
 
             const requestedUrl = mockedFetch.mock.calls[0][0]
-            expect(requestedUrl).toBe('https://any.posthog-instance.com/e/?ip=0&_=1700000000000')
+            expect(requestedUrl).toBe('https://any.posthog-instance.com/e/?foo=bar&_=1700000000000')
         })
 
         it('keeps ver on feature flag requests', () => {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -1,7 +1,7 @@
 import { each, find } from './utils'
 import Config from './config'
 import { Compression, RequestWithOptions, RequestResponse } from './types'
-import { formDataToQuery, getQueryParam } from './utils/request-utils'
+import { convertToURL, formDataToQuery, getQueryParam } from './utils/request-utils'
 
 import { logger } from './utils/logger'
 import { AbortController, CompressionStream, fetch, navigator, XMLHttpRequest } from './utils/globals'
@@ -388,10 +388,31 @@ const _sendBeacon = (options: RequestWithOptions) => {
     }
 }
 
+const VERSIONLESS_ENDPOINTS = ['/e/', '/s/']
+
+const getURLPath = (url: string): string => {
+    const parsedURL = convertToURL(url)
+    const path = parsedURL?.pathname || url.split(/[?#]/)[0]
+
+    return path ? (path[0] === '/' ? path : `/${path}`) : '/'
+}
+
+const hasEndpointSuffix = (path: string, endpoint: string): boolean => {
+    return path.slice(path.length - endpoint.length) === endpoint
+}
+
+const isVersionlessEndpoint = (url: string): boolean => {
+    const path = getURLPath(url)
+
+    return VERSIONLESS_ENDPOINTS.some((endpoint) => hasEndpointSuffix(path, endpoint))
+}
+
 const buildRequestURL = (url: string, compression?: RequestWithOptions['compression']): string => {
-    return extendURLParams(url, {
+    const versionlessEndpoint = isVersionlessEndpoint(url)
+
+    return extendURLParams(versionlessEndpoint ? removeURLParam(url, 'ver') : url, {
         _: new Date().getTime().toString(),
-        ver: Config.JS_SDK_VERSION,
+        ...(versionlessEndpoint ? {} : { ver: Config.JS_SDK_VERSION }),
         compression,
     })
 }


### PR DESCRIPTION
## Problem

The capture backend no longer uses the legacy `ver` query parameter for capture and session recording endpoints. The browser SDK was still appending it to every SDK request, including browser capture endpoints where it is now unnecessary, while feature flags still need it.

## Changes

- Stop adding `ver` to browser capture/session recording endpoints: `/e/` and `/s/`.
- Remove any pre-existing `ver` query parameter when sending to those endpoints, including configured/prefixed/proxied paths like `/i/v0/e/`, `/i/v0/s/`, and `/ingest/s/`.
- Keep sending `ver` for non-capture endpoints such as `/flags/`.
- Use the existing compat-safe URL parsing helper to identify request paths.
- Avoid `String.prototype.endsWith` so older browsers without that method do not fail remote config/request setup.
- Add request tests covering removed browser capture `ver`, proxied capture paths, existing `ver` removal, feature flag preservation, and missing `String.prototype.endsWith`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the browser SDK follow-up to the already-merged backend capture change. The implementation intentionally limits `ver` removal to the browser SDK's capture/session recording endpoints and preserves feature flag behavior because feature flags still use the SDK version hint.

Verification run:

- `pnpm exec eslint src/request.ts src/__tests__/request.test.ts`
- `pnpm exec jest src/__tests__/request.test.ts --runInBand`
- `pnpm turbo --filter=posthog-js... build`
- `pnpm --filter posthog-js test:unit -- request.test.ts`
