### PR TITLE
chore(ci): fix minimum TS version check for TypeScript 7

### DIFF
--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -23,7 +23,7 @@ jobs:
           - version: "5.9.2"
             extra-flags: "--moduleResolution node"
           - version: "latest"
-            extra-flags: "--moduleResolution node --ignoreConfig --ignoreDeprecations 6.0"
+            extra-flags: "--ignoreConfig"
           - version: "6.0.0-dev.20251204"
             extra-flags: "--ignoreConfig"
     steps:


### PR DESCRIPTION
## Problem

The `Minimum TypeScript version check` workflow is red on every open PR and on `main`. `typescript@latest` was just published as `7.0.2`, which removed `moduleResolution: node10`. The workflow's `latest` matrix leg still forces `--moduleResolution node`, so it now fails with:

```
error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration.
```

`--ignoreDeprecations 6.0` (added for the TS 6 deprecation warning) can't suppress a hard removal in TS 7, so this needs a flag change rather than a deprecation override.

## Changes

- Drop `--moduleResolution node` and `--ignoreDeprecations 6.0` from the `latest` matrix leg, leaving just `--ignoreConfig`.
- This mirrors the existing `6.0.0-dev.20251204` leg, which already dropped `--moduleResolution` when `node10` was first deprecated. With `--module commonjs` still set, `tsc` picks a valid default resolution under TS 7.
- Verified locally against a fresh TypeScript 7.0.2 install: the old flags reproduce `TS5108`, the new flags pass.
- The `4.7.4`/`5.9.2` legs are untouched — those TS versions still support `node10`, so coverage isn't lost.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

CI-only change, no library affected.

## Checklist

- [x] Tests for new code — n/a, CI workflow config only
- [x] Accounted for the impact of any changes across different platforms — verified against a clean TypeScript 7.0.2 install
- [x] Accounted for backwards compatibility of any changes (no breaking changes!) — older TS matrix legs unchanged
- [x] Took care not to unnecessarily increase the bundle size — n/a

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file — not needed, workflow-only change (consistent with the prior `--ignoreConfig` fix in #3288)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and fixed via a Cursor agent session, starting from investigating a failing check on posthog-js#4153. Confirmed the root cause (TypeScript 7.0.2 removing `moduleResolution=node10`) by pulling the raw job log, then checked repo history to find the precedent for handling a `node10` removal (the `6.0.0-dev` leg's `--ignoreConfig`-only approach), and reproduced both the failure and the fix against a real TypeScript 7.0.2 install before opening this PR.