### PR TITLE
feat(replay): add session_recording.sampling for mousemove capture

### DIFF
--- a/.changeset/replay-mouse-sampling.md
+++ b/.changeset/replay-mouse-sampling.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+Add `session_recording.sampling` to disable or throttle mousemove capture (and optionally mouseInteraction) in session replay. Canvas recording now merges its canvas sampling with user-provided sampling instead of overwriting it.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -3837,6 +3837,124 @@ describe('Lazy SessionRecording', () => {
         })
     })
 
+    describe('sampling passthrough', () => {
+        it('passes user sampling for mousemove and mouseInteraction to rrweb.record', () => {
+            posthog.config.session_recording.sampling = { mousemove: false, mouseInteraction: false }
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                    },
+                })
+            )
+
+            expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sampling: { mousemove: false, mouseInteraction: false },
+                })
+            )
+        })
+
+        it('passes a falsy numeric mousemove value of 0 to rrweb.record', () => {
+            posthog.config.session_recording.sampling = { mousemove: 0 }
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                    },
+                })
+            )
+
+            expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sampling: { mousemove: 0 },
+                })
+            )
+        })
+
+        it('passes a numeric mousemove throttle to rrweb.record', () => {
+            posthog.config.session_recording.sampling = { mousemove: 250 }
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                    },
+                })
+            )
+
+            expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sampling: { mousemove: 250 },
+                })
+            )
+        })
+
+        it('merges user sampling with canvas sampling', () => {
+            posthog.config.session_recording.sampling = { mousemove: false }
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                        canvasQuality: '0.2',
+                        canvasFps: 6,
+                        recordCanvas: true,
+                    },
+                })
+            )
+
+            sessionRecording['_onScriptLoaded']()
+
+            expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    recordCanvas: true,
+                    sampling: { mousemove: false, canvas: 6 },
+                })
+            )
+        })
+
+        it('ignores sampling keys that are not allowlisted', () => {
+            posthog.config.session_recording.sampling = {
+                canvas: 1,
+                scroll: 100,
+                mousemove: false,
+            } as any
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                    },
+                })
+            )
+
+            expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sampling: { mousemove: false },
+                })
+            )
+        })
+
+        it('does not set sampling when not configured', () => {
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                    },
+                })
+            )
+
+            expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sampling: undefined,
+                })
+            )
+        })
+    })
+
     describe('console logs', () => {
         it('if not enabled, plugin is not used', () => {
             posthog.config.enable_recording_console_log = false

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -73,6 +73,7 @@ import {
     Properties,
     SessionIdChangedCallback,
     SessionRecordingOptions,
+    SessionRecordingSamplingConfig,
     SessionRecordingPersistedConfig,
     SessionStartReason,
 } from '../../../types'
@@ -2085,6 +2086,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             collectFonts: false,
             inlineStylesheet: true,
             recordCrossOriginIframes: false,
+            sampling: undefined,
             attributeFilter: undefined,
         }
 
@@ -2095,6 +2097,18 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                 if (key === 'maskInputOptions') {
                     // ensure password config is set if not included
                     sessionRecordingOptions.maskInputOptions = { password: true, ...value }
+                } else if (key === 'sampling') {
+                    // only allow a narrow subset of rrweb's sampling options;
+                    // canvas sampling is owned by the canvas recording config
+                    const userSampling = (value ?? {}) as SessionRecordingSamplingConfig
+                    const sampling: recordOptions['sampling'] = {}
+                    if (!isUndefined(userSampling.mousemove)) {
+                        sampling.mousemove = userSampling.mousemove
+                    }
+                    if (!isUndefined(userSampling.mouseInteraction)) {
+                        sampling.mouseInteraction = userSampling.mouseInteraction
+                    }
+                    sessionRecordingOptions.sampling = sampling
                 } else {
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore
@@ -2105,7 +2119,12 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         if (this._canvasRecording && this._canvasRecording.enabled) {
             sessionRecordingOptions.recordCanvas = true
-            sessionRecordingOptions.sampling = { canvas: this._canvasRecording.fps }
+            // canvas fps is owned by the canvas recording config; merge so that
+            // user-provided sampling (e.g. mousemove) survives
+            sessionRecordingOptions.sampling = {
+                ...sessionRecordingOptions.sampling,
+                canvas: this._canvasRecording.fps,
+            }
             sessionRecordingOptions.dataURLOptions = { type: 'image/webp', quality: this._canvasRecording.quality }
             sessionRecordingOptions.canvasResolutionScale = this._canvasResolutionScale
             sessionRecordingOptions.canvasMasking = {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -97,6 +97,7 @@ export type {
     ErrorTrackingOptions,
     MaskInputOptions,
     SlimDOMOptions,
+    SessionRecordingSamplingConfig,
     SessionRecordingOptions,
     RequestQueueConfig,
 } from '@posthog/types'

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -545,6 +545,22 @@ exports[`config snapshot for PostHogConfig 1`] = `
       "false",
       "true"
     ],
+    "sampling": [
+      "undefined",
+      {
+        "mousemove": [
+          "undefined",
+          "number",
+          "false",
+          "true"
+        ],
+        "mouseInteraction": [
+          "undefined",
+          "false",
+          "true"
+        ]
+      }
+    ],
     "sampleRate": [
       "undefined",
       "number"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -75,6 +75,7 @@ export type {
     ExceptionRateLimiterConfig,
     MaskInputOptions,
     SlimDOMOptions,
+    SessionRecordingSamplingConfig,
     SessionRecordingOptions,
     RequestQueueConfig,
     LogCaptureOptions,

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -530,6 +530,27 @@ export interface SlimDOMOptions {
     headTitleMutations?: boolean
 }
 
+/**
+ * Sampling options for session recording, a subset of rrweb's sampling strategy
+ */
+export interface SessionRecordingSamplingConfig {
+    /**
+     * Controls capture of mouse movement within a recorded session.
+     * `false` disables capture entirely; NB this also disables touchmove and drag capture.
+     * A number throttles capture so that positions are captured at most once every N milliseconds.
+     * When `undefined` (or `true`), rrweb's default applies: capture throttled to every 50ms.
+     * @default undefined
+     */
+    mousemove?: boolean | number
+    /**
+     * When `false`, disables capture of mouse interaction events
+     * (click, mouse up/down, hover, and touch start/end).
+     * NB replays will not show clicks when this is disabled.
+     * @default undefined
+     */
+    mouseInteraction?: boolean
+}
+
 export interface SessionRecordingOptions {
     /**
      * Derived from `rrweb.record` options
@@ -803,6 +824,23 @@ export interface SessionRecordingOptions {
      * @default false
      */
     strictMinimumDuration?: boolean
+
+    /**
+     * Derived from `rrweb.record` options. Controls how often certain event types are captured
+     * within an already-recorded session, e.g. `{ mousemove: false }` stops recording mouse movement.
+     *
+     * Not to be confused with `sampleRate` below, which controls whether a session is recorded
+     * at all, or with `posthog.startSessionRecording({ sampling: true })`, which overrides that
+     * session-level sample rate.
+     *
+     * NB disabled event types no longer count as user activity for replay idle detection
+     * (`session_idle_threshold_ms`). For example, with `mousemove: false` pure mouse movement
+     * no longer keeps a session active, while clicks, scrolls, and inputs still do.
+     *
+     * @see https://github.com/rrweb-io/rrweb/blob/master/guide.md
+     * @default undefined
+     */
+    sampling?: SessionRecordingSamplingConfig
 
     /**
      * The sample rate for session recordings, a number between 0 and 1.


### PR DESCRIPTION
## Problem

Closes #3982

Customers want to keep mouse movement out of session replay recordings, both for privacy and to cut recording payload size. rrweb already exposes sampling controls for this (`mousemove`, `mouseInteraction`), but posthog-js does not pass them through: the recorder's allowlist of rrweb options has no `sampling` key, and the canvas branch assigns `sampling` wholesale.

## Changes

- New narrow typed option `session_recording.sampling?: { mousemove?: boolean | number; mouseInteraction?: boolean }` (interface `SessionRecordingSamplingConfig` in `@posthog/types`, following the locally duplicated rrweb subset pattern of `MaskInputOptions` / `SlimDOMOptions`).
- The recorder allowlist passes only the `mousemove` and `mouseInteraction` keys through to `rrweb.record` (runtime filter, so untyped callers cannot smuggle in `canvas`, `scroll`, etc.).
- Canvas recording now merges its `canvas` fps into the sampling object instead of overwriting it, so user sampling and canvas recording coexist. The previous hard assignment would have discarded any other sampling key.

**Why this API shape:** it is what the issue triage suggested (a narrow typed `session_recording.sampling` option), and it follows the existing convention that rrweb passthrough options keep their rrweb names (`maskAllInputs`, `slimDOMOptions`, ...). The `canvas` key is deliberately not exposed because canvas fps is owned by the canvas recording config. The JSDoc explicitly disambiguates from `sampleRate` (controls whether a session is recorded at all) and from `posthog.startSessionRecording({ sampling: true })`. Happy to adjust naming or scope if the team prefers a different shape.

**Behavioral note:** with `mousemove: false`, rrweb also stops touchmove/drag capture, and pure mouse movement no longer counts as user activity for replay idle detection (clicks, scrolls and inputs still do). Both are documented in the JSDoc; the idle sources themselves are deliberately unchanged.

**Test strategy:** 6 new unit tests in `lazy-sessionrecording.test.ts` assert at the `rrweb.record` mock boundary: passthrough of both keys, numeric throttle, falsy `mousemove: 0`, merge with canvas sampling (regression test for the overwrite fix), filtering of non-allowlisted keys, and unchanged behavior when not configured. The existing exact-match default-options test stays untouched as a regression guard. Locally green: replay unit suite (656/656), `pnpm typecheck`, prettier.

Docs follow-up: I will open a separate posthog.com PR for the session replay docs once this is merged.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Planned and implemented with Claude Code. The repo was researched before writing any code: the recorder's allowlist mechanism, the existing rrweb subset type precedents (`MaskInputOptions`, `SlimDOMOptions`), the canvas sampling assignment, and the three existing "sampling" concepts in the codebase. A raw full `sampling` passthrough and a bespoke option name were considered and rejected (canvas ownership, naming collision with `sampleRate`). Code and tests were independently re-reviewed against the actual diff; unit tests, typecheck and formatting were run locally (Windows). I directed the work, reviewed the changes, and can explain every line.
