### PR TITLE
feat(mcp): stable sessions and client metadata on stateless / multi-pod MCP servers

### DIFF
--- a/.changeset/mcp-stateless-session-token.md
+++ b/.changeset/mcp-stateless-session-token.md
@@ -1,0 +1,9 @@
+---
+'@posthog/mcp': minor
+---
+
+feat(mcp): stable sessions and client metadata on stateless / multi-pod MCP servers
+
+On stateless servers every request became its own session and `$mcp_client_name`/`$mcp_client_version` were missing after `initialize`. The SDK now mints the `Mcp-Session-Id` response header at `initialize` as a token carrying the session id and client name/version; clients replay it on every request, so any pod recovers both with no server-side store. Auto-minting requires `enableJsonResponse: true` on `StreamableHTTPServerTransport`; SSE-mode servers can set the header at the HTTP layer with the new exports.
+
+New exports: `encodeSessionId`, `decodeSessionId`, `MCP_SESSION_HEADER`, `SessionTokenPayload`, `newSessionId`.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -13,11 +13,33 @@ SDK usage examples and code snippets live in the official documentation so they 
 On stateless deployments the SDK mints the `Mcp-Session-Id` response header at `initialize`
 as a token carrying the session id and client name/version. Clients replay the header on
 every request, so any pod keeps `$session_id` and `$mcp_client_name`/`$mcp_client_version`
-stable with no server-side store. Works out of the box on `StreamableHTTPServerTransport`
-with `enableJsonResponse: true` and a fresh transport per request.
+stable with no server-side store.
 
-SSE-streaming servers flush headers before handlers run, so set the header at the HTTP layer
-instead — the SDK decodes it either way:
+### Streamable HTTP: set `enableJsonResponse: true`
+
+The token is minted onto the `Mcp-Session-Id` **response** header from inside the `initialize`
+handler, so it only reaches the client when the transport builds the response **after** the
+handler runs — i.e. **JSON mode**. In **SSE (streaming) mode** `StreamableHTTPServerTransport`
+flushes the response headers **before** the handler runs, so the minted header never lands and
+behavior silently falls back to a session-per-request. This is a property of the transport, so
+it applies to **every** Streamable-HTTP host — set `enableJsonResponse: true` (and use a fresh
+transport per request):
+
+```ts
+// @modelcontextprotocol/sdk
+new StreamableHTTPServerTransport({ sessionIdGenerator: undefined, enableJsonResponse: true })
+
+// Cloudflare agents / createMcpHandler (SSE is the default)
+createMcpHandler(server, { enableJsonResponse: true })
+
+// @rekog/mcp-nest
+McpModule.forRoot({ streamableHttp: { enableJsonResponse: true } })
+```
+
+### If you must stream (SSE)
+
+Set the header yourself at the HTTP layer with the exported `encodeSessionId` (read `clientInfo`
+from the `initialize` body) — the SDK decodes it either way:
 
 ```ts
 import { MCP_SESSION_HEADER, encodeSessionId, newSessionId } from '@posthog/mcp'

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -8,6 +8,35 @@ SDK usage examples and code snippets live in the official documentation so they 
 
 - [MCP analytics docs](https://posthog.com/docs/mcp-analytics)
 
+## Stateless & multi-pod servers
+
+On stateless deployments the SDK mints the `Mcp-Session-Id` response header at `initialize`
+as a token carrying the session id and client name/version. Clients replay the header on
+every request, so any pod keeps `$session_id` and `$mcp_client_name`/`$mcp_client_version`
+stable with no server-side store. Works out of the box on `StreamableHTTPServerTransport`
+with `enableJsonResponse: true` and a fresh transport per request.
+
+SSE-streaming servers flush headers before handlers run, so set the header at the HTTP layer
+instead — the SDK decodes it either way:
+
+```ts
+import { MCP_SESSION_HEADER, encodeSessionId, newSessionId } from '@posthog/mcp'
+
+// after parsing the POST body, before flushing headers:
+if (body?.method === 'initialize' && !req.headers[MCP_SESSION_HEADER]) {
+  res.setHeader(
+    MCP_SESSION_HEADER,
+    encodeSessionId({
+      sessionId: newSessionId(),
+      clientName: body.params?.clientInfo?.name,
+      clientVersion: body.params?.clientInfo?.version,
+    })
+  )
+}
+```
+
+Details: [docs/ARCHITECTURE.md §4](./docs/ARCHITECTURE.md).
+
 ## Developing locally
 
 To test local changes in a consumer app (e.g. a dummy MCP server), symlink **both**

--- a/packages/mcp/docs/ARCHITECTURE.md
+++ b/packages/mcp/docs/ARCHITECTURE.md
@@ -31,10 +31,10 @@ The host application supplies its own `posthog-node` client as the positional `p
 
 Two thin adapters exist for the two MCP server shapes, each wrapping the shared `captureToolCall()` lifecycle in `src/extensions/instrumentation.ts`:
 
-| Server type                              | File                       | Entry                       |
-| ---------------------------------------- | -------------------------- | --------------------------- |
-| Low-level `Server` (raw protocol SDK)    | `src/extensions/instrument-lowlevel.ts`   | `instrumentLowLevelServer()`    |
-| High-level `McpServer` (typed wrapper)   | `src/extensions/instrument-highlevel.ts`| `instrumentHighLevelServer()`           |
+| Server type                            | File                                     | Entry                         |
+| -------------------------------------- | ---------------------------------------- | ----------------------------- |
+| Low-level `Server` (raw protocol SDK)  | `src/extensions/instrument-lowlevel.ts`  | `instrumentLowLevelServer()`  |
+| High-level `McpServer` (typed wrapper) | `src/extensions/instrument-highlevel.ts` | `instrumentHighLevelServer()` |
 
 Both converge on the same internal `McpEvent` shape (`src/types.ts`) and funnel through `captureToolCall` in `src/extensions/instrumentation.ts`, which owns the shared tool-call lifecycle and the same publish pipeline.
 
@@ -73,10 +73,17 @@ The pipeline lives in an exported `processMcpEvent()` function in `src/extension
 ## 4. Session & identity
 
 - **Session ID format**: `ses_<uuidv7>` (`src/extensions/ids.ts`). Uses `uuidv7` from `@posthog/core`.
-- **Session resolution order** (`src/extensions/session.ts`):
-  1. If `extra.sessionId` (MCP protocol session) is present, derive a deterministic id by hashing it (`deterministicPrefixedId("ses", mcpSessionId)`). This means the same protocol session always maps to the same PostHog session across server restarts.
-  2. If the MCP session id disappears mid-stream, keep using the last derived id (transient drops don't split sessions).
-  3. Otherwise, generate `ses_<uuidv7>` and rotate after **30 minutes of inactivity** (`INACTIVITY_TIMEOUT_IN_MINUTES`).
+- **Session resolution** (`getSessionId`, `src/extensions/session.ts`) — three sources, in order:
+  1. **Session token** (the replayed `mcp-session-id` request header): use the session id inside it and save the token's client name/version for events. See "Session tokens" below.
+  2. **Transport session id** (`extra.sessionId`, stateful servers): hash it (`deriveSessionIdFromMCPSession`) so the same MCP session maps to the same PostHog session across restarts.
+  3. **Memory**: keep the current id. Only generated sessions roll over, after **30 minutes of inactivity**; token/MCP sessions live as long as the client replays them.
+- **Session tokens — stateless / multi-pod continuity** (`src/extensions/session-token.ts`):
+  - **Problem**: a stateless server keeps nothing between requests, so sessions fragment to one per request and `$mcp_client_name`/`$mcp_client_version` go missing after `initialize`.
+  - **Mechanism**: the `Mcp-Session-Id` header is the only value clients replay on every request (spec: MUST; any visible-ASCII string is allowed). At `initialize`, when neither the client nor the transport supplied a session id, `mintStatelessSessionOnInitialize` sets the response header to `base64url(JSON)` with shortened keys (`sid` = session id, `cn`/`cv` = client name/version). Any pod decodes the replayed header — no store, no sticky routing, no client changes.
+  - **JSON-mode constraint**: the auto-mint reaches the wire only with `enableJsonResponse: true` (headers are built after handlers run). SSE flushes headers first, so SSE servers set the header themselves with the exported `encodeSessionId`; the SDK still decodes it. Stateless mode also needs the SDK's usual fresh-transport-per-request pattern.
+  - **Trust**: unsigned — it carries only what the client already self-reports at `initialize`. A stateless server answering `DELETE` with 405 is spec-compliant.
+  - **Degradation**: clients that don't replay the header fall back to the pre-token behavior — a generated session per request.
+  - **Shelf life**: the MCP 2026-07-28 revision (RC) removes `Mcp-Session-Id` and moves client info into per-request `_meta`; supporting it will be its own change.
 - **`distinct_id`** (`posthog-events.ts`): `identifyActorGivenId || sessionId || "anonymous"`. Pre-identify events are session-scoped; once `options.identify()` returns a user, subsequent events attribute to that user and PostHog's standard identity merge takes over.
 - **Person processing**: events for sessions with **no resolved identity** carry `$process_person_profile: false`, so anonymous MCP sessions don't each mint a throwaway person profile (the distinct id is just the session id). Once an identity is resolved, person processing stays on so `$set` lands on a real person.
 - **`$identify` event**: fires only when the identity returned by `options.identify()` _changes_ for a given session. Dedupe is handled by an `IdentityCache` (bounded LRU, max 1000 entries) keyed by session id — but it is **per-server**: one instance lives on each server's tracking data via the `WeakMap` (`src/extensions/internal.ts`), so identities never bleed across server instances. An unchanged identity is silently deduped.
@@ -87,19 +94,19 @@ The pipeline lives in an exported `processMcpEvent()` function in `src/extension
 
 All events are emitted by `buildPostHogCaptureEvents`. The main event name is computed by looking up the internal `MCPAnalyticsEventType` in `BUILT_IN_EVENT_NAME_BY_TYPE`.
 
