### PR TITLE
fix(browser): omit gzip compression query parameter

### DIFF
--- a/.changeset/sharp-lions-glow.md
+++ b/.changeset/sharp-lions-glow.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Stop adding the gzip compression query parameter to browser SDK requests.

--- a/packages/browser/functional_tests/mock-server.ts
+++ b/packages/browser/functional_tests/mock-server.ts
@@ -13,17 +13,19 @@ const capturedRequests: { '/e/': any[]; '/engage/': any[]; '/flags/': any[] } = 
     '/flags/': [],
 }
 
+const isGzipData = (data: Uint8Array): boolean => data[0] === 0x1f && data[1] === 0x8b
+
 const handleRequest = (group: string) => (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
     let body = req.body
 
     if (typeof body === 'string') {
         try {
             const b64Encoded = req.url.href.includes('compression=base64')
-            const gzipCompressed = req.url.href.includes('compression=gzip-js')
+            const data = new Uint8Array(req._body)
+            const gzipCompressed = isGzipData(data)
             if (b64Encoded) {
                 body = JSON.parse(Buffer.from(decodeURIComponent(body.split('=')[1]), 'base64').toString())
             } else if (gzipCompressed) {
-                const data = new Uint8Array(req._body)
                 const decoded = strFromU8(decompressSync(data))
                 body = JSON.parse(decoded)
             } else {

--- a/packages/browser/playwright/mocked/capture.spec.ts
+++ b/packages/browser/playwright/mocked/capture.spec.ts
@@ -9,6 +9,8 @@ function getGzipEncodedPayloady(req: Request): Record<string, any> {
     if (!data) {
         throw new Error('Expected body to be present')
     }
+    expect(data[0]).toBe(0x1f)
+    expect(data[1]).toBe(0x8b)
     const decoded = strFromU8(decompressSync(data))
 
     return JSON.parse(decoded)
@@ -56,7 +58,9 @@ test.describe('event capture', () => {
         expect(captureRequests.length).toEqual(1)
         const captureRequest = captureRequests[0]
         expect(captureRequest.headers()['content-type']).toEqual('text/plain')
-        expect(captureRequest.url()).toMatch(/gzip/)
+        const captureRequestUrl = new URL(captureRequest.url())
+        expect(captureRequestUrl.searchParams.has('compression')).toBe(false)
+        expect(captureRequest.url()).not.toContain('gzip')
         // webkit doesn't allow us to read the body for some reason
         // see e.g. https://github.com/microsoft/playwright/issues/6479
         if (browserName !== 'webkit') {

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -260,6 +260,31 @@ describe('request', () => {
             )
         })
 
+        it('does not add a compression query param for gzip requests', () => {
+            request(
+                createRequest({
+                    method: 'POST',
+                    compression: Compression.GZipJS,
+                    data: { foo: 'bar' },
+                })
+            )
+
+            expect(mockedFetch.mock.calls[0][0]).toBe('https://any.posthog-instance.com?ver=1.23.45&_=1700000000000')
+        })
+
+        it('removes an existing compression query param for gzip requests', () => {
+            request(
+                createRequest({
+                    url: 'https://any.posthog-instance.com?ver=1.23.45&compression=gzip-js',
+                    method: 'POST',
+                    compression: Compression.GZipJS,
+                    data: { foo: 'bar' },
+                })
+            )
+
+            expect(mockedFetch.mock.calls[0][0]).toBe('https://any.posthog-instance.com?ver=1.23.45&_=1700000000000')
+        })
+
         it('calls the callback handler when successful', async () => {
             request(createRequest())
             await flushPromises()
@@ -494,14 +519,7 @@ describe('request', () => {
         describe('keepalive with fetch and large bodies can cause some browsers to reject network calls', () => {
             it.each([
                 ['always keepalive with small json POST', 'POST', 'small', undefined, true, ''],
-                [
-                    'always keepalive with small gzip POST',
-                    'POST',
-                    'small',
-                    Compression.GZipJS,
-                    true,
-                    '&compression=gzip-js',
-                ],
+                ['always keepalive with small gzip POST', 'POST', 'small', Compression.GZipJS, true, ''],
                 [
                     'always keepalive with small base64 POST',
                     'POST',
@@ -510,16 +528,9 @@ describe('request', () => {
                     true,
                     '&compression=base64',
                 ],
-                ['never keepalive with GET', 'GET', undefined, Compression.GZipJS, false, '&compression=gzip-js'],
+                ['never keepalive with GET', 'GET', undefined, Compression.GZipJS, false, ''],
                 ['never keepalive with large JSON POST', 'POST', veryLargeBodyData, undefined, false, ''],
-                [
-                    'never keepalive with large GZIP POST',
-                    'POST',
-                    veryLargeBodyData,
-                    Compression.GZipJS,
-                    false,
-                    '&compression=gzip-js',
-                ],
+                ['never keepalive with large GZIP POST', 'POST', veryLargeBodyData, Compression.GZipJS, false, ''],
                 [
                     'never keepalive with large base64 POST',
                     'POST',
@@ -772,7 +783,7 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
-                    'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45&compression=gzip-js',
+                    'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45',
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
@@ -910,7 +921,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
 
@@ -931,7 +942,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
 
             mockedIsolatedFetch.mockClear()
@@ -950,7 +961,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
 
@@ -996,7 +1007,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
     })

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -260,29 +260,28 @@ describe('request', () => {
             )
         })
 
-        it('does not add a compression query param for gzip requests', () => {
+        it.each([
+            [
+                'does not add a compression query param for gzip requests',
+                'https://any.posthog-instance.com?ver=1.23.45',
+                'https://any.posthog-instance.com?ver=1.23.45&_=1700000000000',
+            ],
+            [
+                'removes an existing compression query param for gzip requests',
+                'https://any.posthog-instance.com?ver=1.23.45&compression=gzip-js',
+                'https://any.posthog-instance.com?ver=1.23.45&_=1700000000000',
+            ],
+        ])('%s', (_label, url, expectedUrl) => {
             request(
                 createRequest({
+                    url,
                     method: 'POST',
                     compression: Compression.GZipJS,
                     data: { foo: 'bar' },
                 })
             )
 
-            expect(mockedFetch.mock.calls[0][0]).toBe('https://any.posthog-instance.com?ver=1.23.45&_=1700000000000')
-        })
-
-        it('removes an existing compression query param for gzip requests', () => {
-            request(
-                createRequest({
-                    url: 'https://any.posthog-instance.com?ver=1.23.45&compression=gzip-js',
-                    method: 'POST',
-                    compression: Compression.GZipJS,
-                    data: { foo: 'bar' },
-                })
-            )
-
-            expect(mockedFetch.mock.calls[0][0]).toBe('https://any.posthog-instance.com?ver=1.23.45&_=1700000000000')
+            expect(mockedFetch.mock.calls[0][0]).toBe(expectedUrl)
         })
 
         it('calls the callback handler when successful', async () => {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -409,12 +409,16 @@ const isVersionlessEndpoint = (url: string): boolean => {
 
 const buildRequestURL = (url: string, compression?: RequestWithOptions['compression']): string => {
     const versionlessEndpoint = isVersionlessEndpoint(url)
+    const requestURL = versionlessEndpoint ? removeURLParam(url, 'ver') : url
 
-    return extendURLParams(versionlessEndpoint ? removeURLParam(url, 'ver') : url, {
-        _: new Date().getTime().toString(),
-        ...(versionlessEndpoint ? {} : { ver: Config.JS_SDK_VERSION }),
-        compression,
-    })
+    return extendURLParams(
+        compression === Compression.GZipJS ? removeURLParam(requestURL, 'compression') : requestURL,
+        {
+            _: new Date().getTime().toString(),
+            ...(versionlessEndpoint ? {} : { ver: Config.JS_SDK_VERSION }),
+            ...(compression === Compression.GZipJS ? {} : { compression }),
+        }
+    )
 }
 
 const AVAILABLE_TRANSPORTS: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,7 +800,7 @@ importers:
         version: link:../../tooling/tsconfig-base
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(typescript@5.8.2)
+        version: 0.10.6(@microsoft/api-extractor@7.58.9(@types/node@22.16.5))(typescript@5.8.2)
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
@@ -815,7 +815,7 @@ importers:
         version: link:../browser
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.11(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)))(typescript@5.8.2)
 
   packages/plugin-utils:
     dependencies:
@@ -20874,7 +20874,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 26.0.1
+      '@types/node': 22.20.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -23856,7 +23856,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 22.20.0
 
   '@types/http-errors@2.0.5': {}
 
@@ -30645,7 +30645,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 26.0.1
+      '@types/node': 22.20.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -30864,7 +30864,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 22.20.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -32182,7 +32182,7 @@ snapshots:
   metro-source-map@0.83.1:
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.4'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.7'
       '@babel/types': 7.28.5
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -34591,8 +34591,10 @@ snapshots:
       which: 2.0.2
       yargs: 17.7.2
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
       - typescript
+      - utf-8-validate
 
   react-native-codegen@0.69.2(@babel/preset-env@7.28.5(@babel/core@7.28.5)):
     dependencies:
@@ -36730,6 +36732,27 @@ snapshots:
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.28.5
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      esbuild: 0.25.10
+      jest-util: 29.7.0
+
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)))(typescript@5.8.2):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.2
+      type-fest: 4.41.0
+      typescript: 5.8.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.7
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.29.7)


### PR DESCRIPTION
## Problem

Browser SDK gzip-compressed requests no longer need to advertise gzip via the `compression=gzip-js` query parameter because ingestion can identify gzip payloads from their magic leading bytes. Keeping the query parameter is unnecessary, while base64 payloads still need `compression=base64` for decoding.

## Changes

- Skip adding `compression=gzip-js` to browser SDK request URLs.
- Remove any pre-existing `compression` query parameter when a request is sent with gzip compression.
- Preserve `compression=base64` behavior for base64-compressed requests.
- Update the browser functional test mock server to detect gzip payloads from the `0x1f 0x8b` magic bytes.
- Update request tests to cover gzip URLs without the query parameter and base64 URLs with it.
- Repair the pnpm lockfile so frozen installs can resolve the current dependency graph in CI.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A pi coding agent implemented the requested browser SDK request URL change in a dedicated worktree. The change keeps base64 query-parameter behavior intact while relying on gzip magic-byte detection for gzip payloads, updates tests plus the functional mock server, and repairs the lockfile issue that caused CI jobs to fail during frozen install setup.

Verification run:

```bash
PUPPETEER_SKIP_DOWNLOAD=1 pnpm install --frozen-lockfile --ignore-scripts
pnpm --filter @posthog/types build
pnpm --filter @posthog/core build
pnpm --filter posthog-js exec jest src/__tests__/request.test.ts --runInBand
pnpm --filter posthog-js exec eslint src/request.ts src/__tests__/request.test.ts functional_tests/mock-server.ts
pnpm --filter posthog-js exec prettier --check src/request.ts src/__tests__/request.test.ts functional_tests/mock-server.ts
```
