### PR TITLE
fix(browser): keep sendBeacon content type CORS-simple when uncompressed

### DIFF
--- a/.changeset/beacon-cors-simple-content-type.md
+++ b/.changeset/beacon-cors-simple-content-type.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Encode uncompressed `sendBeacon` bodies as base64 form data so the beacon keeps a CORS-simple content type. Previously an uncompressed unload beacon was sent as `application/json`, which forces a CORS preflight — a preflight cannot complete while the page unloads, so on cross-origin hosts the browser silently dropped the POST and the final batch of events was lost. Compression is inactive whenever the remote config request fails (flaky network, blocked endpoint), when the config response omits `supportedCompression`, or with `disable_compression: true`.

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -720,7 +720,7 @@ describe('request', () => {
                 transport = 'sendBeacon'
             })
 
-            it("should encode data to a string and send it as a blob if it's a POST request", async () => {
+            it('base64-encodes uncompressed POST data so the content type stays CORS-simple', async () => {
                 request(
                     createRequest({
                         url: 'https://any.posthog-instance.com/',
@@ -730,11 +730,11 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
-                    'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45',
+                    'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45&compression=base64',
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
-                expect(blob.type).toBe('application/json')
+                expect(blob.type).toBe('application/x-www-form-urlencoded')
 
                 const reader = new FileReader()
                 const result = await new Promise((resolve) => {
@@ -742,7 +742,7 @@ describe('request', () => {
                     reader.readAsText(blob)
                 })
 
-                expect(result).toMatchInlineSnapshot(`"{"foo":"bar"}"`)
+                expect(result).toMatchInlineSnapshot(`"data=eyJmb28iOiJiYXIifQ%3D%3D"`)
             })
 
             it('should respect base64 compression', async () => {
@@ -812,7 +812,10 @@ describe('request', () => {
             })
 
             it.each([
-                ['no compression', undefined, 'application/json'],
+                // Every content type here must be CORS-simple: a preflight cannot complete while
+                // the page unloads, so a preflighted beacon (e.g. application/json) is silently
+                // dropped by the browser on cross-origin hosts and its events are lost.
+                ['no compression', undefined, 'application/x-www-form-urlencoded'],
                 ['base64 compression', Compression.Base64, 'application/x-www-form-urlencoded'],
                 ['gzip compression', Compression.GZipJS, 'text/plain'],
             ])(

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -381,22 +381,25 @@ describe('request', () => {
                 },
             ],
             [
+                // beacons cannot fall back to JSON: application/json requires a CORS
+                // preflight, which never completes during page unload
                 'sendBeacon',
                 { transport: 'sendBeacon' as const, url: 'https://any.posthog-instance.com/' },
                 async () => {
                     expect(mockedNavigator?.sendBeacon.mock.calls[0][0]).not.toContain('compression=gzip-js')
+                    expect(mockedNavigator?.sendBeacon.mock.calls[0][0]).toContain('compression=base64')
                     const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
-                    expect(blob.type).toBe('application/json')
+                    expect(blob.type).toBe('application/x-www-form-urlencoded')
                     const result = await new Promise<string>((resolve) => {
                         const reader = new FileReader()
                         reader.onload = () => resolve(reader.result as string)
                         reader.readAsText(blob)
                     })
-                    expect(result).toBe('{"foo":"bar"}')
+                    expect(result).toBe('data=eyJmb28iOiJiYXIifQ%3D%3D')
                 },
             ],
         ])(
-            'falls back to JSON if a pre-encoded gzip body is not actually gzip before %s send',
+            'falls back to a non-gzip encoding if a pre-encoded gzip body is not actually gzip before %s send',
             async (_name, overrides, assertTransport) => {
                 request(invalidPreEncodedGzipRequest(overrides))
                 await assertTransport()
@@ -844,6 +847,30 @@ describe('request', () => {
                 "�      �VJ��W�RJJ,R� ��+�
                    "
             `)
+            })
+
+            it('falls back to base64 if gzip encoding throws before the beacon send', () => {
+                const gzipSpy = jest.spyOn(fflate, 'gzipSync').mockImplementation(() => {
+                    throw new Error('gzip failed')
+                })
+
+                try {
+                    request(
+                        createRequest({
+                            url: 'https://any.posthog-instance.com/',
+                            method: 'POST',
+                            compression: Compression.GZipJS,
+                            data: { foo: 'bar' },
+                        })
+                    )
+
+                    expect(mockedNavigator?.sendBeacon).toHaveBeenCalledTimes(1)
+                    expect(mockedNavigator?.sendBeacon.mock.calls[0][0]).toContain('compression=base64')
+                    const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
+                    expect(blob.type).toBe('application/x-www-form-urlencoded')
+                } finally {
+                    gzipSpy.mockRestore()
+                }
             })
 
             it('should not call sendBeacon when body is undefined', () => {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -152,6 +152,19 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
 
 const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest => {
     const fallbackToUncompressed = (): EncodedRequest => {
+        // beacon bodies must keep a CORS-simple content type even on the gzip-failure
+        // fallback — uncompressed application/json preflights, base64 form data does not
+        if (options.transport === 'sendBeacon') {
+            return {
+                url: extendURLParams(options.url, { compression: Compression.Base64 }),
+                encodedBody: encodePostData({
+                    ...options,
+                    compression: Compression.Base64,
+                    _encodedBody: undefined,
+                }),
+            }
+        }
+
         return {
             url: removeURLParam(options.url, 'compression'),
             encodedBody: encodePostData({

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -14,6 +14,7 @@ import {
     isGzipRequest,
     isNativeAsyncGzipError,
     isNativeAsyncGzipReadError,
+    isUndefined,
 } from '@posthog/core'
 
 interface RequestWithEncodedBody extends RequestWithOptions {
@@ -454,9 +455,15 @@ export const request = (_options: RequestWithOptions) => {
     const options: RequestWithEncodedBody = { ..._options }
     options.timeout = options.timeout || 60000
 
-    options.url = buildRequestURL(options.url, options.compression)
-
     const transport = options.transport ?? 'fetch'
+
+    // beacons fire during page unload, where a CORS preflight cannot complete — the body
+    // must keep a CORS-simple content type, which uncompressed (application/json) is not
+    if (transport === 'sendBeacon' && isUndefined(options.compression) && options.data) {
+        options.compression = Compression.Base64
+    }
+
+    options.url = buildRequestURL(options.url, options.compression)
 
     const availableTransports = AVAILABLE_TRANSPORTS.filter(
         (t) => !options.disableTransport || !t.transport || !options.disableTransport.includes(t.transport)


### PR DESCRIPTION
## Problem

Events flushed via `sendBeacon` on page unload are silently lost on cross-origin hosts whenever compression is inactive. The uncompressed encoding uses `Content-Type: application/json`, which is not CORS-simple, so the browser sends a preflight `OPTIONS` first — and a preflight cannot complete while the page tears down. The preflight reaches the server; the `POST` with the events never does. `sendBeacon()` still returns `true`, so the loss is invisible.

Compression is inactive whenever:

- the remote config request **fails** (flaky network, blocked endpoint) — the failure path applies an empty config, which resets `this.compression`,
- the config response omits `supportedCompression` (e.g. a reverse proxy rewriting it), or
- `disable_compression: true` is set.

PostHog Cloud advertises gzip, so healthy default setups are unaffected — but any of the above loses the final event batch of every bouncing visitor. Surfaced while investigating a customer report of bounce-related event loss.

## Changes

- In the `request()` entrypoint, a `sendBeacon` request with a body and no compression now uses `Compression.Base64`: `data=<base64>` with `application/x-www-form-urlencoded` — CORS-simple, and a wire format `/e` already accepts. The URL gains `compression=base64` so the server decodes it. Gzip (`text/plain`) and explicit Base64 beacons are unchanged.
- Updated the `sendBeacon` unit tests to pin the new wire shape.

Verified end-to-end with a two-origin harness (page and API on different origins, real Chromium): with a failing config request, capture + 200ms bounce previously produced a preflight and no `POST` (events lost); with this change the `POST` arrives with the base64 form body. Same result for the omitted-`supportedCompression` variant. Also verified against real ingestion: the fixed bundle's failure-path beacon was forwarded to PostHog Cloud and all events were queryable afterwards by a run-id property, with UUIDs matching the client-side capture trace.

One trade-off worth a reviewer's eye: base64 inflates the body ~33% vs raw JSON, so a very large unload batch could exceed the `sendBeacon` quota where JSON previously fit. Cross-origin those batches were lost anyway; this only affects same-origin setups with unusually large final batches. The alternative (keeping gzip active when config fails or omits `supportedCompression`) avoids the inflation but touches compression state more broadly — opinions welcome.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code. Reproduced the reported loss in a local two-origin harness (Playwright + a delay/fail proxy) before changing the SDK, which isolated the trigger to the uncompressed `application/json` beacon: pre-config the SDK already compresses optimistically, so the loss only appears once a config response (or failure) deactivates compression. Chose the Base64 fallback over raw urlencoded JSON because it is an existing, known-good wire shape for `/e`. Regression-checked the same scenarios against 1.315.0 and 1.399.2 bundles.
