### PR TITLE
fix(react-native): reword nativeCrashes macOS floor so public API references regenerate cleanly

### DIFF
--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2113,7 +2113,7 @@
           "name": "console"
         },
         {
-          "description": "Enables native iOS/Android/macOS crash autocapture through the optional native plugin. Disabled by default. Requires `@posthog/react-native-plugin` installed (>= 2.2.0 for macOS).",
+          "description": "Enables native iOS/Android/macOS crash autocapture through the optional native plugin. Disabled by default. Requires `@posthog/react-native-plugin` installed (2.2.0 or newer for macOS).",
           "type": "boolean",
           "name": "nativeCrashes"
         },

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -25,7 +25,7 @@ interface AutocaptureOptions {
   console?: boolean | LogLevel[]
   /**
    * Enables native iOS/Android/macOS crash autocapture through the optional native plugin.
-   * Disabled by default. Requires `@posthog/react-native-plugin` installed (>= 2.2.0 for macOS).
+   * Disabled by default. Requires `@posthog/react-native-plugin` installed (2.2.0 or newer for macOS).
    */
   nativeCrashes?: boolean
 }


### PR DESCRIPTION
## Problem

PR #4111 merged with the `Generate references` check red, so `pnpm check:public-api` now fails on `main`. The committed public API reference for `posthog-react-native` doesn't match what `pnpm generate-references` produces.

The cause: in #4111 the `nativeCrashes` JSDoc documented the macOS floor as `(>= 2.2.0 for macOS)`, and the reference JSON was hand-edited to match instead of regenerated. The generator renders TSDoc, and a bare `>` isn't a `PlainText` node, so the renderer in `scripts/docs/utils.js` drops it and emits `(= 2.2.0 for macOS)`. The hand-written `>=` was never going to match generator output. And `= 2.2.0` is wrong in the public docs anyway, since it reads as "exactly 2.2.0" instead of a floor.

## Changes

Reworded the `nativeCrashes` doc comment from `(>= 2.2.0 for macOS)` to `(2.2.0 or newer for macOS)`. That drops the `>` the TSDoc renderer can't handle, so the generated reference comes out correct and stable. Then regenerated `posthog-react-native-references-latest.json` from source instead of by hand.

Docs and reference only, no runtime change, no release needed.

Verified locally: `pnpm turbo --filter=posthog-react-native generate-references` then `node scripts/check-public-api.js` prints "Public API references are up to date". Re-running the generator produces no further diff.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
