### PR TITLE
fix(react-native): R8-safe dedup of RN fatal JS errors on Android via ignoredExceptionTypes

### DIFF
--- a/.changeset/rn-android-ignore-javascript-exception.md
+++ b/.changeset/rn-android-ignore-javascript-exception.md
@@ -1,0 +1,7 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+fix(react-native): drop native duplicates of fatal JS errors on Android via class matching
+
+The Android plugin suppressed React Native's natively rethrown fatal JS errors (`JavascriptException`) with a `beforeSend` hook matching serialized class-name strings, which R8/ProGuard renaming can defeat in release builds. It now registers the class in posthog-android's `errorTrackingConfig.ignoredExceptionTypes` (added in posthog-android 6.24.0), which matches by `Class.isInstance` across the cause chain and is unaffected by minification.

--- a/.changeset/rn-android-ignore-javascript-exception.md
+++ b/.changeset/rn-android-ignore-javascript-exception.md
@@ -2,6 +2,4 @@
 '@posthog/react-native-plugin': patch
 ---
 
-fix(react-native): drop native duplicates of fatal JS errors on Android via class matching
-
-The Android plugin suppressed React Native's natively rethrown fatal JS errors (`JavascriptException`) with a `beforeSend` hook matching serialized class-name strings, which R8/ProGuard renaming can defeat in release builds. It now registers the class in posthog-android's `errorTrackingConfig.ignoredExceptionTypes` (added in posthog-android 6.24.0), which matches by `Class.isInstance` across the cause chain and is unaffected by minification.
+Fix fatal JS errors being double-reported on Android in minified release builds: the plugin's dedup matched serialized class-name strings, which R8/ProGuard renaming can defeat. It now registers `JavascriptException` in posthog-android's `errorTrackingConfig.ignoredExceptionTypes` (requires core 6.24.0), which matches by class across the cause chain and is unaffected by minification.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -86,7 +86,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.posthog:posthog-android:3.53.5"
-  // errorTrackingConfig.ignoredExceptionTypes needs core 6.24.0; posthog-android 3.53.5 still pins 6.23.3
+  // remove once posthog-android pins core >= 6.24.0
   implementation "com.posthog:posthog:6.24.0"
 }
 

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,7 +85,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.53.5"
-  implementation "com.posthog:posthog:6.24.0"
+  implementation "com.posthog:posthog-android:3.53.6"
 }
 

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -86,7 +86,6 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.posthog:posthog-android:3.53.5"
-  // remove once posthog-android pins core >= 6.24.0
   implementation "com.posthog:posthog:6.24.0"
 }
 

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,6 +85,8 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.52.0"
+  implementation "com.posthog:posthog-android:3.53.5"
+  // errorTrackingConfig.ignoredExceptionTypes needs core 6.24.0; posthog-android 3.53.5 still pins 6.23.3
+  implementation "com.posthog:posthog:6.24.0"
 }
 

--- a/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
+++ b/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
@@ -7,9 +7,9 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.common.JavascriptException
 import com.posthog.PostHog
 import com.posthog.PostHogConfig
-import com.posthog.PostHogEvent
 import com.posthog.android.PostHogAndroid
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.internal.PostHogPreferences
@@ -117,7 +117,7 @@ class PosthogReactNativePluginModule(
 
               // React Native rethrows fatal JS errors natively as JavascriptException.
               // The JS layer already captured them, so drop the native duplicate.
-              addBeforeSend { event -> if (isReactNativeFatalJsError(event)) null else event }
+              errorTrackingConfig.ignoredExceptionTypes.add(JavascriptException::class.java)
 
               // Always apply the session replay configuration so that recording started later
               // (e.g. startRecording or a linked feature flag) uses the right mode and masking;
@@ -319,16 +319,6 @@ class PosthogReactNativePluginModule(
     map: ReadableMap?,
     key: String,
   ): Double? = runCatching { if (hasKey(map, key)) map?.getDouble(key) else null }.getOrNull()
-
-  private fun isReactNativeFatalJsError(event: PostHogEvent): Boolean {
-    if (event.event != "\$exception") return false
-    val exceptionList = event.properties?.get("\$exception_list") as? List<*> ?: return false
-    return exceptionList.any { item ->
-      val exception = item as? Map<*, *> ?: return@any false
-      exception["type"] == "JavascriptException" &&
-        (exception["module"] as? String)?.startsWith("com.facebook.react") == true
-    }
-  }
 
   private fun logError(
     method: String,


### PR DESCRIPTION
## Problem

Closes the last gap in PostHog/posthog-android#567: when React Native apps enable native crash autocapture, RN rethrows fatal JS errors natively as `com.facebook.react.common.JavascriptException`, duplicating the `$exception` the JS layer already captured.

The Android plugin currently dedups this with a `beforeSend` hook that string-matches the serialized class name (`type == "JavascriptException"`, `module.startsWith("com.facebook.react")`). R8/ProGuard renaming can defeat that match in release builds — the serialized names come from runtime classes, so a minified app sends the duplicate anyway. This is the same reason string matching was rejected in posthog-android's review (PostHog/posthog-android#569 → #608).

## Changes

- The Android plugin now registers `JavascriptException::class.java` in posthog-android's `errorTrackingConfig.ignoredExceptionTypes` (new in core 6.24.0, PostHog/posthog-android#608): `Class.isInstance` matching across the cause chain, unaffected by minification. The `beforeSend` hook and its name-matching helper are removed.
- Registration stays unconditional at plugin setup, matching the shipped `beforeSend` semantics and the iOS side (posthog-ios ships an `RCTFatalException` default in core since PostHog/posthog-ios#666 — iOS needs no change here). A conditional variant (only when JS `uncaughtExceptions` capture is enabled) was considered and deliberately not done: it would change existing behavior beyond this mechanism swap. See the design discussion on why the default lives in the RN plugin rather than posthog-android core: https://github.com/PostHog/posthog-android/pull/608#discussion_r3560027314
- Dependency: `posthog-android` 3.52.0 → 3.53.5, plus an explicit `com.posthog:posthog:6.24.0` (published on Maven Central). The explicit core line is needed because 3.53.5's POM pins core 6.23.3, which predates the API, and no posthog-android release is queued to re-pin it.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/react-native-plugin

## Checklist

- [x] Tests for new code — the Android module has no unit-test harness (the removed helper had none either), so verification is end-to-end instead: a live release-build emulator test of this branch confirms the duplicate is dropped and the crash still propagates (see **Live test** section), and posthog-android's own suite covers the `ignoredExceptionTypes` matching.
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size
- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session directed by @turnipdabeets, completing the ignoredExceptionTypes chain (posthog-android#608 merged, posthog-ios#666/#713).
- Read the #3677 wiring on both the TS and Kotlin sides before changing anything; found the existing name-based `beforeSend` workaround and swapped its mechanism without changing its semantics.
- Kotlin compilation is exercised by the example-app CI build against core 6.24.0 from Maven Central. No JS/TS files changed.

## Live test (Android emulator, release build)

Built `examples/example-rn-native-plugin` in release mode against this branch, with exception autocapture enabled via remote config, and threw a fatal JS error. Result:

```
PostHog : Exception autocapture is enabled.
AndroidRuntime: FATAL EXCEPTION: mqt_v_native
AndroidRuntime: com.facebook.react.common.JavascriptException: Error: ... fatal JS error
PostHog : Skipping $exception: com.facebook.react.common.JavascriptException (or a cause in its chain) matches ignoredExceptionTypes
```

The native duplicate is dropped by the new mechanism, the process still terminates (handler chaining preserved), and the PostHog project received zero `$exception` events for the test window (verified via the API).






