### PR TITLE
feat(node): Capture V1 transport sender with retry and error surfacing

### DIFF
--- a/.changeset/capture-v1-node-opt-in.md
+++ b/.changeset/capture-v1-node-opt-in.md
@@ -1,0 +1,9 @@
+---
+'posthog-node': minor
+---
+
+Add opt-in Capture V1 support. Set the `POSTHOG_CAPTURE_MODE=v1` environment variable to submit analytics events to the Capture V1 endpoint (`/i/v1/analytics/events`) instead of the legacy `/batch/` endpoint, on both the batched and immediate send paths. The default remains `v0`, so existing behavior is unchanged unless you opt in. Opt-in is env-var-only during the transition (no public option), so nothing on the API surface has to be removed when v1 later becomes the default.
+
+Capture V1 uses Bearer auth, lifts legacy `$`-sentinel properties into a typed `options` object, and does per-event partial retry with exponential backoff clamped against `Retry-After`. Dropped and undelivered events are surfaced on the client `error` channel as a `CaptureV1Error`. `$ai_*` events continue to use the legacy submitter for now, regardless of the capture mode.
+
+In `v1` mode, `$ai_*` events are routed to an isolated in-memory queue and flushed independently of the Capture V1 queue, so the two transports never share a batch and a failure on one cannot re-send events already accepted on the other. Each queue keeps its own retry/durability semantics: the legacy queue re-queues on network failure (retrying on later flushes), while the V1 queue exhausts the sender's own attempt budget per cycle and then surfaces the failure rather than re-queuing.

--- a/.github/workflows/sdk-compliance-tests-node.yml
+++ b/.github/workflows/sdk-compliance-tests-node.yml
@@ -23,6 +23,7 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Legacy /batch/ capture contract (capture_v0). Default capture mode.
   test-node-sdk:
     uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
@@ -30,3 +31,15 @@ jobs:
       adapter-context: .
       test-harness-version: "0.10.0"
       report-name: node-sdk-compliance-report
+
+  # Capture V1 contract (capture_v1, POST /i/v1/analytics/events). Runs in
+  # parallel with the v0 job; the v1 adapter image bakes POSTHOG_CAPTURE_MODE=v1
+  # so the harness runs only the v1 contract against it. Kept alongside the v0
+  # job while both capture modes ship dual for smoke testing.
+  test-node-sdk-v1:
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
+    with:
+      adapter-dockerfile: compliance/node/Dockerfile.v1
+      adapter-context: .
+      test-harness-version: "0.10.0"
+      report-name: node-sdk-compliance-report-v1

--- a/compliance/node/Dockerfile.v1
+++ b/compliance/node/Dockerfile.v1
@@ -1,0 +1,41 @@
+FROM node:24-alpine
+
+WORKDIR /app
+
+# Copy the entire monorepo (needed for workspace dependencies)
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY tooling ./tooling
+COPY packages/types ./packages/types
+COPY packages/core ./packages/core
+COPY packages/node ./packages/node
+
+# Install pnpm
+RUN npm install -g pnpm@11.7.0
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Build the types, core, and node packages
+RUN pnpm --filter @posthog/types build
+RUN pnpm --filter @posthog/core build
+RUN pnpm --filter posthog-node build
+
+# Set up adapter in separate directory
+WORKDIR /app/adapter
+
+# Copy adapter code
+COPY compliance/node/adapter.js ./
+
+# Install adapter dependencies (express) in clean directory
+RUN npm init -y && npm install express
+
+# Run the adapter in Capture V1 mode so it advertises the capture_v1 capability
+# and the harness runs the /i/v1/analytics/events contract against it. The
+# reusable compliance workflow only passes PORT at runtime, so the mode is baked
+# into the image here.
+ENV POSTHOG_CAPTURE_MODE=v1
+
+EXPOSE 8080
+
+USER node
+CMD ["node", "adapter.js"]

