### PR TITLE
fix(node): allow non-string person and group properties in flag options

### DIFF
--- a/.changeset/node-flag-person-properties-types.md
+++ b/.changeset/node-flag-person-properties-types.md
@@ -2,4 +2,4 @@
 'posthog-node': patch
 ---
 
-fix: `personProperties` and `groupProperties` on the feature flag methods are no longer typed as `Record<string, string>`, so numeric and boolean values type-check without a cast. Local evaluation already handled them — `matchProperty` takes `Record<string, any>` and compares numerically for `gt`/`gte`/`lt`/`lte` — only the public types disagreed. These now use `Record<string, any>`, matching `SendFeatureFlagsOptions`, which already allowed it. Types only, no runtime change.
+fix: `personProperties` and `groupProperties` on the feature flag methods are no longer typed as `Record<string, string>`, so numeric and boolean values type-check without a cast. Local evaluation already handled them — `matchProperty` takes `Record<string, any>` and compares numerically for `gt`/`gte`/`lt`/`lte` — only the public types disagreed. These now use the shared `Properties` type (`personProperties?: Properties`, `groupProperties?: Record<string, Properties>`), matching `setPersonPropertiesForFlags`/`setGroupPropertiesForFlags` so the `any` can be narrowed later. Types only, no runtime change.

--- a/.changeset/node-flag-person-properties-types.md
+++ b/.changeset/node-flag-person-properties-types.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+fix: `personProperties` and `groupProperties` on the feature flag methods are no longer typed as `Record<string, string>`, so numeric and boolean values type-check without a cast. Local evaluation already handled them — `matchProperty` takes `Record<string, any>` and compares numerically for `gt`/`gte`/`lt`/`lte` — only the public types disagreed. These now use `Record<string, any>`, matching `SendFeatureFlagsOptions`, which already allowed it. Types only, no runtime change.

--- a/.changeset/node-flag-person-properties-types.md
+++ b/.changeset/node-flag-person-properties-types.md
@@ -1,5 +1,6 @@
 ---
 'posthog-node': patch
+'@posthog/core': patch
 ---
 
 fix: `personProperties` and `groupProperties` on the feature flag methods are no longer typed as `Record<string, string>`, so numeric and boolean values type-check without a cast. Local evaluation already handled them — `matchProperty` takes `Record<string, any>` and compares numerically for `gt`/`gte`/`lt`/`lte` — only the public types disagreed. These now use the shared `Properties` type (`personProperties?: Properties`, `groupProperties?: Record<string, Properties>`), matching `setPersonPropertiesForFlags`/`setGroupPropertiesForFlags` so the `any` can be narrowed later. Types only, no runtime change.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,9 @@ export type { CaptureLogOptions, LogAttributeValue, LogAttributes, LogSeverityLe
 // Re-export the shared error tracking rate-limiter config type so SDKs built on core
 // (e.g. posthog-node) don't have to depend on `@posthog/types` directly.
 export type { ExceptionRateLimiterConfig } from '@posthog/types'
+// Re-export the shared `Properties` type for the same reason, so SDKs can type
+// person/group property bags consistently without importing `@posthog/types`.
+export type { Property, Properties } from '@posthog/types'
 export {
   PostHogMetrics,
   buildOtlpMetricsPayload,

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -652,7 +652,7 @@
             {
               "description": "Optional configuration for flag evaluation",
               "isOptional": true,
-              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Properties;\n        groupProperties?: Record<string, Properties>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
               "name": "options"
             }
           ],
@@ -709,7 +709,7 @@
             {
               "description": "Optional configuration for flag evaluation",
               "isOptional": true,
-              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Properties;\n        groupProperties?: Record<string, Properties>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
               "name": "options"
             }
           ],
@@ -1030,7 +1030,7 @@
             {
               "description": "Optional configuration for flag evaluation",
               "isOptional": true,
-              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Properties;\n        groupProperties?: Record<string, Properties>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
               "name": "options"
             }
           ],
