### PR TITLE
fix(rrweb): keep untainted-prototype iframe attached on Safari (adopt upstream #1854)

### DIFF
--- a/.changeset/safari-mutationobserver-keepalive.md
+++ b/.changeset/safari-mutationobserver-keepalive.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rrweb-utils': patch
+---
+
+fix: keep the untainted-prototype fallback iframe attached on Safari so MutationObserver callbacks are not silently dropped (port of upstream rrweb #1854)

--- a/packages/rrweb/rrweb/test/untainted-prototype.test.ts
+++ b/packages/rrweb/rrweb/test/untainted-prototype.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+// getUntaintedPrototype falls back to pulling prototypes out of a temporary
+// same-origin iframe when the page's globals have been monkey-patched. On
+// WebKit/Safari a detached iframe's ScriptExecutionContext is torn down and
+// MutationObserver.deliver() silently drops callbacks (webkit.org/b/179224),
+// so on Safari the iframe must stay attached for the lifetime of the page.
+// Ported from upstream rrweb #1854.
+//
+// In jsdom no prototype method has a native-code toString, so every call takes
+// the iframe fallback path, which is exactly the path under test.
+
+const SAFARI_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15';
+const CHROME_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36';
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+}
+
+function keepaliveIframes(): HTMLIFrameElement[] {
+  return Array.from(
+    document.querySelectorAll('iframe[__rrwebUntaintedPrototype]'),
+  );
+}
+
+async function freshGetUntaintedPrototype() {
+  // the untainted prototype cache is module state, so each test needs a
+  // fresh module instance
+  vi.resetModules();
+  const module = await import('@posthog/rrweb-utils');
+  return module.getUntaintedPrototype;
+}
+
+describe('getUntaintedPrototype iframe fallback', () => {
+  afterEach(() => {
+    document
+      .querySelectorAll('iframe')
+      .forEach((iframe) => iframe.remove());
+    vi.restoreAllMocks();
+  });
+
+  it('removes the fallback iframe on non-Safari browsers', async () => {
+    setUserAgent(CHROME_UA);
+    const getUntaintedPrototype = await freshGetUntaintedPrototype();
+
+    const prototype = getUntaintedPrototype('MutationObserver');
+
+    expect(prototype).toBeDefined();
+    expect(document.querySelectorAll('iframe').length).toBe(0);
+  });
+
+  it('keeps the fallback iframe attached on Safari so its context stays live', async () => {
+    setUserAgent(SAFARI_UA);
+    const getUntaintedPrototype = await freshGetUntaintedPrototype();
+
+    const prototype = getUntaintedPrototype('MutationObserver');
+
+    expect(prototype).toBeDefined();
+    const iframes = keepaliveIframes();
+    expect(iframes.length).toBe(1);
+    expect(iframes[0].getAttribute('__rrwebUntaintedPrototype')).toBe(
+      'MutationObserver',
+    );
+  });
+
+  it('hides the kept iframe and blocks it from being recorded', async () => {
+    setUserAgent(SAFARI_UA);
+    const getUntaintedPrototype = await freshGetUntaintedPrototype();
+
+    getUntaintedPrototype('MutationObserver');
+
+    const iframe = keepaliveIframes()[0];
+    expect(iframe.style.display).toBe('none');
+    // upstream rrweb default block class and the PostHog default, so the
+    // recorder skips this iframe whichever config is in use
+    expect(iframe.classList.contains('rr-block')).toBe(true);
+    expect(iframe.classList.contains('ph-no-capture')).toBe(true);
+  });
+
+  it('reuses the cached prototype instead of attaching more iframes', async () => {
+    setUserAgent(SAFARI_UA);
+    const getUntaintedPrototype = await freshGetUntaintedPrototype();
+
+    const first = getUntaintedPrototype('MutationObserver');
+    const second = getUntaintedPrototype('MutationObserver');
+
+    expect(second).toBe(first);
+    expect(keepaliveIframes().length).toBe(1);
+  });
+
+  it('returns a usable MutationObserver constructor from the kept iframe', async () => {
+    setUserAgent(SAFARI_UA);
+    const getUntaintedPrototype = await freshGetUntaintedPrototype();
+
+    const prototype = getUntaintedPrototype('MutationObserver');
+    const observer = new (prototype.constructor as new (
+      callback: MutationCallback,
+    ) => MutationObserver)(() => {});
+
+    expect(observer.observe).toBeDefined();
+    observer.observe(document.body, { childList: true, subtree: true });
+    observer.disconnect();
+  });
+});

--- a/packages/rrweb/utils/src/index.ts
+++ b/packages/rrweb/utils/src/index.ts
@@ -107,6 +107,8 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   }
 
   const iframeEl = document.createElement('iframe');
