### PR TITLE
fix: don't overwrite registered $referrer with document.referrer

### DIFF
--- a/.changeset/referrer-register-guard.md
+++ b/.changeset/referrer-register-guard.md
@@ -1,0 +1,5 @@
+---
+"posthog-js": patch
+---
+
+Don't let save_referrer overwrite a $referrer / $referring_domain that was explicitly set via posthog.register(), so registered attribution values survive pageviews in SPA and iframe contexts

--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -289,6 +289,65 @@ describe('posthog core', () => {
                 expect(laterProperties['$referrer']).toBe('https://blabla.fr/')
                 expect(laterProperties['$referring_domain']).toBe('blabla.fr')
             })
+
+            it('should let a register() called after a capture win over the already-stored session referrer', () => {
+                // arrange: a first capture stores document.referrer in session persistence
+                mockReferrer.mockReturnValue('https://iframe-origin.example.com/some/path')
+                const { posthog, beforeSendMock } = setup()
+                posthog.capture(eventName, eventProperties)
+                const { properties: firstProperties } = beforeSendMock.mock.calls[0][0]
+                expect(firstProperties['$referrer']).toBe('https://iframe-origin.example.com/some/path')
+
+                // act: register a custom referrer after the session value is already present
+                posthog.register({
+                    $referrer: 'https://blabla.fr/',
+                    $referring_domain: 'blabla.fr',
+                })
+                posthog.capture(eventName, eventProperties)
+
+                // assert: the registered value wins over the stale session value
+                const { properties } = beforeSendMock.mock.calls[1][0]
+                expect(properties['$referrer']).toBe('https://blabla.fr/')
+                expect(properties['$referring_domain']).toBe('blabla.fr')
+            })
+
+            it('should only override the referrer key that was registered, leaving the other automatic', () => {
+                // arrange
+                mockReferrer.mockReturnValue('https://iframe-origin.example.com/some/path')
+                const { posthog, beforeSendMock } = setup()
+                posthog.register({ $referrer: 'https://blabla.fr/' })
+
+                // act
+                posthog.capture(eventName, eventProperties)
+
+                // assert: registered key is preserved, the other still comes from document.referrer
+                const { properties } = beforeSendMock.mock.calls[0][0]
+                expect(properties['$referrer']).toBe('https://blabla.fr/')
+                expect(properties['$referring_domain']).toBe('iframe-origin.example.com')
+            })
+
+            it('should fall back to document.referrer after the registered value is unregistered', () => {
+                // arrange
+                mockReferrer.mockReturnValue('https://iframe-origin.example.com/some/path')
+                const { posthog, beforeSendMock } = setup()
+                posthog.register({
+                    $referrer: 'https://blabla.fr/',
+                    $referring_domain: 'blabla.fr',
+                })
+                posthog.capture(eventName, eventProperties)
+                const { properties: registeredProperties } = beforeSendMock.mock.calls[0][0]
+                expect(registeredProperties['$referrer']).toBe('https://blabla.fr/')
+
+                // act
+                posthog.unregister('$referrer')
+                posthog.unregister('$referring_domain')
+                posthog.capture(eventName, eventProperties)
+
+                // assert
+                const { properties } = beforeSendMock.mock.calls[1][0]
+                expect(properties['$referrer']).toBe('https://iframe-origin.example.com/some/path')
+                expect(properties['$referring_domain']).toBe('iframe-origin.example.com')
+            })
         })
 
         describe('campaign params', () => {

--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -266,6 +266,29 @@ describe('posthog core', () => {
                 expect(properties['$referrer']).toBe('$direct')
                 expect(properties['$referring_domain']).toBe('$direct')
             })
+
+            it('should not overwrite a referrer that was registered via register()', () => {
+                // arrange
+                mockReferrer.mockReturnValue('https://iframe-origin.example.com/some/path')
+                const { posthog, beforeSendMock } = setup()
+                posthog.register({
+                    $referrer: 'https://blabla.fr/',
+                    $referring_domain: 'blabla.fr',
+                })
+
+                // act
+                posthog.capture(eventName, eventProperties)
+
+                // assert
+                const { properties } = beforeSendMock.mock.calls[0][0]
+                expect(properties['$referrer']).toBe('https://blabla.fr/')
+                expect(properties['$referring_domain']).toBe('blabla.fr')
+                // and the registered values keep surviving on subsequent captures
+                posthog.capture(eventName, eventProperties)
+                const { properties: laterProperties } = beforeSendMock.mock.calls[1][0]
+                expect(laterProperties['$referrer']).toBe('https://blabla.fr/')
+                expect(laterProperties['$referring_domain']).toBe('blabla.fr')
+            })
         })
 
         describe('campaign params', () => {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1376,7 +1376,7 @@ export class PostHog implements PostHogInterface {
             this.sessionPersistence.update_campaign_params()
         }
         if (this.config.save_referrer) {
-            this.sessionPersistence.update_referrer_info(this.persistence.props)
+            this.sessionPersistence.update_referrer_info()
         }
 
         if (this.config.save_campaign_params || this.config.save_referrer) {
@@ -1637,14 +1637,23 @@ export class PostHog implements PostHogInterface {
         // don't write to the persistence properties object and info
         // properties object by passing in a new object
 
+        // $referrer / $referring_domain are written to the sessionPersistence from document.referrer
+        // on every capture, and sessionPersistence is merged after the regular persistence below, so
+        // they normally win. When the user has explicitly set one of these via posthog.register()
+        // (which writes to the regular persistence), let that value win instead. Resolve the
+        // precedence per property so a single registered key does not suppress the other, and a
+        // stale session value cannot shadow the registered one. Without this an SPA or iframe
+        // reports document.referrer (the iframe's own origin) rather than the registered value.
+        const persistenceProperties = this.persistence.properties()
+        const sessionPersistenceProperties = this.sessionPersistence.properties()
+        each(['$referrer', '$referring_domain'], (referrerKey) => {
+            if (referrerKey in persistenceProperties) {
+                delete sessionPersistenceProperties[referrerKey]
+            }
+        })
+
         // update properties with pageview info and super-properties
-        properties = extend(
-            {},
-            infoProperties,
-            this.persistence.properties(),
-            this.sessionPersistence.properties(),
-            properties
-        )
+        properties = extend({}, infoProperties, persistenceProperties, sessionPersistenceProperties, properties)
 
         properties['$is_identified'] = this._isIdentified()
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1376,7 +1376,7 @@ export class PostHog implements PostHogInterface {
             this.sessionPersistence.update_campaign_params()
         }
         if (this.config.save_referrer) {
-            this.sessionPersistence.update_referrer_info()
+            this.sessionPersistence.update_referrer_info(this.persistence.props)
         }
 
         if (this.config.save_campaign_params || this.config.save_referrer) {

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -728,8 +728,19 @@ export class PostHogPersistence {
         this.register(getSearchInfo())
     }
 
-    update_referrer_info(): void {
-        this.register_once(getReferrerInfo(), undefined)
+    update_referrer_info(userRegisteredProps?: Properties): void {
+        // Referrer info lives in the session persistence and is sent with every event, so it takes
+        // precedence over the same keys in the regular persistence. When a user explicitly sets
+        // $referrer / $referring_domain via posthog.register(), don't overwrite it with
+        // document.referrer, which is the iframe's own origin in an embedded context.
+        const referrerInfo = getReferrerInfo()
+        const props: Properties = {}
+        each(referrerInfo, (val, key) => {
+            if (!userRegisteredProps || !userRegisteredProps.hasOwnProperty(key)) {
+                props[key] = val
+            }
+        })
+        this.register_once(props, undefined)
     }
 
     set_initial_person_info(): void {

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -728,19 +728,8 @@ export class PostHogPersistence {
         this.register(getSearchInfo())
     }
 
-    update_referrer_info(userRegisteredProps?: Properties): void {
-        // Referrer info lives in the session persistence and is sent with every event, so it takes
-        // precedence over the same keys in the regular persistence. When a user explicitly sets
-        // $referrer / $referring_domain via posthog.register(), don't overwrite it with
-        // document.referrer, which is the iframe's own origin in an embedded context.
-        const referrerInfo = getReferrerInfo()
-        const props: Properties = {}
-        each(referrerInfo, (val, key) => {
-            if (!userRegisteredProps || !userRegisteredProps.hasOwnProperty(key)) {
-                props[key] = val
-            }
-        })
-        this.register_once(props, undefined)
+    update_referrer_info(): void {
+        this.register_once(getReferrerInfo(), undefined)
     }
 
     set_initial_person_info(): void {


### PR DESCRIPTION
## Problem

`$referrer` / `$referring_domain` set with `posthog.register()` are dropped on every capture in SPA and iframe setups. In an iframe the reported value becomes the iframe's own origin instead of the value the user registered.

Root cause: `register()` writes these to the main `persistence`, but `save_referrer` writes `document.referrer` into `sessionPersistence` via `update_referrer_info()`. In `calculateEventProperties()` the `sessionPersistence` props are spread after the main persistence, so they shadow the user's registered value on every event.

Fixes #[67448](https://github.com/PostHog/posthog-js/issues/4208)

## Changes

`update_referrer_info()` is left as-is and still populates the session referrer from `document.referrer` on every capture. The precedence is resolved per property at the `calculateEventProperties()` merge instead: for `$referrer` / `$referring_domain`, a value present in the regular persistence (i.e. one the user set via `register()`) wins over the session value.

This is the approach @dustinbyrne suggested on the earlier, now-stale PR PostHog/posthog#4052 (resolve precedence per key at the final merge rather than skipping the session update). It also handles the two edge cases raised there:

- A session referrer already stored before `register()` is called no longer shadows the registered value.
- Registering only one of the two keys does not suppress the other, which still falls back to `document.referrer`.

## Testing

Added unit tests in the existing `referrer` suite covering:

- a registered `$referrer` / `$referring_domain` surviving subsequent captures,
- `register()` called after an initial capture winning over the already-stored session value,
- a single registered key while the other stays automatic,
- `unregister()` restoring the `document.referrer` fallback.

All referrer unit tests pass (8/8, including the 4 new cases), and the full `posthog-core.test.ts` suite passes (35/35). Changeset included.