-| PostHog event          | When                                                          | Notable extras                                                                                                                                                                  |
-| ---------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `$mcp_tool_call`       | Every tool invocation                                         | `$mcp_tool_name`, `$mcp_tool_description`, `$mcp_tool_category`, `$mcp_parameters`, `$mcp_response`, `$mcp_duration_ms`, `$mcp_is_error`, optionally `$mcp_intent` / `$mcp_intent_source`               |
-| `$mcp_tools_list`      | Client lists tools                                            | `$mcp_listed_tool_names` (array of tool names advertised); useful for "did this client discover us?" and "which advertised tools never get called?"                              |
-| `$mcp_initialize`      | Client/server handshake                                       | `$mcp_client_name`, `$mcp_client_version`, `$mcp_server_name`, `$mcp_server_version`                                                                                            |
-| `$mcp_missing_capability` | Agent calls the `get_more_tools` virtual tool             | A capability gap, **not** a tool invocation. The `context` arg is captured as `$mcp_intent` with `$mcp_intent_source = "context_parameter"`                                      |
-| `$mcp_resources_list`  | Client lists resources                                        | —                                                                                                                                                                               |
-| `$mcp_resource_read`   | Resource fetched                                              | `$mcp_resource_name`, `$mcp_parameters`, `$mcp_response`                                                                                                                        |
-| `$mcp_prompts_list`    | Client lists prompts                                          | —                                                                                                                                                                               |
-| `$mcp_prompt_get`      | Prompt fetched                                                | `$mcp_resource_name` (= prompt name)                                                                                                                                            |
-| _(your event name)_    | `analytics.capture({ event, properties })`                    | A customer event sent under the verbatim `event` name (not `$`-prefixed). Carries `$session_id`, `distinct_id`, server/client metadata, plus whatever you pass in `properties`   |
-| `$identify`            | `options.identify` returned a new identity for the session    | `$set` populated                                                                                                                                                                |
-| `$exception`           | Sibling to any errored event (unless `enableExceptionAutocapture: false`) | `$exception_list`, `$exception_level` (standard `@posthog/core` error-tracking shape)                                                                              |
+| PostHog event             | When                                                                      | Notable extras                                                                                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$mcp_tool_call`          | Every tool invocation                                                     | `$mcp_tool_name`, `$mcp_tool_description`, `$mcp_tool_category`, `$mcp_parameters`, `$mcp_response`, `$mcp_duration_ms`, `$mcp_is_error`, optionally `$mcp_intent` / `$mcp_intent_source` |
+| `$mcp_tools_list`         | Client lists tools                                                        | `$mcp_listed_tool_names` (array of tool names advertised); useful for "did this client discover us?" and "which advertised tools never get called?"                                       |
+| `$mcp_initialize`         | Client/server handshake                                                   | `$mcp_client_name`, `$mcp_client_version`, `$mcp_server_name`, `$mcp_server_version`                                                                                                      |
+| `$mcp_missing_capability` | Agent calls the `get_more_tools` virtual tool                             | A capability gap, **not** a tool invocation. The `context` arg is captured as `$mcp_intent` with `$mcp_intent_source = "context_parameter"`                                               |
+| `$mcp_resources_list`     | Client lists resources                                                    | —                                                                                                                                                                                         |
+| `$mcp_resource_read`      | Resource fetched                                                          | `$mcp_resource_name`, `$mcp_parameters`, `$mcp_response`                                                                                                                                  |
+| `$mcp_prompts_list`       | Client lists prompts                                                      | —                                                                                                                                                                                         |
+| `$mcp_prompt_get`         | Prompt fetched                                                            | `$mcp_resource_name` (= prompt name)                                                                                                                                                      |
+| _(your event name)_       | `analytics.capture({ event, properties })`                                | A customer event sent under the verbatim `event` name (not `$`-prefixed). Carries `$session_id`, `distinct_id`, server/client metadata, plus whatever you pass in `properties`            |
+| `$identify`               | `options.identify` returned a new identity for the session                | `$set` populated                                                                                                                                                                          |
+| `$exception`              | Sibling to any errored event (unless `enableExceptionAutocapture: false`) | `$exception_list`, `$exception_level` (standard `@posthog/core` error-tracking shape)                                                                                                     |
 
 ## 6. Property catalog
 
@@ -107,34 +114,34 @@ All wire keys live in `PostHogMCPAnalyticsProperty` (`src/extensions/constants.t
 
 ### Core properties (present on most `$mcp_*` events)
 
-| Constant         | Wire key                  | Type                                  | Source                                                                                                                                                                                |
-| ---------------- | ------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SessionId`      | `$session_id`             | string                                | `event.sessionId` (`ses_…`)                                                                                                                                                           |
-| `Source`         | `$mcp_source`             | string                                | Hardcoded `"posthog_mcp_analytics"`                                                                                                                                                   |
-| `ResourceName`   | `$mcp_resource_name`      | string                                | Tool / resource / prompt name                                                                                                                                                         |
-| `ToolName`       | `$mcp_tool_name`          | string                                | Same as `ResourceName`, but **only on `$mcp_tool_call`**                                                                                                                              |
-| `ToolDescription`| `$mcp_tool_description`   | string                                | Tool's current `description` at call time. Cached from `tools/list` and (for `McpServer`) seeded from `_registeredTools`. Only on `$mcp_tool_call` and the paired `$exception` event |
-| `ToolCategory`   | `$mcp_tool_category`      | string                                | Product category declared on the tool's `_meta.category`. Cached from `tools/list` and (for `McpServer`) seeded from `_registeredTools`; `captureToolCall` takes it as `category`. Only on `$mcp_tool_call` and the paired `$exception` event |
-| `ListedToolNames`| `$mcp_listed_tool_names`  | string[]                              | Names of tools advertised in a `tools/list` response. Only on `$mcp_tools_list` events.                                                                                               |
-| `DurationMs`     | `$mcp_duration_ms`        | number (ms)                           | Wall-clock duration                                                                                                                                                                   |
-| `IsError`        | `$mcp_is_error`           | boolean                               | Set from tool result or thrown exception                                                                                                                                              |
-| `ServerName`     | `$mcp_server_name`        | string                                | `server._serverInfo.name`                                                                                                                                                             |
-| `ServerVersion`  | `$mcp_server_version`     | string                                | `server._serverInfo.version`                                                                                                                                                          |
-| `ClientName`     | `$mcp_client_name`        | string                                | `server.getClientVersion().name`                                                                                                                                                      |
-| `ClientVersion`  | `$mcp_client_version`     | string                                | `server.getClientVersion().version`                                                                                                                                                   |
-| `Intent`         | `$mcp_intent`             | string                                | `context` argument when present, else `intentFallback()` return                                                                                                                       |
-| `IntentSource`   | `$mcp_intent_source`      | `"context_parameter" \| "inferred"`   | Where the intent came from                                                                                                                                                            |
-| `ConversationId` | `$mcp_conversation_id`    | string                                | Optional; only set when `enableConversationId: true`                                                                                                                                  |
-| `Parameters`     | `$mcp_parameters`         | object                                | Sanitized MCP request payload (see §3)                                                                                                                                                |
-| `Response`       | `$mcp_response`           | object                                | Sanitized tool result                                                                                                                                                                 |
+| Constant          | Wire key                 | Type                                | Source                                                                                                                                                                                                                                        |
+| ----------------- | ------------------------ | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SessionId`       | `$session_id`            | string                              | `event.sessionId` (`ses_…`)                                                                                                                                                                                                                   |
+| `Source`          | `$mcp_source`            | string                              | Hardcoded `"posthog_mcp_analytics"`                                                                                                                                                                                                           |
+| `ResourceName`    | `$mcp_resource_name`     | string                              | Tool / resource / prompt name                                                                                                                                                                                                                 |
+| `ToolName`        | `$mcp_tool_name`         | string                              | Same as `ResourceName`, but **only on `$mcp_tool_call`**                                                                                                                                                                                      |
+| `ToolDescription` | `$mcp_tool_description`  | string                              | Tool's current `description` at call time. Cached from `tools/list` and (for `McpServer`) seeded from `_registeredTools`. Only on `$mcp_tool_call` and the paired `$exception` event                                                          |
+| `ToolCategory`    | `$mcp_tool_category`     | string                              | Product category declared on the tool's `_meta.category`. Cached from `tools/list` and (for `McpServer`) seeded from `_registeredTools`; `captureToolCall` takes it as `category`. Only on `$mcp_tool_call` and the paired `$exception` event |
+| `ListedToolNames` | `$mcp_listed_tool_names` | string[]                            | Names of tools advertised in a `tools/list` response. Only on `$mcp_tools_list` events.                                                                                                                                                       |
+| `DurationMs`      | `$mcp_duration_ms`       | number (ms)                         | Wall-clock duration                                                                                                                                                                                                                           |
+| `IsError`         | `$mcp_is_error`          | boolean                             | Set from tool result or thrown exception                                                                                                                                                                                                      |
+| `ServerName`      | `$mcp_server_name`       | string                              | `server._serverInfo.name`                                                                                                                                                                                                                     |
+| `ServerVersion`   | `$mcp_server_version`    | string                              | `server._serverInfo.version`                                                                                                                                                                                                                  |
+| `ClientName`      | `$mcp_client_name`       | string                              | `server.getClientVersion().name`                                                                                                                                                                                                              |
+| `ClientVersion`   | `$mcp_client_version`    | string                              | `server.getClientVersion().version`                                                                                                                                                                                                           |
+| `Intent`          | `$mcp_intent`            | string                              | `context` argument when present, else `intentFallback()` return                                                                                                                                                                               |
+| `IntentSource`    | `$mcp_intent_source`     | `"context_parameter" \| "inferred"` | Where the intent came from                                                                                                                                                                                                                    |
+| `ConversationId`  | `$mcp_conversation_id`   | string                              | Optional; only set when `enableConversationId: true`                                                                                                                                                                                          |
+| `Parameters`      | `$mcp_parameters`        | object                              | Sanitized MCP request payload (see §3)                                                                                                                                                                                                        |
+| `Response`        | `$mcp_response`          | object                              | Sanitized tool result                                                                                                                                                                                                                         |
 
 ### Person & group properties
 