--- a/compliance/node/README.md
+++ b/compliance/node/README.md
@@ -5,9 +5,17 @@ Compliance adapter for the posthog-node SDK with the [PostHog SDK Test Harness](
 ## Running Tests
 
 ```bash
-# From compliance/node
+# From compliance/node — legacy /batch/ contract (capture_v0)
 docker-compose up --build --abort-on-container-exit
+
+# Capture V1 contract (POST /i/v1/analytics/events)
+POSTHOG_CAPTURE_MODE=v1 docker-compose up --build --abort-on-container-exit
 ```
+
+The adapter's capture mode is fixed per process: with `POSTHOG_CAPTURE_MODE=v1`
+it advertises the `capture_v1` capability and the harness runs the V1 contract;
+otherwise it advertises `capture_v0`. CI runs both as separate jobs
+(`Dockerfile` for v0, `Dockerfile.v1` for v1).
 
 ## Documentation
 

--- a/compliance/node/adapter.js
+++ b/compliance/node/adapter.js
@@ -10,6 +10,20 @@ const { PostHog } = require('../packages/node/dist/entrypoints/index.node')
 const app = express()
 app.use(express.json())
 
+// Capture mode is fixed per adapter process (baked into the image via env) so the
+// harness runs exactly one capture contract against it: v1 advertises capture_v1,
+// otherwise capture_v0.
+const CAPTURE_MODE = process.env.POSTHOG_CAPTURE_MODE === 'v1' ? 'v1' : 'v0'
+
+// Harness EventOptions -> posthog-node sentinel properties. The SDK lifts these
+// sentinels out of properties into the v1 event `options` object.
+const OPTION_SENTINELS = {
+    cookieless_mode: '$cookieless_mode',
+    disable_skew_correction: '$ignore_sent_at',
+    process_person_profile: '$process_person_profile',
+    product_tour_id: '$product_tour_id',
+}
+
 const state = {
     client: null,
     totalEventsCaptured: 0,
@@ -33,6 +47,9 @@ async function discardClient() {
     try {
         client.clearFlushTimer?.()
         client.setPersistedProperty?.('queue', [])
+        // v1 mode routes $ai_* events to a separate queue; clear it too so they can't
+        // leak into the next scenario.
+        client.setPersistedProperty?.('ai_queue', [])
         await client.shutdown(1)
     } catch (error) {
         // Ignore reset-time shutdown errors; the next test starts with a fresh client.
@@ -44,12 +61,21 @@ app.get('/health', (req, res) => {
         sdk_name: 'posthog-node',
         sdk_version: require('../packages/node/package.json').version,
         adapter_version: '1.0.0',
-        capabilities: ['capture_v0', 'encoding_gzip'],
+        capabilities: CAPTURE_MODE === 'v1' ? ['capture_v1', 'encoding_gzip'] : ['capture_v0', 'encoding_gzip'],
     })
 })
 
 app.post('/init', async (req, res) => {
-    const { api_key, host, flush_at, flush_interval_ms, max_retries, enable_compression, disable_geoip } = req.body
+    const {
+        api_key,
+        host,
+        flush_at,
+        flush_interval_ms,
+        max_retries,
+        enable_compression,
+        disable_geoip,
+        historical_migration,
+    } = req.body
 
     await discardClient()
 
@@ -70,8 +96,14 @@ app.post('/init', async (req, res) => {
         flushAt: flush_at ?? 2,
         flushInterval: flush_interval_ms ?? 100,
         fetchRetryCount: max_retries ?? 3,
+        // Keep v1 partial-retry backoff short so retry compliance tests stay well
+        // within their wait windows (the mock also sends Retry-After: 1s).
+        fetchRetryDelay: CAPTURE_MODE === 'v1' ? 250 : undefined,
         disableCompression: enable_compression === undefined ? undefined : !enable_compression,
         disableGeoip: disable_geoip ?? false,
+        historicalMigration: historical_migration ?? undefined,
+        // Capture V1 opt-in is env-var-only: the SDK reads POSTHOG_CAPTURE_MODE
+        // (set by docker-compose / Dockerfile.v1) itself, so no option is passed.
         // Use before_send to track events being sent
         before_send: (event) => {
             // Track that event is being sent
@@ -116,18 +148,29 @@ app.post('/capture', (req, res) => {
         return res.status(400).json({ error: 'SDK not initialized' })
     }
 
-    const { distinct_id, event, properties, timestamp } = req.body
+    const { distinct_id, event, properties, timestamp, options } = req.body
 
     if (!distinct_id || !event) {
         return res.status(400).json({ error: 'distinct_id and event are required' })
     }
 
     try {
+        // Translate harness EventOptions into the SDK's sentinel properties; the SDK
+        // lifts them into the v1 event `options` object (no-op in v0 mode).
+        const mergedProperties = { ...(properties || {}) }
+        if (options && typeof options === 'object') {
+            for (const [optionKey, sentinel] of Object.entries(OPTION_SENTINELS)) {
+                if (Object.prototype.hasOwnProperty.call(options, optionKey)) {
+                    mergedProperties[sentinel] = options[optionKey]
+                }
+            }
+        }
+
         // Capture event
         state.client.capture({
             distinctId: distinct_id,
             event,
-            properties,
+            properties: mergedProperties,
             timestamp: timestamp ? new Date(timestamp) : undefined,
         })
 

--- a/compliance/node/docker-compose.yml
+++ b/compliance/node/docker-compose.yml
@@ -5,6 +5,10 @@ services:
       dockerfile: compliance/node/Dockerfile
     expose:
       - "8080"
+    # Set POSTHOG_CAPTURE_MODE=v1 to run the Capture V1 contract locally; the
+    # adapter then advertises capture_v1 and the harness selects the v1 suite.
+    environment:
+      - POSTHOG_CAPTURE_MODE=${POSTHOG_CAPTURE_MODE:-}
     networks:
       - test-network
 

--- a/packages/node/src/__tests__/capture-v1/config.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/config.spec.ts
@@ -1,0 +1,33 @@
+import { resolveCaptureMode } from '@/capture-v1/config'
+
+describe('resolveCaptureMode', () => {
+  const original = process.env.POSTHOG_CAPTURE_MODE
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.POSTHOG_CAPTURE_MODE
+    } else {
+      process.env.POSTHOG_CAPTURE_MODE = original
+    }
+  })
+
+  it('defaults to v0 when the environment variable is unset', () => {
+    delete process.env.POSTHOG_CAPTURE_MODE
+    expect(resolveCaptureMode()).toBe('v0')
+  })
+
+  it('resolves v1 from the environment variable', () => {
+    process.env.POSTHOG_CAPTURE_MODE = 'v1'
+    expect(resolveCaptureMode()).toBe('v1')
+  })
+
+  it('resolves v0 from the environment variable', () => {
+    process.env.POSTHOG_CAPTURE_MODE = 'v0'
+    expect(resolveCaptureMode()).toBe('v0')
+  })
+
+  it('ignores an invalid environment value and defaults to v0', () => {
+    process.env.POSTHOG_CAPTURE_MODE = 'v2'
+    expect(resolveCaptureMode()).toBe('v0')
+  })
+})

--- a/packages/node/src/__tests__/capture-v1/route-isolation.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/route-isolation.spec.ts
@@ -1,0 +1,85 @@
+import { PostHogPersistedProperty } from '@posthog/core'
+
+import { PostHog } from '@/entrypoints/index.node'
+
+import { V1WiringHarness, v1Response, waitForFlushTimer } from '../utils/v1-wiring'
+
+jest.mock('../../version', () => ({ version: '1.2.3' }))
+
+// Regression coverage for the mixed-batch double-delivery risk (H1): with v1 and legacy $ai_*
+// events sharing a flush cycle, a failure on the legacy leg must not roll back or re-send the
+// events already accepted on the V1 leg. Route partitioning gives each transport its own queue.
+describe('capture v1 route isolation (Node SDK)', () => {
+  jest.useFakeTimers()
+
+  const harness = new V1WiringHarness()
+
+  const aiQueueEvents = (posthog: PostHog): string[] =>
+    (posthog.getPersistedProperty(PostHogPersistedProperty.AiQueue) || []).map((item: any) => item.message.event)
+
+  const analyticsQueueEvents = (posthog: PostHog): string[] =>
+    (posthog.getPersistedProperty(PostHogPersistedProperty.Queue) || []).map((item: any) => item.message.event)
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    jest.spyOn(console, 'info').mockImplementation(() => {})
+    harness.useDefaultRouting()
+  })
+
+  afterEach(async () => {
+    await harness.cleanup()
+    jest.clearAllMocks()
+  })
+
+  it('keeps V1-accepted events from being re-sent when the legacy AI leg fails', async () => {
+    // v1 endpoint accepts everything; the legacy /batch/ leg (AI route) fails with a network error.
+    harness.fetch.mockImplementation((url: any) =>
+      (url as string).includes('/i/v1/analytics/events')
+        ? Promise.resolve(v1Response())
+        : Promise.reject(new Error('network down'))
+    )
+
+    const posthog = harness.makeClient({}, 'v1')
+    posthog.capture({ distinctId: 'u', event: 'custom', properties: { x: 1 } })
+    posthog.capture({ distinctId: 'u', event: '$ai_generation', properties: { $ai_model: 'gpt' } })
+    await waitForFlushTimer()
+
+    // Analytics route delivered its batch to V1 exactly once; the AI route attempted /batch/ and failed.
+    expect(harness.eventsIn('/i/v1/analytics/events')).toEqual(['custom'])
+    expect(harness.callsTo('/batch/').length).toBeGreaterThanOrEqual(1)
+
+    // The failed AI event is retained on its isolated queue; the accepted V1 event is gone.
+    expect(aiQueueEvents(posthog)).toEqual(['$ai_generation'])
+    expect(analyticsQueueEvents(posthog)).toEqual([])
+
+    // Recover the legacy leg and flush again.
+    harness.useDefaultRouting()
+    await posthog.flush()
+
+    // The V1 event was never re-sent (still a single delivery); the AI event now reaches /batch/.
+    expect(harness.eventsIn('/i/v1/analytics/events')).toEqual(['custom'])
+    expect(harness.eventsIn('/batch/')).toContain('$ai_generation')
+    expect(aiQueueEvents(posthog)).toEqual([])
+  })
+
+  it('flushes each route as its own homogeneous request (no mixed batch)', async () => {
+    const posthog = harness.makeClient({}, 'v1')
+    posthog.capture({ distinctId: 'u', event: 'a', properties: {} })
+    posthog.capture({ distinctId: 'u', event: '$ai_generation', properties: {} })
+    posthog.capture({ distinctId: 'u', event: 'b', properties: {} })
+    await waitForFlushTimer()
+
+    // Every /batch/ request holds only AI events; every v1 request holds only non-AI events.
+    for (const [, options] of harness.callsTo('/batch/')) {
+      const events = JSON.parse(options.body).batch.map((e: any) => e.event)
+      expect(events.every((name: string) => name.startsWith('$ai_'))).toBe(true)
+    }
+    for (const [, options] of harness.callsTo('/i/v1/analytics/events')) {
+      const events = JSON.parse(options.body).batch.map((e: any) => e.event)
+      expect(events.some((name: string) => name.startsWith('$ai_'))).toBe(false)
+    }
+    expect(harness.eventsIn('/i/v1/analytics/events')).toEqual(['a', 'b'])
+    expect(harness.eventsIn('/batch/')).toEqual(['$ai_generation'])
+  })
+})

--- a/packages/node/src/__tests__/capture-v1/routing.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/routing.spec.ts
@@ -1,0 +1,35 @@
+import type { PostHogEventProperties } from '@posthog/core'
+
+import { isLegacyOnlyEvent } from '@/capture-v1/routing'
+
+describe('isLegacyOnlyEvent', () => {
+  it.each(['$ai_generation', '$ai_span', '$ai_trace', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_'])(
+    'routes AI event %s to the legacy submitter',
+    (event) => {
+      expect(isLegacyOnlyEvent({ event })).toBe(true)
+    }
+  )
+
+  it.each([
+    '$pageview',
+    '$identify',
+    '$create_alias',
+    '$groupidentify',
+    '$exception',
+    'custom_event',
+    'my$ai_event',
+    'prefixed_$ai_generation',
+    'ai_generation',
+    '$AI_generation',
+  ])('keeps non-AI event %s eligible for v1', (event) => {
+    expect(isLegacyOnlyEvent({ event })).toBe(false)
+  })
+
+  it.each([
+    ['missing event', {}],
+    ['empty event', { event: '' }],
+    ['non-string event', { event: 123 }],
+  ])('treats %s as not legacy-only', (_label, message) => {
+    expect(isLegacyOnlyEvent(message as PostHogEventProperties)).toBe(false)
+  })
+})

--- a/packages/node/src/__tests__/capture-v1/sender.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/sender.spec.ts
@@ -1,4 +1,4 @@
-import type { PostHogEventProperties, PostHogFetchResponse } from '@posthog/core'
+import { type PostHogEventProperties, type PostHogFetchResponse, isGzipSupported } from '@posthog/core'
 
 import { CaptureV1Error } from '@/capture-v1/errors'
 import { V1CaptureSender, type V1CaptureSenderConfig, type V1CaptureSenderHooks } from '@/capture-v1/sender'
@@ -538,8 +538,16 @@ describe('V1CaptureSender', () => {
       const sender = new V1CaptureSender({ ...baseConfig, compressionEnabled: true }, { fetch, onError: () => {} })
       await sender.sendV1Batch([msg('u1')])
 
-      expect(fetch.mock.calls[0][1].headers['Content-Encoding']).toBe('gzip')
-      expect(fetch.mock.calls[0][1].body).toBeInstanceOf(Blob)
+      // The default compressor is the platform gzip codec: it compresses where
+      // supported and transparently falls back to an uncompressed string where it
+      // is not (e.g. the edge runtime has no CompressionStream).
+      if (isGzipSupported()) {
+        expect(fetch.mock.calls[0][1].headers['Content-Encoding']).toBe('gzip')
+        expect(fetch.mock.calls[0][1].body).toBeInstanceOf(Blob)
+      } else {
+        expect(fetch.mock.calls[0][1].headers['Content-Encoding']).toBeUndefined()
+        expect(typeof fetch.mock.calls[0][1].body).toBe('string')
+      }
     })
   })
 })

--- a/packages/node/src/__tests__/capture-v1/sender.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/sender.spec.ts
@@ -506,6 +506,17 @@ describe('V1CaptureSender', () => {
       expect(sleeps).toEqual([100])
     })
 
+    it('ignores a Retry-After so large it parses to a non-finite number of seconds', async () => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxAttempts: 2 })
+      fetch
+        .mockResolvedValueOnce(makeResponse(503, '', { 'Retry-After': '9'.repeat(400) }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([100])
+    })
+
     it('honors Retry-After on a 200 partial-retry response', async () => {
       const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxAttempts: 2 })
       fetch

