### PR TITLE
feat(react-native): add dimmed backdrop behind survey modal

### DIFF
--- a/.changeset/rn-survey-backdrop.md
+++ b/.changeset/rn-survey-backdrop.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+add a dimmed backdrop behind the survey modal, matching the scrim posthog-ios and posthog-android already render

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -116,7 +116,7 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
     >
       {contentMounted && (
         <KeyboardAvoidingView behavior={keyboardBehavior} style={styles.fill}>
-          <View style={[styles.fill, { justifyContent: vertical }]} onTouchStart={Keyboard.dismiss}>
+          <View style={[styles.fill, styles.backdrop, { justifyContent: vertical }]} onTouchStart={Keyboard.dismiss}>
             <View style={[styles.modalRow, { justifyContent: horizontal }]}>
               <View style={styles.modalContent} pointerEvents="box-none">
                 <View
@@ -171,6 +171,9 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
 const styles = createSafeStyleSheet({
   fill: {
     flex: 1,
+  },
+  backdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.32)',
   },
   modalRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Problem

The React Native survey modal renders with no backdrop — it's a transparent RN `Modal` with nothing behind the survey card. On a busy screen the survey blends into the app UI behind it (the original request in [#3523](https://github.com/PostHog/posthog-js/issues/3523)).

Note  ([#3628](https://github.com/PostHog/posthog-js/pull/3628)) was originally closed because we thought it was "drifting implementations from other mobile sdks" But actually, this is also a cross-SDK inconsistency: **React Native is the only mobile SDK without a scrim.** The others all dim the background behind the survey by default:

| SDK | Survey presentation | Scrim behind it |
| --- | --- | --- |
| posthog-ios | `UISheetPresentationController` (`.sheet`) | Yes — system sheet dimming (~black 40%) |
| posthog-android | Material 3 `ModalBottomSheet` | Yes — `colorScheme.scrim`, black @ 32% |
| posthog-flutter | `showModalBottomSheet` | Yes — default `black54` barrier |
| **posthog-react-native** | RN `<Modal transparent>` | **No** |

RN's `Modal` is deliberately transparent and doesn't carry the native presentation-controller scrim that iOS/Android/Flutter get for free — so the survey already blocks touches like a modal, it just doesn't *look* like one. This adds the missing scrim.

## Changes

Adds a `backdrop` style — a semi-transparent black fill (`rgba(0, 0, 0, 0.32)`) — to the existing full-screen container behind the survey card in `SurveyModal.tsx`.

- **32% opacity** to match posthog-android's Material 3 scrim exactly (iOS is ~40%, Flutter 54% — 32% sits at the low, least-intrusive end of the native range).
- No new props or config surface: the scrim is always-on, matching how iOS/Android/Flutter ship it — non-configurable by design, so RN doesn't drift with an RN-only knob.
- The scrim sits *behind* the survey card, so it's independent of the survey's own customizable `backgroundColor` and can't clash with it.
- No dark-mode handling needed: a scrim is always semi-transparent black on every platform (it darkens the background — it never inverts), so a fixed color is correct in both light and dark.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-react-native

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @turnipdabeets. Built with Claude Code ([session](https://claude.ai/code/session_01FVZpWdPmBStKwpfqGdixuF)).

- Verified the backdrop rendering on device — iOS simulator (light **and** dark mode) and an Android emulator — by running the `example-expo-53` app against a live test survey. Screenshots confirm the 32% scrim in all three.
- Cross-checked the other SDKs' scrim behavior in source (posthog-ios `UISheetPresentationController`, posthog-android Material 3 `ModalBottomSheet`, posthog-flutter `showModalBottomSheet`) and confirmed iOS/Android dim by default on real hardware/emulator; RN was the only one missing it.
- Chose 32% to match Android's Material default rather than the 50% used in the earlier bundled attempt ([#3628](https://github.com/PostHog/posthog-js/pull/3628)), landing at the least-intrusive end of the native range.
- Scoped to backdrop only. Tap-outside-to-close ([#3524](https://github.com/PostHog/posthog-js/issues/3524)) is intentionally left out — iOS and Android both disable outside-dismissal, and it was previously removed here for causing accidental dismissals.
- No unit test for the scrim style: the RN jsdom test shim doesn't apply array styles to the DOM, so a style assertion isn't observable without changing the shared shim. The existing `SurveyModal.spec.tsx` suite stays green as the regression guard; verification is the on-device screenshots above.

Closes [#3523](https://github.com/PostHog/posthog-js/issues/3523)

# React Native:
<img width="354" height="769" alt="Screenshot 2026-07-08 at 8 19 04 PM" src="https://github.com/user-attachments/assets/59237dee-8943-4550-babe-0b0ffe2db132" />
<img width="432" height="836" alt="Screenshot 2026-07-08 at 7 11 35 PM" src="https://github.com/user-attachments/assets/c84c4d45-100d-42d1-b308-fbc3302c406c" />

# Native:
<img width="357" height="764" alt="Screenshot 2026-07-08 at 6 53 28 PM" src="https://github.com/user-attachments/assets/f0535e9e-dd37-4632-9642-2651bc0a50c9" />
<img width="414" height="840" alt="Screenshot 2026-07-08 at 8 26 38 PM" src="https://github.com/user-attachments/assets/35072929-bf17-45d7-bec1-5d93a768703a" />

