### PR TITLE
fix(ci): support TypeScript 7 in minimum version check

### DIFF
--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -19,13 +19,13 @@ jobs:
         node-version: [20, 22, 24]
         typescript-version:
           - version: "4.7.4"
-            extra-flags: "--moduleResolution node"
+            extra-flags: "--module commonjs --moduleResolution node"
           - version: "5.9.2"
-            extra-flags: "--moduleResolution node"
+            extra-flags: "--module commonjs --moduleResolution node"
           - version: "latest"
-            extra-flags: "--moduleResolution node --ignoreConfig --ignoreDeprecations 6.0"
+            extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
           - version: "6.0.0-dev.20251204"
-            extra-flags: "--ignoreConfig"
+            extra-flags: "--module commonjs --ignoreConfig"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,6 +45,6 @@ jobs:
         run: |
           rm ci-ts-file.js || true
           pnpm exec tsc --version
-          pnpm exec tsc ci-ts-file.ts --strict --target es2017 --module commonjs --skipLibCheck ${{ matrix.typescript-version.extra-flags }}
+          pnpm exec tsc ci-ts-file.ts --strict --target es2017 --skipLibCheck ${{ matrix.typescript-version.extra-flags }}
           node ci-ts-file.js
         working-directory: packages/browser


### PR DESCRIPTION
## Problem

The minimum TypeScript version workflow started failing on `main` after `typescript@latest` began resolving to TypeScript 7. TypeScript 7 removes the legacy `node`/`node10` module-resolution mode, but the workflow passes `--moduleResolution node` to every stable/latest compiler invocation.

## Changes

- Move the module mode into each TypeScript matrix entry.
- Keep the existing CommonJS/legacy Node resolution check for TypeScript 4.7 and 5.9.
- Use matching `nodenext` module and module-resolution modes for `typescript@latest`.
- Remove the TypeScript 6 deprecation suppression from the latest entry because the deprecated mode is no longer used.

Validated the same compile-and-run import check locally against TypeScript 4.7.4, 5.9.2, 6.0.0-dev.20251204, and latest (currently 7.0.2); all four passed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

No package release is required for this CI-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi after diagnosing the failing workflow on both PR #4152 and the latest `main` run. We reproduced the TypeScript 7 failure, selected `nodenext` rather than suppressing a removed option, and exercised the workflow's compile-and-run command with all four matrix compiler versions. No package source or release metadata changes are included.