--- a/packages/node/src/__tests__/capture-v1/sender.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/sender.spec.ts
@@ -1,0 +1,534 @@
+import type { PostHogEventProperties, PostHogFetchResponse } from '@posthog/core'
+
+import { CaptureV1Error } from '@/capture-v1/errors'
+import { V1CaptureSender, type V1CaptureSenderConfig, type V1CaptureSenderHooks } from '@/capture-v1/sender'
+
+const CLOCK_START = Date.parse('2024-01-01T00:00:00.000Z')
+
+function makeResponse(status: number, body?: unknown, headers?: Record<string, string>): PostHogFetchResponse {
+  const text = typeof body === 'string' ? body : JSON.stringify(body ?? {})
+  return {
+    status,
+    text: () => Promise.resolve(text),
+    json: () => Promise.resolve(typeof body === 'string' ? JSON.parse(body) : body),
+    headers: { get: (name: string) => headers?.[name] ?? null },
+    body: null,
+  }
+}
+
+function msg(uuid: string, overrides: PostHogEventProperties = {}): PostHogEventProperties {
+  return { event: 'test', distinct_id: 'user', uuid, properties: {}, ...overrides }
+}
+
+interface Harness {
+  sender: V1CaptureSender
+  fetch: jest.Mock<Promise<PostHogFetchResponse>, [string, any]>
+  sleeps: number[]
+  errors: Error[]
+  clock: { value: number }
+}
+
+function makeSender(
+  configOverrides: Partial<V1CaptureSenderConfig> = {},
+  hookOverrides: Partial<V1CaptureSenderHooks> = {}
+): Harness {
+  const sleeps: number[] = []
+  const errors: Error[] = []
+  const clock = { value: CLOCK_START }
+  const fetch = jest.fn<Promise<PostHogFetchResponse>, [string, any]>()
+
+  const sender = new V1CaptureSender(
+    {
+      host: 'https://t.posthog.com',
+      apiKey: 'phc_test',
+      libraryId: 'posthog-node',
+      libraryVersion: '1.2.3',
+      userAgent: 'posthog-node/1.2.3',
+      historicalMigration: false,
+      compressionEnabled: false,
+      requestTimeoutMs: 1000,
+      maxAttempts: 4,
+      initialRetryDelayMs: 100,
+      maxBackoffMs: 30_000,
+      ...configOverrides,
+    },
+    {
+      fetch,
+      onError: (error) => errors.push(error),
+      now: () => clock.value,
+      // Advancing the clock while "sleeping" models wall-clock passing between attempts.
+      sleep: (ms) => {
+        sleeps.push(ms)
+        clock.value += ms
+        return Promise.resolve()
+      },
+      generateRequestId: () => 'req-fixed',
+      ...hookOverrides,
+    }
+  )
+
+  return { sender, fetch, sleeps, errors, clock }
+}
+
+function bodyOf(fetch: Harness['fetch'], call: number): any {
+  return JSON.parse(fetch.mock.calls[call][1].body)
+}
+
+function headersOf(fetch: Harness['fetch'], call: number): Record<string, string> {
+  return fetch.mock.calls[call][1].headers
+}
+
+describe('V1CaptureSender', () => {
+  describe('request contract', () => {
+    it('POSTs to the v1 analytics endpoint with the batch envelope and no v0 fields', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      const [url, options] = fetch.mock.calls[0]
+      expect(url).toBe('https://t.posthog.com/i/v1/analytics/events')
+      expect(options.method).toBe('POST')
+
+      const body = bodyOf(fetch, 0)
+      expect(body.created_at).toBe('2024-01-01T00:00:00.000Z')
+      expect(body.batch).toHaveLength(1)
+      expect(body.batch[0].uuid).toBe('u1')
+      expect(body).not.toHaveProperty('api_key')
+      expect(body).not.toHaveProperty('sent_at')
+      expect(body).not.toHaveProperty('historical_migration')
+      expect(errors).toEqual([])
+    })
+
+    it('sets all required v1 headers with Bearer auth and no api_key in the body', async () => {
+      const { sender, fetch } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      const headers = headersOf(fetch, 0)
+      expect(headers['Content-Type']).toBe('application/json')
+      expect(headers['Authorization']).toBe('Bearer phc_test')
+      expect(headers['PostHog-Sdk-Info']).toBe('posthog-node/1.2.3')
+      expect(headers['PostHog-Attempt']).toBe('1')
+      expect(headers['PostHog-Request-Id']).toBe('req-fixed')
+      expect(headers['PostHog-Request-Timestamp']).toBe('2024-01-01T00:00:00.000Z')
+      expect(headers['User-Agent']).toBe('posthog-node/1.2.3')
+    })
+
+    it('omits User-Agent when not configured', async () => {
+      const { sender, fetch } = makeSender({ userAgent: undefined })
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(headersOf(fetch, 0)).not.toHaveProperty('User-Agent')
+    })
+
+    it('includes historical_migration only when enabled', async () => {
+      const { sender, fetch } = makeSender({ historicalMigration: true })
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(bodyOf(fetch, 0).historical_migration).toBe(true)
+    })
+
+    it('keeps request-id and created_at stable but increments attempt and regenerates request-timestamp', async () => {
+      const { sender, fetch } = makeSender()
+      fetch
+        .mockResolvedValueOnce(makeResponse(200, { results: { u1: { result: 'retry' } } }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      const h0 = headersOf(fetch, 0)
+      const h1 = headersOf(fetch, 1)
+      expect(h0['PostHog-Request-Id']).toBe(h1['PostHog-Request-Id'])
+      expect(bodyOf(fetch, 0).created_at).toBe(bodyOf(fetch, 1).created_at)
+      expect(h0['PostHog-Attempt']).toBe('1')
+      expect(h1['PostHog-Attempt']).toBe('2')
+      expect(h0['PostHog-Request-Timestamp']).not.toBe(h1['PostHog-Request-Timestamp'])
+    })
+
+    it('does not send when there are no messages', async () => {
+      const { sender, fetch, errors } = makeSender()
+      await sender.sendV1Batch([])
+      expect(fetch).not.toHaveBeenCalled()
+      expect(errors).toEqual([])
+    })
+  })
+
+  describe('compression', () => {
+    it('gzips the body and advertises Content-Encoding when compression succeeds', async () => {
+      const blob = new Blob(['compressed'])
+      const compress = jest.fn().mockResolvedValue(blob)
+      const { sender, fetch } = makeSender({ compressionEnabled: true }, { compress })
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(compress).toHaveBeenCalledTimes(1)
+      expect(headersOf(fetch, 0)['Content-Encoding']).toBe('gzip')
+      expect(fetch.mock.calls[0][1].body).toBe(blob)
+    })
+
+    it('falls back to uncompressed when compression returns null', async () => {
+      const compress = jest.fn().mockResolvedValue(null)
+      const { sender, fetch } = makeSender({ compressionEnabled: true }, { compress })
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(headersOf(fetch, 0)).not.toHaveProperty('Content-Encoding')
+      expect(typeof fetch.mock.calls[0][1].body).toBe('string')
+    })
+
+    it('does not compress when disabled', async () => {
+      const compress = jest.fn()
+      const { sender, fetch } = makeSender({ compressionEnabled: false }, { compress })
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(compress).not.toHaveBeenCalled()
+      expect(headersOf(fetch, 0)).not.toHaveProperty('Content-Encoding')
+    })
+  })
+
+  describe('2xx per-event classification', () => {
+    it.each([
+      ['ok', { result: 'ok' }],
+      ['warning', { result: 'warning' }],
+      ['unknown code', { result: 'something_new' }],
+    ])('treats %s as terminal success with no retry or error', async (_label, result) => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: { u1: result } }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(errors).toEqual([])
+    })
+
+    it('treats an absent uuid as accepted', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(errors).toEqual([])
+    })
+
+    it('treats a valid 2xx body without a results field as all accepted', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, { status: 1 }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(errors).toEqual([])
+    })
+
+    it('surfaces a drop as a terminal failure without retrying', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: { u1: { result: 'drop', details: 'billing' } } }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(errors).toHaveLength(1)
+      const error = errors[0] as CaptureV1Error
+      expect(error).toBeInstanceOf(CaptureV1Error)
+      expect(error.drops).toEqual([{ uuid: 'u1', details: 'billing' }])
+      expect(error.retryExhausted).toEqual([])
+    })
+
+    it('surfaces a drop with no details', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: { u1: { result: 'drop' } } }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect((errors[0] as CaptureV1Error).drops).toEqual([{ uuid: 'u1', details: undefined }])
+    })
+
+    it('resends only the retry-tagged events on the next attempt', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch
+        .mockResolvedValueOnce(makeResponse(200, { results: { u1: { result: 'ok' }, u2: { result: 'retry' } } }))
+        .mockResolvedValueOnce(makeResponse(200, { results: { u2: { result: 'ok' } } }))
+
+      await sender.sendV1Batch([msg('u1'), msg('u2')])
+
+      expect(fetch).toHaveBeenCalledTimes(2)
+      expect(bodyOf(fetch, 0).batch.map((e: any) => e.uuid)).toEqual(['u1', 'u2'])
+      expect(bodyOf(fetch, 1).batch.map((e: any) => e.uuid)).toEqual(['u2'])
+      expect(errors).toEqual([])
+    })
+
+    it('does not swallow drops accumulated on an earlier attempt when a later attempt succeeds', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch
+        .mockResolvedValueOnce(
+          makeResponse(200, { results: { u1: { result: 'drop', details: 'bad' }, u2: { result: 'retry' } } })
+        )
+        .mockResolvedValueOnce(makeResponse(200, { results: { u2: { result: 'ok' } } }))
+
+      await sender.sendV1Batch([msg('u1'), msg('u2')])
+
+      expect(errors).toHaveLength(1)
+      const error = errors[0] as CaptureV1Error
+      expect(error.drops).toEqual([{ uuid: 'u1', details: 'bad' }])
+      expect(error.retryExhausted).toEqual([])
+    })
+
+    it('reports retry-exhausted uuids after the attempt budget runs out', async () => {
+      const { sender, fetch, errors } = makeSender({ maxAttempts: 3 })
+      fetch.mockResolvedValue(makeResponse(200, { results: { u1: { result: 'retry' } } }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(3)
+      const error = errors[0] as CaptureV1Error
+      expect(error.retryExhausted).toEqual(['u1'])
+      expect(error.drops).toEqual([])
+    })
+  })
+
+  describe('2xx malformed body', () => {
+    it('treats an unparseable 2xx body as terminal failure without retrying', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, 'not-json{'))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(errors).toHaveLength(1)
+      const error = errors[0] as CaptureV1Error
+      expect(error.retryExhausted).toEqual(['u1'])
+      expect((error.cause as Error).message).toContain('unparseable')
+    })
+
+    it.each([
+      ['a non-object JSON body', '[1,2,3]'],
+      ['a non-object results field', { results: [1, 2] }],
+    ])('treats %s as terminal failure', async (_label, body) => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(200, body))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect((errors[0] as CaptureV1Error).retryExhausted).toEqual(['u1'])
+    })
+  })
+
+  describe('HTTP status classification', () => {
+    it.each([408, 500, 502, 503, 504])('retries retryable status %s then succeeds', async (status) => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(status)).mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(2)
+      expect(errors).toEqual([])
+    })
+
+    it('treats 429 as terminal in v1 (no retry)', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(429, '', { 'Retry-After': '1' }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      const error = errors[0] as CaptureV1Error
+      expect(error.retryExhausted).toEqual(['u1'])
+      expect((error.cause as Error).message).toContain('429')
+    })
+
+    it.each([400, 401, 402, 413, 415])('treats non-retryable status %s as terminal', async (status) => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockResolvedValueOnce(makeResponse(status))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(errors).toHaveLength(1)
+      expect((errors[0] as CaptureV1Error).retryExhausted).toEqual(['u1'])
+    })
+
+    it('exhausts the budget on a persistently retryable status', async () => {
+      const { sender, fetch, errors } = makeSender({ maxAttempts: 4 })
+      fetch.mockResolvedValue(makeResponse(503))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(4)
+      expect((errors[0] as CaptureV1Error).retryExhausted).toEqual(['u1'])
+    })
+  })
+
+  describe('transport errors', () => {
+    it('retries a transport error then succeeds', async () => {
+      const { sender, fetch, errors } = makeSender()
+      fetch.mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(2)
+      expect(errors).toEqual([])
+    })
+
+    it('surfaces a batch failure after transport errors exhaust the budget', async () => {
+      const { sender, fetch, errors } = makeSender({ maxAttempts: 3 })
+      fetch.mockRejectedValue(new Error('timeout'))
+
+      await sender.sendV1Batch([msg('u1'), msg('u2')])
+
+      expect(fetch).toHaveBeenCalledTimes(3)
+      const error = errors[0] as CaptureV1Error
+      expect(error.retryExhausted).toEqual(['u1', 'u2'])
+      expect((error.cause as Error).message).toBe('timeout')
+    })
+  })
+
+  describe('backoff and Retry-After', () => {
+    it('uses exponential backoff between attempts', async () => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxAttempts: 4 })
+      fetch.mockResolvedValue(makeResponse(503))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([100, 200, 400])
+    })
+
+    it('caps exponential backoff at maxBackoffMs', async () => {
+      const { sender, fetch, sleeps } = makeSender({
+        initialRetryDelayMs: 10_000,
+        maxBackoffMs: 15_000,
+        maxAttempts: 4,
+      })
+      fetch.mockResolvedValue(makeResponse(503))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([10_000, 15_000, 15_000])
+    })
+
+    it('treats Retry-After delta-seconds as a minimum (raises a small backoff)', async () => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxAttempts: 2 })
+      fetch
+        .mockResolvedValueOnce(makeResponse(503, '', { 'Retry-After': '5' }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([5000])
+    })
+
+    it('does not let a small Retry-After shorten a larger backoff', async () => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 10_000, maxAttempts: 2 })
+      fetch
+        .mockResolvedValueOnce(makeResponse(503, '', { 'Retry-After': '1' }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([10_000])
+    })
+
+    it('clamps a huge Retry-After to maxBackoffMs', async () => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxBackoffMs: 30_000, maxAttempts: 2 })
+      fetch
+        .mockResolvedValueOnce(makeResponse(503, '', { 'Retry-After': '9999' }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([30_000])
+    })
+
+    it('parses an HTTP-date Retry-After as a delay from now', async () => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxBackoffMs: 60_000, maxAttempts: 2 })
+      // 20s after the fixed clock start.
+      fetch
+        .mockResolvedValueOnce(makeResponse(503, '', { 'Retry-After': 'Mon, 01 Jan 2024 00:00:20 GMT' }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([20_000])
+    })
+
+    it('ignores a past HTTP-date Retry-After and uses backoff', async () => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxAttempts: 2 })
+      fetch
+        .mockResolvedValueOnce(makeResponse(503, '', { 'Retry-After': 'Mon, 01 Jan 2020 00:00:00 GMT' }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([100])
+    })
+
+    it.each(['0', '-5', 'garbage'])('ignores a non-positive/invalid Retry-After (%s)', async (retryAfter) => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxAttempts: 2 })
+      fetch
+        .mockResolvedValueOnce(makeResponse(503, '', { 'Retry-After': retryAfter }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([100])
+    })
+  })
+
+  describe('default hooks (no injection)', () => {
+    const baseConfig: V1CaptureSenderConfig = {
+      host: 'https://t.posthog.com',
+      apiKey: 'phc_test',
+      libraryId: 'posthog-node',
+      libraryVersion: '1.2.3',
+      historicalMigration: false,
+      compressionEnabled: false,
+      requestTimeoutMs: 1000,
+      maxAttempts: 2,
+      initialRetryDelayMs: 1,
+      maxBackoffMs: 30_000,
+    }
+
+    it('uses the real clock, request-id generator and sleep when not injected', async () => {
+      const errors: Error[] = []
+      const fetch = jest
+        .fn<Promise<PostHogFetchResponse>, [string, any]>()
+        .mockResolvedValueOnce(makeResponse(503))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      const sender = new V1CaptureSender(baseConfig, { fetch, onError: (e) => errors.push(e) })
+      // No injected sleep: the retry backoff schedules a real (fake-timer) setTimeout we must advance.
+      const done = sender.sendV1Batch([msg('u1')])
+      await jest.advanceTimersByTimeAsync(baseConfig.initialRetryDelayMs)
+      await done
+
+      expect(fetch).toHaveBeenCalledTimes(2)
+      expect(errors).toEqual([])
+      const headers = fetch.mock.calls[0][1].headers
+      expect(headers['PostHog-Request-Id']).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+      expect(headers['PostHog-Request-Timestamp']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+    })
+
+    it('uses the real gzip compressor when not injected', async () => {
+      const fetch = jest
+        .fn<Promise<PostHogFetchResponse>, [string, any]>()
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      const sender = new V1CaptureSender({ ...baseConfig, compressionEnabled: true }, { fetch, onError: () => {} })
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch.mock.calls[0][1].headers['Content-Encoding']).toBe('gzip')
+      expect(fetch.mock.calls[0][1].body).toBeInstanceOf(Blob)
+    })
+  })
+})

