### PR TITLE
chore: add SessionStart hook for Secretive commit signing

### DIFF
--- a/.claude/hooks/setup-code-signing.sh
+++ b/.claude/hooks/setup-code-signing.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# SessionStart hook: detect Secretive SSH agent for git commit signing.
+#
+# If SSH_AUTH_SOCK is unset (or still the default macOS launchd agent) and the
+# Secretive agent socket exists, point SSH_AUTH_SOCK at it so git commit
+# signing works out of the box on macOS.
+
+if [ -z "$CLAUDE_ENV_FILE" ]; then
+  exit 0
+fi
+
+SECRETIVE_SOCKET="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+if [ -S "$SECRETIVE_SOCKET" ]; then
+  # Repoint at Secretive when either:
+  #   - SSH_AUTH_SOCK is unset, or
+  #   - it points at the default macOS launchd agent AND that agent has no
+  #     identities loaded (so we don't stomp on a working custom agent).
+  # The launchd socket path varies by how the session was started
+  # (/var/run/..., /private/tmp/..., /var/folders/...), so match the suffix
+  # rather than a single prefix.
+  agent_has_no_identities() {
+    # ssh-add -l exits 1 if the agent has no identities, 2 if it can't contact
+    # the agent at all. Either means "not a useful agent for signing".
+    SSH_AUTH_SOCK="$SSH_AUTH_SOCK" ssh-add -l >/dev/null 2>&1
+    local rc=$?
+    [ "$rc" -eq 1 ] || [ "$rc" -eq 2 ]
+  }
+  if [ -z "$SSH_AUTH_SOCK" ] \
+    || { [[ "$SSH_AUTH_SOCK" == *com.apple.launchd.*/Listeners ]] && agent_has_no_identities; }; then
+    printf 'export SSH_AUTH_SOCK=%q\n' "$SECRETIVE_SOCKET" >> "$CLAUDE_ENV_FILE"
+  fi
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+    "hooks": {
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/setup-code-signing.sh"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Problem

PR to copy the session start hook that fixes secretive from the main posthog monorepo

Claude code continues:

Claude Code sessions on macOS inherit the default launchd SSH agent, which holds no identities when keys live in [Secretive](https://github.com/maxgoedjen/secretive). With `gpg.format = ssh` and `commit.gpgsign = true`, every commit inside a session fails with:

```
error: No private key found for public key "...Secretive.SecretAgent/Data/PublicKeys/....pub"?
fatal: failed to write commit object
```

## Changes

Ports the `setup-code-signing.sh` SessionStart hook from the main posthog repo, wired up via `.claude/settings.json`. On session start it points `SSH_AUTH_SOCK` at the Secretive agent socket, but only when:

- the Secretive socket actually exists, **and**
- `SSH_AUTH_SOCK` is unset, or points at the default macOS launchd agent with no identities loaded

so a working custom agent is never stomped. No-ops entirely on non-macOS / non-Secretive setups (including CI), since the socket won't exist and `CLAUDE_ENV_FILE` is only set inside Claude Code sessions.

`.claude/settings.local.json` remains git-ignored; only the shared `settings.json` and the hook script are committed.

## Testing

Dry-ran the hook from a session whose `SSH_AUTH_SOCK` pointed at the identity-less launchd agent: it wrote the Secretive socket export to `CLAUDE_ENV_FILE`, and this PR's own commit was SSH-signed through that socket (verified `%G?` = G).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*