### PR TITLE
chore(react-native-plugin): bump posthog-android to 3.54.0 for session replay ANR fix

### DIFF
--- a/.changeset/rn-plugin-android-anr-fix-bump.md
+++ b/.changeset/rn-plugin-android-anr-fix-bump.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Bump `com.posthog:posthog-android` to `3.54.0` to pick up the session replay ANR fix from 3.53.7: clearing the replay buffer on session rotation (e.g. `identify()` at login) no longer blocks the main thread waiting on the replay executor.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,6 +85,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.53.6"
+  implementation "com.posthog:posthog-android:3.54.0"
 }
 


### PR DESCRIPTION
## Problem

React Native apps are still exposed to the session replay ANR that was fixed in `posthog-android` [3.53.7](https://github.com/PostHog/posthog-android/releases/tag/android-v3.53.7) (PostHog/posthog-android#612): when the session id rotates while replay is active (e.g. `identify()` at login), the replay buffer clear blocked the main thread waiting on the single-threaded replay executor, ANRing if that executor was busy with snapshot disk IO. The React Native plugin pins `com.posthog:posthog-android:3.53.6`, which predates the fix.

An enterprise customer hit this in production (~115 ANR occurrences before disabling replay) and is waiting on a React Native release with the fix (support ticket #2884).

## Changes

- Bump `com.posthog:posthog-android` from `3.53.6` to `3.54.0` (current latest; includes the 3.53.7 ANR fix) in `packages/react-native-plugin/android/build.gradle`.
- Changeset marking `@posthog/react-native-plugin` for a patch release.

No iOS podspec change — the fix is Android-only.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code (dependency pin bump only — covered by posthog-android's own test suite)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) authored this change while investigating a Slack report of ANR spikes in the Play SDK console. It traced the ANRs to the session-rotation buffer-clear fix released in posthog-android 3.53.7, confirmed the RN plugin still pinned 3.53.6 on `main` with no bump PR open, and followed the convention from #3931 (pin bump + patch changeset). Android-only bump was a deliberate choice since the fix has no iOS counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