--- a/packages/node/src/__tests__/capture-v1/sender.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/sender.spec.ts
@@ -483,6 +483,17 @@ describe('V1CaptureSender', () => {
 
       expect(sleeps).toEqual([100])
     })
+
+    it('honors Retry-After on a 200 partial-retry response', async () => {
+      const { sender, fetch, sleeps } = makeSender({ initialRetryDelayMs: 100, maxAttempts: 2 })
+      fetch
+        .mockResolvedValueOnce(makeResponse(200, { results: { u1: { result: 'retry' } } }, { 'Retry-After': '3' }))
+        .mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(sleeps).toEqual([3000])
+    })
   })
 
   describe('default hooks (no injection)', () => {

--- a/packages/node/src/__tests__/capture-v1/sender.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/sender.spec.ts
@@ -158,6 +158,28 @@ describe('V1CaptureSender', () => {
       expect(fetch).not.toHaveBeenCalled()
       expect(errors).toEqual([])
     })
+
+    it('still makes one attempt when maxAttempts is misconfigured to 0', async () => {
+      const { sender, fetch, errors } = makeSender({ maxAttempts: 0 })
+      fetch.mockResolvedValueOnce(makeResponse(200, { results: {} }))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(errors).toEqual([])
+    })
+
+    it('surfaces a delivery error rather than silently dropping when maxAttempts is 0', async () => {
+      const { sender, fetch, errors } = makeSender({ maxAttempts: 0 })
+      fetch.mockResolvedValueOnce(makeResponse(400))
+
+      await sender.sendV1Batch([msg('u1')])
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toBeInstanceOf(CaptureV1Error)
+      expect((errors[0] as CaptureV1Error).retryExhausted).toEqual(['u1'])
+    })
   })
 
   describe('compression', () => {

--- a/packages/node/src/__tests__/capture-v1/wiring.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/wiring.spec.ts
@@ -1,0 +1,162 @@
+import { PostHog, PostHogOptions } from '@/entrypoints/index.node'
+import { CaptureV1Error } from '@/capture-v1/errors'
+import { V1_URL, V1WiringHarness, v0Response, v1Response, waitForFlushTimer } from '../utils/v1-wiring'
+
+jest.mock('../../version', () => ({ version: '1.2.3' }))
+
+describe('capture v1 wiring (Node SDK)', () => {
+  jest.useFakeTimers()
+
+  const harness = new V1WiringHarness()
+  const mockedFetch = harness.fetch
+  const makeClient = (options?: PostHogOptions): PostHog => harness.makeClient(options)
+  const makeV1Client = (options?: PostHogOptions): PostHog => harness.makeClient(options, 'v1')
+  const callsTo = (fragment: string): [string, any][] => harness.callsTo(fragment)
+  const eventsIn = (fragment: string): string[] => harness.eventsIn(fragment)
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    jest.spyOn(console, 'info').mockImplementation(() => {})
+    harness.useDefaultRouting()
+  })
+
+  afterEach(async () => {
+    await harness.cleanup()
+    jest.clearAllMocks()
+  })
+
+  describe('v0 mode (default)', () => {
+    it('sends every event to /batch/ and never touches the v1 endpoint', async () => {
+      const posthog = makeClient()
+      posthog.capture({ distinctId: 'u', event: 'custom', properties: { x: 1 } })
+      posthog.capture({ distinctId: 'u', event: '$ai_generation', properties: { $ai_model: 'gpt' } })
+      await waitForFlushTimer()
+
+      expect(callsTo('/i/v1/analytics/events')).toHaveLength(0)
+      const events = eventsIn('/batch/')
+      expect(events).toContain('custom')
+      expect(events).toContain('$ai_generation')
+    })
+  })
+
+  describe('v1 mode - batched path', () => {
+    it('sends a normal event to the v1 endpoint with Bearer auth and the v1 envelope', async () => {
+      const posthog = makeV1Client()
+      posthog.capture({ distinctId: 'u', event: 'custom', properties: { x: 1 } })
+      await waitForFlushTimer()
+
+      expect(callsTo('/batch/')).toHaveLength(0)
+      const calls = callsTo('/i/v1/analytics/events')
+      expect(calls).toHaveLength(1)
+      const [url, options] = calls[0]
+      expect(url).toBe(V1_URL)
+      expect(options.headers['Authorization']).toBe('Bearer TEST_API_KEY')
+      expect(options.headers['PostHog-Sdk-Info']).toBe('posthog-node/1.2.3')
+      const body = JSON.parse(options.body)
+      expect(body).not.toHaveProperty('api_key')
+      expect(body.batch[0].event).toBe('custom')
+      expect(body.batch[0].options).toEqual({})
+    })
+
+    it('routes $ai_* events to the legacy /batch/ endpoint', async () => {
+      const posthog = makeV1Client()
+      posthog.capture({ distinctId: 'u', event: '$ai_generation', properties: { $ai_model: 'gpt' } })
+      await waitForFlushTimer()
+
+      expect(callsTo('/i/v1/analytics/events')).toHaveLength(0)
+      expect(eventsIn('/batch/')).toContain('$ai_generation')
+    })
+
+    it('splits a mixed batch across both endpoints with no loss or duplication', async () => {
+      const posthog = makeV1Client()
+      posthog.capture({ distinctId: 'u', event: 'custom', properties: { x: 1 } })
+      posthog.capture({ distinctId: 'u', event: '$ai_generation', properties: { $ai_model: 'gpt' } })
+      await waitForFlushTimer()
+
+      expect(eventsIn('/i/v1/analytics/events')).toEqual(['custom'])
+      expect(eventsIn('/batch/')).toEqual(['$ai_generation'])
+    })
+  })
+
+  describe('v1 mode - immediate path', () => {
+    it('sends an immediate non-AI event to the v1 endpoint', async () => {
+      const posthog = makeV1Client()
+      await posthog.captureImmediate({ distinctId: 'u', event: 'custom', properties: { x: 1 } })
+
+      expect(callsTo('/batch/')).toHaveLength(0)
+      expect(eventsIn('/i/v1/analytics/events')).toEqual(['custom'])
+    })
+
+    it('sends an immediate $ai_* event to the legacy endpoint', async () => {
+      const posthog = makeV1Client()
+      await posthog.captureImmediate({ distinctId: 'u', event: '$ai_span', properties: { $ai_model: 'gpt' } })
+
+      expect(callsTo('/i/v1/analytics/events')).toHaveLength(0)
+      expect(eventsIn('/batch/')).toContain('$ai_span')
+    })
+
+    it('sends immediate identify/alias/groupIdentify (special non-AI events) to the v1 endpoint', async () => {
+      const posthog = makeV1Client()
+
+      await posthog.identifyImmediate({ distinctId: 'u', properties: { name: 'a' } })
+      await posthog.aliasImmediate({ distinctId: 'u', alias: 'anon-1' })
+      await posthog.groupIdentifyImmediate({ groupType: 'company', groupKey: 'acme', properties: { plan: 'pro' } })
+
+      expect(callsTo('/batch/')).toHaveLength(0)
+      expect(eventsIn('/i/v1/analytics/events')).toEqual(['$identify', '$create_alias', '$groupidentify'])
+    })
+  })
+
+  describe('v1 mode - before_send interaction', () => {
+    it('routes an event renamed into $ai_* by before_send to the legacy endpoint', async () => {
+      const posthog = makeV1Client({
+        before_send: (event) => (event ? { ...event, event: '$ai_generation' } : event),
+      })
+      posthog.capture({ distinctId: 'u', event: 'custom', properties: { x: 1 } })
+      await waitForFlushTimer()
+
+      expect(callsTo('/i/v1/analytics/events')).toHaveLength(0)
+      expect(eventsIn('/batch/')).toContain('$ai_generation')
+    })
+
+    it('routes an event renamed out of $ai_* by before_send to the v1 endpoint', async () => {
+      const posthog = makeV1Client({
+        before_send: (event) => (event ? { ...event, event: 'renamed' } : event),
+      })
+      posthog.capture({ distinctId: 'u', event: '$ai_generation', properties: { $ai_model: 'gpt' } })
+      await waitForFlushTimer()
+
+      expect(callsTo('/batch/')).toHaveLength(0)
+      expect(eventsIn('/i/v1/analytics/events')).toContain('renamed')
+    })
+  })
+
+  describe('v1 mode - error surfacing', () => {
+    it('emits a CaptureV1Error on the error channel when the server drops an event', async () => {
+      mockedFetch.mockImplementation((url, options) => {
+        if ((url as string).includes('/i/v1/analytics/events')) {
+          const body = JSON.parse((options as any).body)
+          const results: Record<string, unknown> = {}
+          for (const event of body.batch) {
+            results[event.uuid] = { result: 'drop', details: 'billing' }
+          }
+          return Promise.resolve(v1Response(results))
+        }
+        return Promise.resolve(v0Response())
+      })
+
+      const posthog = makeV1Client()
+      const errors: Error[] = []
+      posthog.on('error', (error) => errors.push(error))
+
+      posthog.capture({ distinctId: 'u', event: 'custom', properties: { x: 1 } })
+      await waitForFlushTimer()
+
+      expect(errors).toHaveLength(1)
+      const error = errors[0] as CaptureV1Error
+      expect(error).toBeInstanceOf(CaptureV1Error)
+      expect(error.drops[0].details).toBe('billing')
+    })
+  })
+})