-| Key                        | On                                | Source                                                                                       |
-| -------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------- |
-| `$set.<anything>`          | events with a resolved identity   | Keys of `UserIdentity.properties` (e.g. `name`, `email`), written to `$set` verbatim         |
-| `$groups`                  | every event for the session       | `UserIdentity.groups` (`{ groupType: groupKey }`) — callers never hand-write the `$groups` key |
-| `$process_person_profile`  | events with **no** resolved identity | Set to `false` so anonymous sessions don't mint a person profile each (see §4)             |
+| Key                       | On                                   | Source                                                                                         |
+| ------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `$set.<anything>`         | events with a resolved identity      | Keys of `UserIdentity.properties` (e.g. `name`, `email`), written to `$set` verbatim           |
+| `$groups`                 | every event for the session          | `UserIdentity.groups` (`{ groupType: groupKey }`) — callers never hand-write the `$groups` key |
+| `$process_person_profile` | events with **no** resolved identity | Set to `false` so anonymous sessions don't mint a person profile each (see §4)                 |
 
 ### Exception properties (`$exception` event)
 
@@ -148,17 +155,17 @@ The `eventProperties` callback returns key/value pairs that are **spread flat at
 
 The `posthog-node` client is **not** an option — it is the required positional 2nd argument to `instrument(server, posthog, options?)`. You construct and own it (host, project token, batching, lifecycle all configured there). The options below are the optional 3rd argument.
 
-| Option                       | Default                                   | Use case                                                                                                                                |
-| ---------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `logger`                     | no-op                                     | STDIO-safe log sink for SDK-internal warnings. Receives single string messages.                                                         |
-| `enableExceptionAutocapture` | `true`                                    | When `false`, a failed tool call does not emit the sibling `$exception` event.                                                          |
-| `enableConversationId`       | `false`                                   | Inject the `conversation_id` parameter into every tool and stamp `$mcp_conversation_id` on events.                                      |
-| `reportMissing`              | `false`                                   | Register the `get_more_tools` virtual tool.                                                                                             |
-| `context`                    | `true` (object form: `{ description }`)   | Inject required `context` arg into every tool schema.                                                                                   |
-| `intentFallback`             | —                                         | Consumer-supplied callback returning a `$mcp_intent` string when the client didn't pass a `context` argument. SDK does no inference.    |
-| `identify`                   | —                                         | Per-request callback returning `{ distinctId, properties?, groups? } \| null` — posthog-node's `identify` shape. `properties` → `$set`, `groups` → `$groups`. |
-| `beforeSend`                 | —                                         | `(event) => event \| null \| undefined` (sync or async), matching posthog-node. Runs on each fully-built payload right before `posthog.capture()` — once per emitted event, including the `$exception` sibling. Return nullish (or throw) to drop that event. |
-| `eventProperties`            | —                                         | Freeform JSON, spread flat.                                                                                                             |
+| Option                       | Default                                 | Use case                                                                                                                                                                                                                                                      |
+| ---------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `logger`                     | no-op                                   | STDIO-safe log sink for SDK-internal warnings. Receives single string messages.                                                                                                                                                                               |
+| `enableExceptionAutocapture` | `true`                                  | When `false`, a failed tool call does not emit the sibling `$exception` event.                                                                                                                                                                                |
+| `enableConversationId`       | `false`                                 | Inject the `conversation_id` parameter into every tool and stamp `$mcp_conversation_id` on events.                                                                                                                                                            |
+| `reportMissing`              | `false`                                 | Register the `get_more_tools` virtual tool.                                                                                                                                                                                                                   |
+| `context`                    | `true` (object form: `{ description }`) | Inject required `context` arg into every tool schema.                                                                                                                                                                                                         |
+| `intentFallback`             | —                                       | Consumer-supplied callback returning a `$mcp_intent` string when the client didn't pass a `context` argument. SDK does no inference.                                                                                                                          |
+| `identify`                   | —                                       | Per-request callback returning `{ distinctId, properties?, groups? } \| null` — posthog-node's `identify` shape. `properties` → `$set`, `groups` → `$groups`.                                                                                                 |
+| `beforeSend`                 | —                                       | `(event) => event \| null \| undefined` (sync or async), matching posthog-node. Runs on each fully-built payload right before `posthog.capture()` — once per emitted event, including the `$exception` sibling. Return nullish (or throw) to drop that event. |
+| `eventProperties`            | —                                       | Freeform JSON, spread flat.                                                                                                                                                                                                                                   |
 
 ## 8. Useful queries
 
