### PR TITLE
fix(next): consolidate bootstrap configuration

### DIFF
--- a/.changeset/bright-taxis-bootstrap.md
+++ b/.changeset/bright-taxis-bootstrap.md
@@ -1,0 +1,5 @@
+---
+'@posthog/next': patch
+---
+
+Remove the Pages Router `PostHogProvider.bootstrap` prop; move its value to `clientOptions.bootstrap`. For App Router server-evaluated bootstrap, use fresh evaluated flags and payloads while preserving configured identity and session fields.

--- a/packages/next/scripts/check-pages-router-ssr.mjs
+++ b/packages/next/scripts/check-pages-router-ssr.mjs
@@ -17,11 +17,13 @@ renderToStaticMarkup(
         PostHogProvider,
         {
             apiKey: 'phc_test',
-            bootstrap: {
-                distinctID: 'ssr-user',
-                isIdentifiedID: false,
-                featureFlags: { [flagKey]: 'variant-a' },
-                featureFlagPayloads: {},
+            clientOptions: {
+                bootstrap: {
+                    distinctID: 'ssr-user',
+                    isIdentifiedID: false,
+                    featureFlags: { [flagKey]: 'variant-a' },
+                    featureFlagPayloads: {},
+                },
             },
         },
         React.createElement(FlagResult)

--- a/packages/next/src/app/PostHogProvider.tsx
+++ b/packages/next/src/app/PostHogProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import type { PostHogConfig } from 'posthog-js'
+import type { BootstrapConfig, PostHogConfig } from 'posthog-js'
+import { isUndefined } from '@posthog/core'
 import { ClientPostHogProvider } from '../client/ClientPostHogProvider.js'
-import type { BootstrapConfig } from '../client/ClientPostHogProvider.js'
 import { cookies } from 'next/headers.js'
 import type { PostHogOptions } from 'posthog-node'
 import { getOrCreateNodeClient } from '../server/clientCache.node.js'
@@ -103,6 +103,7 @@ export async function PostHogProvider({
             // If evaluateFlags returned undefined (no cookie, opted-out), the client
             // still needs to fetch flags on first load.
             if (bootstrap) {
+                resolvedOptions.bootstrap = mergeBootstrap(bootstrap, resolvedOptions.bootstrap, bootstrapFlags)
                 resolvedOptions.advanced_disable_feature_flags_on_first_load = true
             }
         } catch (error) {
@@ -112,10 +113,44 @@ export async function PostHogProvider({
     }
 
     return (
-        <ClientPostHogProvider apiKey={apiKey} options={resolvedOptions} bootstrap={bootstrap}>
+        <ClientPostHogProvider apiKey={apiKey} options={resolvedOptions}>
             {children}
         </ClientPostHogProvider>
     )
+}
+
+function mergeBootstrap(
+    evaluatedBootstrap: BootstrapConfig,
+    configuredBootstrap: BootstrapConfig | undefined,
+    bootstrapFlags: boolean | BootstrapFlagsConfig
+): BootstrapConfig {
+    const evaluatedFlagKeys = typeof bootstrapFlags === 'object' ? bootstrapFlags.flags : undefined
+
+    // A full evaluation is the source of truth for the complete flag state.
+    if (!evaluatedFlagKeys) {
+        return {
+            ...configuredBootstrap,
+            ...evaluatedBootstrap,
+            featureFlags: evaluatedBootstrap.featureFlags ?? {},
+            featureFlagPayloads: evaluatedBootstrap.featureFlagPayloads ?? {},
+        }
+    }
+
+    // For a targeted evaluation, replace every requested key while preserving
+    // configured values for flags that were intentionally not evaluated.
+    const featureFlags = { ...configuredBootstrap?.featureFlags }
+    const featureFlagPayloads = { ...configuredBootstrap?.featureFlagPayloads }
+    for (const key of evaluatedFlagKeys) {
+        delete featureFlags[key]
+        delete featureFlagPayloads[key]
+    }
+
+    return {
+        ...configuredBootstrap,
+        ...evaluatedBootstrap,
+        featureFlags: { ...featureFlags, ...evaluatedBootstrap.featureFlags },
+        featureFlagPayloads: { ...featureFlagPayloads, ...evaluatedBootstrap.featureFlagPayloads },
+    }
 }
 
 async function evaluateFlags(
@@ -132,6 +167,14 @@ async function evaluateFlags(
 
     const cookieState = readPostHogCookie(cookieStore, apiKey)
     if (!cookieState) {
+        return undefined
+    }
+
+    // Server-evaluated flags must match the identity the browser SDK will bootstrap.
+    // If the configured identity differs from the cookie, let the client resolve its
+    // final identity and fetch fresh flags instead of serving decisions for another user.
+    const configuredDistinctID = options?.bootstrap?.distinctID
+    if (!isUndefined(configuredDistinctID) && configuredDistinctID !== cookieState.distinctId) {
         return undefined
     }
 

--- a/packages/next/src/client/ClientPostHogProvider.tsx
+++ b/packages/next/src/client/ClientPostHogProvider.tsx
@@ -4,9 +4,7 @@ import React from 'react'
 import { posthog as posthogJs } from 'posthog-js'
 import { isUndefined } from '@posthog/core'
 import { PostHogContext } from '@posthog/react'
-import type { BootstrapConfig, PostHogConfig } from 'posthog-js'
-
-export type { BootstrapConfig }
+import type { PostHogConfig } from 'posthog-js'
 
 function hasTracingHeadersConfig(options?: Partial<PostHogConfig>): boolean {
     return (
@@ -37,8 +35,6 @@ export interface ClientPostHogProviderProps {
     apiKey: string
     /** Optional posthog-js configuration overrides */
     options?: Partial<PostHogConfig>
-    /** Server-evaluated feature flag values to bootstrap the client SDK with */
-    bootstrap?: BootstrapConfig
     children: React.ReactNode
 }
 
@@ -56,21 +52,23 @@ export interface ClientPostHogProviderProps {
  * the `client` prop, we guarantee the instance is fully configured before any
  * child code runs.
  */
-export function ClientPostHogProvider({ apiKey, options, bootstrap, children }: ClientPostHogProviderProps) {
+export function ClientPostHogProvider({ apiKey, options, children }: ClientPostHogProviderProps) {
     if (!apiKey) {
         // eslint-disable-next-line no-console
         console.warn('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
         return <>{children}</>
     }
 
-    const mergedOptions = bootstrap ? { ...options, bootstrap: { ...options?.bootstrap, ...bootstrap } } : options
-
     // Initialize eagerly during render on the client so that child effects
     // see a fully configured posthog instance. The `__loaded` guard prevents
     // double-init (e.g. React StrictMode).
     if (typeof window !== 'undefined' && !posthogJs.__loaded) {
-        posthogJs.init(apiKey, withDefaultTracingHeaders(mergedOptions))
+        posthogJs.init(apiKey, withDefaultTracingHeaders(options))
     }
 
-    return <PostHogContext.Provider value={{ client: posthogJs, bootstrap }}>{children}</PostHogContext.Provider>
+    return (
+        <PostHogContext.Provider value={{ client: posthogJs, bootstrap: options?.bootstrap }}>
+            {children}
+        </PostHogContext.Provider>
+    )
 }

--- a/packages/next/src/pages/PostHogProvider.tsx
+++ b/packages/next/src/pages/PostHogProvider.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { PostHogConfig, BootstrapConfig } from 'posthog-js'
+import type { PostHogConfig } from 'posthog-js'
 import { ClientPostHogProvider } from '../client/ClientPostHogProvider.js'
 import { NEXTJS_CLIENT_DEFAULTS, resolveApiKey, resolveHostOrDefault } from '../shared/config.js'
 
@@ -11,12 +11,6 @@ export interface PagesPostHogProviderProps {
     apiKey?: string
     /** Optional posthog-js configuration overrides. */
     clientOptions?: Partial<PostHogConfig>
-    /**
-     * Server-evaluated bootstrap data from createPostHog().getPostHog(ctx).
-     *
-     * @deprecated Use `clientOptions.bootstrap` instead. This prop will be removed before v1.
-     */
-    bootstrap?: BootstrapConfig
     children: React.ReactNode
 }
 
@@ -40,7 +34,7 @@ export interface PagesPostHogProviderProps {
  */
 let apiKeyWarned = false
 
-export function PostHogProvider({ apiKey: apiKeyProp, clientOptions, bootstrap, children }: PagesPostHogProviderProps) {
+export function PostHogProvider({ apiKey: apiKeyProp, clientOptions, children }: PagesPostHogProviderProps) {
     const apiKey = resolveApiKey(apiKeyProp)
     if (!apiKey) {
         return <>{children}</>
@@ -62,7 +56,7 @@ export function PostHogProvider({ apiKey: apiKeyProp, clientOptions, bootstrap, 
     }
 
     return (
-        <ClientPostHogProvider apiKey={apiKey} options={resolvedOptions} bootstrap={bootstrap}>
+        <ClientPostHogProvider apiKey={apiKey} options={resolvedOptions}>
             {children}
         </ClientPostHogProvider>
     )

--- a/packages/next/tests/ClientPostHogProvider.test.tsx
+++ b/packages/next/tests/ClientPostHogProvider.test.tsx
@@ -104,14 +104,14 @@ describe('ClientPostHogProvider', () => {
         expect(contextValue.client).toBe(mockPostHogJs)
     })
 
-    it('merges bootstrap into options when provided', () => {
+    it('passes options.bootstrap to posthog-js', () => {
         const bootstrap = {
             distinctID: 'user_abc',
             isIdentifiedID: true,
             featureFlags: { 'flag-a': true, 'flag-b': 'variant-1' },
         }
         render(
-            <ClientPostHogProvider apiKey="phc_test123" bootstrap={bootstrap}>
+            <ClientPostHogProvider apiKey="phc_test123" options={{ bootstrap }}>
                 <div>Child</div>
             </ClientPostHogProvider>
         )
@@ -121,63 +121,21 @@ describe('ClientPostHogProvider', () => {
         )
     })
 
-    it('merges bootstrap with existing options without overwriting', () => {
-        const options = { api_host: 'https://custom.posthog.com' }
-        const bootstrap = { featureFlags: { 'flag-a': true } }
-        render(
-            <ClientPostHogProvider apiKey="phc_test123" options={options} bootstrap={bootstrap}>
-                <div>Child</div>
-            </ClientPostHogProvider>
-        )
-        expect(mockPostHogJs.init).toHaveBeenCalledWith(
-            'phc_test123',
-            expect.objectContaining({
-                api_host: 'https://custom.posthog.com',
-                bootstrap,
-            })
-        )
-    })
-
-    it('preserves existing options.bootstrap fields when merging server bootstrap', () => {
-        const options = {
-            bootstrap: { sessionID: 'sess_123' },
-        } as any
-        const bootstrap = {
-            distinctID: 'user_abc',
-            featureFlags: { 'flag-a': true },
-        }
-        render(
-            <ClientPostHogProvider apiKey="phc_test123" options={options} bootstrap={bootstrap}>
-                <div>Child</div>
-            </ClientPostHogProvider>
-        )
-        expect(mockPostHogJs.init).toHaveBeenCalledWith(
-            'phc_test123',
-            expect.objectContaining({
-                bootstrap: expect.objectContaining({
-                    sessionID: 'sess_123',
-                    distinctID: 'user_abc',
-                    featureFlags: { 'flag-a': true },
-                }),
-            })
-        )
-    })
-
-    it('provides bootstrap via context for SSR hook access', () => {
+    it('provides options.bootstrap via context for SSR hook access', () => {
         const bootstrap = {
             featureFlags: { 'flag-a': true, 'flag-b': 'variant-1' },
             featureFlagPayloads: { 'flag-b': { key: 'value' } },
         }
         let contextValue: any
         render(
-            <ClientPostHogProvider apiKey="phc_test123" bootstrap={bootstrap}>
+            <ClientPostHogProvider apiKey="phc_test123" options={{ bootstrap }}>
                 <ContextReader onContext={(ctx) => (contextValue = ctx)} />
             </ClientPostHogProvider>
         )
         expect(contextValue.bootstrap).toEqual(bootstrap)
     })
 
-    it('context bootstrap is undefined when no bootstrap prop provided', () => {
+    it('context bootstrap is undefined when options.bootstrap is not provided', () => {
         let contextValue: any
         render(
             <ClientPostHogProvider apiKey="phc_test123">
@@ -209,7 +167,7 @@ describe('ClientPostHogProvider', () => {
             return <div data-testid="flag">{String(flagValue)}</div>
         }
         render(
-            <ClientPostHogProvider apiKey="phc_test123" bootstrap={bootstrap}>
+            <ClientPostHogProvider apiKey="phc_test123" options={{ bootstrap }}>
                 <FlagReader />
             </ClientPostHogProvider>
         )
@@ -227,7 +185,7 @@ describe('ClientPostHogProvider', () => {
             return null
         }
         render(
-            <ClientPostHogProvider apiKey="phc_test123" bootstrap={bootstrap}>
+            <ClientPostHogProvider apiKey="phc_test123" options={{ bootstrap }}>
                 <FlagReader />
             </ClientPostHogProvider>
         )

--- a/packages/next/tests/PagesPostHogProvider.test.tsx
+++ b/packages/next/tests/PagesPostHogProvider.test.tsx
@@ -139,13 +139,15 @@ describe('Pages PostHogProvider', () => {
         delete process.env.NEXT_PUBLIC_POSTHOG_HOST
     })
 
-    it('passes bootstrap prop through to ClientPostHogProvider', () => {
+    it('passes clientOptions.bootstrap to ClientPostHogProvider', () => {
         const bootstrap = { featureFlags: { 'flag-a': true } }
         render(
-            <PostHogProvider apiKey="phc_test123" bootstrap={bootstrap}>
+            <PostHogProvider apiKey="phc_test123" clientOptions={{ bootstrap }}>
                 <div>Child</div>
             </PostHogProvider>
         )
-        expect(mockClientPostHogProvider).toHaveBeenCalledWith(expect.objectContaining({ bootstrap }))
+        expect(mockClientPostHogProvider).toHaveBeenCalledWith(
+            expect.objectContaining({ options: expect.objectContaining({ bootstrap }) })
+        )
     })
 })

--- a/packages/next/tests/PostHogProvider.test.tsx
+++ b/packages/next/tests/PostHogProvider.test.tsx
@@ -81,17 +81,14 @@ describe('PostHogProvider', () => {
         )
     })
 
-    it('does not pass bootstrap when bootstrapFlags is not set', async () => {
+    it('does not add bootstrap to options when bootstrapFlags is not set', async () => {
         const element = await PostHogProvider({
             apiKey: 'phc_test123',
             children: <div>Child</div>,
         })
         render(element)
-        expect(mockClientProvider).toHaveBeenCalledWith(
-            expect.objectContaining({
-                bootstrap: undefined,
-            })
-        )
+        expect(mockClientProvider.mock.calls[0][0]).not.toHaveProperty('bootstrap')
+        expect(mockClientProvider.mock.calls[0][0].options).not.toHaveProperty('bootstrap')
     })
 
     describe('Next.js client defaults', () => {
@@ -299,11 +296,132 @@ describe('PostHogProvider', () => {
             expect(mockGetAllFlagsAndPayloads).toHaveBeenCalledWith('user_abc', {})
             expect(mockClientProvider).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    bootstrap: expect.objectContaining({
-                        featureFlags: { 'flag-1': true },
-                        featureFlagPayloads: { 'flag-1': { color: 'blue' } },
+                    options: expect.objectContaining({
+                        bootstrap: expect.objectContaining({
+                            featureFlags: { 'flag-1': true },
+                            featureFlagPayloads: { 'flag-1': { color: 'blue' } },
+                        }),
                     }),
                 })
+            )
+        })
+
+        it('uses evaluated flags as the source of truth while preserving configured identity and session data', async () => {
+            const clientBootstrap = {
+                distinctID: 'user_abc',
+                isIdentifiedID: true,
+                sessionID: '019f6199-c144-764d-8527-964285825db8',
+                featureFlags: { 'flag-1': false, 'client-only': true },
+                featureFlagPayloads: { 'flag-1': { color: 'red' }, 'client-only': { source: 'client' } },
+            }
+            const element = await PostHogProvider({
+                apiKey: 'phc_test123',
+                clientOptions: { bootstrap: clientBootstrap },
+                bootstrapFlags: true,
+                children: <div>Child</div>,
+            })
+            render(element)
+
+            expect(mockClientProvider).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    options: expect.objectContaining({
+                        bootstrap: {
+                            distinctID: 'user_abc',
+                            isIdentifiedID: true,
+                            sessionID: '019f6199-c144-764d-8527-964285825db8',
+                            featureFlags: { 'flag-1': true },
+                            featureFlagPayloads: { 'flag-1': { color: 'blue' } },
+                        },
+                    }),
+                })
+            )
+        })
+
+        it('replaces configured flags with an empty evaluated result', async () => {
+            mockGetAllFlagsAndPayloads.mockResolvedValue({ featureFlags: {}, featureFlagPayloads: {} })
+
+            const element = await PostHogProvider({
+                apiKey: 'phc_test123',
+                clientOptions: {
+                    bootstrap: {
+                        featureFlags: { 'configured-flag': true },
+                        featureFlagPayloads: { 'configured-flag': { source: 'client' } },
+                    },
+                },
+                bootstrapFlags: true,
+                children: <div>Child</div>,
+            })
+            render(element)
+
+            expect(mockClientProvider).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    options: expect.objectContaining({
+                        bootstrap: expect.objectContaining({
+                            featureFlags: {},
+                            featureFlagPayloads: {},
+                        }),
+                    }),
+                })
+            )
+        })
+
+        it('overwrites targeted evaluated flags while preserving non-evaluated configured flags', async () => {
+            mockGetAllFlagsAndPayloads.mockResolvedValue({
+                featureFlags: { 'flag-1': true },
+                featureFlagPayloads: {},
+            })
+
+            const element = await PostHogProvider({
+                apiKey: 'phc_test123',
+                clientOptions: {
+                    bootstrap: {
+                        featureFlags: { 'flag-1': false, 'client-only': true },
+                        featureFlagPayloads: {
+                            'flag-1': { color: 'red' },
+                            'client-only': { source: 'client' },
+                        },
+                    },
+                },
+                bootstrapFlags: { flags: ['flag-1'] },
+                children: <div>Child</div>,
+            })
+            render(element)
+
+            expect(mockClientProvider).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    options: expect.objectContaining({
+                        bootstrap: expect.objectContaining({
+                            featureFlags: { 'flag-1': true, 'client-only': true },
+                            featureFlagPayloads: { 'client-only': { source: 'client' } },
+                        }),
+                    }),
+                })
+            )
+        })
+
+        it('skips server evaluation when the configured identity differs from the cookie', async () => {
+            const clientBootstrap = {
+                distinctID: 'configured-distinct-id',
+                isIdentifiedID: true,
+                featureFlags: { 'client-only': true },
+            }
+            const element = await PostHogProvider({
+                apiKey: 'phc_test123',
+                clientOptions: { bootstrap: clientBootstrap },
+                bootstrapFlags: true,
+                children: <div>Child</div>,
+            })
+            render(element)
+
+            expect(mockGetAllFlagsAndPayloads).not.toHaveBeenCalled()
+            expect(mockClientProvider).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    options: expect.objectContaining({ bootstrap: clientBootstrap }),
+                })
+            )
+            expect(mockClientProvider.mock.calls[0][0].options).not.toHaveProperty(
+                'advanced_disable_feature_flags_on_first_load',
+                true
             )
         })
 
@@ -329,8 +447,10 @@ describe('PostHogProvider', () => {
             expect(mockGetAllFlagsAndPayloads).toHaveBeenCalled()
             expect(mockClientProvider).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    bootstrap: expect.objectContaining({
-                        featureFlagPayloads: { 'flag-1': { color: 'blue' } },
+                    options: expect.objectContaining({
+                        bootstrap: expect.objectContaining({
+                            featureFlagPayloads: { 'flag-1': { color: 'blue' } },
+                        }),
                     }),
                 })
             )
@@ -364,11 +484,8 @@ describe('PostHogProvider', () => {
             })
             render(element)
 
-            expect(mockClientProvider).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    bootstrap: undefined,
-                })
-            )
+            expect(mockClientProvider.mock.calls[0][0]).not.toHaveProperty('bootstrap')
+            expect(mockClientProvider.mock.calls[0][0].options).not.toHaveProperty('bootstrap')
             expect(warnSpy).toHaveBeenCalledWith(
                 '[PostHog Next.js] Failed to evaluate bootstrap flags:',
                 expect.any(Error)
@@ -436,7 +553,8 @@ describe('PostHogProvider', () => {
             render(element)
 
             expect(mockGetAllFlagsAndPayloads).not.toHaveBeenCalled()
-            expect(mockClientProvider).toHaveBeenCalledWith(expect.objectContaining({ bootstrap: undefined }))
+            expect(mockClientProvider.mock.calls[0][0]).not.toHaveProperty('bootstrap')
+            expect(mockClientProvider.mock.calls[0][0].options).not.toHaveProperty('bootstrap')
         })
 
         it('evaluates flags when consent cookie is 1', async () => {
@@ -469,7 +587,8 @@ describe('PostHogProvider', () => {
             render(element)
 
             expect(mockGetAllFlagsAndPayloads).not.toHaveBeenCalled()
-            expect(mockClientProvider).toHaveBeenCalledWith(expect.objectContaining({ bootstrap: undefined }))
+            expect(mockClientProvider.mock.calls[0][0]).not.toHaveProperty('bootstrap')
+            expect(mockClientProvider.mock.calls[0][0].options).not.toHaveProperty('bootstrap')
         })
 
         it('evaluates flags when no consent cookie and opt_out_capturing_by_default is false (default)', async () => {


### PR DESCRIPTION
## Problem

`@posthog/next` currently has two ways to provide browser bootstrap data: `clientOptions.bootstrap` and a separate Pages Router `PostHogProvider.bootstrap` prop that is forwarded through an internal provider prop. Keeping both paths allows the SDK initialization options and React context bootstrap values to diverge.

The package is still pre-1.0, so this consolidates bootstrap configuration before the public API stabilizes.

## Changes

- Remove the deprecated Pages Router `PostHogProvider.bootstrap` prop. Pages Router callers now use `clientOptions.bootstrap` exclusively.
- Remove the internal standalone bootstrap prop and initialize both `posthog-js` and `PostHogContext` from `options.bootstrap`.
- Merge App Router server-evaluated flags into `clientOptions.bootstrap`, treating fresh evaluated flags and payloads as the source of truth while preserving configured identity/session data (and non-evaluated configured flags during targeted evaluation).
- Skip server evaluation when the configured identity differs from the cookie identity so the client can fetch for its resolved identity.
- Update provider tests for the consolidated path and precedence rules.
- Update #4150's native Node Pages SSR build check to use `clientOptions.bootstrap`.
- Add a patch changeset with migration guidance.

The stacked tarball was installed into the production Next.js 15 smoke fixture and the Pages SSR reproduction returned HTTP 200 with a real PostHog Cloud flag and payload.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility (intentional pre-1.0 removal with migration guidance)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The original change went through a pre-PR review loop and real PostHog Cloud smoke tests in both App and Pages Router fixtures. The smoke test exposed the independent SSR interop bug fixed by the parent PR; this stacked branch preserves that fix and updates its native SSR regression check for the consolidated API.
