### PR TITLE
fix(core): coalesce concurrent flushes

### DIFF
--- a/.changeset/chilly-wolves-dance.md
+++ b/.changeset/chilly-wolves-dance.md
@@ -1,5 +1,6 @@
 ---
 "@posthog/core": patch
+"posthog-react-native": patch
 ---
 
 Coalesce concurrent flush requests to avoid chaining redundant flushes while offline.

--- a/.changeset/chilly-wolves-dance.md
+++ b/.changeset/chilly-wolves-dance.md
@@ -1,0 +1,5 @@
+---
+"@posthog/core": patch
+---
+
+Coalesce concurrent flush requests to avoid chaining redundant flushes while offline.

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -257,6 +257,92 @@ describe('PostHog Core', () => {
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
     })
 
+    it('coalesces flush calls made while a flush is already queued', async () => {
+      jest.useRealTimers()
+      let resolveFetch!: () => void
+      mocks.fetch.mockImplementation(async () => {
+        await new Promise<void>((resolve) => (resolveFetch = resolve))
+        return {
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+        }
+      })
+
+      posthog.capture('test-event-1')
+      const inFlight = posthog.flush()
+      await waitForPromises() // let the first flush start its fetch
+
+      const queued = posthog.flush()
+      const coalesced = posthog.flush()
+
+      expect(coalesced).toBe(queued)
+      expect(queued).not.toBe(inFlight)
+
+      resolveFetch()
+      await expect(inFlight).resolves.not.toThrow()
+      await expect(queued).resolves.not.toThrow()
+      // the follow-up found an empty queue, so only one fetch happened
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('sends events captured during an in-flight flush via the coalesced follow-up', async () => {
+      jest.useRealTimers()
+      const batches: any[][] = []
+      let resolveFirstFetch!: () => void
+      mocks.fetch.mockImplementation(async (_, options) => {
+        batches.push(JSON.parse((options.body || '') as string).batch)
+        if (batches.length === 1) {
+          await new Promise<void>((resolve) => (resolveFirstFetch = resolve))
+        }
+        return {
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+        }
+      })
+
+      posthog.capture('first')
+      const inFlight = posthog.flush()
+      await waitForPromises() // first flush has read the queue and is mid-fetch
+
+      posthog.capture('second')
+      const followUp = posthog.flush()
+      posthog.capture('third')
+      expect(posthog.flush()).toBe(followUp)
+
+      resolveFirstFetch()
+      await Promise.all([inFlight, followUp])
+
+      expect(batches[0]).toMatchObject([{ event: 'first' }])
+      expect(batches[1]).toMatchObject([{ event: 'second' }, { event: 'third' }])
+    })
+
+    it('does not chain one flush per capture while flushes fail', async () => {
+      jest.useRealTimers()
+      ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
+        flushAt: 2,
+        fetchRetryCount: 0,
+        preloadFeatureFlags: false,
+      })
+      mocks.fetch.mockImplementation(() => Promise.reject(new Error('network down')))
+
+      for (let i = 0; i < 20; i++) {
+        posthog.capture(`offline-event-${i}`)
+      }
+      await delay(50) // let the flush chain settle
+
+      // all 20 captures coalesced into a single flush — not one flush per capture
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.Queue)).toHaveLength(20)
+
+      // coalescing doesn't leave flushing permanently stuck
+      posthog.capture('offline-event-20')
+      await delay(50)
+      expect(mocks.fetch).toHaveBeenCalledTimes(2)
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.Queue)).toHaveLength(21)
+    })
+
     it('should flush all events even if larger than batch size', async () => {
       ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 10 })
 

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -189,6 +189,7 @@ export abstract class PostHogCoreStateless {
   private maxQueueSize: number
   private flushInterval: number
   private flushPromise: Promise<any> | null = null
+  private pendingFlushPromise: Promise<void> | null = null
   private flushPromises: Set<Promise<any>> = new Set()
   private shutdownPromise: Promise<void> | null = null
   private requestTimeout: number
@@ -1191,6 +1192,9 @@ export abstract class PostHogCoreStateless {
    * Avoids unnecessary promise errors
    */
   private flushBackground(): void {
+    if (this.pendingFlushPromise) {
+      return
+    }
     void this.flush().catch(async (err) => {
       await logFlushError(err)
     })
@@ -1259,6 +1263,10 @@ export abstract class PostHogCoreStateless {
       return Promise.resolve()
     }
 
+    if (!waitForPendingPromises && this.pendingFlushPromise) {
+      return this.pendingFlushPromise
+    }
+
     const previousFlushPromise = this.flushPromise
     const maxPromiseId = this.promiseQueue.maxId
 
@@ -1275,15 +1283,22 @@ export abstract class PostHogCoreStateless {
       // Use a custom allSettled implementation to avoid issues with patching Promise on RN
       .then(() => allSettled([previousFlushPromise]))
       .then(() => {
+        if (this.pendingFlushPromise === nextFlushPromise) {
+          this.pendingFlushPromise = null
+        }
         return this._flush()
       })
 
+    this.pendingFlushPromise = nextFlushPromise
     this.flushPromise = nextFlushPromise
     this.flushPromises.add(nextFlushPromise)
     void this.addPendingPromise(nextFlushPromise)
 
     allSettled([nextFlushPromise]).then(() => {
       this.flushPromises.delete(nextFlushPromise)
+      if (this.pendingFlushPromise === nextFlushPromise) {
+        this.pendingFlushPromise = null
+      }
       // If there are no others waiting to flush, clear the promise.
       // We don't strictly need to do this, but it could make debugging easier
       if (this.flushPromise === nextFlushPromise) {

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -943,6 +943,55 @@ describe('PostHog Node.js', () => {
     })
   })
 
+  describe('flush coalescing', () => {
+    beforeEach(() => {
+      jest.useRealTimers()
+    })
+
+    afterEach(() => {
+      jest.useFakeTimers()
+    })
+
+    it('coalesces threshold-triggered flushes while fetch is failing', async () => {
+      const rejectFetch: Array<(err: Error) => void> = []
+      mockedFetch.mockImplementation(() => new Promise((_, reject) => rejectFetch.push(reject)) as any)
+
+      const ph = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        fetchRetryCount: 0,
+        flushAt: 2,
+        disableCompression: true,
+      })
+
+      for (let i = 0; i < 20; i++) {
+        ph.capture({ event: `offline-event-${i}`, distinctId: '123' })
+      }
+
+      // all 20 captures coalesced into a single flush — not one flush per capture
+      await wait(10)
+      expect(mockedFetch).toHaveBeenCalledTimes(1)
+
+      rejectFetch.shift()!(new Error('network down'))
+      await wait(10)
+      expect(mockedFetch).toHaveBeenCalledTimes(1)
+
+      // coalescing doesn't leave flushing permanently stuck
+      ph.capture({ event: 'offline-event-20', distinctId: '123' })
+      await wait(10)
+      expect(mockedFetch).toHaveBeenCalledTimes(2)
+
+      rejectFetch.shift()!(new Error('network down'))
+      await wait(10)
+
+      mockedFetch.mockResolvedValue({
+        status: 200,
+        text: () => Promise.resolve('ok'),
+        json: () => Promise.resolve({ status: 'ok' }),
+      } as any)
+      await ph.shutdown()
+    })
+  })
+
   describe('shutdown', () => {
     beforeEach(() => {
       mockedFetch.mockImplementation(async () => {


### PR DESCRIPTION
## Problem

When many captures cross `flushAt` while an event flush is already queued or in flight, each capture can schedule another background flush. If the network is failing, that can build a long chain of redundant flush attempts instead of coalescing into one follow-up attempt.

## Changes

- Track a single pending non-blocking flush promise in `@posthog/core`.
- Reuse that pending promise for concurrent `flush()` calls and skip duplicate background flush scheduling.
- Clear the pending marker when the flush starts or settles so future captures can retry normally after a failure.
- Add core regression coverage for coalesced manual/background flushes and Node coverage for threshold-triggered flushes while fetch is failing.
- Added a patch changeset for `@posthog/core`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

Underlying shared package affected: `@posthog/core`.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Generated a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi reviewed the local diff, committed the existing implementation, added the requested changeset commit, and opened this PR. The chosen approach keeps the public `flush()` API unchanged while coalescing only non-`flushWithPendingPromises` calls, preserving shutdown/pending-promise behavior.

Validation run:

```bash
pnpm turbo --filter=@posthog/core test:unit -- packages/core/src/__tests__/posthog.flush.spec.ts --runInBand
pnpm turbo --filter=posthog-node test:unit -- packages/node/src/__tests__/posthog-node.spec.ts --runInBand
pnpm changeset status --since=main
```