@@ -258,16 +265,16 @@ The previous version of this SDK lived in a separate repo and depended on `posth
 
 ### Breaking changes
 
-| Concern                                | Old (standalone 0.0.x)                                          | New (monorepo 0.1.0)                                                                  |
-| -------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| PostHog client                         | Required `posthog-node` runtime dep, or BYO via `posthogClient` | BYO `posthog-node` client via the `posthog` option (matches `@posthog/ai`)            |
-| `posthogClient` option                 | Accepted any duck-typed client                                  | Renamed to `posthog`; expects a `posthog-node` `PostHog` instance                     |
-| `posthogOptions` option                | Forwarded to `posthog-node`                                     | Removed — configure the `posthog-node` client you pass in directly                    |
-| `eventTags` callback                   | Constrained string map; spread flat on events                   | Removed — fold all metadata into `eventProperties`                                    |
-| `~/posthog-mcp-analytics.log`          | SDK wrote to the user's home directory                          | Removed; pass `logger?: (msg: string) => void` if you want to capture internal logs   |
-| PostHog event names                    | Plain (`mcp_tool_call`, `mcp_custom`, `posthog_identify`, …)    | SDK events `$`-prefixed (`$mcp_tool_call`, `$identify`, …); `capture()` events keep your verbatim name |
-| `POSTHOG_MCP_ANALYTICS_HOST` env var   | Read at `instrument()` time                                          | Removed; pass `host` directly                                                         |
-| Session id source                      | `uuidv4` via `node:crypto`                                      | `uuidv7` from `@posthog/core`                                                         |
+| Concern                              | Old (standalone 0.0.x)                                          | New (monorepo 0.1.0)                                                                                   |
+| ------------------------------------ | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| PostHog client                       | Required `posthog-node` runtime dep, or BYO via `posthogClient` | BYO `posthog-node` client via the `posthog` option (matches `@posthog/ai`)                             |
+| `posthogClient` option               | Accepted any duck-typed client                                  | Renamed to `posthog`; expects a `posthog-node` `PostHog` instance                                      |
+| `posthogOptions` option              | Forwarded to `posthog-node`                                     | Removed — configure the `posthog-node` client you pass in directly                                     |
+| `eventTags` callback                 | Constrained string map; spread flat on events                   | Removed — fold all metadata into `eventProperties`                                                     |
+| `~/posthog-mcp-analytics.log`        | SDK wrote to the user's home directory                          | Removed; pass `logger?: (msg: string) => void` if you want to capture internal logs                    |
+| PostHog event names                  | Plain (`mcp_tool_call`, `mcp_custom`, `posthog_identify`, …)    | SDK events `$`-prefixed (`$mcp_tool_call`, `$identify`, …); `capture()` events keep your verbatim name |
+| `POSTHOG_MCP_ANALYTICS_HOST` env var | Read at `instrument()` time                                     | Removed; pass `host` directly                                                                          |
+| Session id source                    | `uuidv4` via `node:crypto`                                      | `uuidv7` from `@posthog/core`                                                                          |
 
 ### Insight migration checklist
 
@@ -341,26 +348,26 @@ The SDK does **not**: call an LLM, inspect tool arguments, build heuristics, or 
 
 ## File map quick reference
 
-| Concern                                          | File                                                       |
-| ------------------------------------------------ | ---------------------------------------------------------- |
-| Public API entry                                 | `src/index.ts`                                             |
-| Public types & options                           | `src/types.ts`                                             |
-| Property/event constants                         | `src/extensions/constants.ts`                                 |
-| Event serialization to PostHog                   | `src/extensions/posthog-events.ts`                            |
-| Internal event types                             | `src/extensions/event-types.ts`                               |
-| `McpEventSink` + `processMcpEvent` pipeline      | `src/extensions/sink.ts`                                      |
-| Per-server `captureEvent` helper                 | `src/extensions/capture.ts`                                  |
-| Shared tool-call lifecycle / list / initialize   | `src/extensions/instrumentation.ts`                              |
-| High-level `McpServer` wrapping (thin adapter over `instrumentation`) | `src/extensions/instrument-highlevel.ts`              |
-| Low-level `Server` wrapping (thin adapter over `instrumentation`)     | `src/extensions/instrument-lowlevel.ts`                 |
-| Intent resolution (context arg + fallback)       | `src/extensions/intent.ts`                                    |
-| Identity cache + identify dispatch               | `src/extensions/internal.ts`                                  |
-| Session id derivation & timeout                  | `src/extensions/session.ts`, `src/extensions/ids.ts`             |
-| `conversation_id` injection + minting            | `src/extensions/conversation-id.ts`                           |
-| `get_more_tools` virtual tool                    | `src/extensions/tools.ts`                                     |
-| Auto-redaction & binary stubbing                 | `src/extensions/sanitization.ts`, `src/extensions/mcp-payloads.ts` |
-| Size / depth / breadth caps                      | `src/extensions/truncation.ts`                                |
-| `context` JSON-Schema injection                  | `src/extensions/context-parameters.ts`                        |
-| STDIO-safe logger sink                           | `src/extensions/logger.ts`                                    |
-| Exception capture & stack-trace parsing          | `src/extensions/exceptions.ts`                                |
-| MCP SDK version compat shims                     | `src/extensions/compatibility.ts`, `src/extensions/mcp-sdk-compat.ts` |
+| Concern                                                               | File                                                                  |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Public API entry                                                      | `src/index.ts`                                                        |
+| Public types & options                                                | `src/types.ts`                                                        |
+| Property/event constants                                              | `src/extensions/constants.ts`                                         |
+| Event serialization to PostHog                                        | `src/extensions/posthog-events.ts`                                    |
+| Internal event types                                                  | `src/extensions/event-types.ts`                                       |
+| `McpEventSink` + `processMcpEvent` pipeline                           | `src/extensions/sink.ts`                                              |
+| Per-server `captureEvent` helper                                      | `src/extensions/capture.ts`                                           |
+| Shared tool-call lifecycle / list / initialize                        | `src/extensions/instrumentation.ts`                                   |
+| High-level `McpServer` wrapping (thin adapter over `instrumentation`) | `src/extensions/instrument-highlevel.ts`                              |
+| Low-level `Server` wrapping (thin adapter over `instrumentation`)     | `src/extensions/instrument-lowlevel.ts`                               |
+| Intent resolution (context arg + fallback)                            | `src/extensions/intent.ts`                                            |
+| Identity cache + identify dispatch                                    | `src/extensions/internal.ts`                                          |
+| Session id derivation & timeout                                       | `src/extensions/session.ts`, `src/extensions/ids.ts`                  |
+| `conversation_id` injection + minting                                 | `src/extensions/conversation-id.ts`                                   |
+| `get_more_tools` virtual tool                                         | `src/extensions/tools.ts`                                             |
+| Auto-redaction & binary stubbing                                      | `src/extensions/sanitization.ts`, `src/extensions/mcp-payloads.ts`    |
+| Size / depth / breadth caps                                           | `src/extensions/truncation.ts`                                        |
+| `context` JSON-Schema injection                                       | `src/extensions/context-parameters.ts`                                |
+| STDIO-safe logger sink                                                | `src/extensions/logger.ts`                                            |
+| Exception capture & stack-trace parsing                               | `src/extensions/exceptions.ts`                                        |
+| MCP SDK version compat shims                                          | `src/extensions/compatibility.ts`, `src/extensions/mcp-sdk-compat.ts` |

--- a/packages/mcp/src/__tests__/session-id.test.ts
+++ b/packages/mcp/src/__tests__/session-id.test.ts
@@ -1,6 +1,7 @@
 import { instrument } from '../index'
 import { getServerTrackingData } from '../extensions/internal'
-import { deriveSessionIdFromMCPSession, getServerSessionId } from '../extensions/session'
+import { deriveSessionIdFromMCPSession, getSessionId } from '../extensions/session'
+import { MCP_SESSION_HEADER, encodeSessionId } from '../extensions/session-token'
 import type { HighLevelMCPServerLike } from '../types'
 import { EventCapture, fakePostHog } from './test-utils'
 import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
@@ -62,7 +63,7 @@ describe('Session ID Management', () => {
       const extra = { sessionId: mcpSessionId }
 
       // Get session ID with MCP sessionId provided
-      const sessionId = getServerSessionId(lowLevelServer, extra)
+      const sessionId = getSessionId(lowLevelServer, extra)
 
       // Verify it's deterministically derived
       const expectedSessionId = deriveSessionIdFromMCPSession(mcpSessionId)
@@ -70,7 +71,6 @@ describe('Session ID Management', () => {
 
       // Verify tracking data is updated
       const data = getServerTrackingData(lowLevelServer)
-      expect(data?.lastMcpSessionId).toBe(mcpSessionId)
       expect(data?.sessionSource).toBe('mcp')
 
       await eventCapture.stop()
@@ -85,16 +85,15 @@ describe('Session ID Management', () => {
       const lowLevelServer = server.server
 
       // Get initial session ID without MCP sessionId
-      const sessionId1 = getServerSessionId(lowLevelServer)
+      const sessionId1 = getSessionId(lowLevelServer)
       expect(sessionId1).toMatch(SESSION_ID_PATTERN)
 
       // Verify tracking data shows PostHog MCP analytics source
       const data = getServerTrackingData(lowLevelServer)
       expect(data?.sessionSource).toBe('generated')
-      expect(data?.lastMcpSessionId).toBeUndefined()
 
       // Get session ID again - should be the same
-      const sessionId2 = getServerSessionId(lowLevelServer)
+      const sessionId2 = getSessionId(lowLevelServer)
       expect(sessionId2).toBe(sessionId1)
 
       await eventCapture.stop()
@@ -110,7 +109,7 @@ describe('Session ID Management', () => {
       const lowLevelServer = server.server
 
       // Start with no MCP sessionId
-      const generatedSessionId = getServerSessionId(lowLevelServer)
+      const generatedSessionId = getSessionId(lowLevelServer)
       expect(generatedSessionId).toMatch(SESSION_ID_PATTERN)
 
       let data = getServerTrackingData(lowLevelServer)
@@ -118,7 +117,7 @@ describe('Session ID Management', () => {
 
       // Now provide MCP sessionId
       const extra = { sessionId: mcpSessionId }
-      const mcpDerivedSessionId = getServerSessionId(lowLevelServer, extra)
+      const mcpDerivedSessionId = getSessionId(lowLevelServer, extra)
 
       // Verify it switched to MCP-derived ID
       const expectedSessionId = deriveSessionIdFromMCPSession(mcpSessionId)
@@ -127,7 +126,6 @@ describe('Session ID Management', () => {
 
       // Verify tracking data is updated
       data = getServerTrackingData(lowLevelServer)
-      expect(data?.lastMcpSessionId).toBe(mcpSessionId)
       expect(data?.sessionSource).toBe('mcp')
 
       await eventCapture.stop()
@@ -144,13 +142,13 @@ describe('Session ID Management', () => {
 
       // Provide MCP sessionId
       const extra = { sessionId: mcpSessionId }
-      const mcpDerivedSessionId = getServerSessionId(lowLevelServer, extra)
+      const mcpDerivedSessionId = getSessionId(lowLevelServer, extra)
 
       const expectedSessionId = deriveSessionIdFromMCPSession(mcpSessionId)
       expect(mcpDerivedSessionId).toBe(expectedSessionId)
 
       // Now call without MCP sessionId (it disappeared)
-      const sessionIdAfterDisappear = getServerSessionId(lowLevelServer)
+      const sessionIdAfterDisappear = getSessionId(lowLevelServer)
 
       // Should keep using the last derived sessionId
       expect(sessionIdAfterDisappear).toBe(mcpDerivedSessionId)
@@ -158,7 +156,6 @@ describe('Session ID Management', () => {
       // Verify tracking data still shows MCP source
       const data = getServerTrackingData(lowLevelServer)
       expect(data?.sessionSource).toBe('mcp')
-      expect(data?.lastMcpSessionId).toBe(mcpSessionId)
 
       await eventCapture.stop()
     })
@@ -175,14 +172,14 @@ describe('Session ID Management', () => {
 
       // Provide first MCP sessionId
       const extra1 = { sessionId: mcpSessionId1 }
-      const sessionId1 = getServerSessionId(lowLevelServer, extra1)
+      const sessionId1 = getSessionId(lowLevelServer, extra1)
 
       const expectedSessionId1 = deriveSessionIdFromMCPSession(mcpSessionId1)
       expect(sessionId1).toBe(expectedSessionId1)
 
       // Change to second MCP sessionId
       const extra2 = { sessionId: mcpSessionId2 }
-      const sessionId2 = getServerSessionId(lowLevelServer, extra2)
+      const sessionId2 = getSessionId(lowLevelServer, extra2)
 
       const expectedSessionId2 = deriveSessionIdFromMCPSession(mcpSessionId2)
       expect(sessionId2).toBe(expectedSessionId2)
@@ -190,7 +187,6 @@ describe('Session ID Management', () => {
 
       // Verify tracking data is updated
       const data = getServerTrackingData(lowLevelServer)
-      expect(data?.lastMcpSessionId).toBe(mcpSessionId2)
       expect(data?.sessionSource).toBe('mcp')
 
       await eventCapture.stop()
@@ -209,7 +205,7 @@ describe('Session ID Management', () => {
 
       // Get MCP-derived session ID
       const extra = { sessionId: mcpSessionId }
-      const sessionId1 = getServerSessionId(lowLevelServer, extra)
+      const sessionId1 = getSessionId(lowLevelServer, extra)
 
       // Manually set lastActivity to simulate timeout (31 minutes ago)
       const data = getServerTrackingData(lowLevelServer)
@@ -218,7 +214,7 @@ describe('Session ID Management', () => {
       }
 
       // Get session ID again with same MCP sessionId
-      const sessionId2 = getServerSessionId(lowLevelServer, extra)
+      const sessionId2 = getSessionId(lowLevelServer, extra)
 
       // Should still be the same (no timeout for MCP sessions)
       expect(sessionId2).toBe(sessionId1)
@@ -235,7 +231,7 @@ describe('Session ID Management', () => {
       const lowLevelServer = server.server
 
       // Get PostHog MCP analytics-generated session ID
-      const sessionId1 = getServerSessionId(lowLevelServer)
+      const sessionId1 = getSessionId(lowLevelServer)
 
       // Manually set lastActivity to simulate timeout (31 minutes ago)
       const data = getServerTrackingData(lowLevelServer)
@@ -244,13 +240,96 @@ describe('Session ID Management', () => {
       }
 
       // Get session ID again without MCP sessionId
-      const sessionId2 = getServerSessionId(lowLevelServer)
+      const sessionId2 = getSessionId(lowLevelServer)
 
       // Should be different (timeout occurred)
       expect(sessionId2).not.toBe(sessionId1)
       expect(sessionId2).toMatch(SESSION_ID_PATTERN)
 
       await eventCapture.stop()
+    })
+  })
+
+  describe('Self-encoded session token resolution', () => {
+    const tokenPayload = { sessionId: 'ses_0199f41e7a2e', clientName: 'TokenClient', clientVersion: '9.9.9' }
+
+    it('recovers the session id and client info from a token in the request headers (stateless replay)', () => {
+      instrument(server, fakePostHog())
+      const lowLevelServer = server.server
+
+      const token = encodeSessionId(tokenPayload)
+      const extra = { requestInfo: { headers: { [MCP_SESSION_HEADER]: token } } }
+
+      const sessionId = getSessionId(lowLevelServer, extra)
+
+      expect(sessionId).toBe(tokenPayload.sessionId)
+      const data = getServerTrackingData(lowLevelServer)
+      expect(data?.sessionSource).toBe('token')
+      expect(data?.sessionInfo.clientName).toBe('TokenClient')
+      expect(data?.sessionInfo.clientVersion).toBe('9.9.9')
+    })
+
+    it('treats a token in extra.sessionId as a plain transport id (tokens only count from the header)', () => {
+      instrument(server, fakePostHog())
+      const lowLevelServer = server.server
+
+      const token = encodeSessionId(tokenPayload)
+      const sessionId = getSessionId(lowLevelServer, { sessionId: token })
+
+      expect(sessionId).toBe(deriveSessionIdFromMCPSession(token))
+      expect(getServerTrackingData(lowLevelServer)?.sessionSource).toBe('mcp')
+    })
+
+    it('leaves non-token session ids on the hash path', () => {
+      instrument(server, fakePostHog())
+      const lowLevelServer = server.server
+
+      const sessionId = getSessionId(lowLevelServer, { sessionId: 'plain-mcp-session' })
+
+      expect(sessionId).toBe(deriveSessionIdFromMCPSession('plain-mcp-session'))
+      expect(getServerTrackingData(lowLevelServer)?.sessionSource).toBe('mcp')
+    })
+
+    it('ignores a non-token header when the transport supplies no sessionId', () => {
+      instrument(server, fakePostHog())
+      const lowLevelServer = server.server
+
+      const extra = { requestInfo: { headers: { [MCP_SESSION_HEADER]: 'not-a-token-uuid' } } }
+      const sessionId = getSessionId(lowLevelServer, extra)
+
+      expect(sessionId).toMatch(SESSION_ID_PATTERN)
+      expect(getServerTrackingData(lowLevelServer)?.sessionSource).toBe('generated')
+    })
+
+    it('keeps the token-derived session id when a later request arrives bare', () => {
+      instrument(server, fakePostHog())
+      const lowLevelServer = server.server
+
+      const token = encodeSessionId(tokenPayload)
+      const first = getSessionId(lowLevelServer, {
+        requestInfo: { headers: { [MCP_SESSION_HEADER]: token } },
+      })
+      const second = getSessionId(lowLevelServer)
+
+      expect(second).toBe(first)
+      expect(getServerTrackingData(lowLevelServer)?.sessionSource).toBe('token')
+    })
+
+    it('does NOT apply the inactivity rollover to token-derived sessions', () => {
+      instrument(server, fakePostHog())
+      const lowLevelServer = server.server
+
+      const token = encodeSessionId(tokenPayload)
+      const extra = { requestInfo: { headers: { [MCP_SESSION_HEADER]: token } } }
+      const first = getSessionId(lowLevelServer, extra)
+
+      const data = getServerTrackingData(lowLevelServer)
+      if (data) {
+        data.lastActivity = new Date(Date.now() - 31 * 60 * 1000)
+      }
+
+      expect(getSessionId(lowLevelServer, extra)).toBe(first)
+      expect(getSessionId(lowLevelServer)).toBe(first)
     })
   })
 

--- a/packages/mcp/src/__tests__/session-token.test.ts
+++ b/packages/mcp/src/__tests__/session-token.test.ts
@@ -1,0 +1,164 @@
+import {
+  MCP_SESSION_HEADER,
+  decodeSessionId,
+  encodeSessionId,
+  readMcpSessionHeader,
+  writeSessionIdToTransport,
+  type SessionTokenPayload,
+} from '../extensions/session-token'
+
+/** Builds a raw wire value (base64url JSON) — the only place short keys exist. */
+const wire = (value: unknown): string => Buffer.from(JSON.stringify(value), 'utf8').toString('base64url')
+
+describe('session token codec', () => {
+  describe('encodeSessionId / decodeSessionId round trip', () => {
+    it('round-trips a session-id-only payload', () => {
+      const token = encodeSessionId({ sessionId: 'ses_0199aabb' })
+      expect(decodeSessionId(token)).toEqual({ sessionId: 'ses_0199aabb' })
+    })
+
+    it('round-trips session id + client name/version', () => {
+      const payload: SessionTokenPayload = { sessionId: 'ses_0199aabb', clientName: 'Claude', clientVersion: '1.2.3' }
+      expect(decodeSessionId(encodeSessionId(payload))).toEqual(payload)
+    })
+
+    it('round-trips unicode client names', () => {
+      const payload: SessionTokenPayload = {
+        sessionId: 'ses_0199aabb',
+        clientName: 'Клиент 😀 客户端',
+        clientVersion: '1.0',
+      }
+      const token = encodeSessionId(payload)
+      // The header value itself must stay visible-ASCII per the MCP spec.
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/)
+      expect(decodeSessionId(token)).toEqual(payload)
+    })
+
+    it('clamps oversized client fields at encode time', () => {
+      const token = encodeSessionId({ sessionId: 'ses_x', clientName: 'a'.repeat(500), clientVersion: 'b'.repeat(500) })
+      const decoded = decodeSessionId(token)
+      expect(decoded?.clientName).toHaveLength(200)
+      expect(decoded?.clientVersion).toHaveLength(200)
+    })
+
+    it('omits missing client fields', () => {
+      const token = encodeSessionId({ sessionId: 'ses_x', clientName: undefined, clientVersion: undefined })
+      expect(decodeSessionId(token)).toEqual({ sessionId: 'ses_x' })
+    })
+
+    it('throws on a missing session id (public API misuse)', () => {
+      expect(() => encodeSessionId({ sessionId: '' })).toThrow()
+      expect(() => encodeSessionId(undefined as unknown as SessionTokenPayload)).toThrow()
+    })
+
+    it('encodes and decodes identically without Buffer (edge runtimes)', () => {
+      const payload: SessionTokenPayload = { sessionId: 'ses_0199aabb', clientName: 'Клиент 😀', clientVersion: '1.0' }
+      const withBuffer = encodeSessionId(payload)
+
+      const g = globalThis as { Buffer?: typeof Buffer }
+      const originalBuffer = g.Buffer
+      delete g.Buffer
+      try {
+        expect(typeof Buffer).toBe('undefined')
+        expect(encodeSessionId(payload)).toBe(withBuffer)
+        expect(decodeSessionId(withBuffer)).toEqual(payload)
+      } finally {
+        g.Buffer = originalBuffer
+      }
+    })
+  })
+
+  describe('decodeSessionId strictness', () => {
+    it.each([
+      ['a plain UUID', '550e8400-e29b-41d4-a716-446655440000'],
+      ['an SDK-generated session id', 'ses_0199aabbccdd'],
+      ['a JWT-shaped value', 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig'],
+      ['a value with invalid characters', 'not a token!'],
+      ['base64url of non-JSON', Buffer.from('not json at all', 'utf8').toString('base64url')],
+      ['an empty string', ''],
+    ])('returns null for %s', (_label, value) => {
+      expect(decodeSessionId(value)).toBeNull()
+    })
+
+    it('returns null for non-string inputs', () => {
+      expect(decodeSessionId(undefined)).toBeNull()
+      expect(decodeSessionId(null)).toBeNull()
+      expect(decodeSessionId(42)).toBeNull()
+      expect(decodeSessionId(['a'])).toBeNull()
+    })
+
+    it('returns null for JSON that is not a token object', () => {
+      expect(decodeSessionId(wire(['ses_x']))).toBeNull()
+      expect(decodeSessionId(wire('ses_x'))).toBeNull()
+      expect(decodeSessionId(wire(null))).toBeNull()
+      expect(decodeSessionId(wire({ cn: 'no sid' }))).toBeNull()
+      expect(decodeSessionId(wire({ sid: 42 }))).toBeNull()
+      expect(decodeSessionId(wire({ sid: '' }))).toBeNull()
+      expect(decodeSessionId(wire({ sid: 'x'.repeat(200) }))).toBeNull()
+    })
+
+    it('returns null for oversized header values', () => {
+      const huge = wire({ sid: 'ses_x', cn: 'y'.repeat(8000) })
+      expect(huge.length).toBeGreaterThan(4096)
+      expect(decodeSessionId(huge)).toBeNull()
+    })
+
+    it('keeps the session id but drops malformed client fields', () => {
+      expect(decodeSessionId(wire({ sid: 'ses_x', cn: 42, cv: {} }))).toEqual({ sessionId: 'ses_x' })
+    })
+  })
+
+  describe('readMcpSessionHeader', () => {
+    it('reads the lowercased header', () => {
+      expect(readMcpSessionHeader({ [MCP_SESSION_HEADER]: 'abc' })).toBe('abc')
+    })
+
+    it('falls back to a case-insensitive match', () => {
+      expect(readMcpSessionHeader({ 'Mcp-Session-Id': 'abc' })).toBe('abc')
+    })
+
+    it('takes the first element of a multi-value header', () => {
+      expect(readMcpSessionHeader({ [MCP_SESSION_HEADER]: ['abc', 'def'] })).toBe('abc')
+    })
+
+    it('returns undefined for missing/empty/non-object inputs', () => {
+      expect(readMcpSessionHeader({})).toBeUndefined()
+      expect(readMcpSessionHeader({ [MCP_SESSION_HEADER]: '' })).toBeUndefined()
+      expect(readMcpSessionHeader({ [MCP_SESSION_HEADER]: '   ' })).toBeUndefined()
+      expect(readMcpSessionHeader({ [MCP_SESSION_HEADER]: 42 })).toBeUndefined()
+      expect(readMcpSessionHeader(undefined)).toBeUndefined()
+      expect(readMcpSessionHeader('headers')).toBeUndefined()
+    })
+  })
+
+  describe('writeSessionIdToTransport', () => {
+    it('writes to a plain mutable sessionId (web-standard transport shape)', () => {
+      const transport: { sessionId?: string } = {}
+      expect(writeSessionIdToTransport(transport, 'tok')).toBe(true)
+      expect(transport.sessionId).toBe('tok')
+    })
+
+    it('writes through _webStandardTransport when sessionId is getter-only (Node wrapper shape)', () => {
+      const inner: { sessionId?: string } = {}
+      const wrapper: { _webStandardTransport: typeof inner; sessionId?: string } = { _webStandardTransport: inner }
+      Object.defineProperty(wrapper, 'sessionId', {
+        get: () => inner.sessionId,
+        configurable: true,
+      })
+
+      expect(writeSessionIdToTransport(wrapper, 'tok')).toBe(true)
+      expect(inner.sessionId).toBe('tok')
+      expect(wrapper.sessionId).toBe('tok')
+    })
+
+    it('returns false without throwing when nothing is writable', () => {
+      const gettersOnly = {}
+      Object.defineProperty(gettersOnly, 'sessionId', { get: () => undefined, configurable: true })
+      expect(writeSessionIdToTransport(gettersOnly, 'tok')).toBe(false)
+
+      expect(writeSessionIdToTransport(Object.freeze({}), 'tok')).toBe(false)
+      expect(writeSessionIdToTransport(undefined, 'tok')).toBe(false)
+      expect(writeSessionIdToTransport('transport', 'tok')).toBe(false)
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/stateless-session.test.ts
+++ b/packages/mcp/src/__tests__/stateless-session.test.ts
@@ -1,0 +1,199 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { instrument } from '../index'
+import { getServerTrackingData } from '../extensions/internal'
+import { decodeSessionId } from '../extensions/session-token'
+import type { CompatibleRequestHandlerExtra, MCPRequestLike, MCPServerLike } from '../types'
+import { EventCapture, fakePostHog } from './test-utils'
+
+/**
+ * Stateless / multi-pod coverage: `initialize` mints an `Mcp-Session-Id` token,
+ * and later requests — even on other pods — decode the same session and client
+ * identity from it.
+ *
+ * Patched handlers are invoked directly with hand-crafted `extra` objects
+ * (matching session-id.test.ts), which is what the SDK does after routing.
+ */
+
+const INITIALIZE_REQUEST: MCPRequestLike = {
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'Claude', version: '1.2.3' },
+  },
+}
+
+/** A stateless "pod": fresh instrumented low-level Server with an echo tool. */
+function createPod(podName: string): { server: Server; lowLevel: MCPServerLike } {
+  const server = new Server({ name: podName, version: '1.0.0' }, { capabilities: { tools: {} } })
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [{ name: 'echo', description: 'Echo', inputSchema: { type: 'object', properties: {} } }],
+  }))
+  server.setRequestHandler(CallToolRequestSchema, async (request) => ({
+    content: [{ type: 'text', text: `echo: ${(request.params?.arguments as { text?: string })?.text ?? ''}` }],
+  }))
+  instrument(server, fakePostHog())
+  return { server, lowLevel: server as unknown as MCPServerLike }
+}
+
+function setFakeTransport(server: Server, transport: unknown): void {
+  ;(server as unknown as { _transport?: unknown })._transport = transport
+}
+
+async function invokeHandler(
+  lowLevel: MCPServerLike,
+  method: string,
+  request: MCPRequestLike,
+  extra?: CompatibleRequestHandlerExtra
+): Promise<unknown> {
+  const handler = lowLevel._requestHandlers.get(method)
+  if (!handler) {
+    throw new Error(`No handler registered for ${method}`)
+  }
+  const result = await handler(request, extra)
+  // captureEvent publishes fire-and-forget; let the sink drain.
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  return result
+}
+
+describe('Stateless session minting', () => {
+  let eventCapture: EventCapture
+
+  beforeEach(async () => {
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+  })
+
+  afterEach(async () => {
+    await eventCapture.stop()
+  })
+
+  it('mints a decodable token onto a writable transport and uses its sid for $mcp_initialize', async () => {
+    const { server, lowLevel } = createPod('pod-mint')
+    const transport: { sessionId?: string } = {}
+    setFakeTransport(server, transport)
+
+    await invokeHandler(lowLevel, 'initialize', INITIALIZE_REQUEST, { requestInfo: { headers: {} } })
+
+    const decoded = decodeSessionId(transport.sessionId)
+    expect(decoded).not.toBeNull()
+    expect(decoded?.clientName).toBe('Claude')
+    expect(decoded?.clientVersion).toBe('1.2.3')
+
+    const data = getServerTrackingData(lowLevel)
+    expect(data?.sessionSource).toBe('token')
+    expect(data?.sessionId).toBe(decoded?.sessionId)
+
+    const initEvents = eventCapture.findCapturesByEvent('$mcp_initialize')
+    expect(initEvents).toHaveLength(1)
+    expect(initEvents[0].properties.$session_id).toBe(decoded?.sessionId)
+    expect(initEvents[0].properties.$mcp_client_name).toBe('Claude')
+    expect(initEvents[0].properties.$mcp_client_version).toBe('1.2.3')
+  })
+
+  it('mints through a getter-only wrapper transport (Node StreamableHTTP shape)', async () => {
+    const { server, lowLevel } = createPod('pod-wrapper')
+    const inner: { sessionId?: string } = {}
+    const wrapper: { _webStandardTransport: typeof inner; sessionId?: string } = { _webStandardTransport: inner }
+    Object.defineProperty(wrapper, 'sessionId', { get: () => inner.sessionId, configurable: true })
+    setFakeTransport(server, wrapper)
+
+    await invokeHandler(lowLevel, 'initialize', INITIALIZE_REQUEST, { requestInfo: { headers: {} } })
+
+    const decoded = decodeSessionId(inner.sessionId)
+    expect(decoded).not.toBeNull()
+    expect(getServerTrackingData(lowLevel)?.sessionId).toBe(decoded?.sessionId)
+  })
+
+  describe('mint guards', () => {
+    it('does not mint without requestInfo (stdio / in-memory transports)', async () => {
+      const { server, lowLevel } = createPod('pod-stdio')
+      const transport: { sessionId?: string } = {}
+      setFakeTransport(server, transport)
+
+      await invokeHandler(lowLevel, 'initialize', INITIALIZE_REQUEST, undefined)
+
+      expect(transport.sessionId).toBeUndefined()
+      expect(getServerTrackingData(lowLevel)?.sessionSource).toBe('generated')
+    })
+
+    it('does not mint when the client already sent a session id header', async () => {
+      const { server, lowLevel } = createPod('pod-replay')
+      const transport: { sessionId?: string } = {}
+      setFakeTransport(server, transport)
+
+      await invokeHandler(lowLevel, 'initialize', INITIALIZE_REQUEST, {
+        requestInfo: { headers: { 'mcp-session-id': 'client-supplied' } },
+      })
+
+      expect(transport.sessionId).toBeUndefined()
+    })
+
+    it('does not mint over a stateful transport that owns its session id', async () => {
+      const { server, lowLevel } = createPod('pod-stateful')
+      const transport: { sessionId?: string } = { sessionId: 'transport-owned-uuid' }
+      setFakeTransport(server, transport)
+
+      await invokeHandler(lowLevel, 'initialize', INITIALIZE_REQUEST, {
+        sessionId: 'transport-owned-uuid',
+        requestInfo: { headers: {} },
+      })
+
+      expect(transport.sessionId).toBe('transport-owned-uuid')
+      expect(getServerTrackingData(lowLevel)?.sessionSource).toBe('mcp')
+    })
+
+    it('does not mint (and does not throw) without a transport', async () => {
+      const { lowLevel } = createPod('pod-transportless')
+
+      await invokeHandler(lowLevel, 'initialize', INITIALIZE_REQUEST, { requestInfo: { headers: {} } })
+
+      expect(getServerTrackingData(lowLevel)?.sessionSource).toBe('generated')
+    })
+
+    it('leaves session state untouched when the transport write fails', async () => {
+      const { server, lowLevel } = createPod('pod-frozen')
+      setFakeTransport(server, Object.freeze({}))
+
+      await invokeHandler(lowLevel, 'initialize', INITIALIZE_REQUEST, { requestInfo: { headers: {} } })
+
+      const data = getServerTrackingData(lowLevel)
+      expect(data?.sessionSource).toBe('generated')
+    })
+  })
+
+  it('attributes a tool call on a different pod to the minted session and client (multi-pod)', async () => {
+    // Pod A handles initialize and mints the token.
+    const podA = createPod('pod-a')
+    const transportA: { sessionId?: string } = {}
+    setFakeTransport(podA.server, transportA)
+    await invokeHandler(podA.lowLevel, 'initialize', INITIALIZE_REQUEST, { requestInfo: { headers: {} } })
+
+    const token = transportA.sessionId
+    const decoded = decodeSessionId(token)
+    expect(decoded).not.toBeNull()
+
+    // Pod B shares nothing with pod A — the client replays the token header.
+    const podB = createPod('pod-b')
+    expect(podB.lowLevel.getClientVersion()).toBeUndefined()
+
+    await invokeHandler(
+      podB.lowLevel,
+      'tools/call',
+      { method: 'tools/call', params: { name: 'echo', arguments: { text: 'hi' } } },
+      { requestInfo: { headers: { 'mcp-session-id': token } } }
+    )
+
+    const initEvents = eventCapture.findCapturesByEvent('$mcp_initialize')
+    const toolCalls = eventCapture.findCapturesByEvent('$mcp_tool_call')
+    expect(initEvents).toHaveLength(1)
+    expect(toolCalls).toHaveLength(1)
+
+    // Same session across pods, client identity recovered from the token alone.
+    expect(toolCalls[0].properties.$session_id).toBe(decoded?.sessionId)
+    expect(toolCalls[0].properties.$session_id).toBe(initEvents[0].properties.$session_id)
+    expect(toolCalls[0].properties.$mcp_client_name).toBe('Claude')
+    expect(toolCalls[0].properties.$mcp_client_version).toBe('1.2.3')
+  })
+})

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -3,7 +3,14 @@
 // Licensed under the MIT License: https://github.com/MCPCat/mcpcat-typescript-sdk/blob/main/LICENSE
 
 import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
-import type { CompatibleRequestHandlerExtra, MCPAnalyticsData, MCPRequestLike, MCPServerLike, McpEvent } from '../types'
+import type {
+  CompatibleRequestHandlerExtra,
+  MCPAnalyticsData,
+  MCPRequestLike,
+  MCPServerLike,
+  McpEvent,
+  ServerClientInfoLike,
+} from '../types'
 import { addContextParameterToTools, getContextDescription, isContextEnabled } from './context-parameters'
 import {
   addConversationIdToTools,
@@ -17,11 +24,12 @@ import { captureEvent } from './capture'
 import { MCPAnalyticsEventType } from './event-types'
 import { captureException } from './exceptions'
 import { resolveToolCallIntent, setEventIntent, setExplicitContextIntent } from './intent'
-import { getServerTrackingData, handleIdentify } from './internal'
+import { getServerTrackingData, handleIdentify, setServerTrackingData } from './internal'
 import { log } from './logger'
 import { buildCapturedMcpParameters } from './mcp-payloads'
 import { getLiteralValue, getObjectShape } from './mcp-sdk-compat'
-import { getServerSessionId } from './session'
+import { getSessionId, newSessionId } from './session'
+import { encodeSessionId, readMcpSessionHeader, writeSessionIdToTransport } from './session-token'
 import { getReportMissingToolDescriptor, resolveMissingCapabilityToolName } from './tools'
 import { applyResolvedMetadata, isToolResultError } from './tracing-helpers'
 
@@ -129,7 +137,7 @@ async function prepareToolCallEvent(
   eventType: MCPAnalyticsEventType
 ): Promise<McpEvent | null> {
   try {
-    const sessionId = getServerSessionId(server, extra)
+    const sessionId = getSessionId(server, extra)
     await handleIdentify(server, data, sessionId, request, extra)
 
     const toolName = request.params?.name
@@ -283,7 +291,7 @@ export async function handleListToolsRequest(
   const data = getServerTrackingData(server)
   const startTime = new Date()
   const event: McpEvent = {
-    sessionId: getServerSessionId(server, extra),
+    sessionId: getSessionId(server, extra),
     parameters: buildCapturedMcpParameters(request),
     eventType: MCPAnalyticsEventType.mcpToolsList,
     timestamp: startTime,
@@ -411,6 +419,71 @@ export function cacheToolCategories(cache: Map<string, string>, tools: ListTools
 // --- initialize -----------------------------------------------------------
 
 /**
+ * Stateless servers never issue a session id, so sessions fragment and the
+ * client name/version is lost after `initialize`. Fix: mint the
+ * `Mcp-Session-Id` response header as a token carrying both. Clients replay
+ * the header on every request, so any pod recovers them with no server-side
+ * store (decoded in `getSessionId`).
+ *
+ * The header only reaches the wire when response headers are built after the
+ * handler runs — StreamableHTTP with `enableJsonResponse: true`. SSE flushes
+ * headers first; those servers set the header themselves with the exported
+ * `encodeSessionId`, and this mint is a harmless no-op.
+ */
+function mintStatelessSessionOnInitialize(
+  server: MCPServerLike,
+  data: MCPAnalyticsData,
+  request: MCPRequestLike,
+  extra: CompatibleRequestHandlerExtra | undefined
+): void {
+  try {
+    const headers = extra?.requestInfo?.headers
+    if (!headers || typeof headers !== 'object') {
+      return // not an HTTP transport (stdio/in-memory) — nothing to mint into
+    }
+    if (readMcpSessionHeader(headers)) {
+      return // client already replays a session id (ours or the transport's)
+    }
+    const transport = server.transport
+    if (!transport || extra?.sessionId || transport.sessionId) {
+      return // stateful transports manage their own session id — leave it alone
+    }
+
+    const sessionId = newSessionId()
+    const clientInfo = readInitializeClientInfo(request)
+    const token = encodeSessionId({ sessionId, clientName: clientInfo?.name, clientVersion: clientInfo?.version })
+    if (!writeSessionIdToTransport(transport, token)) {
+      return // transport can't carry a response session id — keep generated behavior
+    }
+
+    data.sessionId = sessionId
+    data.sessionSource = 'token'
+    data.sessionInfo.clientName = clientInfo?.name
+    data.sessionInfo.clientVersion = clientInfo?.version
+    data.lastActivity = new Date()
+    setServerTrackingData(server, data)
+  } catch (error) {
+    log(`Warning: PostHog MCP analytics failed to mint a stateless session id - ${error}`)
+  }
+}
+
+/**
+ * Read the client name/version off the `initialize` request body — the SDK
+ * hasn't stored it yet (`getClientVersion()`) when our patch runs.
+ */
+function readInitializeClientInfo(request: MCPRequestLike): ServerClientInfoLike | undefined {
+  const clientInfo = request.params?.clientInfo
+  if (!clientInfo || typeof clientInfo !== 'object') {
+    return undefined
+  }
+  const { name, version } = clientInfo as Record<string, unknown>
+  return {
+    name: typeof name === 'string' ? name : undefined,
+    version: typeof version === 'string' ? version : undefined,
+  }
+}
+
+/**
  * Captures the connection handshake (and resolves identity) on `initialize`
  * before the original handler runs.
  */
@@ -428,7 +501,9 @@ export async function handleInitializeRequest(
     return await originalInitializeHandler(request, extra)
   }
 
-  const sessionId = getServerSessionId(server, extra)
+  // Mint first so the `$mcp_initialize` event below already carries the minted id.
+  mintStatelessSessionOnInitialize(server, data, request, extra)
+  const sessionId = getSessionId(server, extra)
   await handleIdentify(server, data, sessionId, request, extra)
 
   const event: McpEvent = {

--- a/packages/mcp/src/extensions/session-token.ts
+++ b/packages/mcp/src/extensions/session-token.ts
@@ -1,0 +1,168 @@
+/**
+ * Self-encoded session tokens for stateless / multi-pod MCP servers.
+ *
+ * A stateless server keeps nothing between requests, so every request starts a
+ * new session and the client name/version (only sent at `initialize`) is lost.
+ * The one value clients replay on every request is the `Mcp-Session-Id` header.
+ * So at `initialize` we mint that header as a token carrying the session id and
+ * client identity — any pod can read them back from the header alone.
+ *
+ * The token is unsigned: it holds only what the client already self-reports.
+ */
+
+export const MCP_SESSION_HEADER = 'mcp-session-id'
+
+/** What a session token carries. */
+export interface SessionTokenPayload {
+  /** PostHog session id (`ses_…`) → `$session_id`. */
+  sessionId: string
+  /** MCP client name → `$mcp_client_name`. */
+  clientName?: string
+  /** MCP client version → `$mcp_client_version`. */
+  clientVersion?: string
+}
+
+// On the wire the token is base64url(JSON) with shortened keys to keep the
+// header small: sid = sessionId, cn = clientName, cv = clientVersion.
+const MAX_TOKEN_LENGTH = 4096
+const MAX_SESSION_ID_LENGTH = 128
+const MAX_CLIENT_FIELD_LENGTH = 200
+
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+={0,2}$/
+
+/**
+ * Encodes a session token for the `Mcp-Session-Id` response header. Also
+ * exported for SSE servers, which flush headers before handlers run and so
+ * must set the header themselves at the HTTP layer.
+ */
+export function encodeSessionId(payload: SessionTokenPayload): string {
+  if (!payload || typeof payload.sessionId !== 'string' || payload.sessionId.length === 0) {
+    throw new Error('encodeSessionId requires a non-empty `sessionId` (use newSessionId())')
+  }
+  const wire: Record<string, string> = { sid: payload.sessionId }
+  if (typeof payload.clientName === 'string' && payload.clientName.length > 0) {
+    wire.cn = payload.clientName.slice(0, MAX_CLIENT_FIELD_LENGTH)
+  }
+  if (typeof payload.clientVersion === 'string' && payload.clientVersion.length > 0) {
+    wire.cv = payload.clientVersion.slice(0, MAX_CLIENT_FIELD_LENGTH)
+  }
+  return utf8ToBase64Url(JSON.stringify(wire))
+}
+
+/**
+ * Decodes an `Mcp-Session-Id` value into a token payload. Returns `null` for
+ * anything that isn't one of our tokens (transport UUIDs, JWTs, garbage) and
+ * never throws.
+ */
+export function decodeSessionId(value: unknown): SessionTokenPayload | null {
+  if (typeof value !== 'string' || value.length === 0 || value.length > MAX_TOKEN_LENGTH) {
+    return null
+  }
+  // JWTs carry dots; UUIDs pass this check but fail JSON.parse below.
+  if (!BASE64URL_PATTERN.test(value)) {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(base64UrlToUtf8(value))
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null
+  }
+  const wire = parsed as Record<string, unknown>
+  if (typeof wire.sid !== 'string' || wire.sid.length === 0 || wire.sid.length > MAX_SESSION_ID_LENGTH) {
+    return null
+  }
+  const payload: SessionTokenPayload = { sessionId: wire.sid }
+  // A bad cn/cv just means no client info — it does not reject the token.
+  if (typeof wire.cn === 'string' && wire.cn.length > 0) {
+    payload.clientName = wire.cn.slice(0, MAX_CLIENT_FIELD_LENGTH)
+  }
+  if (typeof wire.cv === 'string' && wire.cv.length > 0) {
+    payload.clientVersion = wire.cv.slice(0, MAX_CLIENT_FIELD_LENGTH)
+  }
+  return payload
+}
+
+/**
+ * Reads the `mcp-session-id` header off `extra.requestInfo.headers`. The SDK
+ * transports lowercase header keys; the fallback scan covers hand-built extras.
+ */
+export function readMcpSessionHeader(headers: unknown): string | undefined {
+  if (!headers || typeof headers !== 'object') {
+    return undefined
+  }
+  const record = headers as Record<string, unknown>
+  let value = record[MCP_SESSION_HEADER]
+  if (value === undefined) {
+    const key = Object.keys(record).find((k) => k.toLowerCase() === MCP_SESSION_HEADER)
+    value = key === undefined ? undefined : record[key]
+  }
+  const first = Array.isArray(value) ? value[0] : value
+  if (typeof first !== 'string') {
+    return undefined
+  }
+  const trimmed = first.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * Puts a minted token on the transport so it goes out as the `Mcp-Session-Id`
+ * response header. The Node transport's `sessionId` is a getter backed by an
+ * inner web-standard transport, so verify the write by reading back and fall
+ * back to writing the inner one. Returns whether the write stuck; never throws.
+ */
+export function writeSessionIdToTransport(transport: unknown, token: string): boolean {
+  if (!transport || typeof transport !== 'object') {
+    return false
+  }
+  const outer = transport as { sessionId?: string; _webStandardTransport?: unknown }
+  try {
+    outer.sessionId = token
+  } catch {
+    // getter-only wrapper — try the inner transport below
+  }
+  if (outer.sessionId === token) {
+    return true
+  }
+  const inner = outer._webStandardTransport
+  if (inner && typeof inner === 'object') {
+    try {
+      ;(inner as { sessionId?: string }).sessionId = token
+    } catch {
+      // read-only inner transport — the final read-back decides
+    }
+  }
+  return outer.sessionId === token
+}
+
+// base64url without assuming Node: Buffer where available, TextEncoder/btoa on
+// edge runtimes. Must survive non-ASCII client names.
+
+function utf8ToBase64Url(input: string): string {
+  if (typeof Buffer !== 'undefined' && typeof Buffer.from === 'function') {
+    return Buffer.from(input, 'utf8').toString('base64url')
+  }
+  const bytes = new TextEncoder().encode(input)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlToUtf8(input: string): string {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/').replace(/=+$/, '')
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
+  if (typeof Buffer !== 'undefined' && typeof Buffer.from === 'function') {
+    return Buffer.from(padded, 'base64').toString('utf8')
+  }
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return new TextDecoder().decode(bytes)
+}

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -13,6 +13,7 @@ import type {
 import { INACTIVITY_TIMEOUT_IN_MINUTES } from './constants'
 import { deterministicPrefixedId, newPrefixedId } from './ids'
 import { getServerTrackingData, setServerTrackingData } from './internal'
+import { decodeSessionId, readMcpSessionHeader } from './session-token'
 
 export function newSessionId(): string {
   return newPrefixedId('ses')
@@ -27,56 +28,56 @@ export function deriveSessionIdFromMCPSession(mcpSessionId: string): string {
 }
 
 /**
- * Resolves the session id for a request, preferring the MCP protocol sessionId
- * over an SDK-generated one so a transport-supplied session wins.
+ * Resolves the session id for a request: from the replayed session token, from
+ * the transport's MCP session id, or — when the request carries nothing — from
+ * this instance's memory. Also saves the token's client name/version so events
+ * built later in the request can use them (see getSessionInfo).
  */
-export function getServerSessionId(server: MCPServerLike, extra?: CompatibleRequestHandlerExtra): string {
+export function getSessionId(server: MCPServerLike, extra?: CompatibleRequestHandlerExtra): string {
   const data = getServerTrackingData(server)
-
   if (!data) {
     throw new Error('Server tracking data not found')
   }
 
-  const mcpSessionId = extra?.sessionId
+  // Our token rides the `mcp-session-id` request header, which stateless
+  // transports ignore — so read it ourselves.
+  const sessionHeader = readMcpSessionHeader(extra?.requestInfo?.headers)
+  const token = decodeSessionId(sessionHeader)
 
-  if (mcpSessionId) {
-    data.sessionId = deriveSessionIdFromMCPSession(mcpSessionId)
-    data.lastMcpSessionId = mcpSessionId
+  let sessionId: string
+  if (token) {
+    // Token we minted at `initialize` (see session-token.ts).
+    data.sessionSource = 'token'
+    data.sessionInfo.clientName = token.clientName
+    data.sessionInfo.clientVersion = token.clientVersion
+    sessionId = token.sessionId
+  } else if (extra?.sessionId) {
+    // Session id issued by a stateful transport: hash it so the same MCP
+    // session maps to the same SDK session across restarts.
     data.sessionSource = 'mcp'
-    setServerTrackingData(server, data)
-    setLastActivity(server)
-    return data.sessionId
+    sessionId = deriveSessionIdFromMCPSession(extra.sessionId)
+  } else {
+    sessionId = getSessionIdFromMemory(data)
   }
 
-  // Once a session has been MCP-derived, keep that id even if a later request
-  // arrives without the MCP sessionId, so the session doesn't fragment.
-  if (data.sessionSource === 'mcp' && data.lastMcpSessionId) {
-    setLastActivity(server)
-    return data.sessionId
-  }
-
-  // SDK-generated sessions roll over after an inactivity timeout.
-  const now = Date.now()
-  const timeoutMs = INACTIVITY_TIMEOUT_IN_MINUTES * 60 * 1000
-  if (now - data.lastActivity.getTime() > timeoutMs) {
-    data.sessionId = newSessionId()
-    data.sessionSource = 'generated'
-    setServerTrackingData(server, data)
-  }
-  setLastActivity(server)
-
-  return data.sessionId
-}
-
-export function setLastActivity(server: MCPServerLike): void {
-  const data = getServerTrackingData(server)
-
-  if (!data) {
-    throw new Error('Server tracking data not found')
-  }
-
+  data.sessionId = sessionId
   data.lastActivity = new Date()
   setServerTrackingData(server, data)
+  return sessionId
+}
+
+/**
+ * Nothing replayed on this request: keep the id we already have. Only
+ * generated sessions roll over on inactivity — token/MCP ids live as long as
+ * the client replays them, and regenerating one would split the session.
+ */
+function getSessionIdFromMemory(data: MCPAnalyticsData): string {
+  const timeoutMs = INACTIVITY_TIMEOUT_IN_MINUTES * 60 * 1000
+  const isStale = Date.now() - data.lastActivity.getTime() > timeoutMs
+  if (data.sessionSource === 'generated' && isStale) {
+    return newSessionId()
+  }
+  return data.sessionId
 }
 
 /**

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -191,7 +191,16 @@ async function captureCustomEvent(lowLevelServer: MCPServerLike, eventData: Capt
   log(`Captured event "${eventData.event}" for session ${trackingData.sessionId}`)
 }
 
-export { deriveSessionIdFromMCPSession }
+export { deriveSessionIdFromMCPSession, newSessionId }
+// Session tokens for stateless / multi-pod servers. Minted and decoded
+// automatically on JSON-mode StreamableHTTP; SSE servers set the header
+// themselves with `encodeSessionId`.
+export {
+  MCP_SESSION_HEADER,
+  decodeSessionId,
+  encodeSessionId,
+  type SessionTokenPayload,
+} from './extensions/session-token'
 export {
   POSTHOG_MCP_ANALYTICS_SOURCE,
   PostHogMCPAnalyticsEvent,

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -179,9 +179,17 @@ export interface Event {
 /** A partially-built MCP event as it flows through the SDK before capture. */
 export type McpEvent = Partial<Event>
 
+/** HTTP request info the SDK's Streamable HTTP transports attach per request. */
+export interface CompatibleRequestInfoLike {
+  headers?: Record<string, string | string[] | undefined>
+  [key: string]: unknown
+}
+
 export interface CompatibleRequestHandlerExtra {
   headers?: Record<string, string | string[]>
   sessionId?: string
+  /** Present on HTTP transports only — headers ride every request, unlike `clientInfo`. */
+  requestInfo?: CompatibleRequestInfoLike
   [key: string]: unknown
 }
 
@@ -199,9 +207,17 @@ export interface HighLevelMCPServerLike {
   tool?(name: string, description: string, paramsSchema: unknown, cb: ToolCallback): void
 }
 
+/** The connected transport as exposed by the SDK's `Protocol.transport` getter. */
+export interface CompatibleTransportLike {
+  sessionId?: string
+  [key: string]: unknown
+}
+
 export interface MCPServerLike {
   _requestHandlers: Map<string, (request: MCPRequestLike, extra?: CompatibleRequestHandlerExtra) => Promise<unknown>>
   _serverInfo?: ServerClientInfoLike
+  /** Optional so older SDKs (and bare test doubles) still validate. */
+  transport?: CompatibleTransportLike
   getClientVersion(): ServerClientInfoLike | undefined
   setRequestHandler(
     schema: unknown,
@@ -245,11 +261,11 @@ export interface MCPAnalyticsData {
   sink: McpEventSink | undefined
   identifiedSessions: IdentityCache
   lastActivity: Date
-  lastMcpSessionId?: string
   options: MCPAnalyticsOptions
   sessionId: string
   sessionInfo: SessionInfo
-  sessionSource: 'generated' | 'mcp'
+  /** `token` = recovered from a self-encoded `Mcp-Session-Id` token (see session-token.ts). */
+  sessionSource: 'generated' | 'mcp' | 'token'
   toolCategories: Map<string, string>
   toolDescriptions: Map<string, string>
 }


### PR DESCRIPTION
## Problem

On **stateless** MCP servers (a fresh `Server` + transport per request — serverless, Cloudflare Workers, horizontally-scaled pods) every request became its own session, and `$mcp_client_name` / `$mcp_client_version` went missing after `initialize` (they're only sent in the init body, and `getClientVersion()` is empty on any instance that didn't handle init). A real customer saw `sessions == tool_calls` and a 100% "Other" client breakdown.

Fixes: https://github.com/PostHog/posthog/issues/68635

## Approach

The only value a spec-compliant client round-trips on **every** request is the `Mcp-Session-Id` header. So at `initialize` we mint it as a self-encoded token — `base64url(JSON{ sid, cn, cv })` — carrying the PostHog session id plus the client name/version. Clients replay it on every subsequent request, so **any pod decodes it and recovers the same `$session_id` + client metadata with no server-side store, no sticky routing, and no client changes.**

- `getSessionId` decodes the replayed token (stateless), or falls back to the transport session id (stateful) / an inactivity-rolling generated id.
- Auto-minting requires `enableJsonResponse: true` (response headers are built after the handler runs). SSE-mode servers set the header at the HTTP layer with the new `encodeSessionId` export; the SDK still decodes it.
- Fully backward compatible — stateful transports and stdio are untouched.

## New exports

`encodeSessionId`, `decodeSessionId`, `MCP_SESSION_HEADER`, `SessionTokenPayload`, `newSessionId`.

## Validation

- Unit tests: token codec round-trip, mint-on-initialize, decode-on-replay — **380 tests green**.
- Manually validated end-to-end on a single stateless mcp-nest server (JSON mode) **and a 2-pod docker-compose cluster behind round-robin nginx (no stickiness)** — `initialize` on pod-1, tool calls round-robined to pod-2, which recovered the same `$session_id` + client metadata despite never seeing the handshake.

## Follow-ups (separate PRs)

- Carry the resolved identity in the token (consistent person cross-pod + identify dedup).
- Filter transport-probe clients (e.g. `mcp-remote-fallback-test`).
- Attribute `tools/list` events to the identified person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
