### PR TITLE
fix(browser): split over-quota beacons and fall back to fetch instead of dropping silently

### DIFF
--- a/.changeset/beacon-quota-chunking.md
+++ b/.changeset/beacon-quota-chunking.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Handle `sendBeacon` quota rejections instead of silently dropping events. A beacon rejected by the browser (over the page's shared ~64KiB in-flight keepalive quota) is now split in half and re-sent recursively so the batch delivers as far as the quota allows; a rejected payload that cannot be split falls back to a non-keepalive fetch and logs a warning. Previously the boolean return of `sendBeacon` was ignored and an over-quota unload batch was lost with no signal.

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -945,6 +945,20 @@ describe('request', () => {
                 })
             })
 
+            it('warns instead of throwing when the beacon call itself throws', () => {
+                const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {})
+                mockedNavigator!.sendBeacon.mockImplementation(() => {
+                    throw new Error('boom')
+                })
+
+                try {
+                    expect(() => request(createRequest({ method: 'POST', data: { foo: 'bar' } }))).not.toThrow()
+                    expect(warnSpy).toHaveBeenCalledWith('Beacon send failed', expect.any(Error))
+                } finally {
+                    warnSpy.mockRestore()
+                }
+            })
+
             it('should not call sendBeacon when body is undefined', () => {
                 request(
                     createRequest({

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -873,6 +873,78 @@ describe('request', () => {
                 }
             })
 
+            describe('quota rejection (sendBeacon returns false)', () => {
+                const bigEvent = (i: number) => ({ event: 'big', i, payload: 'x'.repeat(8 * 1024) })
+                let warnSpy: jest.SpyInstance
+
+                beforeEach(() => {
+                    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {})
+                    mockedFetch.mockImplementation(() =>
+                        Promise.resolve({ status: 200, text: () => Promise.resolve('{}') })
+                    )
+                })
+
+                afterEach(() => {
+                    warnSpy.mockRestore()
+                })
+
+                it('splits a rejected over-quota batch in half and re-sends each piece', () => {
+                    mockedNavigator!.sendBeacon.mockReturnValueOnce(false).mockReturnValue(true)
+
+                    request(
+                        createRequest({
+                            method: 'POST',
+                            data: [bigEvent(1), bigEvent(2), bigEvent(3), bigEvent(4)],
+                        })
+                    )
+
+                    expect(mockedNavigator?.sendBeacon).toHaveBeenCalledTimes(3)
+                    const [full, firstHalf, secondHalf] = mockedNavigator!.sendBeacon.mock.calls.map(
+                        (c) => (c[1] as Blob).size
+                    )
+                    expect(firstHalf).toBeLessThan(full)
+                    expect(secondHalf).toBeLessThan(full)
+                    expect(mockedFetch).not.toHaveBeenCalled()
+                })
+
+                it('splits recursively and falls back to fetch for single events that still do not fit', () => {
+                    mockedNavigator!.sendBeacon.mockReturnValue(false)
+
+                    request(
+                        createRequest({
+                            method: 'POST',
+                            data: [bigEvent(1), bigEvent(2), bigEvent(3), bigEvent(4)],
+                        })
+                    )
+
+                    // 1 full + 2 halves + 4 singles
+                    expect(mockedNavigator?.sendBeacon).toHaveBeenCalledTimes(7)
+                    expect(mockedFetch).toHaveBeenCalledTimes(4)
+                    expect(warnSpy).toHaveBeenCalledTimes(4)
+                    for (const call of mockedFetch.mock.calls) {
+                        expect(call[1].keepalive).toBe(false)
+                    }
+                })
+
+                it('does not split a rejected small batch, the quota is already exhausted', () => {
+                    mockedNavigator!.sendBeacon.mockReturnValue(false)
+
+                    request(
+                        createRequest({
+                            method: 'POST',
+                            data: [
+                                { event: 'small', i: 1 },
+                                { event: 'small', i: 2 },
+                            ],
+                        })
+                    )
+
+                    expect(mockedNavigator?.sendBeacon).toHaveBeenCalledTimes(1)
+                    expect(mockedFetch).toHaveBeenCalledTimes(1)
+                    expect(mockedFetch.mock.calls[0][1].keepalive).toBe(false)
+                })
+            })
+
             it('should not call sendBeacon when body is undefined', () => {
                 request(
                     createRequest({

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -10,6 +10,7 @@ import { gzipSync, strToU8 } from 'fflate'
 import { _base64Encode } from './utils/encode-utils'
 import {
     gzipCompress,
+    isArray,
     isGzipData,
     isGzipRequest,
     isNativeAsyncGzipError,
@@ -290,7 +291,7 @@ const xhr = (options: RequestWithOptions) => {
     req.send(body)
 }
 
-const _fetch = (options: RequestWithOptions) => {
+const _fetch = (options: RequestWithOptions & { _keepaliveDisabled?: boolean }) => {
     const encodedRequest = encodeRequest(options)
     if (!encodedRequest) {
         return
@@ -342,7 +343,9 @@ const _fetch = (options: RequestWithOptions) => {
         // so let's get the best of both worlds and only set keepalive for POST requests
         // where the body is less than 64kb
         // NB this is fetch keepalive and not http keepalive
-        keepalive: options.method === 'POST' && (estimatedSize || 0) < KEEP_ALIVE_THRESHOLD,
+        // _keepaliveDisabled: a beacon-rejected payload would fail a keepalive fetch too (shared quota)
+        keepalive:
+            options.method === 'POST' && !options._keepaliveDisabled && (estimatedSize || 0) < KEEP_ALIVE_THRESHOLD,
         body,
         signal: aborter?.signal,
         ...options.fetchOptions,
@@ -389,13 +392,16 @@ const _fetch = (options: RequestWithOptions) => {
     return
 }
 
+// below this size a rejection means the shared quota is exhausted, not that the payload is too big
+const BEACON_SPLIT_FLOOR_BYTES = 16 * 1024
+
 const _sendBeacon = (options: RequestWithOptions) => {
     // beacon documentation https://w3c.github.io/beacon/
     // beacons format the message and use the type property
 
     try {
         const { url, encodedBody } = encodePostDataSafely(options)
-        const { contentType, body } = encodedBody ?? {}
+        const { contentType, body, estimatedSize } = encodedBody ?? {}
         if (!body) {
             return
         }
@@ -403,7 +409,21 @@ const _sendBeacon = (options: RequestWithOptions) => {
         // Without wrapping, ArrayBuffer bodies are sent with no Content-Type,
         // which can cause issues with proxies/WAFs that require it.
         const sendBeaconBody = body instanceof Blob ? body : new Blob([body], { type: contentType })
-        navigator!.sendBeacon!(url, sendBeaconBody)
+        if (navigator!.sendBeacon!(url, sendBeaconBody)) {
+            return
+        }
+
+        // rejected: over the page's shared ~64KiB in-flight keepalive quota
+        // (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch) — halve so what fits still delivers
+        if (isArray(options.data) && options.data.length > 1 && (estimatedSize ?? 0) > BEACON_SPLIT_FLOOR_BYTES) {
+            const mid = Math.ceil(options.data.length / 2)
+            _sendBeacon({ ...options, data: options.data.slice(0, mid) })
+            _sendBeacon({ ...options, data: options.data.slice(mid) })
+            return
+        }
+
+        logger.warn(`Beacon of ~${estimatedSize ?? 0} bytes was rejected by the browser, falling back to fetch`)
+        _fetch({ ...options, _keepaliveDisabled: true })
     } catch {
         // send beacon is a best-effort, fire-and-forget mechanism on page unload,
         // we don't want to throw errors here

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -424,9 +424,10 @@ const _sendBeacon = (options: RequestWithOptions) => {
 
         logger.warn(`Beacon of ~${estimatedSize ?? 0} bytes was rejected by the browser, falling back to fetch`)
         _fetch({ ...options, _keepaliveDisabled: true })
-    } catch {
+    } catch (error) {
         // send beacon is a best-effort, fire-and-forget mechanism on page unload,
         // we don't want to throw errors here
+        logger.warn('Beacon send failed', error)
     }
 }
 

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -331,6 +331,7 @@
         "_isWidgetRendered",
         "_is_persistence_disabled",
         "_is_supported",
+        "_keepaliveDisabled",
         "_lastActivityTimestamp",
         "_lastCheckedUrl",
         "_lastFullSnapshotSessionId",


### PR DESCRIPTION
## Problem

`sendBeacon` returns `false` when a payload would exceed the page's shared ~64KiB in-flight keepalive quota ([Fetch spec](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch), [Beacon spec](https://w3c.github.io/beacon/#sec-processing-model)). The SDK ignored that return value, so an over-quota unload batch was dropped with no signal — no log, no callback, no retry. Follow-up to #4139, where base64 encoding (~33% larger bodies) made this slightly easier to hit.

## Changes

- `_sendBeacon` now checks the return value. On rejection:
  - a batch is split in half and each piece re-sent recursively, so the browser (the only reliable size oracle) re-judges each piece and as much as fits gets delivered;
  - below a 16KiB floor a rejection means the quota is exhausted rather than the payload being too big, so instead of splitting further the payload falls back to a non-keepalive fetch (keepalive would draw on the same exhausted quota) and logs a warning.
- Measured behavior backing the design: Chromium accepts 5×30KB beacons spaced out but only the first 2 fired synchronously; a single 70KB blob is rejected outright.

Harness A/B (30×~3KB events, compression inactive, bounce at 400ms): previous behavior delivers **0/30** (single rejected beacon, silent); with this change **30/30** arrive across 13 CORS-simple requests. On a slow network the floor is "first ~64KB delivers, in queue order" — events are drained before session recordings, so the most valuable data goes first.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by Anna following review discussion on #4139. Chose reactive splitting (react to `sendBeacon` returning `false`) over proactive size estimation so the browser's quota accounting stays the single source of truth; considered and rejected a size-conditional `application/json` fallback to preserve the "beacon never preflights" invariant from #4139. Verified with unit tests plus a two-origin harness A/B against the pre-change bundle.
