### PR TITLE
perf(rrweb): keep re-added nodes in DOM order in mutation addedSet (adopt upstream #1302)

### DIFF
--- a/.changeset/mutation-addedset-order.md
+++ b/.changeset/mutation-addedset-order.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rrweb': patch
+---
+
+perf: when a node is re-encountered while collecting added nodes, move it to the end of the added set so the emit phase processes adds in latest-DOM order instead of paying for out-of-order deferrals on large mutation batches (port of upstream rrweb #1302)

--- a/.changeset/mutation-addedset-order.md
+++ b/.changeset/mutation-addedset-order.md
@@ -2,4 +2,4 @@
 '@posthog/rrweb': patch
 ---
 
-perf: when a node is re-encountered while collecting added nodes, move it to the end of the added set so the emit phase processes adds in latest-DOM order instead of paying for out-of-order deferrals on large mutation batches (port of upstream rrweb #1302)
+perf: when a node is re-encountered while collecting added nodes, move it to the end of the added set so the emit phase processes adds in latest-DOM order. This avoids paying for out-of-order deferrals on large mutation batches (port of upstream rrweb #1302).

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -799,7 +799,7 @@ export default class MutationBuffer {
     if (this.processedNodeManager.inOtherBuffer(n, this)) return;
 
     // if n is added to set, there is no need to travel it and its' children again
-    if (this.addedSet.has(n)) {
+    if (this.addedSet.delete(n)) {
       // re-insert n so the addedSet iteration order in the `emit` phase matches
       // the latest DOM order; a stale position makes emit's out-of-order
       // deferral list do far more work on large batches (upstream rrweb #1302).
@@ -807,7 +807,6 @@ export default class MutationBuffer {
       // positions and aren't re-appended here, but emit's addList deferral
       // re-derives parentId/nextId, so parent-before-child order still comes
       // out correct.
-      this.addedSet.delete(n);
       this.addedSet.add(n);
       return;
     }

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -799,7 +799,7 @@ export default class MutationBuffer {
     if (this.processedNodeManager.inOtherBuffer(n, this)) return;
 
     // if n is added to set, there is no need to travel it and its' children again
-    if (this.addedSet.delete(n)) {
+    if (this.addedSet.has(n)) {
       // re-insert n so the addedSet iteration order in the `emit` phase matches
       // the latest DOM order; a stale position makes emit's out-of-order
       // deferral list do far more work on large batches (upstream rrweb #1302).
@@ -807,6 +807,7 @@ export default class MutationBuffer {
       // positions and aren't re-appended here, but emit's addList deferral
       // re-derives parentId/nextId, so parent-before-child order still comes
       // out correct.
+      this.addedSet.delete(n);
       this.addedSet.add(n);
       return;
     }

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -802,7 +802,11 @@ export default class MutationBuffer {
     if (this.addedSet.has(n)) {
       // re-insert n so the addedSet iteration order in the `emit` phase matches
       // the latest DOM order; a stale position makes emit's out-of-order
-      // deferral list do far more work on large batches (upstream rrweb #1302)
+      // deferral list do far more work on large batches (upstream rrweb #1302).
+      // this only moves n itself - already-present children keep their earlier
+      // positions and aren't re-appended here, but emit's addList deferral
+      // re-derives parentId/nextId, so parent-before-child order still comes
+      // out correct.
       this.addedSet.delete(n);
       this.addedSet.add(n);
       return;

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -799,7 +799,15 @@ export default class MutationBuffer {
     if (this.processedNodeManager.inOtherBuffer(n, this)) return;
 
     // if n is added to set, there is no need to travel it and its' children again
-    if (this.addedSet.has(n) || this.movedSet.has(n)) return;
+    if (this.addedSet.has(n)) {
+      // re-insert n so the addedSet iteration order in the `emit` phase matches
+      // the latest DOM order; a stale position makes emit's out-of-order
+      // deferral list do far more work on large batches (upstream rrweb #1302)
+      this.addedSet.delete(n);
+      this.addedSet.add(n);
+      return;
+    }
+    if (this.movedSet.has(n)) return;
 
     if (this.mirror.hasNode(n)) {
       if (isIgnored(n, this.mirror, this.slimDOMOptions)) {

--- a/packages/rrweb/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -3425,44 +3425,6 @@ exports[`record integration tests > can record node mutations 1`] = `
           }
         },
         {
-          \\"parentId\\": 45,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"li\\",
-            \\"attributes\\": {
-              \\"class\\": \\"select2-results-dept-0 select2-result select2-result-selectable\\",
-              \\"role\\": \\"presentation\\"
-            },
-            \\"childNodes\\": [],
-            \\"id\\": 67
-          }
-        },
-        {
-          \\"parentId\\": 67,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"div\\",
-            \\"attributes\\": {
-              \\"class\\": \\"select2-result-label\\",
-              \\"id\\": \\"select2-result-label-3\\",
-              \\"role\\": \\"option\\"
-            },
-            \\"childNodes\\": [],
-            \\"id\\": 68
-          }
-        },
-        {
-          \\"parentId\\": 68,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 3,
-            \\"textContent\\": \\"B\\",
-            \\"id\\": 69
-          }
-        },
-        {
           \\"parentId\\": 18,
           \\"nextId\\": 36,
           \\"node\\": {
@@ -3474,7 +3436,21 @@ exports[`record integration tests > can record node mutations 1`] = `
               \\"style\\": \\"\\"
             },
             \\"childNodes\\": [],
-            \\"id\\": 70
+            \\"id\\": 67
+          }
+        },
+        {
+          \\"parentId\\": 45,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"li\\",
+            \\"attributes\\": {
+              \\"class\\": \\"select2-results-dept-0 select2-result select2-result-selectable\\",
+              \\"role\\": \\"presentation\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 68
           }
         },
         {
@@ -3483,12 +3459,49 @@ exports[`record integration tests > can record node mutations 1`] = `
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"2 results are available, use up and down arrow keys to navigate.\\",
+            \\"id\\": 69
+          }
+        },
+        {
+          \\"parentId\\": 68,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"div\\",
+            \\"attributes\\": {
+              \\"class\\": \\"select2-result-label\\",
+              \\"id\\": \\"select2-result-label-3\\",
+              \\"role\\": \\"option\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 70
+          }
+        },
+        {
+          \\"parentId\\": 70,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"B\\",
             \\"id\\": 71
           }
         },
         {
+          \\"parentId\\": 70,
+          \\"nextId\\": 71,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"span\\",
+            \\"attributes\\": {
+              \\"class\\": \\"select2-match\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 72
+          }
+        },
+        {
           \\"parentId\\": 45,
-          \\"nextId\\": 67,
+          \\"nextId\\": 68,
           \\"node\\": {
             \\"type\\": 2,
             \\"tagName\\": \\"li\\",
@@ -3497,11 +3510,11 @@ exports[`record integration tests > can record node mutations 1`] = `
               \\"role\\": \\"presentation\\"
             },
             \\"childNodes\\": [],
-            \\"id\\": 72
+            \\"id\\": 73
           }
         },
         {
-          \\"parentId\\": 72,
+          \\"parentId\\": 73,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 2,
@@ -3512,34 +3525,21 @@ exports[`record integration tests > can record node mutations 1`] = `
               \\"role\\": \\"option\\"
             },
             \\"childNodes\\": [],
-            \\"id\\": 73
-          }
-        },
-        {
-          \\"parentId\\": 73,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 3,
-            \\"textContent\\": \\"A\\",
             \\"id\\": 74
           }
         },
         {
-          \\"parentId\\": 73,
-          \\"nextId\\": 74,
+          \\"parentId\\": 74,
+          \\"nextId\\": null,
           \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"span\\",
-            \\"attributes\\": {
-              \\"class\\": \\"select2-match\\"
-            },
-            \\"childNodes\\": [],
+            \\"type\\": 3,
+            \\"textContent\\": \\"A\\",
             \\"id\\": 75
           }
         },
         {
-          \\"parentId\\": 68,
-          \\"nextId\\": 69,
+          \\"parentId\\": 74,
+          \\"nextId\\": 75,
           \\"node\\": {
             \\"type\\": 2,
             \\"tagName\\": \\"span\\",
@@ -3576,7 +3576,7 @@ exports[`record integration tests > can record node mutations 1`] = `
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 0,
-      \\"id\\": 70
+      \\"id\\": 67
     }
   },
   {


### PR DESCRIPTION
## Problem

Adopts upstream rrweb [#1302](https://github.com/rrweb-io/rrweb/pull/1302), tracked in #3765 (batch-1, recording performance).

`genAdds` skips nodes already in `addedSet`, leaving them at their original position in the set. The emit phase iterates the set in insertion order and pays for every node whose parent hasn't been emitted yet via its deferral list — on large batches where nodes are removed and re-added (virtual-DOM re-renders, list reordering), that stale ordering makes mutation processing markedly more expensive on the customer's page.

## Changes

- When `genAdds` re-encounters a node already in `addedSet`, it re-inserts it (delete + add) so the set's iteration order tracks the latest DOM order. 7 lines, record-path only.
- The integration test snapshot is updated: adds within a single mutation batch are now sequenced differently (and node ids shift accordingly), but every add carries `parentId`/`nextId` so the rebuilt DOM is identical — the replayer suite passes unmodified.

Refs #3765.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code (covered by existing suites: record 34/34, shadow-dom-manager 5/5, integration 50/50, replayer 42/42)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ported as part of the batch-1 adoption plan on #3765 (PostHog Code session). Verified the emit-order change is the only observable difference by re-running the full record/integration/replayer suites; the single integration snapshot diff was inspected by hand (same nodes, same parent/next links, different batch sequence) before updating it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
