### PR TITLE
chore(release): publish the code-split toolbar bundle when posthog/posthog emits it

### DIFF
--- a/.changeset/publish-split-toolbar-bundle.md
+++ b/.changeset/publish-split-toolbar-bundle.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Publish the code-split ESM toolbar bundle when the build emits one. The release tooling now recursively includes `dist/toolbar/` (with explicit JS content types for the strict-MIME ESM chunks) across the immutable, major-alias, and compatibility upload prefixes, and the workflow accepts the canonical `toolbar.js`/`toolbar.css` layout. This is a no-op against today's single-file build.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -79,6 +79,7 @@ module.exports = {
                 'packages/rollup-plugin/**',
                 'examples/**',
                 'playground/**',
+                'tooling/**',
             ],
             rules: {
                 'no-console': 'off',
@@ -119,8 +120,7 @@ module.exports = {
                 'no-restricted-syntax': [
                     'error',
                     {
-                        selector:
-                            "CallExpression[callee.object.name='Promise'][callee.property.name='allSettled']",
+                        selector: "CallExpression[callee.object.name='Promise'][callee.property.name='allSettled']",
                         message:
                             'Use `allSettled` from @posthog/core (packages/core/src/utils) instead of Promise.allSettled — Promise.allSettled can be broken by runtime Promise patching on some RN environments.',
                     },
@@ -129,6 +129,4 @@ module.exports = {
         },
     ],
     ignorePatterns: ['node_modules', 'dist', 'next-env.d.ts', '.next', 'packages/browser/playground/hydration/vendor'],
-
-
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -580,13 +580,13 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
               with:
-                node-version: 24
+                  node-version: 24
 
             - name: Setup pnpm
               uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
               with:
-                cache: false
-                install: false
+                  cache: false
+                  install: false
 
             - name: Install frontend dependencies
               run: pnpm --filter=@posthog/frontend... install --frozen-lockfile
@@ -615,35 +615,42 @@ jobs:
             # upload step has stable filenames. The runtime CSS loader in the
             # JS bundle expects the literal `toolbar.css`.
             #
+            # The upcoming code-split toolbar build emits canonical names
+            # directly: `toolbar.js` is a tiny loader and the hashed ESM app
+            # lives in `dist/toolbar/`. Accept either layout — a file that is
+            # already canonical needs no rename, and the chunk directory's
+            # names are content-hashed by design and must be preserved.
+            #
             # Toolbar source maps are discarded (we don't ship them to end users).
             - name: Normalize toolbar output filenames
               run: |
                   set -euo pipefail
                   # `set -e` alone doesn't propagate failures out of $(...)
                   # command substitutions. Without inherit_errexit, a failing
-                  # `find frontend/dist/assets` inside an echo would silently
-                  # print "0 files" and the step would pass, only to fail
-                  # confusingly later in upload-artifact's if-no-files-found.
+                  # `find` inside an echo would silently print "0 files" and
+                  # the step would pass, only to fail confusingly later in
+                  # upload-artifact's if-no-files-found.
                   shopt -s inherit_errexit
                   shopt -s nullglob
-                  jsfiles=(frontend/dist/toolbar-*.js)
-                  cssfiles=(frontend/dist/toolbar-*.css)
-                  if [ ${#jsfiles[@]} -ne 1 ]; then
-                      echo "❌ expected exactly one frontend/dist/toolbar-*.js, got ${#jsfiles[@]}: ${jsfiles[*]:-}"
-                      ls -la frontend/dist/ || true
-                      exit 1
-                  fi
-                  if [ ${#cssfiles[@]} -ne 1 ]; then
-                      echo "❌ expected exactly one frontend/dist/toolbar-*.css, got ${#cssfiles[@]}: ${cssfiles[*]:-}"
-                      ls -la frontend/dist/ || true
-                      exit 1
-                  fi
-                  mv "${jsfiles[0]}" frontend/dist/toolbar.js
-                  mv "${cssfiles[0]}" frontend/dist/toolbar.css
+                  for ext in js css; do
+                      if [ -f "frontend/dist/toolbar.$ext" ]; then
+                          echo "✓ toolbar.$ext already canonical, no rename needed"
+                          continue
+                      fi
+                      hashed=(frontend/dist/toolbar-*."$ext")
+                      if [ ${#hashed[@]} -ne 1 ]; then
+                          echo "❌ expected exactly one frontend/dist/toolbar-*.$ext, got ${#hashed[@]}: ${hashed[*]:-}"
+                          ls -la frontend/dist/ || true
+                          exit 1
+                      fi
+                      mv "${hashed[0]}" "frontend/dist/toolbar.$ext"
+                  done
                   rm -f frontend/dist/*.map
+                  if [ -d frontend/dist/toolbar ]; then
+                      find frontend/dist/toolbar -type f -name '*.map' -delete
+                  fi
                   echo "✓ normalized toolbar outputs:"
                   ls -la frontend/dist/toolbar.js frontend/dist/toolbar.css
-                  echo "✓ assets/ contains $(find frontend/dist/assets -type f | wc -l) files"
 
             # Assert the cross-repo contract: the `TOOLBAR_PUBLIC_PATH` env
             # var we passed in must actually appear in the bundle. If
@@ -658,17 +665,29 @@ jobs:
                   # step has several $(...) substitutions (find, wc, git
                   # rev-parse) that we want to fail loudly if they break.
                   shopt -s inherit_errexit
-                  if ! grep -aq "$TOOLBAR_PUBLIC_PATH" frontend/dist/toolbar.js; then
-                      echo "❌ toolbar.js does not contain TOOLBAR_PUBLIC_PATH='$TOOLBAR_PUBLIC_PATH'"
+                  # In the single-file build the public path is baked into
+                  # toolbar.js itself. In the code-split build toolbar.js is
+                  # just a loader (it resolves chunks relative to its own URL)
+                  # and the runtime CSS loader that uses TOOLBAR_PUBLIC_PATH
+                  # lives in a chunk under dist/toolbar/ — so search both.
+                  targets=(frontend/dist/toolbar.js)
+                  if [ -d frontend/dist/toolbar ]; then
+                      targets+=(frontend/dist/toolbar)
+                  fi
+                  if ! grep -arq "$TOOLBAR_PUBLIC_PATH" "${targets[@]}"; then
+                      echo "❌ toolbar bundle does not contain TOOLBAR_PUBLIC_PATH='$TOOLBAR_PUBLIC_PATH'"
+                      echo "   searched: ${targets[*]}"
                       echo "   posthog/posthog@$(git rev-parse HEAD) may not honour the env var yet."
                       exit 1
                   fi
+                  count_files() { if [ -d "$1" ]; then find "$1" -type f | wc -l | tr -d ' '; else echo 0; fi; }
                   echo "✓ TOOLBAR_PUBLIC_PATH baked into bundle"
                   echo "  region:              ${{ matrix.region.name }}"
                   echo "  TOOLBAR_PUBLIC_PATH: $TOOLBAR_PUBLIC_PATH"
                   echo "  toolbar.js:          $(wc -c < frontend/dist/toolbar.js) bytes"
                   echo "  toolbar.css:         $(wc -c < frontend/dist/toolbar.css) bytes"
-                  echo "  assets/:             $(find frontend/dist/assets -type f | wc -l | tr -d ' ') files"
+                  echo "  assets/:             $(count_files frontend/dist/assets) files"
+                  echo "  toolbar/:            $(count_files frontend/dist/toolbar) files"
                   echo "  built from:          PostHog/posthog@$(git rev-parse HEAD)"
 
             - name: Upload toolbar artifact
@@ -676,12 +695,18 @@ jobs:
               with:
                   name: toolbar-dist-${{ matrix.region.name }}
                   # Least common ancestor of these paths is `frontend/dist`,
-                  # so the artifact contains `toolbar.js`, `toolbar.css`, and
-                  # `assets/**` at the root (see actions/upload-artifact docs).
+                  # so the artifact contains `toolbar.js`, `toolbar.css`,
+                  # `assets/**`, and `toolbar/**` at the root (see
+                  # actions/upload-artifact docs). `assets/` and `toolbar/`
+                  # are each optional (matching neither layout of the build
+                  # is fine as long as something matched overall): today's
+                  # single-file build emits `assets/`, the upcoming
+                  # code-split build ships the hashed ESM app in `toolbar/`.
                   path: |
                       frontend/dist/toolbar.js
                       frontend/dist/toolbar.css
                       frontend/dist/assets
+                      frontend/dist/toolbar
                   retention-days: 1
                   if-no-files-found: error
 
@@ -765,11 +790,11 @@ jobs:
             - name: Setup pnpm and Node.js
               uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
               with:
-                # TODO: pnpm/setup does not read .nvmrc yet. Keep this in sync with .nvmrc
-                # until https://github.com/jasongin/nvs/pull/315 lands.
-                runtime: node@24
-                cache: false
-                install: false
+                  # TODO: pnpm/setup does not read .nvmrc yet. Keep this in sync with .nvmrc
+                  # until https://github.com/jasongin/nvs/pull/315 lands.
+                  runtime: node@24
+                  cache: false
+                  install: false
 
             - name: Install release tooling dependencies
               run: pnpm install --filter @posthog-tooling/release... --frozen-lockfile

--- a/tooling/release/src/upload-posthog-js-s3.test.ts
+++ b/tooling/release/src/upload-posthog-js-s3.test.ts
@@ -178,14 +178,39 @@ test('collectReleaseAssets publishes the code-split toolbar chunk directory when
         )
 
         const plans = buildAssetUploadPlans('1.370.0', assets)
-        const chunkUpload = plans.immutable.find((upload) => upload.key.endsWith('chunk-hedgehog-E5F6A7B8.js'))
+
+        // The chunk must flow through all three prefixes: the loaders published at the major-alias
+        // (`/static/1/toolbar.js`) and compatibility (`/static/toolbar.js`) paths resolve their chunks
+        // relative to their own URLs too, so a chunk missing from those plans is a broken toolbar for
+        // unversioned-CDN users.
+        const findChunk = (uploads: ReturnType<typeof buildAssetUploadPlans>['immutable']) =>
+            uploads.find((upload) => upload.key.endsWith('chunk-hedgehog-E5F6A7B8.js'))
         assert.deepEqual(
-            { key: chunkUpload?.key, cacheControl: chunkUpload?.cacheControl, contentType: chunkUpload?.contentType },
-            {
-                key: 'static/1.370.0/toolbar/chunk-hedgehog-E5F6A7B8.js',
-                cacheControl: 'public, max-age=31536000, immutable',
-                contentType: 'application/javascript',
-            }
+            (['immutable', 'majorAlias', 'compatibility'] as const).map((prefix) => {
+                const chunkUpload = findChunk(plans[prefix])
+                return {
+                    key: chunkUpload?.key,
+                    cacheControl: chunkUpload?.cacheControl,
+                    contentType: chunkUpload?.contentType,
+                }
+            }),
+            [
+                {
+                    key: 'static/1.370.0/toolbar/chunk-hedgehog-E5F6A7B8.js',
+                    cacheControl: 'public, max-age=31536000, immutable',
+                    contentType: 'application/javascript',
+                },
+                {
+                    key: 'static/1/toolbar/chunk-hedgehog-E5F6A7B8.js',
+                    cacheControl: 'public, max-age=300',
+                    contentType: 'application/javascript',
+                },
+                {
+                    key: 'static/toolbar/chunk-hedgehog-E5F6A7B8.js',
+                    cacheControl: 'public, max-age=300',
+                    contentType: 'application/javascript',
+                },
+            ]
         )
     } finally {
         await fs.rm(distDir, { recursive: true, force: true })

--- a/tooling/release/src/upload-posthog-js-s3.test.ts
+++ b/tooling/release/src/upload-posthog-js-s3.test.ts
@@ -150,6 +150,48 @@ test('collectReleaseAssets includes browser source maps from the dist root', asy
     }
 })
 
+test('collectReleaseAssets publishes the code-split toolbar chunk directory when the build emits one', async () => {
+    const distDir = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-js-dist-'))
+
+    try {
+        await fs.writeFile(path.join(distDir, 'toolbar.js'), '')
+        await fs.writeFile(path.join(distDir, 'toolbar.css'), '')
+        await fs.mkdir(path.join(distDir, 'toolbar'))
+        await fs.mkdir(path.join(distDir, 'toolbar', 'assets'))
+        await fs.writeFile(path.join(distDir, 'toolbar', 'toolbar-app-A1B2C3D4.js'), '')
+        await fs.writeFile(path.join(distDir, 'toolbar', 'toolbar-app.js'), '')
+        await fs.writeFile(path.join(distDir, 'toolbar', 'chunk-hedgehog-E5F6A7B8.js'), '')
+        await fs.writeFile(path.join(distDir, 'toolbar', 'assets', 'sprite.png'), '')
+
+        const assets = await collectReleaseAssets(distDir)
+
+        assert.deepEqual(
+            assets.map(({ relativeKey, contentType }) => ({ relativeKey, contentType })),
+            [
+                { relativeKey: 'toolbar.js', contentType: 'application/javascript' },
+                { relativeKey: 'toolbar.css', contentType: 'text/css' },
+                { relativeKey: 'toolbar/assets/sprite.png', contentType: 'image/png' },
+                { relativeKey: 'toolbar/chunk-hedgehog-E5F6A7B8.js', contentType: 'application/javascript' },
+                { relativeKey: 'toolbar/toolbar-app-A1B2C3D4.js', contentType: 'application/javascript' },
+                { relativeKey: 'toolbar/toolbar-app.js', contentType: 'application/javascript' },
+            ]
+        )
+
+        const plans = buildAssetUploadPlans('1.370.0', assets)
+        const chunkUpload = plans.immutable.find((upload) => upload.key.endsWith('chunk-hedgehog-E5F6A7B8.js'))
+        assert.deepEqual(
+            { key: chunkUpload?.key, cacheControl: chunkUpload?.cacheControl, contentType: chunkUpload?.contentType },
+            {
+                key: 'static/1.370.0/toolbar/chunk-hedgehog-E5F6A7B8.js',
+                cacheControl: 'public, max-age=31536000, immutable',
+                contentType: 'application/javascript',
+            }
+        )
+    } finally {
+        await fs.rm(distDir, { recursive: true, force: true })
+    }
+})
+
 test('assertNoCompatibilityVersionNamespaceCollisions rejects compatibility keys that would shadow reserved version namespaces', () => {
     for (const relativeKey of ['1/array.js', '1.370/array.js', '1.370.0/array.js']) {
         assert.throws(

--- a/tooling/release/src/upload-posthog-js-s3.ts
+++ b/tooling/release/src/upload-posthog-js-s3.ts
@@ -87,6 +87,29 @@ export async function collectReleaseAssets(distDir = DIST_DIR): Promise<ReleaseA
         )
     }
 
+    // The toolbar is moving from a single-file IIFE to a code-split ESM
+    // bundle: `toolbar.js` becomes a small loader that dynamic-import()s
+    // content-hashed chunks from a sibling `toolbar/` directory, resolved
+    // relative to the loader's own URL. Publish that directory whenever the
+    // build emits it — a loader without its chunks is a broken toolbar for
+    // strict_script_versioning users. No-op while posthog/posthog still
+    // produces the single-file build.
+    const toolbarDir = path.join(distDir, 'toolbar')
+    if (await fileExists(toolbarDir)) {
+        const files = (await listFilesRecursively(toolbarDir)).sort()
+        assets.push(
+            ...files.map((filePath) => ({
+                relativeKey: `toolbar/${path.relative(toolbarDir, filePath).replaceAll(path.sep, '/')}`,
+                filePath,
+                contentType: filePath.endsWith('.js.map')
+                    ? 'application/json'
+                    : filePath.endsWith('.js')
+                      ? 'application/javascript'
+                      : inferContentType(filePath),
+            }))
+        )
+    }
+
     return assets
 }
 


### PR DESCRIPTION
## Problem

posthog/posthog is about to change the toolbar build from a single-file IIFE to a code-split ESM layout:

```
dist/
  toolbar.js                # ~1-2 KB classic-script loader (same URL and contract as today)
  toolbar.css
  toolbar/                  # NEW: the real app as ESM with code splitting
    toolbar-app-<hash>.js   # ESM entry (content-hashed)
    toolbar-app.js          # hashless fallback copy
    chunk-*-<hash>.js
```

The loader keeps today's contract (`window.ph_load_toolbar` / `ph_load_editor`, chunks resolved relative to its own `document.currentScript.src`), so **no SDK runtime changes are needed for any posthog-js version, ever**. But our release workflow — which builds the toolbar and publishes it to the version-pinned CDN path for `strict_script_versioning` — copies exactly `toolbar.js` + `toolbar.css` (+ `assets/`). Against the split layout it would publish a loader with no chunks behind it (broken toolbar for versioned-CDN users), and three workflow steps would actually **fail outright**:

- "Normalize toolbar output filenames" demands exactly one hashed `toolbar-*.js` to rename — the split build emits a canonical `toolbar.js` directly.
- "Verify TOOLBAR_PUBLIC_PATH" greps only `toolbar.js` — in the split build the runtime-CSS-URL code that bakes in the public path lives in a chunk, not the loader.
- Both steps run `find frontend/dist/assets` unconditionally (under `inherit_errexit`) — that directory may disappear in the new layout.

## Changes

Everything ships as a **no-op against today's single-file build** ("copy it if it's there"), so there is no migration cutoff and no coordination window with posthog/posthog:

- **`tooling/release/src/upload-posthog-js-s3.ts`**: `collectReleaseAssets()` recursively includes `dist/toolbar/` when present, with explicit JS content types (ESM chunks are strict-MIME CORS fetches). Chunks flow through the existing upload plans: immutable `static/<version>/toolbar/...` (`max-age=31536000, immutable`) plus the major-alias and compatibility prefixes — needed because those loaders resolve chunks relative to their own URLs too.
- **`.github/workflows/release.yml`**: normalize accepts already-canonical `toolbar.js`/`toolbar.css` while keeping the exactly-one-hashed-file check for the current layout, and strips source maps inside `dist/toolbar/`; the `TOOLBAR_PUBLIC_PATH` grep searches `toolbar/` as well as `toolbar.js`; summary counts no longer hard-fail when `assets/` is absent; the toolbar artifact upload includes `frontend/dist/toolbar` when it exists.
- **`.eslintrc.cjs`**: adds `tooling/**` to the override that relaxes browser-only rules (`no-console`, `compat/compat`) — the release tooling is a Node CLI and the pre-commit hook rejected the (pre-existing) console statements in it otherwise.
- New unit test covering collection + upload plan for the split layout.

Explicit non-changes, per the cross-repo design: `loadExternalDependency`'s classic-script injection (`type="text/javascript"`, `crossOrigin="anonymous"`), the `ph_load_toolbar` invocation on script `load`, `prepare_external_dependency_script`, both URL schemes, and previously published version dirs are all untouched.

## How this was tested

- `pnpm test:unit` + `pnpm typecheck` in `tooling/release`.
- The normalize/verify bash was exercised against six layouts (today's hashed build → byte-identical behavior; split build; mixed hashed-CSS/canonical-JS; zero/two hashed files and missing public path still fail loudly).
- **End-to-end dummy of the whole pipeline**: generated a fake split build, ran the *actual* workflow scripts (extracted from this branch's `release.yml`) against it, published it to a fake S3 bucket via the *actual* `collectReleaseAssets`/`buildAssetUploadPlans`, served that bucket from a local "CDN" with the planned headers, and loaded it from a genuinely third-party origin page replicating `loadScript()` exactly, driven by headless Chromium:
  - ✅ versioned pinned URL: toolbar mounts, static + on-demand chunks load, runtime CSS fetched from the baked public path, clean CORS, immutable caching
  - ✅ unversioned `/static/toolbar.js?v=…&t=…`: chunks resolve to the compatibility prefix `/static/toolbar/…`
  - ✅ chunk dir served *without* `Access-Control-Allow-Origin`: loader loads but both hashed entry and hashless fallback are CORS-blocked — confirming the CDN header requirement is real
  - ✅ `Content-Security-Policy: script-src 'nonce-…' 'strict-dynamic'` with the nonce added via the `prepare_external_dependency_script` pattern: mounts with zero CSP violations
  - ✅ bonus finding: nonce-only CSP (no `'strict-dynamic'`) also works in Chromium — dynamic `import()` inherits the referencing script's nonce via its fetch options

## Remaining follow-ups (not coverable in this repo)

- Verify the real CDN (`us-assets.i.posthog.com` / `eu-assets.i.posthog.com`) passes through `Access-Control-Allow-Origin: *` and the S3 content-type/cache-control for the new `/static/<version>/toolbar/*` keys, with a real module fetch from a third-party origin.
- Re-run the acceptance pass against the real posthog/posthog split build once it lands (and cross-browser for the CSP behavior — the nonce-inheritance observation above is Chromium-verified only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)