@@ -1647,11 +1647,11 @@
           "name": "groups"
         },
         {
-          "type": "Record<string, string>",
+          "type": "Properties",
           "name": "personProperties"
         },
         {
-          "type": "Record<string, Record<string, string>>",
+          "type": "Record<string, Properties>",
           "name": "groupProperties"
         },
         {
@@ -1697,11 +1697,11 @@
           "name": "groups"
         },
         {
-          "type": "Record<string, string>",
+          "type": "Properties",
           "name": "personProperties"
         },
         {
-          "type": "Record<string, Record<string, string>>",
+          "type": "Record<string, Properties>",
           "name": "groupProperties"
         },
         {
@@ -2285,11 +2285,11 @@
           "name": "groups"
         },
         {
-          "type": "Record<string, string>",
+          "type": "Properties",
           "name": "personProperties"
         },
         {
-          "type": "Record<string, Record<string, string>>",
+          "type": "Record<string, Properties>",
           "name": "groupProperties"
         },
         {
@@ -3837,11 +3837,11 @@
           "name": "onlyEvaluateLocally"
         },
         {
-          "type": "Record<string, any>",
+          "type": "Properties",
           "name": "personProperties"
         },
         {
-          "type": "Record<string, Record<string, any>>",
+          "type": "Record<string, Properties>",
           "name": "groupProperties"
         },
         {

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -86,7 +86,7 @@ describe('local evaluation', () => {
           latestBuildVersionMajor: undefined,
           latestBuildVersionMinor: undefined,
           latestBuildVersionPatch: undefined,
-        } as unknown as Record<string, string>,
+        },
       })
     ).toEqual(false)
 

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -93,6 +93,56 @@ describe('local evaluation', () => {
     expect(mockedFetch).toHaveBeenCalledWith(...anyLocalEvalCall)
   })
 
