### PR TITLE
fix(replay): key shadow roots by host owner document

### DIFF
--- a/.changeset/replay-shadow-root-owner-doc.md
+++ b/.changeset/replay-shadow-root-owner-doc.md
@@ -1,0 +1,8 @@
+---
+'@posthog/rrweb': patch
+'posthog-js': patch
+---
+
+fix session replay leaking a shadow-root observer when a same-origin iframe is removed
+
+Follow-up to the shadow-observer iframe-teardown fix: `takeFullSnapshot`'s `onSerialize` registers every shadow root with the top-level document, so a root nested in a same-origin iframe was keyed to the wrong document and its observer/buffer were not disconnected when that iframe was removed (they lingered until the next full snapshot). `addShadowRoot` now derives the owning document from the host element, so per-document teardown matches iframe-nested roots too.

--- a/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
@@ -56,10 +56,14 @@ export class ShadowDomManager {
     if (!isNativeShadowDom(shadowRoot)) return;
     if (this.shadowDoms.has(shadowRoot)) return;
     this.shadowDoms.add(shadowRoot);
+    // Derive the owning document from the host so a shadow root nested in an
+    // iframe is keyed to that iframe's document, not whatever the caller passed
+    // (takeFullSnapshot's onSerialize hands us the top-level document).
+    const ownerDoc = dom.host(shadowRoot)?.ownerDocument ?? doc;
     const { observer, buffer } = initMutationObserver(
       {
         ...this.bypassOptions,
-        doc,
+        doc: ownerDoc,
         mutationCb: this.mutationCb,
         mirror: this.mirror,
         shadowDomManager: this,
@@ -67,7 +71,7 @@ export class ShadowDomManager {
       shadowRoot,
     );
     this.restoreHandlers.push({
-      doc,
+      doc: ownerDoc,
       handler: () => {
         observer.disconnect();
         buffer.destroy();
@@ -80,7 +84,7 @@ export class ShadowDomManager {
       },
     });
     this.restoreHandlers.push({
-      doc,
+      doc: ownerDoc,
       handler: initScrollObserver({
         ...this.bypassOptions,
         scrollCb: this.scrollCb,
@@ -101,7 +105,7 @@ export class ShadowDomManager {
           this.mirror.getId(dom.host(shadowRoot)),
         );
       this.restoreHandlers.push({
-        doc,
+        doc: ownerDoc,
         handler: initAdoptedStyleSheetObserver(
           {
             mirror: this.mirror,

--- a/packages/rrweb/rrweb/test/record/shadow-dom-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/shadow-dom-manager.test.ts
@@ -130,4 +130,31 @@ describe('ShadowDomManager', () => {
 
     document.body.removeChild(host);
   });
+
+  it('keys a shadow root by its host owner document, not the passed document', () => {
+    const manager = createManager();
+
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    const iframeDoc = iframe.contentDocument as Document;
+    const host = iframeDoc.createElement('div');
+    iframeDoc.body.appendChild(host);
+    const root = host.attachShadow({ mode: 'open' });
+
+    const buffersBeforeAdd = mutationBuffers.length;
+    // takeFullSnapshot's onSerialize passes the top-level document for every root,
+    // even ones nested inside an iframe.
+    manager.addShadowRoot(root, document);
+    expect(mutationBuffers.length).toBe(buffersBeforeAdd + 1);
+
+    // Tearing down the top-level document must not match the iframe-owned root.
+    manager.resetForDoc(document);
+    expect(mutationBuffers.length).toBe(buffersBeforeAdd + 1);
+
+    // Tearing down the iframe's own document does.
+    manager.resetForDoc(iframeDoc);
+    expect(mutationBuffers.length).toBe(buffersBeforeAdd);
+
+    document.body.removeChild(iframe);
+  });
 });


### PR DESCRIPTION
## Problem

Follow-up to #4112 (already merged). That PR scoped shadow-observer teardown per owning document via `ShadowDomManager.resetForDoc()`, but `takeFullSnapshot`'s `onSerialize` registers **every** shadow root with the top-level `document` — so a root nested in a same-origin iframe was keyed to the wrong document. When that iframe was removed, `resetForDoc(iframeDoc)` didn't match it, leaving a connected `MutationObserver` and dead `MutationBuffer` in the global array until the next full snapshot.

Reported by @arnohillen on #4112.

## Changes

- `ShadowDomManager.addShadowRoot()` derives the owning document from `dom.host(shadowRoot).ownerDocument` instead of trusting the caller-passed `doc`, so callers can't mis-key iframe-nested roots. As a bonus the buffer for such a root now serializes against the correct document.
- Unit test pinning the case: an iframe-owned root registered with the top-level document is torn down by `resetForDoc(iframeDoc)`, not `resetForDoc(document)`.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/rrweb

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (no breaking changes)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out with Claude Code from a review finding on #4112 after that PR had already merged. Fix derives the shadow root's owning document from its host so per-document teardown matches iframe-nested roots.
