### PR TITLE
fix(node): standardize flush interval default

### DIFF
--- a/.changeset/standardize-node-flush-interval.md
+++ b/.changeset/standardize-node-flush-interval.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+Fix the default Node.js event flush interval at 5 seconds.

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -2966,6 +2966,11 @@
         {
           "type": "number[]",
           "name": "experiment_set"
+        },
+        {
+          "description": "Whether the flag is linked to an experiment. Absent when the server does not report it.",
+          "type": "boolean",
+          "name": "has_experiment"
         }
       ],
       "path": "src/types.ts"
@@ -3245,11 +3250,6 @@
           "name": "flushAt"
         },
         {
-          "description": "The interval in milliseconds between periodic flushes",
-          "type": "number",
-          "name": "flushInterval"
-        },
-        {
           "description": "The maximum number of queued messages to be flushed as part of a single batch (must be higher than `flushAt`)",
           "type": "number",
           "name": "maxBatchSize"
@@ -3367,6 +3367,11 @@
         {
           "type": "\"memory\"",
           "name": "persistence"
+        },
+        {
+          "description": "The interval in milliseconds between periodic flushes",
+          "type": "number",
+          "name": "flushInterval"
         },
         {
           "description": "The maximum number of cached messages either in memory or on the local storage (must be higher than `flushAt`)",

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -616,6 +616,16 @@ describe('PostHog Node.js', () => {
     })
   })
 
+  describe('flushInterval', () => {
+    it('defaults to 5000 for Node', () => {
+      const ph = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+      })
+
+      expect((ph as any).flushInterval).toBe(5000)
+    })
+  })
+
   describe('maxQueueSize', () => {
     it('defaults to 10000, higher than the shared core default of 1000', () => {
       const ph = new PostHog('TEST_API_KEY', {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -192,6 +192,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       // Applied after the spread with a nullish fallback so a wrapper forwarding
       // `maxQueueSize: undefined` still gets the Node default, not the core one.
       maxQueueSize: options.maxQueueSize ?? 10000,
+      flushInterval: options.flushInterval ?? 5000,
       host: normalizeHost(options.host),
       personalApiKey: normalizePersonalApiKey(options.secretKey ?? options.personalApiKey),
     }

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -146,8 +146,14 @@ export type FeatureFlagBucketingIdentifier = 'distinct_id' | 'device_id' | '' | 
 
 export type BeforeSendFn = (event: EventMessage | null) => EventMessage | null
 
-export type PostHogOptions = Omit<PostHogCoreOptions, 'before_send' | 'maxQueueSize'> & {
+export type PostHogOptions = Omit<PostHogCoreOptions, 'before_send' | 'flushInterval' | 'maxQueueSize'> & {
   persistence?: 'memory'
+  /**
+   * The interval in milliseconds between periodic flushes
+   *
+   * @default 5000
+   */
+  flushInterval?: number
   /**
    * The maximum number of cached messages either in memory or on the local storage (must be higher than `flushAt`)
    *


### PR DESCRIPTION
## Problem

The Node.js SDK flushes queued events every 10 seconds by default, while the standardized server-side SDK interval is 5 seconds. This delays delivery for low-volume Node.js processes that do not reach the event-count threshold.

See the [server-side SDK event buffer defaults comparison](https://gist.github.com/dustinbyrne/53aae4565ccae67586b9d8d9a1017033). Related standardization changes: [Java server SDK](https://github.com/PostHog/posthog-android/pull/626), [.NET SDK](https://github.com/PostHog/posthog-dotnet/pull/262), and [PHP SDK](https://github.com/PostHog/posthog-php/pull/204).

## Changes

- Set the `posthog-node` default `flushInterval` to 5,000 milliseconds.
- Keep the shared core default at 10,000 milliseconds for browser and other client-side SDKs.
- Update the Node-specific option documentation, generated API reference, default assertion, and patch changeset.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## Testing

- `pnpm turbo --filter=posthog-node... build`
- `pnpm --filter posthog-node exec jest --runInBand` (810 passed)
- `pnpm --filter posthog-node exec jest --env @edge-runtime/jest-environment --no-coverage --runInBand` (810 passed)
- `pnpm --filter posthog-node lint`
- `pnpm --filter posthog-node generate-references`
- Prettier check on all changed files

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent as part of a human-directed server-side SDK default standardization. The Node package now overrides only the flush interval; the shared core behavior used by client-side SDKs is unchanged.
