### PR TITLE
chore: delete eslint-disable comments that suppress nothing

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ const rules = {
     'no-empty': 'off',
     'no-console': 'error',
     'no-only-tests/no-only-tests': 'error',
+    '@eslint-community/eslint-comments/no-unused-disable': 'error',
     'posthog-js/no-external-replay-imports': 'error',
     'posthog-js/no-unsafe-web-global': 'off',
     '@typescript-eslint/naming-convention': [
@@ -52,6 +53,7 @@ module.exports = {
         'eslint-plugin-react-hooks',
         'jest',
         'no-only-tests',
+        '@eslint-community/eslint-comments',
     ],
     extends: extend,
     rules,

--- a/examples/example-next-app-router/app/components/Nav.tsx
+++ b/examples/example-next-app-router/app/components/Nav.tsx
@@ -19,10 +19,8 @@ export function Nav() {
     useEffect(() => {
         const update = () => setUser(localStorage.getItem('posthog-example-user'))
         update()
-        /* eslint-disable posthog-js/no-add-event-listener */
         window.addEventListener('auth-change', update)
         window.addEventListener('storage', update)
-        /* eslint-enable posthog-js/no-add-event-listener */
         return () => {
             window.removeEventListener('auth-change', update)
             window.removeEventListener('storage', update)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@microsoft/api-extractor": "^7.58.9",
         "@microsoft/api-extractor-model": "^7.33.8",
         "@microsoft/tsdoc": "^0.15.1",

--- a/packages/ai/tests/gemini.integration.test.ts
+++ b/packages/ai/tests/gemini.integration.test.ts
@@ -12,7 +12,7 @@ if (!GEMINI_API_KEY) {
 } else {
   // Dynamic imports to avoid ESM parse failures when @google/genai
   // transitive deps are not configured in transformIgnorePatterns.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { PostHog } = require('posthog-node')
 
   jest.mock('posthog-node', () => ({
@@ -23,7 +23,7 @@ if (!GEMINI_API_KEY) {
     })),
   }))
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const PostHogGemini = require('../src/gemini').default
 
   describe('Gemini Integration Tests', () => {

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -49,7 +49,6 @@ jest.mock('openai', () => {
   // instance field (which would overwrite the subclass implementation).
   class MockCompletions {
     constructor() {}
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     create(..._args: any[]): any {
       /* will be stubbed in beforeEach */
       return undefined

--- a/packages/browser/playwright/fixtures/network.ts
+++ b/packages/browser/playwright/fixtures/network.ts
@@ -155,7 +155,6 @@ export class NetworkPage {
             return this.page.waitForResponse(urlPattern)
         })
         await options.action()
-        // eslint-disable-next-line compat/compat
         await Promise.allSettled(responsePromises)
     }
 

--- a/packages/browser/playwright/fixtures/page.ts
+++ b/packages/browser/playwright/fixtures/page.ts
@@ -48,7 +48,6 @@ export const testPage = base.extend<{ page: BasePage; url: string | undefined }>
                 return this.waitForResponse(urlPattern)
             })
             await options.action()
-            // eslint-disable-next-line compat/compat
             await Promise.allSettled(responsePromises)
         }
         page.reloadIdle = async () => {

--- a/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
@@ -32,16 +32,13 @@ test.beforeEach(async ({ context }) => {
                     // and we can't pass window.fetch to the node context when using page.exposeFunction
                     await pg.evaluate(() => {
                         ;(window as any).wrapFetchForTesting = (badlyBehaved: boolean) => {
-                            // eslint-disable-next-line compat/compat
                             const originalFetch = window.fetch
                             ;(window as any).originalFetch = originalFetch
 
-                            // eslint-disable-next-line compat/compat
                             window.fetch = async function (
                                 requestOrURL: URL | RequestInfo,
                                 init?: RequestInit | undefined
                             ) {
-                                // eslint-disable-next-line compat/compat
                                 const req = new Request(requestOrURL, init)
 
                                 const hasBody = typeof requestOrURL !== 'string' && 'body' in requestOrURL

--- a/packages/browser/playwright/mocked/utils/posthog-playwright-test-base.ts
+++ b/packages/browser/playwright/mocked/utils/posthog-playwright-test-base.ts
@@ -89,7 +89,6 @@ export const test = base.extend<{
 
             await options.action()
 
-            // eslint-disable-next-line compat/compat
             await Promise.allSettled(responsePromises)
         }
         page.expectCapturedEventsToBe = async function (expectedEvents: string[]) {

--- a/packages/browser/playwright/mocked/utils/setup.ts
+++ b/packages/browser/playwright/mocked/utils/setup.ts
@@ -101,7 +101,6 @@ export async function start(
     })
 
     // allow promise in e2e tests
-    // eslint-disable-next-line compat/compat
     const flagsMock = new Promise((resolve) => {
         void context.route('**/flags/*', (route) => {
             route.fulfill({

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -1,6 +1,4 @@
 /// <reference lib="dom" />
-/* eslint-disable compat/compat */
-
 import {
     Autocapture,
     autocapturePropertiesForElement,
@@ -72,12 +70,11 @@ describe('Autocapture system', () => {
             configurable: true,
             enumerable: true,
             writable: true,
-            // eslint-disable-next-line compat/compat
+
             value: new URL('https://example.com'),
         })
 
         beforeSendMock = jest.fn().mockImplementation((...args) => args)
-
         posthog = await createPosthogInstance(uuidv7(), {
             api_host: 'https://test.com',
             token: 'testtoken',

--- a/packages/browser/src/__tests__/consent.test.ts
+++ b/packages/browser/src/__tests__/consent.test.ts
@@ -156,7 +156,6 @@ describe('consentManager', () => {
                 before_send: beforeSendMock,
             })
             // Wait for the initial $pageview to be captured
-            // eslint-disable-next-line compat/compat
             await new Promise((r) => setTimeout(r, 10))
             expect(beforeSendMock).toHaveBeenCalledTimes(1)
             expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: '$pageview' }))
@@ -175,7 +174,6 @@ describe('consentManager', () => {
             expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
             expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: '$pageview' }))
             // Wait for the $pageview timeout to be called
-            // eslint-disable-next-line compat/compat
             await new Promise((r) => setTimeout(r, 10))
             expect(beforeSendMock).toHaveBeenCalledTimes(2)
         })
@@ -190,7 +188,6 @@ describe('consentManager', () => {
             expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
             expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: '$pageview' }))
             // Wait for the $pageview timeout to be called
-            // eslint-disable-next-line compat/compat
             await new Promise((r) => setTimeout(r, 10))
             posthog.opt_in_capturing()
             expect(beforeSendMock).toHaveBeenCalledTimes(3)

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-api.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-api.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { PostHogConversations, ConversationsManager } from '../../../extensions/conversations/posthog-conversations'
 import {
     ConversationsRemoteConfig,

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-identity-manager.test.tsx
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-identity-manager.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { ConversationsManager } from '../../../extensions/conversations/external'
 import { ConversationsRemoteConfig } from '../../../posthog-conversations-types'
 import { PostHog } from '../../../posthog-core'

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-identity.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-identity.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { PostHogConversations, ConversationsManager } from '../../../extensions/conversations/posthog-conversations'
 import { ConversationsRemoteConfig } from '../../../posthog-conversations-types'
 import { PostHog } from '../../../posthog-core'

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-manager.test.tsx
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-manager.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { ConversationsManager } from '../../../extensions/conversations/external'
 import {
     ConversationsRemoteConfig,

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-persistence.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-persistence.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { ConversationsPersistence } from '../../../extensions/conversations/external/persistence'
 import { UserProvidedTraits } from '../../../posthog-conversations-types'
 import { PostHog } from '../../../posthog-core'

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-widget.test.tsx
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-widget.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { render, fireEvent, waitFor } from '@testing-library/preact'
 import '@testing-library/jest-dom'
 import { ConversationsWidget } from '../../../extensions/conversations/external/components/ConversationsWidget'

--- a/packages/browser/src/__tests__/extensions/conversations/conversations.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { PostHogConversations, ConversationsManager } from '../../../extensions/conversations/posthog-conversations'
 import { ConversationsRemoteConfig } from '../../../posthog-conversations-types'
 import { PostHog } from '../../../posthog-core'

--- a/packages/browser/src/__tests__/extensions/conversations/rich-content.test.tsx
+++ b/packages/browser/src/__tests__/extensions/conversations/rich-content.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { render } from '@testing-library/preact'
 import '@testing-library/jest-dom'
 import { RichContent } from '../../../extensions/conversations/external/components/RichContent'

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable compat/compat */
-
 import { isNull, ErrorTracking } from '@posthog/core'
 import { expect } from '@jest/globals'
 import { buildErrorPropertiesBuilder } from '../../../posthog-exceptions'

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { PostHog } from '../../../posthog-core'
 import { FlagsResponse } from '../../../types'
 import { ExceptionObserver } from '../../../extensions/exception-autocapture'
@@ -126,7 +125,7 @@ describe('Exception Observer', () => {
             // See e2e tests
             const promiseRejectionEvent = new PromiseRejectionEvent('unhandledrejection', {
                 // this is a test not a browser, so we don't care there's no Promise in IE11
-                // eslint-disable-next-line compat/compat
+
                 promise: Promise.resolve(),
                 reason: error,
             })
@@ -247,7 +246,7 @@ describe('Exception Observer', () => {
             const error = new Error('test error')
             const promiseRejectionEvent = new PromiseRejectionEvent('unhandledrejection', {
                 // this is a test not a browser, so we don't care there's no Promise in IE11
-                // eslint-disable-next-line compat/compat
+
                 promise: Promise.resolve(),
                 reason: error,
             })

--- a/packages/browser/src/__tests__/extensions/replay/rrweb-plugins/patch.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/rrweb-plugins/patch.test.ts
@@ -15,7 +15,6 @@ describe('patch', () => {
 
     it('marks a function as wrapped', () => {
         patch(fakeWindow, 'fakeFetch', () => () => {})
-        // eslint-disable-next-line compat/compat
         expect((fakeWindow.fakeFetch as any).__posthog_wrapped__).toBe(true)
     })
 

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { act, fireEvent, render, renderHook } from '@testing-library/preact'
 import {
     SurveyManager,

--- a/packages/browser/src/__tests__/extensions/surveys/feedback-widget.test.tsx
+++ b/packages/browser/src/__tests__/extensions/surveys/feedback-widget.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import '@testing-library/jest-dom'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { FeedbackWidget } from '../../../extensions/surveys'

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -1373,7 +1373,6 @@ describe('featureflags', () => {
         it('should isolate a throwing callback so later callbacks still fire', () => {
             // The logged error is expected here, so swallow it rather than letting the
             // test setup's console.error guard throw.
-            // eslint-disable-next-line no-console
             console.error = jest.fn()
 
             featureFlags._hasLoadedFlags = true

--- a/packages/browser/src/__tests__/helpers/posthog-instance.ts
+++ b/packages/browser/src/__tests__/helpers/posthog-instance.ts
@@ -27,7 +27,6 @@ export const createPosthogInstance = async (
         },
     } as any
 
-    // eslint-disable-next-line compat/compat
     return await new Promise<PostHog>((resolve) =>
         posthog.init(
             token,

--- a/packages/browser/src/__tests__/posthog-core.set_config.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.set_config.test.ts
@@ -27,7 +27,6 @@ describe('posthog.set_config', () => {
             configurable: true,
             enumerable: true,
             writable: true,
-            // eslint-disable-next-line compat/compat
             value: new URL('https://example.com'),
         })
 

--- a/packages/browser/src/__tests__/posthog-surveys.test.ts
+++ b/packages/browser/src/__tests__/posthog-surveys.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 jest.mock('../utils/logger', () => ({
     createLogger: jest.fn().mockReturnValue({
         info: jest.fn(),

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 /// <reference lib="dom" />
 
 import { TextDecoder } from 'util'
@@ -432,7 +431,6 @@ describe('request', () => {
             expect(reason.name).toBe('AbortError')
             // ...but with a descriptive message so it is never a reason-less "signal is aborted without reason"
             expect(reason.message).toBe('PostHog request timed out after 8000ms')
-
             expect(callback).toHaveBeenCalledTimes(1)
             const response = callback.mock.calls[0][0]
             expect(response.statusCode).toBe(0)

--- a/packages/browser/src/__tests__/retry-queue.test.ts
+++ b/packages/browser/src/__tests__/retry-queue.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable compat/compat */
-
 import { pickNextRetryDelay, RetryQueue } from '../retry-queue'
 import { assignableWindow } from '../utils/globals'
 

--- a/packages/browser/src/__tests__/segment.test.ts
+++ b/packages/browser/src/__tests__/segment.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 /*
  * Test that integration with Segment works as expected. The integration should:
  *

--- a/packages/browser/src/__tests__/setup.js
+++ b/packages/browser/src/__tests__/setup.js
@@ -1,9 +1,8 @@
 beforeEach(() => {
-    // eslint-disable-next-line no-console
     console.error = (...args) => {
         throw new Error(`Unexpected console.error: ${args}`)
     }
-    // eslint-disable-next-line no-console
+
     console.warn = (...args) => {
         throw new Error(`Unexpected console.warn: ${args}`)
     }

--- a/packages/browser/src/__tests__/storage.test.ts
+++ b/packages/browser/src/__tests__/storage.test.ts
@@ -81,7 +81,6 @@ describe('sessionStore', () => {
     describe('sessionStore._is_supported', () => {
         beforeEach(() => {
             // Reset the sessionStorageSupported before each test. Otherwise, we'd just be testing the cached value.
-            // eslint-disable-next-line no-unused-vars
             resetSessionStorageSupported()
         })
         it('returns false if sessionStorage is undefined', () => {

--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -236,7 +236,6 @@ describe('surveys', () => {
             configurable: true,
             enumerable: true,
             writable: true,
-            // eslint-disable-next-line compat/compat
             value: new URL('https://example.com'),
         })
     })
@@ -576,7 +575,6 @@ describe('surveys', () => {
             surveysResponse = {
                 surveys: [surveyWithUrl, surveyWithSelector, surveyWithUrlAndSelector],
             }
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://posthog.com') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithUrl])
@@ -592,7 +590,6 @@ describe('surveys', () => {
                 document.body.removeChild(testSelectorEl)
             }
 
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://posthogapp.com') as unknown as Location
             document.body.appendChild(document.createElement('div')).id = 'foo'
 
@@ -617,35 +614,31 @@ describe('surveys', () => {
             }
 
             const originalWindowLocation = assignableWindow.location
-            // eslint-disable-next-line compat/compat
+
             assignableWindow.location = new URL('https://regex-url.com/test') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithRegexUrl])
             })
             assignableWindow.location = originalWindowLocation
 
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://example.com?name=something') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithParamRegexUrl])
             })
             assignableWindow.location = originalWindowLocation
 
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://app.subdomain.com') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithWildcardSubdomainUrl])
             })
             assignableWindow.location = originalWindowLocation
 
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://wildcard.com/something/other') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithWildcardRouteUrl])
             })
             assignableWindow.location = originalWindowLocation
 
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://example.com/exact') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithExactUrlMatch])
@@ -694,7 +687,6 @@ describe('surveys', () => {
                 surveys: [surveyWithUrlDoesNotContain, surveyWithIsNotUrlMatch, surveyWithUrlDoesNotContainRegex],
             }
 
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://posthog.com') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 // returns surveyWithIsNotUrlMatch and surveyWithUrlDoesNotContainRegex because they don't contain posthog.com
@@ -702,7 +694,6 @@ describe('surveys', () => {
             })
             assignableWindow.location = originalWindowLocation
 
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://example.com/exact') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 // returns surveyWithUrlDoesNotContain and surveyWithUrlDoesNotContainRegex because they are not exact matches
@@ -710,7 +701,6 @@ describe('surveys', () => {
             })
             assignableWindow.location = originalWindowLocation
 
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://regex-url.com/test') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 // returns surveyWithUrlDoesNotContain and surveyWithIsNotUrlMatch because they are not regex matches
@@ -769,7 +759,6 @@ describe('surveys', () => {
         })
 
         it('returns surveys that inclusively matches any of the above', () => {
-            // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://posthogapp.com') as unknown as Location
             document.body.appendChild(document.createElement('div')).className = 'test-selector'
             surveysResponse = { surveys: [activeSurvey, surveyWithSelector, surveyWithEverything] }

--- a/packages/browser/src/__tests__/utils/array-at-polyfill.test.ts
+++ b/packages/browser/src/__tests__/utils/array-at-polyfill.test.ts
@@ -22,7 +22,6 @@ describe('Array.prototype.at polyfill', () => {
                 configurable: true,
             })
         } else {
-            // eslint-disable-next-line no-extend-native
             delete (Array.prototype as any).at
         }
     })
@@ -30,7 +29,7 @@ describe('Array.prototype.at polyfill', () => {
     describe('when Array.prototype.at is missing (old browser)', () => {
         beforeEach(() => {
             // simulate Chrome <92 / iOS Safari <15.4
-            // eslint-disable-next-line no-extend-native
+
             delete (Array.prototype as any).at
             loadPolyfill()
         })

--- a/packages/browser/src/__tests__/web-experiments.test.ts
+++ b/packages/browser/src/__tests__/web-experiments.test.ts
@@ -157,7 +157,6 @@ describe('Web Experimentation', () => {
         const elParent = createTestDocument()
 
         WebExperiments.getWindowLocation = () => {
-            // eslint-disable-next-line compat/compat
             return new URL(testLocation) as unknown as Location
         }
 
@@ -235,7 +234,7 @@ describe('Web Experimentation', () => {
                 const elParent = createTestDocument()
 
                 // raw browser URL would not match the exact condition
-                // eslint-disable-next-line compat/compat
+
                 WebExperiments.getWindowLocation = () => new URL('https://generated-host.skin/x') as unknown as Location
                 posthog.config.get_current_url = () => 'https://example.com/Signup'
 
@@ -248,7 +247,6 @@ describe('Web Experimentation', () => {
                 const webExperiment = new WebExperiments(posthog)
                 const elParent = createTestDocument()
 
-                // eslint-disable-next-line compat/compat
                 WebExperiments.getWindowLocation = () => new URL('https://example.com/Signup') as unknown as Location
                 posthog.config.get_current_url = () => 'https://generated-host.skin/x'
 
@@ -322,7 +320,6 @@ describe('Web Experimentation', () => {
             const original = WebExperiments.getWindowLocation
 
             WebExperiments.getWindowLocation = () => {
-                // eslint-disable-next-line compat/compat
                 return new URL(
                     'https://example.com/landing-page?__experiment_id=3&__experiment_variant=variant-sign-up'
                 ) as unknown as Location

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -131,7 +131,6 @@ export function getPropertiesFromElement(
     let nthOfType = 1
     let currentElem: Element | null = elem
     while ((currentElem = previousElementSibling(currentElem))) {
-        // eslint-disable-line no-cond-assign
         nthChild++
         if (currentElem.tagName === elem.tagName) {
             nthOfType++

--- a/packages/browser/src/entrypoints/tracing-headers.ts
+++ b/packages/browser/src/entrypoints/tracing-headers.ts
@@ -183,7 +183,6 @@ const patchFetch = (
                         // For fetch(Request, init), construct a new Request so init overrides are applied and the
                         // caller's Request is not mutated. For fetch(url, init), avoid this because it exposes string
                         // bodies as ReadableStreams to downstream wrappers in Safari.
-                        // eslint-disable-next-line compat/compat
                         const req = new Request(url, init)
                         addTracingHeaders(hostnames, distinctId, sessionManager, req.url, req.headers)
                         fetchArgs = [req]

--- a/packages/browser/src/extensions/conversations/external/components/ConversationsWidget.tsx
+++ b/packages/browser/src/extensions/conversations/external/components/ConversationsWidget.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { h, Component } from 'preact'
 import {
     ConversationsRemoteConfig,

--- a/packages/browser/src/extensions/history-autocapture.ts
+++ b/packages/browser/src/extensions/history-autocapture.ts
@@ -63,7 +63,6 @@ export class HistoryAutocapture implements Extension {
         }
 
         // Old fashioned, we could also use arrow functions but I think the closure for a patch is more reliable
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this
         patch(window.history, method, (originalMethod) => {
             return function patchedHistoryMethod(

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -107,7 +107,6 @@ function initPerformanceObserver(cb: networkCallback, win: IWindow, options: Req
         })
     })
     // compat checked earlier
-    // eslint-disable-next-line compat/compat
     const entryTypes = PerformanceObserver.supportedEntryTypes.filter((x) =>
         options.performanceEntryTypeToObserve.includes(x)
     )
@@ -309,7 +308,6 @@ function initXhrObserver(cb: networkCallback, win: IWindow, options: Required<Ne
                 // instrumentation fails we degrade gracefully and the original request still proceeds.
                 try {
                     // check IE earlier than this, we only initialize if Request is present
-                    // eslint-disable-next-line compat/compat
                     const req = new Request(url)
                     const networkRequest: Partial<CapturedNetworkRequest> = {}
                     let start: number | undefined
@@ -772,7 +770,6 @@ function initFetchObserver(
             let req: Request
             try {
                 // check IE earlier than this, we only initialize if Request is present
-                // eslint-disable-next-line compat/compat
                 req = new Request(url, init)
             } catch (e) {
                 logger.error('Failed to instrument fetch for network capture', e)

--- a/packages/browser/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/packages/browser/src/extensions/replay/rrweb-plugins/patch.ts
@@ -53,7 +53,6 @@ export function patch(
         // Make sure it's a function first, as we need to attach an empty prototype for `defineProperties` to work
         // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
         if (isFunction(wrapped)) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             wrapped.prototype = wrapped.prototype || {}
             Object.defineProperties(wrapped, {
                 __posthog_wrapped__: {

--- a/packages/browser/src/extensions/utils/matcher-utils.ts
+++ b/packages/browser/src/extensions/utils/matcher-utils.ts
@@ -11,7 +11,6 @@ export function doesDeviceTypeMatch(deviceTypes?: string[], matchType?: Property
         return false
     }
     const deviceType = detectDeviceType(userAgent, {
-        // eslint-disable-next-line compat/compat
         userAgentDataPlatform: navigator?.userAgentData?.platform,
         maxTouchPoints: navigator?.maxTouchPoints,
         screenWidth: window?.screen?.width,

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -957,7 +957,6 @@ export class PostHog implements PostHogInterface {
             // Only time-slice if deferred init is enabled, otherwise run synchronously
             if (this.config.__preview_deferred_init_extensions) {
                 // we don't support IE11 anymore, so performance.now is safe
-                // eslint-disable-next-line compat/compat
                 const elapsed = performance.now() - initStartTime
 
                 // Check if we've exceeded our time budget

--- a/packages/browser/src/posthog-metrics.ts
+++ b/packages/browser/src/posthog-metrics.ts
@@ -78,7 +78,6 @@ export class PostHogMetrics implements Extension {
      */
     flush(transport?: 'XHR' | 'fetch' | 'sendBeacon'): Promise<void> {
         if (!this._core) {
-            // eslint-disable-next-line compat/compat
             return Promise.resolve()
         }
         if (transport) {
@@ -86,7 +85,7 @@ export class PostHogMetrics implements Extension {
             if (payload) {
                 void this._sendMetricsBatch(payload, transport)
             }
-            // eslint-disable-next-line compat/compat
+
             return Promise.resolve()
         }
         return this._core.flush().catch((err) => this._logger.error('PostHog metrics flush failed:', err))

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -22,7 +22,6 @@ interface RequestWithEncodedBody extends RequestWithOptions {
     _encodedBody?: EncodedBody
 }
 
-// eslint-disable-next-line compat/compat
 export const SUPPORTS_REQUEST = !!XMLHttpRequest || !!fetch
 
 const CONTENT_TYPE_PLAIN = 'text/plain'
@@ -310,7 +309,6 @@ const _fetch = (options: RequestWithOptions) => {
     const { url, encodedBody } = encodedRequest
     const { contentType, body, estimatedSize } = encodedBody ?? {}
 
-    // eslint-disable-next-line compat/compat
     const headers = new Headers()
     each(options.headers, function (headerValue, headerName) {
         headers.append(headerName, headerValue)

--- a/packages/browser/src/retry-queue.ts
+++ b/packages/browser/src/retry-queue.ts
@@ -182,7 +182,6 @@ export class RetryQueue {
         for (const { requestOptions } of this._queue) {
             try {
                 // we've had send beacon in place for at least 2 years
-                // eslint-disable-next-line compat/compat
                 this._instance._send_request({
                     ...requestOptions,
                     transport: 'sendBeacon',

--- a/packages/browser/src/sessionid.ts
+++ b/packages/browser/src/sessionid.ts
@@ -374,7 +374,6 @@ export class SessionIdManager {
         }
         const timestamp = _timestamp || new Date().getTime()
 
-        // eslint-disable-next-line prefer-const
         let [, sessionId, startTimestamp] = this._getSessionId()
         const lastActivityTimestamp = this._freshestActivityTimestamp()
         let windowId = this._getWindowId()

--- a/packages/browser/src/utils/device-model-utils.ts
+++ b/packages/browser/src/utils/device-model-utils.ts
@@ -11,7 +11,6 @@ import { logger } from './logger'
  * and return `undefined`.
  */
 export async function getDeviceModel(): Promise<string | undefined> {
-    // eslint-disable-next-line compat/compat
     const uaData = navigator?.userAgentData
     if (!uaData?.getHighEntropyValues) {
         return undefined

--- a/packages/browser/src/utils/logger.ts
+++ b/packages/browser/src/utils/logger.ts
@@ -27,7 +27,6 @@ const _createLogger = (prefix: string, { debugEnabled }: CreateLoggerOptions = {
                         ? (window.console[level] as any)['__rrweb_original__']
                         : window.console[level]
 
-                // eslint-disable-next-line no-console
                 consoleLog(prefix, ...args)
             }
         },

--- a/packages/browser/src/web-experiments.ts
+++ b/packages/browser/src/web-experiments.ts
@@ -221,7 +221,6 @@ export class WebExperiments implements Extension {
         }
         const campaignParams = getCampaignParams()
         if (campaignParams['utm_source']) {
-            // eslint-disable-next-line compat/compat
             const utmCampaignMatched = testVariant.conditions?.utm?.utm_campaign
                 ? testVariant.conditions?.utm?.utm_campaign == campaignParams['utm_campaign']
                 : true

--- a/packages/core/src/__tests__/posthog.gdpr.spec.ts
+++ b/packages/core/src/__tests__/posthog.gdpr.spec.ts
@@ -3,7 +3,6 @@ import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } f
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let mocks: PostHogCoreTestClientMocks
 
   jest.useFakeTimers()

--- a/packages/core/src/__tests__/posthog.listeners.spec.ts
+++ b/packages/core/src/__tests__/posthog.listeners.spec.ts
@@ -2,7 +2,6 @@ import { waitForPromises, createTestClient, PostHogCoreTestClient, PostHogCoreTe
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let mocks: PostHogCoreTestClientMocks
 
   jest.useFakeTimers()

--- a/packages/core/src/__tests__/posthog.register.spec.ts
+++ b/packages/core/src/__tests__/posthog.register.spec.ts
@@ -3,7 +3,6 @@ import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } f
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let mocks: PostHogCoreTestClientMocks
 
   const getEnrichedProperties = (): any => {

--- a/packages/core/src/__tests__/posthog.reset.spec.ts
+++ b/packages/core/src/__tests__/posthog.reset.spec.ts
@@ -3,7 +3,6 @@ import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } f
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let mocks: PostHogCoreTestClientMocks
 
   beforeEach(() => {

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -74,7 +74,6 @@ class PostHogFetchNetworkError extends Error {
 
   constructor(public error: unknown) {
     // TRICKY: "cause" is a newer property but is just ignored otherwise. Cast to any to ignore the type issue.
-    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
     // @ts-ignore
     super('Network error while fetching PostHog', error instanceof Error ? { cause: error } : {})
   }

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -646,7 +646,6 @@ export abstract class PostHogCore extends PostHogCoreStateless {
    *
    * @param _response The remote config or flags response containing config fields
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected onRemoteConfig(_response: PostHogRemoteConfig): void {
     // Override in subclasses
   }

--- a/packages/core/src/utils/type-utils.ts
+++ b/packages/core/src/utils/type-utils.ts
@@ -6,7 +6,6 @@ import {
 } from '../types'
 import { includes } from './string-utils'
 
-// eslint-disable-next-line posthog-js/no-direct-array-check
 const nativeIsArray = Array.isArray
 const ObjProto = Object.prototype
 export const hasOwnProperty = ObjProto.hasOwnProperty
@@ -22,7 +21,6 @@ export const isArray =
 // fails on only one very rare and deliberate custom object:
 // let bomb = { toString : undefined, valueOf: function(o) { return "function BOMBA!"; }};
 export const isFunction = (x: unknown): x is (...args: any[]) => any => {
-  // eslint-disable-next-line posthog-js/no-direct-function-check
   return typeof x === 'function'
 }
 
@@ -53,9 +51,7 @@ export const isString = (x: unknown): x is string => {
 }
 
 export const isEmptyString = (x: unknown): boolean => isString(x) && x.trim().length === 0
-
 export const isNull = (x: unknown): x is null => {
-  // eslint-disable-next-line posthog-js/no-direct-null-check
   return x === null
 }
 
@@ -66,7 +62,6 @@ export const isNull = (x: unknown): x is null => {
 export const isNullish = (x: unknown): x is null | undefined => isUndefined(x) || isNull(x)
 
 export const isNumber = (x: unknown): x is number => {
-  // eslint-disable-next-line posthog-js/no-direct-number-check
   // x !== x is true only for NaN (ES5-compatible NaN check)
   return toString.call(x) == '[object Number]' && x === x
 }
@@ -76,7 +71,6 @@ export const isPositiveNumber = (value: unknown): value is number => {
 }
 
 export const isBoolean = (x: unknown): x is boolean => {
-  // eslint-disable-next-line posthog-js/no-direct-boolean-check
   return toString.call(x) === '[object Boolean]'
 }
 

--- a/packages/mcp/src/__tests__/test-utils.ts
+++ b/packages/mcp/src/__tests__/test-utils.ts
@@ -88,7 +88,6 @@ export class EventCapture {
  * before it ever calls `posthog.capture`, so a no-op `capture` is enough for
  * tests that assert on captured MCP events.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fakePostHog(): any {
   return {
     capture: () => undefined,

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -72,7 +72,6 @@ function emitDeprecationWarningOnce(id: string, message: string): void {
     return
   }
   _emittedDeprecations.add(id)
-  // eslint-disable-next-line no-console
   console.warn(`[PostHog] ${message}`)
 }
 

--- a/packages/node/src/experimental.ts
+++ b/packages/node/src/experimental.ts
@@ -8,7 +8,6 @@
 const postHogNodeExperimentalDeprecationWarning =
   "[PostHog] `posthog-node/experimental` is deprecated. Use `import type { FlagDefinitionCacheData, FlagDefinitionCacheProvider } from 'posthog-node'` instead."
 
-// eslint-disable-next-line no-console
 console.warn(postHogNodeExperimentalDeprecationWarning)
 
 export type { FlagDefinitionCacheProvider, FlagDefinitionCacheData } from './extensions/feature-flags/cache'

--- a/packages/openfeature-node-provider/src/provider.ts
+++ b/packages/openfeature-node-provider/src/provider.ts
@@ -94,7 +94,6 @@ export class PostHogServerProvider implements Provider {
       unsubscribe()
     }
     if (preloadError) {
-      // eslint-disable-next-line no-console
       console.warn(
         '[PostHogServerProvider] initialize() flag preload failed; remote evaluation still available.',
         preloadError

--- a/packages/react-native/src/optional/OptionalAsyncStorage.ts
+++ b/packages/react-native/src/optional/OptionalAsyncStorage.ts
@@ -3,6 +3,5 @@ import type AsyncStorage from '@react-native-async-storage/async-storage'
 export let OptionalAsyncStorage: typeof AsyncStorage | undefined = undefined
 
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   OptionalAsyncStorage = require('@react-native-async-storage/async-storage').default
 } catch (e) {}

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -170,7 +170,6 @@ export function resolveSurveyAlignment(position: string | undefined): {
       resolvedPosition = position as SurveyPosition
     } else if (!warnedUnknownPositions.has(position)) {
       warnedUnknownPositions.add(position)
-      // eslint-disable-next-line no-console
       console.warn(
         `[PostHog.surveys] Unknown survey position ${JSON.stringify(position)} — falling back to ${defaultSurveyAppearance.position}. Expected one of: ${Object.values(SurveyPosition).join(', ')}.`
       )

--- a/packages/react/src/components/PostHogErrorBoundary.tsx
+++ b/packages/react/src/components/PostHogErrorBoundary.tsx
@@ -43,7 +43,6 @@ export class PostHogErrorBoundary extends React.Component<PostHogErrorBoundaryPr
     }
 
     componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
-        //eslint-disable-next-line react/prop-types
         const { additionalProperties } = this.props
         let currentProperties
         if (isFunction(additionalProperties)) {
@@ -63,7 +62,6 @@ export class PostHogErrorBoundary extends React.Component<PostHogErrorBoundaryPr
     }
 
     public render(): React.ReactNode {
-        //eslint-disable-next-line react/prop-types
         const { children, fallback } = this.props
         const state = this.state
 

--- a/packages/react/src/hooks/__tests__/featureFlags.test.tsx
+++ b/packages/react/src/hooks/__tests__/featureFlags.test.tsx
@@ -66,7 +66,6 @@ describe('feature flag hooks', () => {
             } as unknown as PostHog['featureFlags'],
         } as unknown as PostHog
 
-        // eslint-disable-next-line react/display-name
         renderProvider = ({ children }) => <PostHogProvider client={posthog}>{children}</PostHogProvider>
     })
 
@@ -125,7 +124,6 @@ describe('feature flag hooks', () => {
             } as unknown as PostHog['featureFlags'],
         } as unknown as PostHog
 
-        // eslint-disable-next-line react/display-name
         const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
             <PostHogProvider client={client}>{children}</PostHogProvider>
         )
@@ -197,7 +195,6 @@ describe('feature flag hooks', () => {
                 } as unknown as PostHog['featureFlags'],
             } as unknown as PostHog
 
-            // eslint-disable-next-line react/display-name
             const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
                 <PostHogProvider client={client}>{children}</PostHogProvider>
             )
@@ -227,7 +224,6 @@ describe('feature flag hooks', () => {
                     } as unknown as PostHog['featureFlags'],
                 } as unknown as PostHog
 
-                // eslint-disable-next-line react/display-name
                 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
                     <PostHogProvider client={client}>{children}</PostHogProvider>
                 )
@@ -306,7 +302,6 @@ describe('feature flag hooks', () => {
                     } as unknown as PostHog['featureFlags'],
                 } as unknown as PostHog
 
-                // eslint-disable-next-line react/display-name
                 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
                     <PostHogProvider client={client}>{children}</PostHogProvider>
                 )
@@ -349,7 +344,6 @@ describe('feature flag hooks', () => {
                     } as unknown as PostHog['featureFlags'],
                 } as unknown as PostHog
 
-                // eslint-disable-next-line react/display-name
                 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
                     <PostHogProvider client={client}>{children}</PostHogProvider>
                 )

--- a/packages/react/src/utils/type-utils.ts
+++ b/packages/react/src/utils/type-utils.ts
@@ -11,6 +11,5 @@ export const isUndefined = function (x: unknown): x is undefined {
 }
 
 export const isNull = function (x: unknown): x is null {
-    // eslint-disable-next-line posthog-js/no-direct-null-check
     return x === null
 }

--- a/packages/web/src/posthog-web.ts
+++ b/packages/web/src/posthog-web.ts
@@ -104,7 +104,6 @@ export class PostHog extends PostHogCore {
     }
 
     // Old fashioned, we could also use arrow functions but I think the closure for a patch is more reliable
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
 
     patch(window.history, 'pushState', (originalPushState) => {

--- a/packages/web/test/posthog-web.spec.ts
+++ b/packages/web/test/posthog-web.spec.ts
@@ -127,7 +127,6 @@ describe('PostHogWeb', () => {
     })
 
     it('should not patch history methods when captureHistoryEvents is disabled', () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const posthog = new PostHog('TEST_API_KEY', {
         captureHistoryEvents: false,
       })
@@ -137,7 +136,6 @@ describe('PostHogWeb', () => {
     })
 
     it('should patch history methods when captureHistoryEvents is enabled', () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const posthog = new PostHog('TEST_API_KEY', {
         captureHistoryEvents: true,
       })

--- a/playground/flags/remote-config-example.js
+++ b/playground/flags/remote-config-example.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* eslint-disable @typescript-eslint/no-require-imports, no-undef, no-console */
+/* eslint-disable @typescript-eslint/no-require-imports, no-undef */
 /**
  * Simple test script for PostHog remote config endpoint.
  */

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -34,7 +34,6 @@ export default function App({ Component, pageProps }: AppProps) {
     useEffect(() => {
         // make sure we initialize the WebSocket server
         // we don't need to support IE11 here
-        // eslint-disable-next-line compat/compat
         fetch('/api/socket')
     }, [])
 

--- a/playground/nextjs/pages/api/socket.ts
+++ b/playground/nextjs/pages/api/socket.ts
@@ -22,7 +22,6 @@ export default function handler(req: NextApiRequest, res: CustomNextApiResponse)
         res.socket.server.io = io
 
         io.on('connection', (socket) => {
-            // eslint-disable-next-line no-console
             console.log('User connected', socket.id)
 
             socket.on('send chat message', (msg) => {
@@ -30,7 +29,6 @@ export default function handler(req: NextApiRequest, res: CustomNextApiResponse)
             })
 
             socket.on('disconnect', () => {
-                // eslint-disable-next-line no-console
                 console.log('User disconnected', socket.id)
             })
         })

--- a/playground/nextjs/pages/chat.tsx
+++ b/playground/nextjs/pages/chat.tsx
@@ -28,7 +28,6 @@ const Chat = () => {
 
     const sendMessage = () => {
         if (!socket) {
-            // eslint-disable-next-line no-console
             console.log('socket not running, ruh roh!')
             return
         }

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { PostHogFeature, useActiveFeatureFlags, usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { cookieConsentGiven, PERSON_PROCESSING_MODE } from '@/src/posthog'

--- a/playground/nextjs/pages/tiktok-proxy.tsx
+++ b/playground/nextjs/pages/tiktok-proxy.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { usePostHog } from 'posthog-js/react'
 import { useState, useCallback } from 'react'
 

--- a/playground/nextjs/pages/ua.tsx
+++ b/playground/nextjs/pages/ua.tsx
@@ -24,7 +24,6 @@ export default function Home() {
             </dd>
             <dt>NavigatorUAData brands</dt>
             <dd>
-                {/* eslint-disable-next-line compat/compat */}
                 <code>{JSON.stringify((navigator as any).userAgentData?.brands)}</code>
             </dd>
         </dl>

--- a/playground/nextjs/src/AuthModal.tsx
+++ b/playground/nextjs/src/AuthModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable compat/compat */
 import { useState } from 'react'
 import { getUser, TEAMS, User, useUser } from './auth'
 import { posthogHelpers } from './posthog'

--- a/playground/nextjs/src/CookieBanner.tsx
+++ b/playground/nextjs/src/CookieBanner.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable posthog-js/no-direct-null-check */
 import { ReactElement, useEffect, useState } from 'react'
 import { ConsentState, cookieConsentGiven, posthog, updatePostHogConsent } from './posthog'
 
@@ -23,7 +22,6 @@ export function useCookieConsent(): [ConsentState, (consentGiven: 'granted' | 'd
 export function CookieBanner(): ReactElement | null {
     const [consentGiven, setConsentGiven] = useCookieConsent()
 
-    // eslint-disable-next-line posthog-js/no-direct-undefined-check
     if (consentGiven === undefined || posthog.config.cookieless_mode === 'always') {
         return null
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@22.19.1)
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.7.2
+        version: 4.7.2(eslint@8.57.0)
       '@microsoft/api-extractor':
         specifier: ^7.58.9
         version: 7.58.9(@types/node@22.19.1)
@@ -254,7 +257,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.20.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.8.2))
+        version: 29.7.0(@types/node@26.0.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@26.0.1)(typescript@5.8.2))
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -656,7 +659,7 @@ importers:
         version: 29.7.0
       next:
         specifier: ^15.0.0
-        version: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 15.5.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -1081,7 +1084,7 @@ importers:
         version: 5.1.0
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@26.0.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@26.0.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@22.20.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.8.2))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2111,12 +2114,6 @@ packages:
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-module-transforms@7.29.7':
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
@@ -2350,12 +2347,6 @@ packages:
 
   '@babel/plugin-syntax-import-assertions@7.27.1':
     resolution: {integrity: sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.27.1':
-    resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3714,6 +3705,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2':
+    resolution: {integrity: sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4134,10 +4131,6 @@ packages:
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
-    engines: {node: '>=8'}
-
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
   '@istanbuljs/schema@0.1.6':
@@ -7457,11 +7450,6 @@ packages:
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
 
-  babel-preset-current-node-syntax@1.0.1:
-    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   babel-preset-current-node-syntax@1.2.0:
     resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
     peerDependencies:
@@ -10101,9 +10089,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graceful-fs@4.2.9:
-    resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
-
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
@@ -10992,10 +10977,6 @@ packages:
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
-
-  istanbul-lib-coverage@3.2.0:
-    resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
-    engines: {node: '>=8'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -17486,22 +17467,22 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3
       lodash.debounce: 4.0.8
-      resolve: 1.22.11
+      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3
       lodash.debounce: 4.0.8
-      resolve: 1.22.11
+      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
@@ -17529,24 +17510,6 @@ snapshots:
     dependencies:
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -17581,7 +17544,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17590,7 +17553,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17599,7 +17562,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17608,14 +17571,14 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17633,9 +17596,9 @@ snapshots:
 
   '@babel/helper-wrap-function@7.27.1':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17667,7 +17630,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17675,7 +17638,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17721,7 +17684,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17729,7 +17692,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17882,16 +17845,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
@@ -18062,7 +18015,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18071,14 +18024,14 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -18087,7 +18040,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
     transitivePeerDependencies:
@@ -18166,11 +18119,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-globals': 7.28.0
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18178,11 +18131,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-globals': 7.28.0
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.7)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18190,13 +18143,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/template': 7.27.2
+      '@babel/template': 7.29.7
 
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/template': 7.27.2
+      '@babel/template': 7.29.7
 
   '@babel/plugin-transform-destructuring@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -18207,7 +18160,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18215,7 +18168,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18324,18 +18277,18 @@ snapshots:
   '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18387,7 +18340,7 @@ snapshots:
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -18395,7 +18348,7 @@ snapshots:
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -18403,7 +18356,7 @@ snapshots:
   '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -18411,7 +18364,7 @@ snapshots:
   '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -18419,27 +18372,27 @@ snapshots:
   '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -18447,7 +18400,7 @@ snapshots:
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -18512,22 +18465,22 @@ snapshots:
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18859,11 +18812,11 @@ snapshots:
 
   '@babel/preset-env@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/compat-data': 7.28.5
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.5)
@@ -18871,7 +18824,7 @@ snapshots:
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.28.5)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)
       '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.28.5)
       '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.5)
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.28.5)
@@ -18935,11 +18888,11 @@ snapshots:
 
   '@babel/preset-env@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/compat-data': 7.28.5
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.7)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.7)
@@ -18947,7 +18900,7 @@ snapshots:
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.29.7)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
       '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7)
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.7)
@@ -19020,14 +18973,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.28.5)':
@@ -19710,6 +19663,12 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2(eslint@8.57.0)':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 8.57.0
+      ignore: 7.0.5
+
   '@eslint-community/eslint-utils@4.9.0(eslint@8.57.0)':
     dependencies:
       eslint: 8.57.0
@@ -20370,8 +20329,6 @@ snapshots:
       get-package-type: 0.1.0
       js-yaml: 3.14.2
       resolve-from: 5.0.0
-
-  '@istanbuljs/schema@0.1.3': {}
 
   '@istanbuljs/schema@0.1.6': {}
 
@@ -23693,7 +23650,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.28.6
       '@types/aria-query': 5.0.1
       aria-query: 5.3.0
@@ -24971,7 +24928,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   appdirsjs@1.2.7: {}
 
@@ -25192,7 +25149,7 @@ snapshots:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 29.6.3(@babel/core@7.28.5)
       chalk: 4.1.2
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -25205,7 +25162,7 @@ snapshots:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 29.6.3(@babel/core@7.29.7)
       chalk: 4.1.2
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -25214,7 +25171,7 @@ snapshots:
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
-      '@istanbuljs/schema': 0.1.3
+      '@istanbuljs/schema': 0.1.6
       istanbul-lib-instrument: 5.1.0
       test-exclude: 6.0.0
     transitivePeerDependencies:
@@ -25229,10 +25186,10 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.1.18
-      '@types/babel__traverse': 7.14.2
+      '@types/babel__traverse': 7.28.0
 
   babel-plugin-module-resolver@4.1.0:
     dependencies:
@@ -25260,7 +25217,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
     dependencies:
-      '@babel/compat-data': 7.28.5
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       semver: 6.3.1
@@ -25269,7 +25226,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.7):
     dependencies:
-      '@babel/compat-data': 7.28.5
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
       semver: 6.3.1
@@ -25321,38 +25278,6 @@ snapshots:
       '@babel/plugin-syntax-flow': 7.12.13(@babel/core@7.28.5)
     transitivePeerDependencies:
       - '@babel/core'
-
-  babel-preset-current-node-syntax@1.0.1(@babel/core@7.28.5):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5)
-
-  babel-preset-current-node-syntax@1.0.1(@babel/core@7.29.7):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5):
     dependencies:
@@ -25447,13 +25372,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.28.5)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
 
   babel-preset-jest@29.6.3(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.29.7)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
   balanced-match@1.0.2: {}
 
@@ -28864,8 +28789,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graceful-fs@4.2.9: {}
-
   graphemer@1.4.0: {}
 
   graphlib@2.1.8:
@@ -29717,16 +29640,14 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  istanbul-lib-coverage@3.2.0: {}
-
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.1.0:
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.0
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -32817,31 +32738,6 @@ snapshots:
   nested-error-stacks@2.0.1: {}
 
   netmask@2.1.1: {}
-
-  next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@next/env': 15.5.7
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001755
-      postcss: 8.4.31
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.7)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.7
-      '@next/swc-darwin-x64': 15.5.7
-      '@next/swc-linux-arm64-gnu': 15.5.7
-      '@next/swc-linux-arm64-musl': 15.5.7
-      '@next/swc-linux-x64-gnu': 15.5.7
-      '@next/swc-linux-x64-musl': 15.5.7
-      '@next/swc-win32-arm64-msvc': 15.5.7
-      '@next/swc-win32-x64-msvc': 15.5.7
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.61.1
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
 
   next@15.5.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -36077,13 +35973,6 @@ snapshots:
 
   style-inject@0.3.0: {}
 
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.7):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.7
-    optionalDependencies:
-      '@babel/core': 7.28.5
-
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
@@ -36296,7 +36185,7 @@ snapshots:
 
   test-exclude@6.0.0:
     dependencies:
-      '@istanbuljs/schema': 0.1.3
+      '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
 


### PR DESCRIPTION
## Problem

We have many eslint-disable comments that don't do anything. Let's clear this up automatically.

Claude code continues:

`eslint-disable` comments that no longer suppress anything rot silently: the rule they reference stops firing (config change, code change, plugin behavior change) and the comment lives on, misleading readers about what's dangerous. We just hit this in review on #4143, where it was unclear whether a `compat/compat` disable was actually doing anything.

## Changes

- Adds [`@eslint-community/eslint-comments/no-unused-disable`](https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html) as an `error` in the shared root `.eslintrc.cjs`, so it applies to every package and shows up in editors, not just CI.
- Removes the ~50 existing disable comments the rule flagged across 17 packages (auto-fixed via `lint:fix`; the fixer replaces whole-line comments with blank lines, which were then deleted). Two multi-rule inline disables were trimmed to just the rule that still fires.
- One dev dependency added at the workspace root: `@eslint-community/eslint-plugin-eslint-comments` (the maintained fork of `eslint-plugin-eslint-comments`).

All changes outside the config are comment deletions only — no code changes. `turbo lint` passes across all packages with the rule enforced.

## Caveat worth knowing

Some of the removed `compat/compat` disables may have been silenced by an upstream `eslint-plugin-compat` false-negative rather than being genuinely unnecessary: a `URL` (or similar DOM global) appearing as a TypeScript *type annotation* in a file suppresses compat checking of that API for the whole file. Removing those disables is still lint-consistent — if the loophole ever closes or the annotation moves, the compat error resurfaces and the disable gets re-added, now provably needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*