### PR TITLE
feat(flags): add $feature_flag_has_experiment to $feature_flag_called events

### DIFF
--- a/.changeset/feature-flag-has-experiment.md
+++ b/.changeset/feature-flag-has-experiment.md
@@ -8,4 +8,4 @@
 
 add `$feature_flag_has_experiment` to `$feature_flag_called` events
 
-Every `$feature_flag_called` event now carries a `$feature_flag_has_experiment` boolean sourced from the server's `has_experiment` flag metadata (the `/flags?v=2` response for remote evaluation, the `/api/feature_flag/local_evaluation` definitions for posthog-node local evaluation). The property defaults to `false` when the server does not report the field.
+`$feature_flag_called` events now carry a `$feature_flag_has_experiment` boolean sourced from the server's `has_experiment` flag metadata (the `/flags?v=2` response for remote evaluation, the `/api/feature_flag/local_evaluation` definitions for posthog-node local evaluation). The property is only sent when the server explicitly reports `has_experiment`; it is omitted entirely when the value is unknown (older servers, missing metadata, bootstrapped or locally injected flags).

--- a/.changeset/feature-flag-has-experiment.md
+++ b/.changeset/feature-flag-has-experiment.md
@@ -1,0 +1,11 @@
+---
+'@posthog/core': minor
+'@posthog/types': minor
+'posthog-js': minor
+'posthog-node': minor
+'posthog-react-native': minor
+---
+
+add `$feature_flag_has_experiment` to `$feature_flag_called` events
+
+Every `$feature_flag_called` event now carries a `$feature_flag_has_experiment` boolean sourced from the server's `has_experiment` flag metadata (the `/flags?v=2` response for remote evaluation, the `/api/feature_flag/local_evaluation` definitions for posthog-node local evaluation). The property defaults to `false` when the server does not report the field.

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -891,7 +891,6 @@ describe('featureflags', () => {
                     $feature_flag_bootstrapped_response: null,
                     $feature_flag_bootstrapped_payload: null,
                     $used_bootstrap_value: true,
-                    $feature_flag_has_experiment: false,
                 })
             })
 