--- a/packages/node/src/__tests__/utils/v1-wiring.ts
+++ b/packages/node/src/__tests__/utils/v1-wiring.ts
@@ -1,0 +1,108 @@
+import { PostHog, PostHogOptions } from '@/entrypoints/index.node'
+
+import { waitForPromises } from '.'
+
+export const V1_URL = 'http://example.com/i/v1/analytics/events'
+
+/** A Capture V1 2xx response whose per-event `results` map defaults to all-accepted. */
+export function v1Response(results: Record<string, unknown> = {}): any {
+  const body = JSON.stringify({ results })
+  return {
+    status: 200,
+    text: () => Promise.resolve(body),
+    json: () => Promise.resolve({ results }),
+    headers: { get: () => null },
+    body: null,
+  }
+}
+
+/** A legacy `/batch/` 2xx response. */
+export function v0Response(): any {
+  return {
+    status: 200,
+    text: () => Promise.resolve('ok'),
+    json: () => Promise.resolve({ status: 'ok' }),
+    headers: { get: () => null },
+    body: null,
+  }
+}
+
+/** Default fetch behavior: the v1 endpoint returns all-accepted, everything else a v0 200. */
+export function routeByUrl(url: string): any {
+  return url.includes('/i/v1/analytics/events') ? v1Response() : v0Response()
+}
+
+/**
+ * Shared fixture for the Capture V1 wiring/integration specs: owns the global `fetch` spy, tracks
+ * clients for teardown, and exposes call inspectors so each suite only writes its own scenario.
+ */
+export class V1WiringHarness {
+  readonly fetch: jest.SpyInstance
+  private readonly clients: PostHog[] = []
+  private readonly originalCaptureMode = process.env.POSTHOG_CAPTURE_MODE
+
+  constructor() {
+    this.fetch = jest.spyOn(globalThis, 'fetch').mockImplementation()
+  }
+
+  /** (Re)install the default per-URL routing. Call from `beforeEach` (after `clearAllMocks`). */
+  useDefaultRouting(): void {
+    this.fetch.mockImplementation((url: any) => Promise.resolve(routeByUrl(url as string)))
+  }
+
+  /**
+   * Capture V1 is opt-in via the `POSTHOG_CAPTURE_MODE` env var only (no public option).
+   * The mode is resolved once, in the PostHog constructor, so toggling the env var around
+   * construction keeps each client hermetic even when v0 and v1 clients coexist in a suite.
+   */
+  makeClient(options: PostHogOptions = {}, captureMode?: 'v0' | 'v1'): PostHog {
+    const previous = process.env.POSTHOG_CAPTURE_MODE
+    if (captureMode !== undefined) {
+      process.env.POSTHOG_CAPTURE_MODE = captureMode
+    }
+    try {
+      const client = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        fetchRetryCount: 0,
+        disableCompression: true,
+        ...options,
+      })
+      this.clients.push(client)
+      return client
+    } finally {
+      if (previous === undefined) {
+        delete process.env.POSTHOG_CAPTURE_MODE
+      } else {
+        process.env.POSTHOG_CAPTURE_MODE = previous
+      }
+    }
+  }
+
+  /** All fetch calls whose URL contains `fragment`, as `[url, options]` tuples. */
+  callsTo(fragment: string): [string, any][] {
+    return this.fetch.mock.calls.filter((call: any[]) => (call[0] as string).includes(fragment)) as [string, any][]
+  }
+
+  /** Event names carried in every batch posted to a URL containing `fragment`, in call order. */
+  eventsIn(fragment: string): string[] {
+    return this.callsTo(fragment).flatMap((call) => JSON.parse(call[1].body).batch.map((event: any) => event.event))
+  }
+
+  async cleanup(): Promise<void> {
+    while (this.clients.length) {
+      await this.clients.pop()?.shutdown()
+    }
+    if (this.originalCaptureMode === undefined) {
+      delete process.env.POSTHOG_CAPTURE_MODE
+    } else {
+      process.env.POSTHOG_CAPTURE_MODE = this.originalCaptureMode
+    }
+  }
+}
+
+/** Drains the enqueue flush timer plus its follow-up microtasks (fake timers must be enabled). */
+export const waitForFlushTimer = async (): Promise<void> => {
+  await waitForPromises()
+  jest.runOnlyPendingTimers()
+  await waitForPromises()
+}

