### PR TITLE
fix(replay): stop iframe teardown from disconnecting shadow DOM observers

### DIFF
--- a/.changeset/replay-shadow-observer-iframe-teardown.md
+++ b/.changeset/replay-shadow-observer-iframe-teardown.md
@@ -1,0 +1,8 @@
+---
+'@posthog/rrweb': patch
+'posthog-js': patch
+---
+
+fix session replay silently dropping shadow DOM mutations after an iframe teardown
+
+The single shared ShadowDomManager observes every shadow root on the page, but MutationBuffer.reset() disconnected it. That reset fires whenever any one buffer is torn down, so an iframe being removed or navigating away disconnected every shadow-root observer page-wide. Shadow DOM content (for example a widget mounted in an open shadow root) then stopped recording until the next periodic full snapshot re-registered it. Buffer teardown now releases only its own resources; global shadow observation is reset by takeFullSnapshot and on recording stop.

--- a/packages/rrweb/rrweb/src/record/index.ts
+++ b/packages/rrweb/rrweb/src/record/index.ts
@@ -762,9 +762,7 @@ function record<T = eventWithTime>(
       iframeManager.removeLoadListener();
       iframeManager.destroy();
       iframeObserverCleanups.clear();
-      // Disconnect all shadow-root observers here rather than from per-buffer
-      // reset(), so tearing down a single iframe buffer no longer nukes the
-      // whole page's shadow observation.
+      // Global shadow teardown belongs to the recording lifecycle, not per-buffer reset() which would fire on every iframe teardown.
       shadowDomManager.reset();
       mirror.reset();
       recording = false;

--- a/packages/rrweb/rrweb/src/record/index.ts
+++ b/packages/rrweb/rrweb/src/record/index.ts
@@ -762,6 +762,10 @@ function record<T = eventWithTime>(
       iframeManager.removeLoadListener();
       iframeManager.destroy();
       iframeObserverCleanups.clear();
+      // Disconnect all shadow-root observers here rather than from per-buffer
+      // reset(), so tearing down a single iframe buffer no longer nukes the
+      // whole page's shadow observation.
+      shadowDomManager.reset();
       mirror.reset();
       recording = false;
       unregisterErrorHandler();

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -259,8 +259,7 @@ export default class MutationBuffer {
     this.releaseCanvasManager();
   }
 
-  // Releases at most once even if reset() runs twice (iframe pagehide + stop). Separate from
-  // reset() so shadow-root teardown can release without re-entering shadowDomManager.reset().
+  // Idempotent so teardown can run twice (iframe pagehide + stop); shadow restore handlers call this directly, not reset(), per the recursion-guard unit test.
   public releaseCanvasManager() {
     if (this.canvasManagerReleased) {
       return;

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -255,11 +255,7 @@ export default class MutationBuffer {
   }
 
   public reset() {
-    // Only release this buffer's own resources. The shadowDomManager is a
-    // single shared instance, so resetting it here would disconnect every
-    // shadow-root observer on the page whenever any one buffer is torn down
-    // (e.g. an iframe navigating away). Global shadow teardown is driven by
-    // takeFullSnapshot's shadowDomManager.init() and the record() stop path.
+    // Don't reset the shared shadowDomManager here — that would disconnect every shadow-root observer on the page when any single buffer is torn down.
     this.releaseCanvasManager();
   }
 

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -255,7 +255,11 @@ export default class MutationBuffer {
   }
 
   public reset() {
-    this.shadowDomManager.reset();
+    // Only release this buffer's own resources. The shadowDomManager is a
+    // single shared instance, so resetting it here would disconnect every
+    // shadow-root observer on the page whenever any one buffer is torn down
+    // (e.g. an iframe navigating away). Global shadow teardown is driven by
+    // takeFullSnapshot's shadowDomManager.init() and the record() stop path.
     this.releaseCanvasManager();
   }
 

--- a/packages/rrweb/rrweb/src/record/observer.ts
+++ b/packages/rrweb/rrweb/src/record/observer.ts
@@ -1394,6 +1394,9 @@ export function initObservers(
         mutationBuffers.splice(index, 1);
       }
     }
+    // Disconnect the shadow observers owned by this document (e.g. an iframe being
+    // torn down) without touching the rest of the page's shadow observation.
+    o.shadowDomManager.resetForDoc(o.doc);
     mutationObserver?.disconnect();
     mousemoveHandler();
     mouseInteractionHandler();

--- a/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
@@ -28,7 +28,9 @@ export class ShadowDomManager {
   private scrollCb: scrollCallback;
   private bypassOptions: BypassOptions;
   private mirror: Mirror;
-  private restoreHandlers: (() => void)[] = [];
+  // Handlers are tagged with the document that owns their shadow root so a
+  // single iframe can be torn down without disconnecting the rest of the page.
+  private restoreHandlers: { doc: Document; handler: () => void }[] = [];
 
   constructor(options: {
     mutationCb: mutationCallBack;
@@ -64,18 +66,22 @@ export class ShadowDomManager {
       },
       shadowRoot,
     );
-    this.restoreHandlers.push(() => {
-      observer.disconnect();
-      buffer.destroy();
-      // Release the canvas ref directly; buffer.reset() would re-enter shadowDomManager.reset().
-      buffer.releaseCanvasManager();
-      const index = mutationBuffers.indexOf(buffer);
-      if (index !== -1) {
-        mutationBuffers.splice(index, 1);
-      }
+    this.restoreHandlers.push({
+      doc,
+      handler: () => {
+        observer.disconnect();
+        buffer.destroy();
+        // Release the canvas directly, not via buffer.reset(), per the recursion-guard unit test.
+        buffer.releaseCanvasManager();
+        const index = mutationBuffers.indexOf(buffer);
+        if (index !== -1) {
+          mutationBuffers.splice(index, 1);
+        }
+      },
     });
-    this.restoreHandlers.push(
-      initScrollObserver({
+    this.restoreHandlers.push({
+      doc,
+      handler: initScrollObserver({
         ...this.bypassOptions,
         scrollCb: this.scrollCb,
         // https://gist.github.com/praveenpuglia/0832da687ed5a5d7a0907046c9ef1813
@@ -83,7 +89,7 @@ export class ShadowDomManager {
         doc: shadowRoot as unknown as Document,
         mirror: this.mirror,
       }),
-    );
+    });
     // Defer this to avoid adoptedStyleSheet events being created before the full snapshot is created or attachShadow action is recorded.
     setTimeout(() => {
       if (
@@ -94,15 +100,16 @@ export class ShadowDomManager {
           shadowRoot.adoptedStyleSheets,
           this.mirror.getId(dom.host(shadowRoot)),
         );
-      this.restoreHandlers.push(
-        initAdoptedStyleSheetObserver(
+      this.restoreHandlers.push({
+        doc,
+        handler: initAdoptedStyleSheetObserver(
           {
             mirror: this.mirror,
             stylesheetManager: this.bypassOptions.stylesheetManager,
           },
           shadowRoot,
         ),
-      );
+      });
     }, 0);
   }
 
@@ -133,8 +140,9 @@ export class ShadowDomManager {
   ) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manager = this;
-    this.restoreHandlers.push(
-      patch(
+    this.restoreHandlers.push({
+      doc,
+      handler: patch(
         element.prototype,
         'attachShadow',
         function (original: (init: ShadowRootInit) => ShadowRoot) {
@@ -150,11 +158,11 @@ export class ShadowDomManager {
           };
         },
       ),
-    );
+    });
   }
 
   public reset() {
-    this.restoreHandlers.forEach((handler) => {
+    this.restoreHandlers.forEach(({ handler }) => {
       try {
         handler();
       } catch (e) {
@@ -163,5 +171,22 @@ export class ShadowDomManager {
     });
     this.restoreHandlers = [];
     this.shadowDoms = new WeakSet();
+  }
+
+  // Tear down only the shadow observers owned by `doc` (e.g. one iframe being removed), leaving the rest of the page's shadow observation intact.
+  public resetForDoc(doc: Document) {
+    const remaining: { doc: Document; handler: () => void }[] = [];
+    for (const entry of this.restoreHandlers) {
+      if (entry.doc === doc) {
+        try {
+          entry.handler();
+        } catch (e) {
+          //
+        }
+      } else {
+        remaining.push(entry);
+      }
+    }
+    this.restoreHandlers = remaining;
   }
 }

--- a/packages/rrweb/rrweb/test/html/shadow-dom-iframe.html
+++ b/packages/rrweb/rrweb/test/html/shadow-dom-iframe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div class="my-element"></div>
+    <iframe id="frame" src="about:blank"></iframe>
+    <script>
+      // Attach an open shadow root synchronously at load, before recording starts.
+      var host = document.querySelector('.my-element');
+      var root = host.attachShadow({ mode: 'open' });
+      root.innerHTML = '<ul id="log"></ul>';
+      window.__log = root.getElementById('log');
+    </script>
+  </body>
+</html>

--- a/packages/rrweb/rrweb/test/integration.test.ts
+++ b/packages/rrweb/rrweb/test/integration.test.ts
@@ -14,7 +14,12 @@ import {
   ISuite,
 } from './utils';
 import type { recordOptions } from '../src/types';
-import { eventWithTime, NodeType, EventType } from '@posthog/rrweb-types';
+import {
+  eventWithTime,
+  NodeType,
+  EventType,
+  IncrementalSource,
+} from '@posthog/rrweb-types';
 import { visitSnapshot } from '@posthog/rrweb-snapshot';
 
 describe('record integration tests', function (this: ISuite) {
@@ -933,7 +938,7 @@ describe('record integration tests', function (this: ISuite) {
     const countShadowLiAdds = () =>
       page.evaluate(`
         window.snapshots
-          .filter((e) => e.type === 3 && e.data.source === 0)
+          .filter((e) => e.type === ${EventType.IncrementalSnapshot} && e.data.source === ${IncrementalSource.Mutation})
           .flatMap((e) => e.data.adds || [])
           .filter((a) => a.node && a.node.tagName === 'li').length
       `) as Promise<number>;

--- a/packages/rrweb/rrweb/test/integration.test.ts
+++ b/packages/rrweb/rrweb/test/integration.test.ts
@@ -921,6 +921,41 @@ describe('record integration tests', function (this: ISuite) {
     await assertSnapshot(snapshots);
   });
 
+  it('should keep recording shadow DOM mutations after an iframe is torn down', async () => {
+    // A single shared ShadowDomManager observes every shadow root. Tearing down
+    // one iframe's mutation buffer must not disconnect the page's other shadow
+    // observers, or shadow mutations silently stop until the next full snapshot.
+    const page: puppeteer.Page = await browser.newPage();
+    await page.goto('about:blank');
+    await page.setContent(getHtml.call(this, 'shadow-dom-iframe.html'));
+    await page.waitForTimeout(50);
+
+    const countShadowLiAdds = () =>
+      page.evaluate(`
+        window.snapshots
+          .filter((e) => e.type === 3 && e.data.source === 0)
+          .flatMap((e) => e.data.adds || [])
+          .filter((a) => a.node && a.node.tagName === 'li').length
+      `) as Promise<number>;
+
+    await page.evaluate(
+      `window.__log.appendChild(document.createElement('li'))`,
+    );
+    await page.waitForTimeout(50);
+    expect(await countShadowLiAdds()).toBe(1);
+
+    // Removing the iframe runs its per-buffer teardown.
+    await page.evaluate(`document.getElementById('frame').remove()`);
+    await page.waitForTimeout(50);
+
+    await page.evaluate(
+      `window.__log.appendChild(document.createElement('li'))`,
+    );
+    await page.waitForTimeout(50);
+    // The second li must still be recorded; before the fix it was dropped.
+    expect(await countShadowLiAdds()).toBe(2);
+  });
+
   it('should record shadow DOM 2', async () => {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto('about:blank');

--- a/packages/rrweb/rrweb/test/record/shadow-dom-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/shadow-dom-manager.test.ts
@@ -66,10 +66,8 @@ describe('ShadowDomManager', () => {
     document.body.appendChild(host);
     host.attachShadow({ mode: 'open' });
 
-    // Spy on MutationBuffer.prototype.reset to verify it's NOT called
-    // during ShadowDomManager.reset(). Calling buffer.reset() from the
-    // restoreHandler creates infinite mutual recursion because
-    // MutationBuffer.reset() calls this.shadowDomManager.reset()
+    // restoreHandlers must release via releaseCanvasManager(), never buffer.reset() —
+    // guards against reintroducing the shadowDomManager.reset() recursion that coupling once caused.
     const resetSpy = vi.spyOn(MutationBuffer.prototype, 'reset');
 
     manager.reset();
@@ -107,6 +105,28 @@ describe('ShadowDomManager', () => {
     manager.reset();
 
     expect(() => manager.reset()).not.toThrow();
+
+    document.body.removeChild(host);
+  });
+
+  it('resetForDoc() only tears down handlers owned by the given document', () => {
+    const manager = createManager();
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const buffersBeforeAdd = mutationBuffers.length;
+    host.attachShadow({ mode: 'open' });
+    expect(mutationBuffers.length).toBe(buffersBeforeAdd + 1);
+
+    // Tearing down a different document must leave this doc's shadow buffers alone.
+    const otherDoc = document.implementation.createHTMLDocument('other');
+    manager.resetForDoc(otherDoc);
+    expect(mutationBuffers.length).toBe(buffersBeforeAdd + 1);
+
+    // Tearing down the owning document removes them.
+    manager.resetForDoc(document);
+    expect(mutationBuffers.length).toBe(buffersBeforeAdd);
 
     document.body.removeChild(host);
   });


### PR DESCRIPTION
## Problem

Session replay silently stops recording shadow DOM mutations after an iframe is torn down.

One shared `ShadowDomManager` observes every shadow root, but `MutationBuffer.reset()` reset it — and that fires on any buffer teardown, so an iframe being removed or navigating away disconnected every shadow-root observer page-wide until the next full snapshot. Reproduced from a customer session where a widget in an open shadow root stopped recording ~1s in.

## Changes

- `MutationBuffer.reset()` releases only its own resources; global shadow teardown now runs from `takeFullSnapshot` and `record()` stop.
- Shadow restore handlers are keyed by owning document, and `ShadowDomManager.resetForDoc()` (called from the observer-bundle disposer) tears down exactly the departing document's shadow observers — so a removed iframe no longer leaves its own shadow observers connected until the next full snapshot.
- Regression + unit tests: shadow mutations keep flowing after an unrelated iframe is removed (fails without the fix), and `resetForDoc()` only tears down the given document's handlers.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/rrweb

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (no breaking changes)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused and fixed with Claude Code from a customer replay export; iframe teardown was disconnecting the shared shadow observer. Verified with a puppeteer repro (removal + navigation + stop leak-check) before writing the committed test.