@@ -938,7 +937,6 @@ describe('featureflags', () => {
                     $feature_flag_bootstrapped_response: null,
                     $feature_flag_bootstrapped_payload: null,
                     $used_bootstrap_value: true,
-                    $feature_flag_has_experiment: false,
                     $feature_flag_original_response: false,
                     $feature_flag_original_payload: { status: 'original' },
                     $feature_flag_request_id: undefined,
@@ -955,7 +953,6 @@ describe('featureflags', () => {
                     $feature_flag_bootstrapped_response: null,
                     $feature_flag_bootstrapped_payload: null,
                     $used_bootstrap_value: true,
-                    $feature_flag_has_experiment: false,
                     $feature_flag_original_response: false,
                     $feature_flag_request_id: undefined,
                 })
@@ -971,7 +968,6 @@ describe('featureflags', () => {
                     $feature_flag_bootstrapped_response: null,
                     $feature_flag_bootstrapped_payload: null,
                     $used_bootstrap_value: true,
-                    $feature_flag_has_experiment: false,
                     $feature_flag_original_response: 'multivariate-variant-1',
                     $feature_flag_request_id: undefined,
                 })
@@ -2909,16 +2905,15 @@ describe('featureflags', () => {
             )
         })
 
-        it('includes $feature_flag_has_experiment false when server omits has_experiment', () => {
+        it('omits $feature_flag_has_experiment when server omits has_experiment', () => {
             receiveFlagWithMetadata({ id: 1, version: 2 })
 
             featureFlags.getFeatureFlag('test-flag')
 
             expect(instance.capture).toHaveBeenCalledWith(
                 '$feature_flag_called',
-                expect.objectContaining({
-                    $feature_flag: 'test-flag',
-                    $feature_flag_has_experiment: false,
+                expect.not.objectContaining({
+                    $feature_flag_has_experiment: expect.anything(),
                 })
             )
         })

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -891,6 +891,7 @@ describe('featureflags', () => {
                     $feature_flag_bootstrapped_response: null,
                     $feature_flag_bootstrapped_payload: null,
                     $used_bootstrap_value: true,
+                    $feature_flag_has_experiment: false,
                 })
             })
 
@@ -937,6 +938,7 @@ describe('featureflags', () => {
                     $feature_flag_bootstrapped_response: null,
                     $feature_flag_bootstrapped_payload: null,
                     $used_bootstrap_value: true,
+                    $feature_flag_has_experiment: false,
                     $feature_flag_original_response: false,
                     $feature_flag_original_payload: { status: 'original' },
                     $feature_flag_request_id: undefined,
@@ -953,6 +955,7 @@ describe('featureflags', () => {
                     $feature_flag_bootstrapped_response: null,
                     $feature_flag_bootstrapped_payload: null,
                     $used_bootstrap_value: true,
+                    $feature_flag_has_experiment: false,
                     $feature_flag_original_response: false,
                     $feature_flag_request_id: undefined,
                 })
@@ -968,6 +971,7 @@ describe('featureflags', () => {
                     $feature_flag_bootstrapped_response: null,
                     $feature_flag_bootstrapped_payload: null,
                     $used_bootstrap_value: true,
+                    $feature_flag_has_experiment: false,
                     $feature_flag_original_response: 'multivariate-variant-1',
                     $feature_flag_request_id: undefined,
                 })
@@ -2854,6 +2858,67 @@ describe('featureflags', () => {
                 '$feature_flag_called',
                 expect.objectContaining({
                     $feature_flag_evaluated_at: NEW_EVALUATED_AT,
+                })
+            )
+        })
+    })
+
+    describe('Feature Flag Has Experiment', () => {
+        const receiveFlagWithMetadata = (metadata?: Record<string, any>) => {
+            featureFlags.receivedFeatureFlags({
+                featureFlags: { 'test-flag': true },
+                featureFlagPayloads: {},
+                flags: {
+                    'test-flag': {
+                        key: 'test-flag',
+                        enabled: true,
+                        variant: undefined,
+                        reason: undefined,
+                        metadata,
+                    },
+                },
+            })
+            featureFlags._hasLoadedFlags = true
+        }
+
+        it('includes $feature_flag_has_experiment true when server reports has_experiment true', () => {
+            receiveFlagWithMetadata({ id: 1, version: 2, has_experiment: true })
+
+            featureFlags.getFeatureFlag('test-flag')
+
+            expect(instance.capture).toHaveBeenCalledWith(
+                '$feature_flag_called',
+                expect.objectContaining({
+                    $feature_flag: 'test-flag',
+                    $feature_flag_has_experiment: true,
+                })
+            )
+        })
+
+        it('includes $feature_flag_has_experiment false when server reports has_experiment false', () => {
+            receiveFlagWithMetadata({ id: 1, version: 2, has_experiment: false })
+
+            featureFlags.getFeatureFlag('test-flag')
+
+            expect(instance.capture).toHaveBeenCalledWith(
+                '$feature_flag_called',
+                expect.objectContaining({
+                    $feature_flag: 'test-flag',
+                    $feature_flag_has_experiment: false,
+                })
+            )
+        })
+
+        it('includes $feature_flag_has_experiment false when server omits has_experiment', () => {
+            receiveFlagWithMetadata({ id: 1, version: 2 })
+
+            featureFlags.getFeatureFlag('test-flag')
+
+            expect(instance.capture).toHaveBeenCalledWith(
+                '$feature_flag_called',
+                expect.objectContaining({
+                    $feature_flag: 'test-flag',
+                    $feature_flag_has_experiment: false,
                 })
             )
         })

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -896,7 +896,10 @@ export class PostHogFeatureFlags implements Extension {
                     $feature_flag_bootstrapped_payload: this._config.bootstrap?.featureFlagPayloads?.[key] || null,
                     // If we haven't yet received a response from the /flags endpoint, we must have used the bootstrapped value
                     $used_bootstrap_value: !this._flagsLoadedFromRemote,
-                    $feature_flag_has_experiment: flagDetails?.metadata?.has_experiment ?? false,
+                }
+
+                if (!isUndefined(flagDetails?.metadata?.has_experiment)) {
+                    properties.$feature_flag_has_experiment = flagDetails.metadata.has_experiment
                 }
 
                 if (!isUndefined(flagDetails?.metadata?.version)) {

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -896,6 +896,7 @@ export class PostHogFeatureFlags implements Extension {
                     $feature_flag_bootstrapped_payload: this._config.bootstrap?.featureFlagPayloads?.[key] || null,
                     // If we haven't yet received a response from the /flags endpoint, we must have used the bootstrapped value
                     $used_bootstrap_value: !this._flagsLoadedFromRemote,
+                    $feature_flag_has_experiment: flagDetails?.metadata?.has_experiment ?? false,
                 }
 
                 if (!isUndefined(flagDetails?.metadata?.version)) {

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -865,10 +865,10 @@ describe('PostHog Feature Flags v4', () => {
           expect(await getFlagCalledProperties()).toMatchObject({ $feature_flag_has_experiment: false })
         })
 
-        it('should send $feature_flag_has_experiment false when the server omits has_experiment', async () => {
+        it('should omit $feature_flag_has_experiment when the server omits has_experiment', async () => {
           mockFlagsWithMetadata({ id: 1, version: 1, description: undefined, payload: undefined })
 
-          expect(await getFlagCalledProperties()).toMatchObject({ $feature_flag_has_experiment: false })
+          expect(await getFlagCalledProperties()).not.toHaveProperty('$feature_flag_has_experiment')
         })
       })
 

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -807,6 +807,71 @@ describe('PostHog Feature Flags v4', () => {
         }
       )
 
+      describe('$feature_flag_has_experiment', () => {
+        const mockFlagsWithMetadata = (metadata: Record<string, any>): void => {
+          mocks.fetch.mockImplementation((url) => {
+            if (url.includes('/flags/?v=2')) {
+              return Promise.resolve({
+                status: 200,
+                text: () => Promise.resolve('ok'),
+                json: () =>
+                  Promise.resolve({
+                    flags: {
+                      'feature-1': {
+                        key: 'feature-1',
+                        enabled: true,
+                        variant: undefined,
+                        reason: undefined,
+                        metadata,
+                      },
+                    },
+                  }),
+              })
+            }
+
+            return Promise.resolve({
+              status: 200,
+              text: () => Promise.resolve('ok'),
+              json: () => Promise.resolve({ status: 'ok' }),
+            })
+          })
+        }
+
+        const getFlagCalledProperties = async (): Promise<Record<string, any>> => {
+          await posthog.reloadFeatureFlagsAsync()
+          posthog.getFeatureFlag('feature-1')
+          await waitForPromises()
+          const event = mocks.fetch.mock.calls
+            .flatMap((call) => parseBody(call)?.batch ?? [])
+            .find((e: any) => e.event === '$feature_flag_called')
+          return event.properties
+        }
+
+        it('should send $feature_flag_has_experiment true when the server reports has_experiment true', async () => {
+          mockFlagsWithMetadata({ id: 1, version: 1, description: undefined, payload: undefined, has_experiment: true })
+
+          expect(await getFlagCalledProperties()).toMatchObject({ $feature_flag_has_experiment: true })
+        })
+
+        it('should send $feature_flag_has_experiment false when the server reports has_experiment false', async () => {
+          mockFlagsWithMetadata({
+            id: 1,
+            version: 1,
+            description: undefined,
+            payload: undefined,
+            has_experiment: false,
+          })
+
+          expect(await getFlagCalledProperties()).toMatchObject({ $feature_flag_has_experiment: false })
+        })
+
+        it('should send $feature_flag_has_experiment false when the server omits has_experiment', async () => {
+          mockFlagsWithMetadata({ id: 1, version: 1, description: undefined, payload: undefined })
+
+          expect(await getFlagCalledProperties()).toMatchObject({ $feature_flag_has_experiment: false })
+        })
+      })
+
       it('should not capture $feature_flag_called again if reloaded flags keep the same value', async () => {
         expect(posthog.getFeatureFlag('feature-1')).toEqual(true)
         await waitForPromises()

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -1040,6 +1040,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
         ...maybeAdd('$feature_flag_request_id', details?.requestId),
         ...maybeAdd('$feature_flag_evaluated_at', details?.evaluatedAt),
         ...maybeAdd('$feature_flag_error', featureFlagError),
+        $feature_flag_has_experiment: featureFlag?.metadata?.has_experiment ?? false,
       }
 
       this.capture('$feature_flag_called', properties)

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -1040,7 +1040,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
         ...maybeAdd('$feature_flag_request_id', details?.requestId),
         ...maybeAdd('$feature_flag_evaluated_at', details?.evaluatedAt),
         ...maybeAdd('$feature_flag_error', featureFlagError),
-        $feature_flag_has_experiment: featureFlag?.metadata?.has_experiment ?? false,
+        ...maybeAdd('$feature_flag_has_experiment', featureFlag?.metadata?.has_experiment),
       }
 
       this.capture('$feature_flag_called', properties)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -587,7 +587,7 @@ export type FeatureFlagMetadata = {
   description: string | undefined
   // Payloads in the response are always JSON encoded as a string
   payload: string | undefined
-  // Whether the flag is linked to an experiment. Absent on older servers.
+  /** Whether the flag is linked to an experiment. Absent when the server does not report it. */
   has_experiment?: boolean
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -587,6 +587,8 @@ export type FeatureFlagMetadata = {
   description: string | undefined
   // Payloads in the response are always JSON encoded as a string
   payload: string | undefined
+  // Whether the flag is linked to an experiment. Absent on older servers.
+  has_experiment?: boolean
 }
 
 export type EvaluationReason = {

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -2182,7 +2182,7 @@
       "name": "FeatureFlagMetadata",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    id: number | undefined;\n    version: number | undefined;\n    description: string | undefined;\n    payload: string | undefined;\n}"
+      "example": "{\n    id: number | undefined;\n    version: number | undefined;\n    description: string | undefined;\n    payload: string | undefined;\n    has_experiment?: boolean;\n}"
     },
     {
       "id": "FeatureFlagOverrideOptions",

--- a/packages/node/src/__tests__/evaluate-flags.spec.ts
+++ b/packages/node/src/__tests__/evaluate-flags.spec.ts
@@ -496,7 +496,7 @@ describe('evaluateFlags', () => {
       expect(byKey['missing-flag'].$feature_flag_error).toEqual('errors_while_computing_flags,flag_missing')
     })
 
-    it('attaches $feature_flag_has_experiment from the response metadata, defaulting to false when absent', async () => {
+    it('attaches $feature_flag_has_experiment from the response metadata, omitting it when absent', async () => {
       const response = flagsResponseFixture()
       response.flags['variant-flag'].metadata!.has_experiment = true
       response.flags['boolean-flag'].metadata!.has_experiment = false
@@ -516,7 +516,7 @@ describe('evaluateFlags', () => {
       )
       expect(byKey['variant-flag'].$feature_flag_has_experiment).toBe(true)
       expect(byKey['boolean-flag'].$feature_flag_has_experiment).toBe(false)
-      expect(byKey['disabled-flag'].$feature_flag_has_experiment).toBe(false)
+      expect(byKey['disabled-flag']).not.toHaveProperty('$feature_flag_has_experiment')
     })
 
     it('reports quota_limited from response.quotaLimited', async () => {
@@ -647,7 +647,7 @@ describe('evaluateFlags', () => {
       expect(flagCalled.properties.$feature_flag_definitions_loaded_at).toEqual(expect.any(Number))
     })
 
-    it('attaches $feature_flag_has_experiment from the local definition, defaulting to false when absent', async () => {
+    it('attaches $feature_flag_has_experiment from the local definition', async () => {
       // The beforeEach client already loaded the fixture definitions; build a fresh
       // client against definitions that carry has_experiment.
       await posthog.shutdown()
@@ -664,13 +664,13 @@ describe('evaluateFlags', () => {
       expect(flagCalled.properties.$feature_flag_has_experiment).toBe(true)
     })
 
-    it('defaults $feature_flag_has_experiment to false when the local definition omits it', async () => {
+    it('omits $feature_flag_has_experiment when the local definition omits it', async () => {
       const flags = await posthog.evaluateFlags('user-1')
       flags.isEnabled('local-flag')
 
       await waitForPromises()
       const flagCalled = captures.find((m) => m.event === '$feature_flag_called')
-      expect(flagCalled.properties.$feature_flag_has_experiment).toBe(false)
+      expect(flagCalled.properties).not.toHaveProperty('$feature_flag_has_experiment')
     })
   })
 

--- a/packages/node/src/__tests__/evaluate-flags.spec.ts
+++ b/packages/node/src/__tests__/evaluate-flags.spec.ts
@@ -496,6 +496,29 @@ describe('evaluateFlags', () => {
       expect(byKey['missing-flag'].$feature_flag_error).toEqual('errors_while_computing_flags,flag_missing')
     })
 
+    it('attaches $feature_flag_has_experiment from the response metadata, defaulting to false when absent', async () => {
+      const response = flagsResponseFixture()
+      response.flags['variant-flag'].metadata!.has_experiment = true
+      response.flags['boolean-flag'].metadata!.has_experiment = false
+      // disabled-flag's metadata omits has_experiment (older servers)
+      mockedFetch.mockImplementation(apiImplementationV4(response))
+
+      const flags = await posthog.evaluateFlags('user-1')
+      flags.isEnabled('variant-flag')
+      flags.isEnabled('boolean-flag')
+      flags.isEnabled('disabled-flag')
+
+      await waitForPromises()
+      const byKey = Object.fromEntries(
+        captures
+          .filter((m) => m.event === '$feature_flag_called')
+          .map((m) => [m.properties.$feature_flag, m.properties])
+      )
+      expect(byKey['variant-flag'].$feature_flag_has_experiment).toBe(true)
+      expect(byKey['boolean-flag'].$feature_flag_has_experiment).toBe(false)
+      expect(byKey['disabled-flag'].$feature_flag_has_experiment).toBe(false)
+    })
+
     it('reports quota_limited from response.quotaLimited', async () => {
       const response = flagsResponseFixture()
       ;(response as any).quotaLimited = ['feature_flags']
@@ -622,6 +645,32 @@ describe('evaluateFlags', () => {
       await waitForPromises()
       const flagCalled = captures.find((m) => m.event === '$feature_flag_called')
       expect(flagCalled.properties.$feature_flag_definitions_loaded_at).toEqual(expect.any(Number))
+    })
+
+    it('attaches $feature_flag_has_experiment from the local definition, defaulting to false when absent', async () => {
+      // The beforeEach client already loaded the fixture definitions; build a fresh
+      // client against definitions that carry has_experiment.
+      await posthog.shutdown()
+      const definitions = localFlagsFixture()
+      ;(definitions.flags[0] as any).has_experiment = true
+      mockedFetch.mockImplementation(apiImplementation({ localFlags: definitions }))
+      setup({ personalApiKey: 'TEST_PERSONAL_API_KEY' })
+
+      const flags = await posthog.evaluateFlags('user-1')
+      flags.isEnabled('local-flag')
+
+      await waitForPromises()
+      const flagCalled = captures.find((m) => m.event === '$feature_flag_called')
+      expect(flagCalled.properties.$feature_flag_has_experiment).toBe(true)
+    })
+
+    it('defaults $feature_flag_has_experiment to false when the local definition omits it', async () => {
+      const flags = await posthog.evaluateFlags('user-1')
+      flags.isEnabled('local-flag')
+
+      await waitForPromises()
+      const flagCalled = captures.find((m) => m.event === '$feature_flag_called')
+      expect(flagCalled.properties.$feature_flag_has_experiment).toBe(false)
     })
   })
 

--- a/packages/node/src/__tests__/feature-flags.flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.flags.spec.ts
@@ -821,16 +821,15 @@ describe('getFeatureFlagResult', () => {
         $feature_flag_reason: 'Matched condition set 2',
         $feature_flag_request_id: 'test-request-id',
         locally_evaluated: false,
-        $feature_flag_has_experiment: false,
       },
     })
   })
 
   it.each([
-    ['true when the server reports has_experiment true', true, true],
-    ['false when the server reports has_experiment false', false, false],
-    ['false when the server omits has_experiment', undefined, false],
-  ])('captures $feature_flag_has_experiment %s', async (_, hasExperiment, expected) => {
+    ['sends true when the server reports has_experiment true', true],
+    ['sends false when the server reports has_experiment false', false],
+    ['omits the property when the server omits has_experiment', undefined],
+  ])('$feature_flag_has_experiment: %s', async (_, hasExperiment) => {
     const flagsResponse: PostHogV2FlagsResponse = {
       flags: {
         'test-flag': {
@@ -869,13 +868,12 @@ describe('getFeatureFlagResult', () => {
     await posthog.getFeatureFlagResult('test-flag', 'some-distinct-id')
 
     await waitForPromises()
-    expect(capturedMessage).toMatchObject({
-      event: '$feature_flag_called',
-      properties: {
-        $feature_flag: 'test-flag',
-        $feature_flag_has_experiment: expected,
-      },
-    })
+    expect(capturedMessage.event).toBe('$feature_flag_called')
+    if (hasExperiment === undefined) {
+      expect(capturedMessage.properties).not.toHaveProperty('$feature_flag_has_experiment')
+    } else {
+      expect(capturedMessage.properties.$feature_flag_has_experiment).toBe(hasExperiment)
+    }
   })
 
   it('does not capture event when sendFeatureFlagEvents is false', async () => {
@@ -1134,7 +1132,6 @@ describe('getFeatureFlagResult', () => {
           $feature_flag_response: true,
           $feature_flag_id: 55,
           locally_evaluated: true,
-          $feature_flag_has_experiment: false,
         },
       })
 
@@ -1142,10 +1139,10 @@ describe('getFeatureFlagResult', () => {
     })
 
     it.each([
-      ['true when the definition reports has_experiment true', true, true],
-      ['false when the definition reports has_experiment false', false, false],
-      ['false when the definition omits has_experiment', undefined, false],
-    ])('captures $feature_flag_has_experiment %s on local evaluation', async (_, hasExperiment, expected) => {
+      ['sends true when the definition reports has_experiment true', true],
+      ['sends false when the definition reports has_experiment false', false],
+      ['omits the property when the definition omits has_experiment', undefined],
+    ])('$feature_flag_has_experiment on local evaluation: %s', async (_, hasExperiment) => {
       const localFlags = {
         flags: [
           {
@@ -1176,14 +1173,13 @@ describe('getFeatureFlagResult', () => {
       await posthog.getFeatureFlagResult('simple-flag', 'some-distinct-id')
 
       await waitForPromises()
-      expect(capturedMessage).toMatchObject({
-        event: '$feature_flag_called',
-        properties: {
-          $feature_flag: 'simple-flag',
-          locally_evaluated: true,
-          $feature_flag_has_experiment: expected,
-        },
-      })
+      expect(capturedMessage.event).toBe('$feature_flag_called')
+      expect(capturedMessage.properties.locally_evaluated).toBe(true)
+      if (hasExperiment === undefined) {
+        expect(capturedMessage.properties).not.toHaveProperty('$feature_flag_has_experiment')
+      } else {
+        expect(capturedMessage.properties.$feature_flag_has_experiment).toBe(hasExperiment)
+      }
 
       await posthog.shutdown()
     })

--- a/packages/node/src/__tests__/feature-flags.flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.flags.spec.ts
@@ -821,6 +821,59 @@ describe('getFeatureFlagResult', () => {
         $feature_flag_reason: 'Matched condition set 2',
         $feature_flag_request_id: 'test-request-id',
         locally_evaluated: false,
+        $feature_flag_has_experiment: false,
+      },
+    })
+  })
+
+  it.each([
+    ['true when the server reports has_experiment true', true, true],
+    ['false when the server reports has_experiment false', false, false],
+    ['false when the server omits has_experiment', undefined, false],
+  ])('captures $feature_flag_has_experiment %s', async (_, hasExperiment, expected) => {
+    const flagsResponse: PostHogV2FlagsResponse = {
+      flags: {
+        'test-flag': {
+          key: 'test-flag',
+          enabled: true,
+          variant: undefined,
+          reason: {
+            code: 'condition_match',
+            condition_index: 0,
+            description: 'Matched condition set 1',
+          },
+          metadata: {
+            id: 10,
+            version: 3,
+            payload: undefined,
+            description: 'description',
+            ...(hasExperiment === undefined ? {} : { has_experiment: hasExperiment }),
+          },
+        },
+      },
+      errorsWhileComputingFlags: false,
+      requestId: 'test-request-id',
+      evaluatedAt: 1640995200000,
+    }
+    mockedFetch.mockImplementation(apiImplementationV4(flagsResponse))
+
+    const posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      ...posthogImmediateResolveOptions,
+    })
+    let capturedMessage: any
+    posthog.on('capture', (message) => {
+      capturedMessage = message
+    })
+
+    await posthog.getFeatureFlagResult('test-flag', 'some-distinct-id')
+
+    await waitForPromises()
+    expect(capturedMessage).toMatchObject({
+      event: '$feature_flag_called',
+      properties: {
+        $feature_flag: 'test-flag',
+        $feature_flag_has_experiment: expected,
       },
     })
   })
@@ -1081,6 +1134,54 @@ describe('getFeatureFlagResult', () => {
           $feature_flag_response: true,
           $feature_flag_id: 55,
           locally_evaluated: true,
+          $feature_flag_has_experiment: false,
+        },
+      })
+
+      await posthog.shutdown()
+    })
+
+    it.each([
+      ['true when the definition reports has_experiment true', true, true],
+      ['false when the definition reports has_experiment false', false, false],
+      ['false when the definition omits has_experiment', undefined, false],
+    ])('captures $feature_flag_has_experiment %s on local evaluation', async (_, hasExperiment, expected) => {
+      const localFlags = {
+        flags: [
+          {
+            id: 55,
+            name: 'Simple Flag',
+            key: 'simple-flag',
+            active: true,
+            filters: {
+              groups: [{ rollout_percentage: 100 }],
+            },
+            ...(hasExperiment === undefined ? {} : { has_experiment: hasExperiment }),
+          },
+        ],
+      }
+      mockedFetch.mockImplementation(apiImplementation({ localFlags }))
+
+      const posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        personalApiKey: 'TEST_PERSONAL_API_KEY',
+        ...posthogImmediateResolveOptions,
+      })
+
+      let capturedMessage: any
+      posthog.on('capture', (message) => {
+        capturedMessage = message
+      })
+
+      await posthog.getFeatureFlagResult('simple-flag', 'some-distinct-id')
+
+      await waitForPromises()
+      expect(capturedMessage).toMatchObject({
+        event: '$feature_flag_called',
+        properties: {
+          $feature_flag: 'simple-flag',
+          locally_evaluated: true,
+          $feature_flag_has_experiment: expected,
         },
       })
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1129,6 +1129,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     let flagId: number | undefined = undefined
     let flagVersion: number | undefined = undefined
     let flagReason: string | undefined = undefined
+    let flagHasExperiment = false
 
     // Try local evaluation first
     const localEvaluationEnabled = this.featureFlagsPoller !== undefined
@@ -1146,6 +1147,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
             const value = localResult.value
             flagId = flag.id
             flagReason = 'Evaluated locally'
+            flagHasExperiment = flag.has_experiment ?? false
             result = {
               key,
               enabled: value !== false,
@@ -1200,6 +1202,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           flagId = flagDetail.metadata?.id
           flagVersion = flagDetail.metadata?.version
           flagReason = flagDetail.reason?.description ?? flagDetail.reason?.code
+          flagHasExperiment = flagDetail.metadata?.has_experiment ?? false
 
           // Parse payload once from the API response
           let parsedPayload: JsonType | undefined = undefined
@@ -1239,6 +1242,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         [`$feature/${key}`]: response,
         $feature_flag_request_id: requestId,
         $feature_flag_evaluated_at: flagWasLocallyEvaluated ? Date.now() : evaluatedAt,
+        $feature_flag_has_experiment: flagHasExperiment,
       }
 
       if (flagWasLocallyEvaluated && this.featureFlagsPoller) {
@@ -1935,6 +1939,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           version: undefined,
           reason: 'Evaluated locally',
           locallyEvaluated: true,
+          hasExperiment: flagDef?.has_experiment ?? false,
         }
         locallyEvaluatedKeys.add(key)
       }
@@ -1979,6 +1984,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
             version: detail.metadata?.version,
             reason: detail.reason?.description ?? detail.reason?.code,
             locallyEvaluated: false,
+            hasExperiment: detail.metadata?.has_experiment ?? false,
           }
         }
       }
@@ -2001,6 +2007,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           version: existing?.version,
           reason: existing?.reason,
           locallyEvaluated: existing?.locallyEvaluated ?? false,
+          hasExperiment: existing?.hasExperiment ?? false,
         }
       }
     }

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1129,7 +1129,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     let flagId: number | undefined = undefined
     let flagVersion: number | undefined = undefined
     let flagReason: string | undefined = undefined
-    let flagHasExperiment = false
+    let flagHasExperiment: boolean | undefined = undefined
 
     // Try local evaluation first
     const localEvaluationEnabled = this.featureFlagsPoller !== undefined
@@ -1147,7 +1147,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
             const value = localResult.value
             flagId = flag.id
             flagReason = 'Evaluated locally'
-            flagHasExperiment = flag.has_experiment ?? false
+            flagHasExperiment = flag.has_experiment
             result = {
               key,
               enabled: value !== false,
@@ -1202,7 +1202,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           flagId = flagDetail.metadata?.id
           flagVersion = flagDetail.metadata?.version
           flagReason = flagDetail.reason?.description ?? flagDetail.reason?.code
-          flagHasExperiment = flagDetail.metadata?.has_experiment ?? false
+          flagHasExperiment = flagDetail.metadata?.has_experiment
 
           // Parse payload once from the API response
           let parsedPayload: JsonType | undefined = undefined
@@ -1242,7 +1242,10 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         [`$feature/${key}`]: response,
         $feature_flag_request_id: requestId,
         $feature_flag_evaluated_at: flagWasLocallyEvaluated ? Date.now() : evaluatedAt,
-        $feature_flag_has_experiment: flagHasExperiment,
+      }
+
+      if (flagHasExperiment !== undefined) {
+        properties.$feature_flag_has_experiment = flagHasExperiment
       }
 
       if (flagWasLocallyEvaluated && this.featureFlagsPoller) {
@@ -1939,7 +1942,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           version: undefined,
           reason: 'Evaluated locally',
           locallyEvaluated: true,
-          hasExperiment: flagDef?.has_experiment ?? false,
+          hasExperiment: flagDef?.has_experiment,
         }
         locallyEvaluatedKeys.add(key)
       }
@@ -1984,7 +1987,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
             version: detail.metadata?.version,
             reason: detail.reason?.description ?? detail.reason?.code,
             locallyEvaluated: false,
-            hasExperiment: detail.metadata?.has_experiment ?? false,
+            hasExperiment: detail.metadata?.has_experiment,
           }
         }
       }
@@ -2007,7 +2010,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           version: existing?.version,
           reason: existing?.reason,
           locallyEvaluated: existing?.locallyEvaluated ?? false,
-          hasExperiment: existing?.hasExperiment ?? false,
+          hasExperiment: existing?.hasExperiment,
         }
       }
     }

--- a/packages/node/src/feature-flag-evaluations.ts
+++ b/packages/node/src/feature-flag-evaluations.ts
@@ -17,6 +17,7 @@ export type EvaluatedFlagRecord = {
   version: number | undefined
   reason: string | undefined
   locallyEvaluated: boolean
+  hasExperiment: boolean
 }
 
 /**
@@ -286,6 +287,7 @@ export class FeatureFlagEvaluations {
       [`$feature/${key}`]: response,
       $feature_flag_request_id: this._requestId,
       $feature_flag_evaluated_at: flag?.locallyEvaluated ? Date.now() : this._evaluatedAt,
+      $feature_flag_has_experiment: flag?.hasExperiment ?? false,
     }
 
     if (flag?.locallyEvaluated && this._flagDefinitionsLoadedAt !== undefined) {

--- a/packages/node/src/feature-flag-evaluations.ts
+++ b/packages/node/src/feature-flag-evaluations.ts
@@ -17,7 +17,8 @@ export type EvaluatedFlagRecord = {
   version: number | undefined
   reason: string | undefined
   locallyEvaluated: boolean
-  hasExperiment: boolean
+  /** Whether the flag is linked to an experiment; undefined when the server did not report it. */
+  hasExperiment: boolean | undefined
 }
 
 /**
@@ -287,7 +288,10 @@ export class FeatureFlagEvaluations {
       [`$feature/${key}`]: response,
       $feature_flag_request_id: this._requestId,
       $feature_flag_evaluated_at: flag?.locallyEvaluated ? Date.now() : this._evaluatedAt,
-      $feature_flag_has_experiment: flag?.hasExperiment ?? false,
+    }
+
+    if (flag?.hasExperiment !== undefined) {
+      properties.$feature_flag_has_experiment = flag.hasExperiment
     }
 
     if (flag?.locallyEvaluated && this._flagDefinitionsLoadedAt !== undefined) {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -356,6 +356,8 @@ export type PostHogFeatureFlag = {
   rollout_percentage: null | number
   ensure_experience_continuity: boolean
   experiment_set: number[]
+  // Whether the flag is linked to an experiment. Absent on older servers.
+  has_experiment?: boolean
 }
 
 /**

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -356,7 +356,7 @@ export type PostHogFeatureFlag = {
   rollout_percentage: null | number
   ensure_experience_continuity: boolean
   experiment_set: number[]
-  // Whether the flag is linked to an experiment. Absent on older servers.
+  /** Whether the flag is linked to an experiment. Absent when the server does not report it. */
   has_experiment?: boolean
 }
 

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2527,7 +2527,7 @@
       "name": "FeatureFlagMetadata",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "{\n    id: number | undefined;\n    version: number | undefined;\n    description: string | undefined;\n    payload: string | undefined;\n}"