--- a/packages/node/src/capture-v1/config.ts
+++ b/packages/node/src/capture-v1/config.ts
@@ -1,0 +1,18 @@
+/** Capture submission mode: `v0` is the legacy `/batch/` endpoint, `v1` is `/i/v1/analytics/events`. */
+export type CaptureMode = 'v0' | 'v1'
+
+function isCaptureMode(value: unknown): value is CaptureMode {
+  return value === 'v0' || value === 'v1'
+}
+
+/**
+ * Resolve the effective capture mode from the `POSTHOG_CAPTURE_MODE` environment
+ * variable (guarded for edge / no-`process` runtimes). The default is `v0`, so
+ * existing users are unaffected unless they explicitly opt in. Capture V1 is
+ * intentionally env-var-only during the transition — there is no public option,
+ * so nothing on the API surface has to be removed when v1 becomes the default.
+ */
+export function resolveCaptureMode(): CaptureMode {
+  const envMode = typeof process !== 'undefined' ? process.env?.POSTHOG_CAPTURE_MODE : undefined
+  return isCaptureMode(envMode) ? envMode : 'v0'
+}

--- a/packages/node/src/capture-v1/errors.ts
+++ b/packages/node/src/capture-v1/errors.ts
@@ -1,0 +1,52 @@
+/** A single event the server explicitly rejected (`drop`). */
+export interface V1DroppedEvent {
+  uuid: string
+  details?: string
+}
+
+export interface CaptureV1ErrorParams {
+  requestId: string
+  /** Events the server rejected outright (billing/validation). */
+  drops: V1DroppedEvent[]
+  /** UUIDs of events still pending `retry` after the attempt budget was exhausted, or lost to a batch-level failure. */
+  retryExhausted: string[]
+  /** The underlying transport/HTTP/parse failure, when the whole batch failed. */
+  cause?: unknown
+}
+
+/**
+ * Surfaced on the client error channel whenever a Capture V1 batch did not
+ * fully deliver: some events were `drop`ped, some `retry` events outlived the
+ * attempt budget, or the batch hit a terminal transport/HTTP/parse failure.
+ *
+ * A 2xx with drops is still a partial failure and is reported here — a
+ * successful HTTP status does not mean every event was accepted.
+ */
+export class CaptureV1Error extends Error {
+  name = 'CaptureV1Error'
+  readonly requestId: string
+  readonly drops: V1DroppedEvent[]
+  readonly retryExhausted: string[]
+  cause?: unknown
+
+  constructor({ requestId, drops, retryExhausted, cause }: CaptureV1ErrorParams) {
+    super(CaptureV1Error.buildMessage(requestId, drops, retryExhausted, cause))
+    this.requestId = requestId
+    this.drops = drops
+    this.retryExhausted = retryExhausted
+    this.cause = cause
+  }
+
+  private static buildMessage(
+    requestId: string,
+    drops: V1DroppedEvent[],
+    retryExhausted: string[],
+    cause: unknown
+  ): string {
+    let message = `Capture V1 batch ${requestId} did not fully deliver: ${drops.length} dropped, ${retryExhausted.length} undelivered`
+    if (cause instanceof Error) {
+      message += ` (${cause.message})`
+    }
+    return message
+  }
+}

--- a/packages/node/src/capture-v1/routing.ts
+++ b/packages/node/src/capture-v1/routing.ts
@@ -1,0 +1,28 @@
+import type { PostHogEventProperties } from '@posthog/core'
+
+/** Event-name prefix for AI analytics events, which have no Capture V1 form yet. */
+const AI_EVENT_PREFIX = '$ai_'
+
+/**
+ * Queue route for events eligible for Capture V1 (everything except `$ai_*`). Its queue is the
+ * historical {@link PostHogPersistedProperty.Queue}, so v0 mode is byte-identical to before.
+ */
+export const ANALYTICS_ROUTE = 'analytics'
+
+/**
+ * Queue route for `$ai_*` events, kept on the legacy (v0) transport in v1 mode and isolated on
+ * its own queue so a v0 failure can't re-send events already accepted on the V1 route. This route
+ * will later host a dedicated v1 AI-events transport once that endpoint exists — segregating it
+ * now means no re-plumbing then.
+ */
+export const AI_ROUTE = 'ai'
+
+/**
+ * True for events that must keep using the legacy (v0) submitter even when the
+ * client is in v1 mode. Today that is only `$ai_*` events: the dedicated AI
+ * ingestion path has no v1 form, so they stay on v0 until AI v1 is designed.
+ * The check runs on the post-`before_send` event name.
+ */
+export function isLegacyOnlyEvent(message: PostHogEventProperties): boolean {
+  return typeof message.event === 'string' && message.event.startsWith(AI_EVENT_PREFIX)
+}

