### PR TITLE
chore: update PostHog watcher action

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -30,7 +30,7 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d
+              uses: PostHog/posthog-watcher-action@4eeb4867209b0f75a1bc8a1ee661f002502afe6b
               with:
                   mode: enqueue
                   trigger-drain-workflow: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -42,7 +42,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d
+              uses: PostHog/posthog-watcher-action@4eeb4867209b0f75a1bc8a1ee661f002502afe6b
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -58,3 +58,5 @@ jobs:
                   approve-project-resources: 'true'
                   state-enabled: 'true'
                   pi-session-sharing: 'true'
+                  pi-session-sharing-mode: gist
+                  pi-session-gist-token: ${{ secrets.PI_SESSION_GIST_TOKEN }}

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -48,7 +48,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d
+              uses: PostHog/posthog-watcher-action@4eeb4867209b0f75a1bc8a1ee661f002502afe6b
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -80,7 +80,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y ripgrep
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d
+              uses: PostHog/posthog-watcher-action@4eeb4867209b0f75a1bc8a1ee661f002502afe6b
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -62,6 +62,8 @@ jobs:
                   approve-project-resources: 'true'
                   state-enabled: 'true'
                   pi-session-sharing: 'true'
+                  pi-session-sharing-mode: gist
+                  pi-session-gist-token: ${{ secrets.PI_SESSION_GIST_TOKEN }}
 
     process-issue:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs['issue-number'] != '' }}
@@ -95,3 +97,5 @@ jobs:
                   approve-project-resources: 'true'
                   state-enabled: 'true'
                   pi-session-sharing: 'true'
+                  pi-session-sharing-mode: gist
+                  pi-session-gist-token: ${{ secrets.PI_SESSION_GIST_TOKEN }}


### PR DESCRIPTION
## Problem

The workflow automation pins `PostHog/posthog-watcher-action` to a specific commit SHA. This keeps those workflow references current with the latest upstream watcher action commit and configures shared Pi session output to use gist-backed storage.

## Changes

- Bumped all `PostHog/posthog-watcher-action` workflow references from `4f06ce5e4ea850576c7ee02135164d4bb2d2ef4d` to `4eeb4867209b0f75a1bc8a1ee661f002502afe6b`.
- Set watcher runs with Pi session sharing enabled to `pi-session-sharing-mode: gist`.
- Passed `pi-session-gist-token: ${{ secrets.PI_SESSION_GIST_TOKEN }}` for gist-backed session sharing.
- Verified all watcher action references now point to the same SHA.
- Verified the workflow diff with `git diff --check`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared by Pi after being asked to update the pinned PostHog watcher action and enable gist-backed Pi session sharing. The change is limited to GitHub workflow references; no package code or release changeset is needed.