+      "example": "{\n    id: number | undefined;\n    version: number | undefined;\n    description: string | undefined;\n    payload: string | undefined;\n    has_experiment?: boolean;\n}"
     },
     {
       "id": "FeatureFlagRequestError",

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -30,6 +30,8 @@ export type FeatureFlagMetadata = {
     version: number | undefined
     description: string | undefined
     payload: JsonType | undefined
+    // Whether the flag is linked to an experiment. Absent on older servers.
+    has_experiment?: boolean
     // Only used when overriding a flag payload.
     original_payload?: JsonType | undefined
 }

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -30,7 +30,7 @@ export type FeatureFlagMetadata = {
     version: number | undefined
     description: string | undefined
     payload: JsonType | undefined
-    // Whether the flag is linked to an experiment. Absent on older servers.
+    /** Whether the flag is linked to an experiment. Absent when the server does not report it. */
     has_experiment?: boolean
     // Only used when overriding a flag payload.
     original_payload?: JsonType | undefined


### PR DESCRIPTION
## Problem

Part of a cross-SDK effort to shrink `$feature_flag_called` events. This first phase adds a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, reflecting the server's `has_experiment` signal: `metadata.has_experiment` in the `/flags?v=2` response and `has_experiment` on `/api/feature_flag/local_evaluation` flag definitions. When the server does not report the field (older deployments, bootstrapped flags), the property is omitted, so it is tri-state: `true`, `false`, or absent (unknown).

This lets ingestion distinguish experiment-linked flag events (which need the full property set for exposure analysis) from the rest, and lets us measure the split before a later phase strips the expensive properties (`$feature/<key>`, `$feature_flag_payload`, per-event system metadata) from non-experiment flag events. This PR intentionally minimizes nothing: no properties are removed, no config options are added, and dedupe behavior is unchanged.

## Changes

- `@posthog/core`: `has_experiment?: boolean` on `FeatureFlagMetadata`; `_getFeatureFlagResult` emits `$feature_flag_has_experiment` from `metadata.has_experiment ?? false`. This covers posthog-react-native and other core-based SDKs.
- `posthog-js` (browser): field added to `FeatureFlagMetadata` in `@posthog/types`; property added to the capture in `posthog-featureflags.ts` from the persisted v2 flag details.
- `posthog-node`: all three send paths covered: single-flag local evaluation (from the `/local_evaluation` definition), single-flag remote fallback (from `flagDetail.metadata`), and the `evaluateFlags()` snapshot path (`hasExperiment` threaded through `EvaluatedFlagRecord` for local and remote records).
- Bootstrapped/injected flags carry no server metadata, so they report `false` by design.
- Regenerated API reference files; changeset bumps `@posthog/core`, `@posthog/types`, `posthog-js`, `posthog-node`, `posthog-react-native` (minor).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native