+  it('evaluates numeric person properties with comparison operators', async () => {
+    const flags = {
+      flags: [
+        {
+          id: 1,
+          name: 'Beta Feature',
+          key: 'numeric-person-flag',
+          active: true,
+          filters: {
+            groups: [
+              {
+                variant: null,
+                properties: [
+                  {
+                    key: 'age',
+                    type: 'person',
+                    value: 21,
+                    operator: 'gt',
+                  },
+                ],
+                rollout_percentage: 100,
+              },
+            ],
+          },
+        },
+      ],
+    }
+    mockedFetch.mockImplementation(apiImplementation({ localFlags: flags }))
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
+    })
+
+    expect(
+      await posthog.getFeatureFlag('numeric-person-flag', 'some-distinct-id', {
+        personProperties: { age: 30 },
+      })
+    ).toEqual(true)
+
+    expect(
+      await posthog.getFeatureFlag('numeric-person-flag', 'some-distinct-id', {
+        personProperties: { age: 18 },
+      })
+    ).toEqual(false)
+
+    expect(mockedFetch).toHaveBeenCalledWith(...anyLocalEvalCall)
+  })
+
   it('locally evaluates person distinct_id conditions without sending it in remote person properties', async () => {
     const flags = {
       flags: [

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -15,6 +15,7 @@ import {
   PostHogFlagsResponse,
   PostHogMetrics,
   PostHogPersistedProperty,
+  Properties,
   resolveMetricsConfig,
   RetriableOptions,
   safeSetTimeout,
@@ -1076,8 +1077,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     distinctId: string,
     options: {
       groups?: Record<string, string>
-      personProperties?: Record<string, any>
-      groupProperties?: Record<string, Record<string, any>>
+      personProperties?: Properties
+      groupProperties?: Record<string, Properties>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
       disableGeoip?: boolean
@@ -1343,8 +1344,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     distinctId: string,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, any>
-      groupProperties?: Record<string, Record<string, any>>
+      personProperties?: Properties
+      groupProperties?: Record<string, Properties>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
       disableGeoip?: boolean
@@ -1414,8 +1415,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     matchValue?: FeatureFlagValue,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, any>
-      groupProperties?: Record<string, Record<string, any>>
+      personProperties?: Properties
+      groupProperties?: Record<string, Properties>
       onlyEvaluateLocally?: boolean
       /** @deprecated THIS OPTION HAS NO EFFECT, kept here for backwards compatibility reasons. */
       sendFeatureFlagEvents?: boolean
@@ -1601,8 +1602,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     distinctId: string,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, any>
-      groupProperties?: Record<string, Record<string, any>>
+      personProperties?: Properties
+      groupProperties?: Record<string, Properties>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
       disableGeoip?: boolean
@@ -2620,12 +2621,12 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   private addLocalPersonAndGroupProperties(
     distinctId: string,
     groups?: Record<string, string>,
-    personProperties?: Record<string, any>,
-    groupProperties?: Record<string, Record<string, any>>
-  ): { allPersonProperties: Record<string, any>; allGroupProperties: Record<string, Record<string, any>> } {
+    personProperties?: Properties,
+    groupProperties?: Record<string, Properties>
+  ): { allPersonProperties: Properties; allGroupProperties: Record<string, Properties> } {
     const allPersonProperties = { ...(personProperties || {}) }
 
-    const allGroupProperties: Record<string, Record<string, any>> = {}
+    const allGroupProperties: Record<string, Properties> = {}
     if (groups) {
       for (const groupName of Object.keys(groups)) {
         allGroupProperties[groupName] = {
@@ -2640,7 +2641,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
 
   private personPropertiesForLocalEvaluation(
     distinctId: string,
-    personProperties?: Record<string, any>
+    personProperties?: Properties
   ): Record<string, any> {
     return { distinct_id: distinctId, ...(personProperties || {}) }
   }
@@ -2648,8 +2649,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   private createFeatureFlagEvaluationContext(
     distinctId: string,
     groups?: Record<string, string>,
-    personProperties?: Record<string, any>,
-    groupProperties?: Record<string, Record<string, any>>
+    personProperties?: Properties,
+    groupProperties?: Record<string, Properties>
   ): FeatureFlagEvaluationContext {
     return {
       distinctId,

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2639,10 +2639,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     return { allPersonProperties, allGroupProperties }
   }
 
-  private personPropertiesForLocalEvaluation(
-    distinctId: string,
-    personProperties?: Properties
-  ): Record<string, any> {
+  private personPropertiesForLocalEvaluation(distinctId: string, personProperties?: Properties): Record<string, any> {
     return { distinct_id: distinctId, ...(personProperties || {}) }
   }
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1076,8 +1076,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     distinctId: string,
     options: {
       groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
+      personProperties?: Record<string, any>
+      groupProperties?: Record<string, Record<string, any>>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
       disableGeoip?: boolean
@@ -1343,8 +1343,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     distinctId: string,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
+      personProperties?: Record<string, any>
+      groupProperties?: Record<string, Record<string, any>>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
       disableGeoip?: boolean
@@ -1414,8 +1414,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     matchValue?: FeatureFlagValue,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
+      personProperties?: Record<string, any>
+      groupProperties?: Record<string, Record<string, any>>
       onlyEvaluateLocally?: boolean
       /** @deprecated THIS OPTION HAS NO EFFECT, kept here for backwards compatibility reasons. */
       sendFeatureFlagEvents?: boolean
@@ -1601,8 +1601,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     distinctId: string,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
+      personProperties?: Record<string, any>
+      groupProperties?: Record<string, Record<string, any>>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
       disableGeoip?: boolean
@@ -2620,12 +2620,12 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   private addLocalPersonAndGroupProperties(
     distinctId: string,
     groups?: Record<string, string>,
-    personProperties?: Record<string, string>,
-    groupProperties?: Record<string, Record<string, string>>
-  ): { allPersonProperties: Record<string, string>; allGroupProperties: Record<string, Record<string, string>> } {
+    personProperties?: Record<string, any>,
+    groupProperties?: Record<string, Record<string, any>>
+  ): { allPersonProperties: Record<string, any>; allGroupProperties: Record<string, Record<string, any>> } {
     const allPersonProperties = { ...(personProperties || {}) }
 
-    const allGroupProperties: Record<string, Record<string, string>> = {}
+    const allGroupProperties: Record<string, Record<string, any>> = {}
     if (groups) {
       for (const groupName of Object.keys(groups)) {
         allGroupProperties[groupName] = {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -8,6 +8,7 @@ import type {
   PostHogFetchOptions,
   PostHogFetchResponse,
   PostHogFlagsAndPayloadsResponse,
+  Properties,
 } from '@posthog/core'
 import { ContextData, ContextOptions } from './extensions/context/types'
 
@@ -33,8 +34,8 @@ export type UnsetPersonPropertiesMessage = {
 
 export type SendFeatureFlagsOptions = {
   onlyEvaluateLocally?: boolean
-  personProperties?: Record<string, any>
-  groupProperties?: Record<string, Record<string, any>>
+  personProperties?: Properties
+  groupProperties?: Record<string, Properties>
   flagKeys?: string[]
 }
 
@@ -106,8 +107,8 @@ export type OverrideFeatureFlagsOptions =
 
 export type BaseFlagEvaluationOptions = {
   groups?: Record<string, string>
-  personProperties?: Record<string, any>
-  groupProperties?: Record<string, Record<string, any>>
+  personProperties?: Properties
+  groupProperties?: Record<string, Properties>
   onlyEvaluateLocally?: boolean
   disableGeoip?: boolean
 }
@@ -501,8 +502,8 @@ export interface IPostHog {
     distinctId: string,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, any>
-      groupProperties?: Record<string, Record<string, any>>
+      personProperties?: Properties
+      groupProperties?: Record<string, Properties>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
     }
@@ -532,8 +533,8 @@ export interface IPostHog {
     distinctId: string,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, any>
-      groupProperties?: Record<string, Record<string, any>>
+      personProperties?: Properties
+      groupProperties?: Record<string, Properties>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
     }

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -106,8 +106,8 @@ export type OverrideFeatureFlagsOptions =
 
 export type BaseFlagEvaluationOptions = {
   groups?: Record<string, string>
-  personProperties?: Record<string, string>
-  groupProperties?: Record<string, Record<string, string>>
+  personProperties?: Record<string, any>
+  groupProperties?: Record<string, Record<string, any>>
   onlyEvaluateLocally?: boolean
   disableGeoip?: boolean
 }
@@ -501,8 +501,8 @@ export interface IPostHog {
     distinctId: string,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
+      personProperties?: Record<string, any>
+      groupProperties?: Record<string, Record<string, any>>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
     }
@@ -532,8 +532,8 @@ export interface IPostHog {
     distinctId: string,
     options?: {
       groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
+      personProperties?: Record<string, any>
+      groupProperties?: Record<string, Record<string, any>>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
     }


### PR DESCRIPTION
## Problem

Closes #2133.

`personProperties` is typed as `Record<string, string>`, so passing a numeric person property to `getFeatureFlag` / `getAllFlags` / `evaluateFlags` / `isFeatureEnabled` fails to type-check:

```ts
await posthog.getAllFlags('user_123', {
  personProperties: { age: 30 },
  //                  ~~~ Type 'number' is not assignable to type 'string'.
})
```

Local evaluation has always handled numbers — only the public types disagree:

- `matchProperty` accepts `propertyValues: Record<string, any>`, and the `gt`/`gte`/`lt`/`lte` branch explicitly checks `typeof overrideValue === 'number'` before comparing numerically.
- `personPropertiesForLocalEvaluation` already takes and returns `Record<string, any>`.
- `SendFeatureFlagsOptions.personProperties` is already `Record<string, any>`, so the same value is accepted on the capture path and rejected on the flag path.

The narrow type also shows up as friction in the existing suite, which casts around it:

```ts
} as unknown as Record<string, string>,
```

This matches what was agreed on the issue: types should be relaxed to accept numbers, and doing so isn't breaking since `Record<string, any>` still accepts everything `Record<string, string>` did.

## Changes

Widened `personProperties` to `Record<string, any>` and `groupProperties` to `Record<string, Record<string, any>>` on the flag evaluation options — `BaseFlagEvaluationOptions` (which `FlagEvaluationOptions` and `AllFlagsOptions` extend), the `IPostHog` declarations for `isFeatureEnabled` / `getFeatureFlag`, and their `client.ts` counterparts. `addLocalPersonAndGroupProperties` follows, since it now receives them.

Left alone deliberately:

- `groups?: Record<string, string>` — group keys, not properties.
- `extractPropertiesFromEvent` — it `String()`-coerces every value, so `Record<string, string>` is accurate there.

Types only; no runtime change.

This also removes a now-unnecessary `as unknown as Record<string, string>` cast from the existing "undefined property values" test — the narrow type was the only reason it was there.

### Why `Record<string, any>` and not a narrower union

`Record<string, string | number | boolean>` looks tighter, but it would be wrong here: `null`/`undefined` are legitimate person property values. `matchProperty` has an explicit null guard, and `NULL_VALUES_ALLOWED_OPERATORS` lets `is_not` / `is_set` match on them. A `string | number | boolean` union would reject those, and the existing test above would still need its cast to compile.

`any` is also the established shape for property bags here: `SendFeatureFlagsOptions` and `personPropertiesForLocalEvaluation` already use it, `matchProperty` takes `Record<string, any>`, and `@posthog/types` defines `Property = any` / `Properties = Record<string, Property>` (which the browser SDK re-exports). Using `Properties` by name would be equivalent — it resolves to exactly `Record<string, any>` — but `@posthog/types` isn't currently reachable from `posthog-node` (it comes in via `@posthog/core`, which doesn't re-export it), and adding that re-export felt like more blast radius than this fix warrants. Happy to do it if you'd rather have the named type.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## Test strategy

Added `evaluates numeric person properties with comparison operators` to `feature-flags.spec.ts`, alongside the existing person-property tests. It defines a flag with a `gt: 21` condition on a person property and evaluates it locally with `personProperties: { age: 30 }` (expects `true`) and `{ age: 18 }` (expects `false`) — a positive and a negative case, so the change can't pass by making everything match.

Because jest strips types via babel, that test passes at runtime with or without the fix — the type error is what it's actually guarding. So I verified it against `tsc` in both directions:

- Reverting only `types.ts` + `client.ts` and keeping the test: `tsc --noEmit` fails with `error TS2322: Type 'number' is not assignable to type 'string'` on both new call sites.
- With the fix applied: no errors in `src/`.

Also ran the full `posthog-node` suite (794 passing). Two failures in `exception-autocapture.spec.ts` reproduce identically on a clean checkout of `main`, so they're unrelated to this change. `pnpm lint` is clean, and `packages/node/references/posthog-node-references-latest.json` is regenerated via `pnpm generate-references` — the only delta is the four widened type signatures.

Edge cases considered: `undefined` values still take the existing `null`-guard path in `matchProperty`; string-numeric values like `"10"` still compare numerically via the existing `parseFloat` fallback; `groups` is untouched.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — I'm the DRI. (The template asks for the driver as assignee; I can't set assignees as an external contributor, so noting it here instead — this PR isn't autonomous despite being unassigned.)

I used Claude Code (Opus 4.8) to investigate the issue and draft the change; I reviewed the diff and the reasoning before opening this.

Notes that may help review:

- The fix direction came from reading the runtime rather than the issue title — `matchProperty` already being `Record<string, any>` is what makes this a types-only change, and it's why I widened `groupProperties` alongside `personProperties` rather than only the field named in the issue.
- I first reached for a narrower `string | number | boolean` union before noticing the null guard in `matchProperty` ruled it out — the reasoning for `any` in the section above is the result of checking that, not a preference for looser types.
- `extractPropertiesFromEvent` looked like it needed the same treatment, but it string-coerces its output, so widening it would have made the type less accurate. Left it.