+  iframeEl.style.display = 'none';
+  let keepIframeAttached = false;
   try {
     document.body.appendChild(iframeEl);
     const win = iframeEl.contentWindow;
@@ -118,14 +120,37 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
 
     if (!untaintedObject) return defaultPrototype;
 
+    // WebKit tears down an iframe's ScriptExecutionContext when it is detached
+    // from the DOM, and MutationObserver.deliver() silently drops callbacks when
+    // its scriptExecutionContext() is null (webkit.org/b/179224), so prototypes
+    // taken from a detached iframe stop working on Safari.
+    // Adapted from upstream rrweb #1854, with one difference: the iframe stays
+    // attached for the lifetime of the page instead of being removed on recorder
+    // teardown. Observers are torn down per-document here (e.g. a same-origin
+    // iframe being removed), and the cached prototype must outlive any one of
+    // them; removing the shared iframe on the first teardown - or reusing the
+    // cache after a stop/restart cycle - would silently break the survivors.
+    if (isSafari()) {
+      // both the upstream default block class and the PostHog one, so the
+      // recorder never serializes this iframe whichever config is in use
+      iframeEl.classList.add('rr-block', 'ph-no-capture');
+      iframeEl.setAttribute('__rrwebUntaintedPrototype', key);
+      keepIframeAttached = true;
+    }
+
     return (untaintedBasePrototype[key] = untaintedObject);
   } catch {
     return defaultPrototype;
   } finally {
-    if (iframeEl.parentNode) {
+    if (!keepIframeAttached && iframeEl.parentNode) {
       document.body.removeChild(iframeEl);
     }
   }
+}
+
+function isSafari(): boolean {
+  const ua = navigator.userAgent;
+  return ua.includes('Safari') && !ua.includes('Chrome');
 }
 
 const untaintedAccessorCache: Record<


### PR DESCRIPTION
## Problem

Adopts upstream rrweb [#1854](https://github.com/rrweb-io/rrweb/pull/1854) (the only code change in upstream `2.0.1`), tracked in #3765.

When a page's globals are monkey-patched (Zone.js, LWC, etc.), our fork pulls untainted prototypes out of a temporary same-origin iframe and then removes it. On WebKit/Safari, detaching that iframe tears down its `ScriptExecutionContext`, and `MutationObserver.deliver()` then **silently drops callbacks** ([webkit.org/b/179224](https://bugs.webkit.org/show_bug.cgi?id=179224)) — so on Safari, recordings on monkey-patched sites capture the initial snapshot but no DOM mutations. This regresses the very case our #1597 Zone fix was for.

## Changes

- `getUntaintedPrototype` keeps the fallback iframe attached on Safari (detected the same way upstream does) so the prototype's context stays live. On every other browser the iframe is removed exactly as before.
- The kept iframe is `display: none` and tagged with both `rr-block` (upstream default block class) and `ph-no-capture` (our default), so the recorder never serializes it whichever config is in use.
- The briefly-attached iframe is now also `display: none` on non-Safari browsers, so it can't cause a layout flash.

**Deliberate adaptation vs upstream:** upstream returns a cleanup function that removes the iframe on recorder teardown. We keep it for the lifetime of the page instead, because in our fork observers are torn down per-document (a same-origin iframe being removed would delete the shared keepalive iframe and silently break the surviving observers), and the prototype cache is reused across stop/restart cycles (upstream's cleanup would leave the cached prototype pointing into a destroyed context on restart — recreating the original bug). Cost: one hidden, blocked, empty iframe on Safari, only on pages whose prototypes are tainted. Noted for contribute-back in #3766.

Refs #3765.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code (`packages/rrweb/rrweb/test/untainted-prototype.test.ts`, jsdom — the fallback-iframe path is deterministic there)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ported as part of the batch-1 adoption plan on #3765 (PostHog Code session). Verified the fork lacked the fix (the `finally` block always removed the iframe), ported the upstream logic manually rather than cherry-picking because `getUntaintedPrototype` has diverged (Angular Zone alternative path), and deliberately replaced upstream's teardown-cleanup plumbing with page-lifetime keepalive for the reasons above. Ran utils+rrweb typecheck, lint, build, and the new unit tests; the posthog-js browser build currently fails on main in `web-experiments.ts` (pre-existing, verified via stash on clean main).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