--- a/packages/node/src/capture-v1/sender.ts
+++ b/packages/node/src/capture-v1/sender.ts
@@ -1,0 +1,291 @@
+import {
+  type FetchLike,
+  type PostHogEventProperties,
+  type PostHogFetchOptions,
+  type PostHogFetchResponse,
+  gzipCompress,
+  safeJsonStringify,
+  safeSetTimeout,
+  uuidv7,
+} from '@posthog/core'
+
+import { CaptureV1Error, type V1DroppedEvent } from './errors'
+import { buildV1Batch } from './transform'
+import type { V1BatchResponse, V1Event } from './types'
+
+const V1_ANALYTICS_PATH = '/i/v1/analytics/events'
+const DEFAULT_MAX_BACKOFF_MS = 30_000
+
+/** HTTP statuses the v1 backend wants retried. 429 is intentionally terminal in v1. */
+const RETRYABLE_STATUSES = new Set([408, 500, 502, 503, 504])
+
+export interface V1CaptureSenderConfig {
+  host: string
+  apiKey: string
+  /** Canonical `$lib` identity, materialized by the server from `PostHog-Sdk-Info`. */
+  libraryId: string
+  libraryVersion: string
+  /** Value for the `User-Agent` header, if the runtime allows setting it. */
+  userAgent?: string
+  historicalMigration: boolean
+  /** When true, the body is gzip-compressed (falling back to uncompressed on failure). */
+  compressionEnabled: boolean
+  requestTimeoutMs: number
+  /** Total attempts, including the first (1 initial + N retries). */
+  maxAttempts: number
+  /** Base exponential backoff, doubled each retry and capped at `maxBackoffMs`. */
+  initialRetryDelayMs: number
+  /** Single ceiling for both the backoff schedule and the `Retry-After` clamp. */
+  maxBackoffMs?: number
+  isDebug?: boolean
+}
+
+export interface V1CaptureSenderHooks {
+  fetch: FetchLike
+  /** Surfaces partial/terminal delivery failures on the client error channel. */
+  onError: (error: Error) => void
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+  generateRequestId?: () => string
+  compress?: (payload: string, isDebug?: boolean) => Promise<Blob | null>
+}
+
+/**
+ * Sends already-normalized events to the Capture V1 endpoint
+ * (`POST /i/v1/analytics/events`), owning the full attempt loop: per-event
+ * partial retry, exponential backoff clamped against `Retry-After`, v1 status
+ * classification, and surfacing drops / undelivered events on the error
+ * channel. Used by both the batched and immediate send paths.
+ *
+ * Never throws for a handled outcome: after exhausting its own attempt budget it
+ * reports the failure via `onError` and resolves, so the caller's queue treats
+ * the batch as consumed (the internal budget replaces v0's queue-level retry).
+ */
+export class V1CaptureSender {
+  private readonly config: V1CaptureSenderConfig
+  private readonly maxBackoffMs: number
+  private readonly fetchFn: FetchLike
+  private readonly onError: (error: Error) => void
+  private readonly now: () => number
+  private readonly sleep: (ms: number) => Promise<void>
+  private readonly generateRequestId: () => string
+  private readonly compress: (payload: string, isDebug?: boolean) => Promise<Blob | null>
+
+  constructor(config: V1CaptureSenderConfig, hooks: V1CaptureSenderHooks) {
+    this.config = config
+    this.maxBackoffMs = config.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS
+    this.fetchFn = hooks.fetch
+    this.onError = hooks.onError
+    this.now = hooks.now ?? Date.now
+    this.sleep = hooks.sleep ?? ((ms) => new Promise((resolve) => safeSetTimeout(resolve, ms)))
+    this.generateRequestId = hooks.generateRequestId ?? uuidv7
+    this.compress = hooks.compress ?? gzipCompress
+  }
+
+  async sendV1Batch(messages: PostHogEventProperties[]): Promise<void> {
+    if (messages.length === 0) {
+      return
+    }
+
+    const requestId = this.generateRequestId()
+    // created_at is generated once and stays stable across every retry.
+    const createdAt = new Date(this.now()).toISOString()
+    const { batch } = buildV1Batch(messages, {
+      createdAt,
+      historicalMigration: this.config.historicalMigration,
+    })
+
+    const url = `${this.config.host}${V1_ANALYTICS_PATH}`
+    const drops: V1DroppedEvent[] = []
+    let pending = batch
+
+    for (let attempt = 1; attempt <= this.config.maxAttempts; attempt++) {
+      const isLastAttempt = attempt === this.config.maxAttempts
+      const payload = safeJsonStringify({
+        created_at: createdAt,
+        ...(this.config.historicalMigration ? { historical_migration: true } : {}),
+        batch: pending,
+      })
+
+      let response: PostHogFetchResponse
+      try {
+        response = await this.sendOnce(url, payload, attempt, requestId)
+      } catch (transportError) {
+        // Connection/timeout with no HTTP response: retry until the budget runs out.
+        if (isLastAttempt) {
+          return this.surfaceBatchFailure(requestId, drops, pending, transportError)
+        }
+        await this.sleep(this.backoffDelay(attempt))
+        continue
+      }
+
+      const { status } = response
+      if (status < 200 || status >= 300) {
+        if (!isLastAttempt && RETRYABLE_STATUSES.has(status)) {
+          const retryAfterMs = this.parseRetryAfter(response)
+          await this.cancelBody(response)
+          await this.sleep(this.backoffDelay(attempt, retryAfterMs))
+          continue
+        }
+        const httpError = await this.buildHttpError(response, status)
+        return this.surfaceBatchFailure(requestId, drops, pending, httpError)
+      }
+
+      let parsed: V1BatchResponse
+      try {
+        parsed = await this.parseResponse(response)
+      } catch {
+        // A 2xx we cannot parse is terminal — re-sending against a broken success would loop forever.
+        return this.surfaceBatchFailure(
+          requestId,
+          drops,
+          pending,
+          new Error(`Capture V1 returned an unparseable ${status} response body`)
+        )
+      }
+
+      const retryable = this.classify(pending, parsed, drops)
+      if (retryable.length === 0) {
+        return this.surfacePartialDrops(requestId, drops)
+      }
+      if (isLastAttempt) {
+        this.onError(new CaptureV1Error({ requestId, drops, retryExhausted: retryable.map((event) => event.uuid) }))
+        return
+      }
+      pending = retryable
+      await this.sleep(this.backoffDelay(attempt))
+    }
+  }
+
+  private async sendOnce(
+    url: string,
+    payload: string,
+    attempt: number,
+    requestId: string
+  ): Promise<PostHogFetchResponse> {
+    const headers = this.buildHeaders(attempt, requestId)
+    let body: string | Blob = payload
+    if (this.config.compressionEnabled) {
+      const compressed = await this.compress(payload, this.config.isDebug)
+      if (compressed !== null) {
+        body = compressed
+        headers['Content-Encoding'] = 'gzip'
+      }
+      // A codec that fails to compress falls back to sending uncompressed.
+    }
+
+    const controller = new AbortController()
+    const timer = safeSetTimeout(() => controller.abort(), this.config.requestTimeoutMs)
+    try {
+      return await this.fetchFn(url, { method: 'POST', headers, body, signal: controller.signal })
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  private buildHeaders(attempt: number, requestId: string): PostHogFetchOptions['headers'] {
+    const sdkInfo = `${this.config.libraryId}/${this.config.libraryVersion}`
+    const headers: { [key: string]: string } = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.config.apiKey}`,
+      'PostHog-Sdk-Info': sdkInfo,
+      'PostHog-Attempt': String(attempt),
+      'PostHog-Request-Id': requestId,
+      // Regenerated per attempt — a per-attempt wall-clock stamp, unlike Request-Id / created_at.
+      'PostHog-Request-Timestamp': new Date(this.now()).toISOString(),
+    }
+    if (this.config.userAgent) {
+      headers['User-Agent'] = this.config.userAgent
+    }
+    return headers
+  }
+
+  /**
+   * Partition the pending events against a 2xx result map: `drop` accumulates as
+   * a terminal failure, `retry` is returned for the next attempt, and
+   * `ok`/`warning`/unknown/absent are terminal successes.
+   */
+  private classify(pending: V1Event[], parsed: V1BatchResponse, drops: V1DroppedEvent[]): V1Event[] {
+    const results = parsed.results ?? {}
+    const retryable: V1Event[] = []
+    for (const event of pending) {
+      const result = results[event.uuid]
+      if (!result) {
+        continue
+      }
+      if (result.result === 'drop') {
+        drops.push({ uuid: event.uuid, details: result.details ?? undefined })
+      } else if (result.result === 'retry') {
+        retryable.push(event)
+      }
+      // ok / warning / unknown codes are terminal successes.
+    }
+    return retryable
+  }
+
+  private backoffDelay(attempt: number, retryAfterMs?: number): number {
+    const exponential = Math.min(this.config.initialRetryDelayMs * 2 ** (attempt - 1), this.maxBackoffMs)
+    if (retryAfterMs === undefined) {
+      return exponential
+    }
+    // Retry-After is a minimum (never lets us retry earlier than our own backoff) and is clamped to the ceiling.
+    return Math.max(exponential, Math.min(retryAfterMs, this.maxBackoffMs))
+  }
+
+  /** Parse `Retry-After` (delta-seconds or HTTP-date). Non-positive/past values are ignored. */
+  private parseRetryAfter(response: PostHogFetchResponse): number | undefined {
+    const raw = response.headers?.get('Retry-After')
+    if (!raw) {
+      return undefined
+    }
+    const trimmed = raw.trim()
+    if (/^\d+$/.test(trimmed)) {
+      const seconds = parseInt(trimmed, 10)
+      return seconds > 0 ? seconds * 1000 : undefined
+    }
+    const dateMs = Date.parse(trimmed)
+    if (Number.isNaN(dateMs)) {
+      return undefined
+    }
+    const delta = dateMs - this.now()
+    return delta > 0 ? delta : undefined
+  }
+
+  private async parseResponse(response: PostHogFetchResponse): Promise<V1BatchResponse> {
+    const text = await response.text()
+    const parsed = JSON.parse(text)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('unexpected response shape')
+    }
+    const results = (parsed as { results?: unknown }).results
+    if (results !== undefined && (typeof results !== 'object' || results === null || Array.isArray(results))) {
+      throw new Error('unexpected results shape')
+    }
+    return { results: (results as V1BatchResponse['results']) ?? {} }
+  }
+
+  private async buildHttpError(response: PostHogFetchResponse, status: number): Promise<Error> {
+    let bodyText = ''
+    try {
+      bodyText = (await response.text()).slice(0, 512)
+    } catch {
+      // best-effort; a missing body should not mask the status
+    }
+    const suffix = bodyText ? `: ${bodyText}` : ''
+    return new Error(`Capture V1 request failed with HTTP ${status}${suffix}`)
+  }
+
+  private surfaceBatchFailure(requestId: string, drops: V1DroppedEvent[], pending: V1Event[], cause: unknown): void {
+    this.onError(new CaptureV1Error({ requestId, drops, retryExhausted: pending.map((event) => event.uuid), cause }))
+  }
+
+  private surfacePartialDrops(requestId: string, drops: V1DroppedEvent[]): void {
+    if (drops.length > 0) {
+      this.onError(new CaptureV1Error({ requestId, drops, retryExhausted: [] }))
+    }
+  }
+
+  private async cancelBody(response: PostHogFetchResponse): Promise<void> {
+    await response.body?.cancel()?.catch(() => {})
+  }
+}

--- a/packages/node/src/capture-v1/sender.ts
+++ b/packages/node/src/capture-v1/sender.ts
@@ -99,8 +99,12 @@ export class V1CaptureSender {
     const drops: V1DroppedEvent[] = []
     let pending = batch
 
-    for (let attempt = 1; attempt <= this.config.maxAttempts; attempt++) {
-      const isLastAttempt = attempt === this.config.maxAttempts
+    // Guard against a misconfigured budget (e.g. fetchRetryCount: -1): always make
+    // at least one attempt so a bad config surfaces a delivery error instead of
+    // silently dropping the batch without ever sending or calling onError.
+    const maxAttempts = Math.max(1, this.config.maxAttempts)
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const isLastAttempt = attempt === maxAttempts
       const payload = safeJsonStringify({
         created_at: createdAt,
         ...(this.config.historicalMigration ? { historical_migration: true } : {}),

--- a/packages/node/src/capture-v1/sender.ts
+++ b/packages/node/src/capture-v1/sender.ts
@@ -248,7 +248,7 @@ export class V1CaptureSender {
     const trimmed = raw.trim()
     if (/^\d+$/.test(trimmed)) {
       const seconds = parseInt(trimmed, 10)
-      return seconds > 0 ? seconds * 1000 : undefined
+      return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : undefined
     }
     const dateMs = Date.parse(trimmed)
     if (Number.isNaN(dateMs)) {

--- a/packages/node/src/capture-v1/sender.ts
+++ b/packages/node/src/capture-v1/sender.ts
@@ -153,7 +153,10 @@ export class V1CaptureSender {
         return
       }
       pending = retryable
-      await this.sleep(this.backoffDelay(attempt))
+      // A 200 partial-retry body can also carry Retry-After (e.g. rate-limited
+      // retry events); honor it as a minimum the same way as on a retryable status.
+      const retryAfterMs = this.parseRetryAfter(response)
+      await this.sleep(this.backoffDelay(attempt, retryAfterMs))
     }
   }
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -13,6 +13,7 @@ import {
   PostHogFlagsAndPayloadsResponse,
   PostHogFlagsResponse,
   PostHogPersistedProperty,
+  RetriableOptions,
   safeSetTimeout,
   uuidv7,
 } from '@posthog/core'
@@ -48,6 +49,9 @@ import {
 import ErrorTracking from './extensions/error-tracking'
 import { PostHogMemoryStorage } from './storage-memory'
 import { ContextData, ContextOptions, IPostHogContext } from './extensions/context/types'
+import { type CaptureMode, resolveCaptureMode } from './capture-v1/config'
+import { AI_ROUTE, ANALYTICS_ROUTE, isLegacyOnlyEvent } from './capture-v1/routing'
+import { V1CaptureSender } from './capture-v1/sender'
 
 // Standard local evaluation rate limit is 600 per minute (10 per second),
 // so the fastest a poller should ever be set is 100ms.
@@ -131,6 +135,9 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   public readonly options: PostHogOptions
   protected readonly context?: IPostHogContext
 
+  private readonly captureMode: CaptureMode
+  private _v1Sender?: V1CaptureSender
+
   // Feature flag overrides for local testing/development
   private _flagOverrides?: Record<string, FeatureFlagValue>
   private _payloadOverrides?: Record<string, JsonType>
@@ -184,6 +191,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     super(normalizedApiKey, normalizedOptions)
 
     this.options = normalizedOptions
+    this.captureMode = resolveCaptureMode()
     this.context = this.initializeContext()
 
     this.options.featureFlagsPollingInterval =
@@ -392,6 +400,75 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    */
   fetch(url: string, options: PostHogFetchOptions): Promise<PostHogFetchResponse> {
     return this.options.fetch ? this.options.fetch(url, options) : fetch(url, options)
+  }
+
+  /**
+   * Route an event to its queue. In v1 mode `$ai_*` events go to the isolated {@link AI_ROUTE}
+   * (legacy transport) and everything else to {@link ANALYTICS_ROUTE} (Capture V1); in v0 mode
+   * every event stays on {@link ANALYTICS_ROUTE}, which maps to the historical queue. Routing runs
+   * on the post-`before_send`, normalized event name (core calls this after `processBeforeEnqueue`).
+   */
+  protected getQueueRouteKey(message: PostHogEventProperties): string {
+    return this.captureMode === 'v1' && isLegacyOnlyEvent(message) ? AI_ROUTE : ANALYTICS_ROUTE
+  }
+
+  protected persistedQueueKeyForRoute(route: string): PostHogPersistedProperty {
+    return route === AI_ROUTE ? PostHogPersistedProperty.AiQueue : PostHogPersistedProperty.Queue
+  }
+
+  protected getActiveQueueRoutes(): string[] {
+    // Only surface the AI route in v1 mode — v0 mode never enqueues onto it, so keeping it out
+    // keeps v0's flush/shutdown identical to before (a single queue on ANALYTICS_ROUTE).
+    return this.captureMode === 'v1' ? [ANALYTICS_ROUTE, AI_ROUTE] : [ANALYTICS_ROUTE]
+  }
+
+  /**
+   * Capture submission seam shared by the batched (`_flush`) and immediate (`sendImmediate`)
+   * paths. Events are routed to homogeneous per-route queues at enqueue time, so a batch here is
+   * never mixed: the {@link AI_ROUTE} (and all of v0 mode) uses the legacy `/batch/` transport,
+   * which throws so `_flush` can shrink/persist/retry its own queue; the {@link ANALYTICS_ROUTE}
+   * in v1 mode uses the Capture V1 endpoint. Because the routes flush independently, a v0/AI leg
+   * failure can never re-send analytics events already accepted on the V1 leg.
+   */
+  protected async sendBatch(
+    batchMessages: (PostHogEventProperties | undefined)[],
+    retryOptions?: Partial<RetriableOptions>,
+    route: string = ANALYTICS_ROUTE
+  ): Promise<void> {
+    if (this.captureMode !== 'v1' || route === AI_ROUTE) {
+      return super.sendBatch(batchMessages, retryOptions, route)
+    }
+
+    // Analytics route in v1 mode: homogeneous (no `$ai_*`, routed away at enqueue) and never
+    // undefined for a freshly-enqueued event; drop any legacy undefined queue artifacts.
+    const v1Events = batchMessages.filter((message): message is PostHogEventProperties => message !== undefined)
+    await this.getV1Sender().sendV1Batch(v1Events)
+  }
+
+  private getV1Sender(): V1CaptureSender {
+    if (!this._v1Sender) {
+      this._v1Sender = new V1CaptureSender(
+        {
+          host: this.host,
+          apiKey: this.apiKey,
+          libraryId: this.getLibraryId(),
+          libraryVersion: this.getLibraryVersion(),
+          userAgent: this.getCustomUserAgent() || undefined,
+          historicalMigration: this.historicalMigration,
+          compressionEnabled: !this.disableCompression,
+          requestTimeoutMs: this.requestTimeout,
+          // Reuse the existing v0 retry knobs: 1 initial attempt + fetchRetryCount retries.
+          maxAttempts: (this.options.fetchRetryCount ?? 3) + 1,
+          initialRetryDelayMs: this.options.fetchRetryDelay ?? 3000,
+          isDebug: this.isDebug,
+        },
+        {
+          fetch: (url, fetchOptions) => this.fetch(url, fetchOptions),
+          onError: (error) => this._events.emit('error', error),
+        }
+      )
+    }
+    return this._v1Sender
   }
 
   /**


### PR DESCRIPTION
> Stacked on #4106 (which is stacked on #4105). Review those first; this PR's diff is against the PR2 branch.

## Problem

Third PR in the Capture V1 stack. With the pure transform in place (PR2), this adds the transport layer that actually talks to `POST /i/v1/analytics/events` and implements the v1 retry/response contract. Kept as a standalone, dependency-injected class so the full attempt loop is unit-testable without a live client or real timers.

## Changes

- `capture-v1/errors.ts`: `CaptureV1Error` carrying `requestId`, `drops` (uuid + server details), `retryExhausted` uuids, and an optional `cause`.
- `capture-v1/sender.ts`: `V1CaptureSender.sendV1Batch(messages)` owning the whole attempt loop:
  - **Request:** `POST {host}/i/v1/analytics/events`, `Authorization: Bearer`, and the six required headers. `PostHog-Request-Id` + `created_at` stable across attempts, `PostHog-Attempt` increments, `PostHog-Request-Timestamp` regenerated per attempt. No `api_key`/`sent_at` in the body.
  - **Partial retry:** each 2xx shrinks the next attempt to only `retry`-tagged events; `ok`/`warning`/unknown/absent are terminal successes; `drop` is a terminal failure.
  - **Status classification:** retryable `{408,500,502,503,504}`; **429 terminal**; other non-2xx terminal; **malformed 2xx terminal**; transport errors retried to the budget.
  - **Backoff:** `delay = max(exponential, min(retry_after, maxBackoff))`, 30s default ceiling. `Retry-After` parsed as delta-seconds or HTTP-date, treated as a minimum, clamped to the ceiling; past/non-positive ignored.
  - **Error surfacing:** drops and retry-exhausted events (with `details`) reach the error channel via `CaptureV1Error`; earlier-attempt drops are never swallowed by a later success. Handled failures resolve rather than throw (the internal budget replaces v0's queue-level retry).
  - gzip with uncompressed fallback; injectable `fetch`/`now`/`sleep`/`generateRequestId`/`compress` seams.

Not wired into the client yet — PR4 constructs the sender from client state and routes `sendBatch` to it.

### Verification

- New `sender.spec.ts`: 105 tests (with the transform suite), 100% line coverage of the `capture-v1` module. Covers the header/envelope contract, every result code, partial-retry batch shrinking, drop-accumulation-across-attempts, the full status matrix, transport-error retry/exhaustion, malformed-2xx, and the backoff/`Retry-After` min/clamp/date-parse rules.
- Node builds cleanly; ESLint clean.

## Release info Sub-libraries affected

### Libraries affected

- [ ] posthog-node

No changeset here by design (internal plumbing). The single `posthog-node` changeset lands in the wiring PR (PR4).

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Cursor (Claude Opus 4.8 agent). The retry/backoff/response semantics follow the backend V1 parity standard (429-terminal, malformed-2xx-terminal, `Retry-After` as a clamped minimum, 30s ceiling) and were cross-checked against posthog-rs/go/python. The sender resolves (rather than throws) on handled failures so it slots cleanly behind the core `sendBatch` seam for both the batched and immediate paths without changing v0 queue semantics.
