### PR TITLE
fix(core): prevent shutdown flush drain loop

### DIFF
--- a/.changeset/calm-badgers-wait.md
+++ b/.changeset/calm-badgers-wait.md
@@ -1,5 +1,6 @@
 ---
 "@posthog/core": patch
+"posthog-react-native": patch
 ---
 
 Prevent shutdown from looping forever when a flush makes no queue progress.

--- a/.changeset/calm-badgers-wait.md
+++ b/.changeset/calm-badgers-wait.md
@@ -1,0 +1,5 @@
+---
+"@posthog/core": patch
+---
+
+Prevent shutdown from looping forever when a flush makes no queue progress.

--- a/packages/core/src/__tests__/posthog.shutdown.spec.ts
+++ b/packages/core/src/__tests__/posthog.shutdown.spec.ts
@@ -46,6 +46,40 @@ describe('PostHog Core', () => {
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
     })
 
+    it('does not spin forever if flush resolves without draining the queue', async () => {
+      const flush = jest.fn(() => Promise.resolve())
+      posthog.flush = flush
+      posthog.capture('test-event')
+
+      await posthog.shutdown(100)
+
+      expect(flush).toHaveBeenCalledTimes(1)
+      expect(mocks.fetch).not.toHaveBeenCalled()
+    })
+
+    it('drains events captured during the shutdown flush even if they reuse a uuid', async () => {
+      const uuid = 'f6d64d99-0e4f-4d95-b202-a2160d17b788'
+      const batches: any[][] = []
+      let recaptured = false
+      mocks.fetch.mockImplementation(async (_, options) => {
+        batches.push(JSON.parse((options.body || '') as string).batch)
+        if (!recaptured) {
+          recaptured = true
+          posthog.capture('second-event', undefined, { uuid })
+        }
+        return {
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+        }
+      })
+
+      posthog.capture('first-event', undefined, { uuid })
+      await posthog.shutdown()
+
+      expect(batches.flat()).toMatchObject([{ event: 'first-event' }, { event: 'second-event' }])
+    })
+
     it('return the same promise if called multiple times in parallel', async () => {
       mocks.fetch.mockImplementation(async () => {
         await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -190,6 +190,7 @@ export abstract class PostHogCoreStateless {
   private flushInterval: number
   private flushPromise: Promise<any> | null = null
   private flushPromises: Set<Promise<any>> = new Set()
+  private _dequeuedMessagesCount: number = 0
   private shutdownPromise: Promise<void> | null = null
   private requestTimeout: number
   private featureFlagsRequestTimeoutMs: number
@@ -1331,6 +1332,7 @@ export abstract class PostHogCoreStateless {
         const newQueue = refreshedQueue.slice(batchItems.length)
         this.setPersistedProperty<PostHogQueueItem[]>(PostHogPersistedProperty.Queue, newQueue)
         queue = newQueue
+        this._dequeuedMessagesCount += batchItems.length
         // Wait for storage to complete to prevent duplicate events on app crash
         await this.flushStorage()
       }
@@ -1532,12 +1534,21 @@ export abstract class PostHogCoreStateless {
             break
           }
 
+          const dequeuedBeforeFlush = this._dequeuedMessagesCount
+
           // flush again to make sure we send all events, some of which might've been added
           // while we were waiting for the pending promises to resolve
           // For example, see sendFeatureFlags in posthog-node/src/posthog-node.ts::capture
           await this.flush()
 
           if (hasTimedOut) {
+            break
+          }
+
+          if (this._dequeuedMessagesCount === dequeuedBeforeFlush) {
+            this._logger.warn(
+              'Shutdown flush completed but did not send any queued events. Stopping drain to avoid a loop.'
+            )
             break
           }
         }


### PR DESCRIPTION
## Problem

`shutdown()` drains the event queue by repeatedly calling `flush()` until no queued events remain. If a flush resolves without removing anything from the queue, shutdown can spin until its timeout instead of exiting promptly.

## Changes

- Track a private monotonic count of messages removed from the persisted queue.
- During shutdown queue draining, stop and warn if a flush completed without dequeueing anything.
- Preserve the existing shutdown behavior that performs another flush for events captured while a shutdown flush was in progress.
- Add regression tests for the no-progress flush case and for events captured during shutdown flushes.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common
- [x] @posthog/core

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi reviewed the working tree changes, ran targeted core unit tests, committed the shutdown drain-loop fix, added a patch changeset for `@posthog/core` and `posthog-react-native`, and opened this PR. The guard was implemented as a private dequeue-progress counter so `shutdown()` can detect a no-op flush without changing the public API or the normal follow-up flush behavior for events captured during shutdown.

Validation run:

```bash
pnpm turbo --filter=@posthog/core test:unit -- --runTestsByPath src/__tests__/posthog.flush.spec.ts src/__tests__/posthog.shutdown.spec.ts
```
