### PR TITLE
fix(rrweb): don't let media autoplay unfreeze a frozen page (adopt upstream #1697)

### DIFF
--- a/.changeset/frozen-page-autoplay.md
+++ b/.changeset/frozen-page-autoplay.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rrweb': patch
+---
+
+fix: non-user-initiated events (media autoplay, canvas/font/stylesheet churn) no longer unfreeze a frozen page, so background activity cannot flush the frozen mutation buffer (port of upstream rrweb #1697)

--- a/packages/rrweb/rrweb/src/record/index.ts
+++ b/packages/rrweb/rrweb/src/record/index.ts
@@ -69,6 +69,20 @@ try {
 }
 
 const mirror = createMirror();
+
+// incremental sources which fire without user interaction (e.g. a looping
+// background video, a JS animation) and so must not unfreeze a frozen page
+// (upstream rrweb #1697). Hoisted so the check does not allocate per event.
+const nonUserInitiatedSources = new Set<IncrementalSource>([
+  IncrementalSource.Mutation,
+  IncrementalSource.MediaInteraction, // often automatic e.g. background video loop
+  IncrementalSource.StyleSheetRule,
+  IncrementalSource.CanvasMutation,
+  IncrementalSource.Font,
+  IncrementalSource.Log,
+  IncrementalSource.StyleDeclaration,
+  IncrementalSource.AdoptedStyleSheet,
+]);
 function record<T = eventWithTime>(
   options: recordOptions<T> = {},
 ): listenerHandler | undefined {
@@ -216,7 +230,7 @@ function record<T = eventWithTime>(
       e.type !== EventType.FullSnapshot &&
       !(
         e.type === EventType.IncrementalSnapshot &&
-        e.data.source === IncrementalSource.Mutation
+        nonUserInitiatedSources.has(e.data.source)
       )
     ) {
       // we've got a user initiated event so first we need to apply

--- a/packages/rrweb/rrweb/test/record.test.ts
+++ b/packages/rrweb/rrweb/test/record.test.ts
@@ -1088,6 +1088,53 @@ describe('record', function (this: ISuite) {
     await assertSnapshot(ctx.events);
   });
 
+  it('does not unfreeze the page on non-user-initiated events like media autoplay', async () => {
+    await ctx.page.evaluate(() => {
+      return new Promise((resolve) => {
+        const video = document.createElement('video');
+        document.body.appendChild(video);
+
+        const { record, freezePage } = (window as unknown as IWindow).rrweb;
+        record({
+          emit: (window as unknown as IWindow).emit,
+        });
+        freezePage();
+        setTimeout(() => {
+          const div = document.createElement('div');
+          div.setAttribute('id', 'during-freeze');
+          document.body.appendChild(div);
+        }, 0);
+        setTimeout(() => {
+          // a background video starting to play is not user interaction and
+          // must not flush the frozen mutation buffer
+          video.dispatchEvent(new Event('play', { bubbles: true }));
+        }, 10);
+        setTimeout(() => {
+          resolve(null);
+        }, 25);
+      });
+    });
+    await waitForRAF(ctx.page);
+
+    const mutationEvents = ctx.events.filter(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        e.data.source === IncrementalSource.Mutation,
+    );
+    // the buffered mutation stays frozen even though a media event fired
+    expect(mutationEvents.length).toEqual(0);
+
+    // a real user event still unfreezes and flushes the buffer
+    await ctx.page.evaluate(() => document.body.click());
+    await waitForRAF(ctx.page);
+    const flushed = ctx.events.filter(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        e.data.source === IncrementalSource.Mutation,
+    );
+    expect(flushed.length).toEqual(1);
+  });
+
   describe('loading stylesheets', () => {
     let server: Server;
     let serverURL: string;


### PR DESCRIPTION
## Problem

Adopts upstream rrweb [#1697](https://github.com/rrweb-io/rrweb/pull/1697), tracked in #3765 (batch-1, recording performance).

`wrappedEmit` unfreezes a frozen page on any event except mutations, on the assumption that anything else is user interaction. That's wrong for media autoplay (a looping background video), canvas mutations, font loads, and stylesheet churn — background activity silently unfreezes the page and flushes the frozen mutation buffer, defeating the point of freezing.

## Changes

- Broadens the "does not unfreeze" list from just `Mutation` to all non-user-initiated incremental sources (`MediaInteraction`, `StyleSheetRule`, `CanvasMutation`, `Font`, `Log`, `StyleDeclaration`, `AdoptedStyleSheet`), matching upstream.
- One deliberate improvement over the upstream diff: the source list is hoisted into a module-level `Set` — upstream allocates the array and does an `Array.includes` on **every emitted event**, which is the hottest path in the recorder.
- Honest scoping: posthog-js does not currently call `freezePage`, so this is inert for us today. It's adopted for upstream parity at zero risk, and it makes freezing usable for backgrounded tabs as a future recording-cost optimization.

Refs #3765.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code (new record test: a synthetic media `play` event during freeze must not flush the buffer, a real click still does — verified the test fails without the fix)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ported as part of the batch-1 adoption plan on #3765 (PostHog Code session). Ran the full record suite (35/35) with the new regression test, and confirmed the test goes red when the src change is stashed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
