### PR TITLE
fix(docs): publish real properties for object-shaped type aliases in SDK references

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -25,6 +25,8 @@ jobs:
 
       - run: pnpm test:unit
 
+      - run: pnpm test:docs-scripts
+
   edge-runtime:
     name: Node edge runtime tests
     runs-on: ubuntu-22.04

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "lint:playground:fix": "prettier --write 'playground/**/*.{ts,tsx,js,jsx,mjs,json,md}' && eslint --fix 'playground/**/*.{ts,tsx,js,jsx,mjs}'",
         "test": "turbo test",
         "test:unit": "turbo test:unit",
+        "test:docs-scripts": "node --test \"scripts/docs/__tests__/*.test.js\"",
         "test:functional": "turbo test:functional",
         "test:e2e": "turbo test:e2e",
         "build": "turbo build",

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -2990,12 +2990,12 @@
         },
         {
           "description": "Determines whether PostHog should autocapture events.\nThis setting does not affect capturing pageview events (see `capture_pageview`).\n\nby default autocapture is ignored on elements that match a `ph-no-capture` css class on the element or a parent",
-          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").AutocaptureConfig",
+          "type": "boolean | AutocaptureConfig",
           "name": "autocapture"
         },
         {
           "description": "Determines whether PostHog should capture rage clicks.\n\nBy default, rage clicks are ignored on elements that match a `ph-no-capture` or `ph-no-rageclick` CSS class on the element or a parent.\nWhen `defaults` is `'2025-11-30'` or later, the default is `{ content_ignorelist: true }`.\nWhen `defaults` is `'2026-05-30'` or later, the default also excludes stepper controls (`+`, `-`, `−`, `–`) and text-selection surfaces.",
-          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").RageclickConfig",
+          "type": "boolean | RageclickConfig",
           "name": "rageclick"
         },
         {
@@ -3126,17 +3126,17 @@
         },
         {
           "description": "Survey-specific configuration options.",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").SurveyConfig",
+          "type": "SurveyConfig",
           "name": "surveys"
         },
         {
           "description": "Logs-specific configuration options.",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").LogsConfig",
+          "type": "LogsConfig",
           "name": "logs"
         },
         {
           "description": "Metrics-specific configuration options for the posthog.metrics API.",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").MetricsConfig",
+          "type": "MetricsConfig",
           "name": "metrics"
         },
         {
@@ -3277,7 +3277,7 @@
         },
         {
           "description": "Configuration defaults for breaking changes. When set to a specific date,\nenables new default behaviors that were introduced on that date.\n\n- `'unset'`: Use legacy default behaviors\n- `'2025-05-24'`: Use updated default behaviors (e.g. capture_pageview defaults to 'history_change')\n- `'2025-11-30'`: Defaults from '2025-05-24' plus additional changes (e.g. strict minimum duration for replay and rageclick content ignore list defaults to active)\n- `'2026-01-30'`: Defaults from '2025-11-30' plus external_scripts_inject_target defaults to 'head' (avoids SSR hydration errors)\n- `'2026-05-30'`: Defaults from '2026-01-30' plus `persistence_save_debounce_ms` defaults to `250`, `split_storage` and `detect_google_search_app` default to `true`, and rageclick defaults also exclude stepper controls and text-selection surfaces\n- `'2026-06-25'`: Defaults from '2026-05-30' plus `session_recording.streamNetworkBody` defaults to `true` (streams network bodies to enforce the payload size limit)",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ConfigDefaults",
+          "type": "ConfigDefaults",
           "name": "defaults"
         },
         {
@@ -3297,7 +3297,7 @@
         },
         {
           "description": "Determines the error tracking options.",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ErrorTrackingOptions",
+          "type": "ErrorTrackingOptions",
           "name": "error_tracking"
         },
         {
@@ -3406,7 +3406,7 @@
         },
         {
           "description": "This function or array of functions - if provided - are called immediately before sending data to the server.\nIt allows you to edit data before it is sent, or choose not to send it all.\nif provided as an array the functions are called in the order they are provided\nany one function returning null means the event will not be sent",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").BeforeSendFn | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").BeforeSendFn[]",
+          "type": "BeforeSendFn | BeforeSendFn[]",
           "name": "before_send"
         },
         {
@@ -3419,7 +3419,7 @@
           "name": "sanitize_properties"
         },
         {
-          "type": "(eventName: string, eventData: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureResult) => void",
+          "type": "(eventName: string, eventData: CaptureResult) => void",
           "name": "_onCapture"
         },
         {
@@ -3434,17 +3434,17 @@
         },
         {
           "description": "An object containing the `distinctID`, `isIdentifiedID`, and `featureFlags` keys,\nwhere `distinctID` is a string, and `featureFlags` is an object of key-value pairs.\n\nSince there is a delay between initializing PostHog and fetching feature flags,\nfeature flags are not always available immediately.\nThis makes them unusable if you want to do something like redirecting a user\nto a different page based on a feature flag.\n\nYou can, therefore, fetch the feature flags in your server and pre-fill them here,\nallowing PostHog to know the feature flag values immediately.\n\nAfter the SDK fetches feature flags from PostHog, it will use those flag values instead of bootstrapped ones.",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").BootstrapConfig",
+          "type": "BootstrapConfig",
           "name": "bootstrap"
         },
         {
           "description": "The segment analytics object.",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/segment\").SegmentAnalytics",
+          "type": "SegmentAnalytics",
           "name": "segment"
         },
         {
           "description": "Determines whether to capture heatmaps.",
-          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").HeatmapConfig",
+          "type": "boolean | HeatmapConfig",
           "name": "capture_heatmaps"
         },
         {
@@ -3453,12 +3453,12 @@
         },
         {
           "description": "Determines whether to capture dead clicks.\n\nby default dead clicks are ignored on elements that match a `ph-no-capture` or `ph-no-deadclick` css class on the element or a parent",
-          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").DeadClicksAutoCaptureConfig",
+          "type": "boolean | DeadClicksAutoCaptureConfig",
           "name": "capture_dead_clicks"
         },
         {
           "description": "Determines whether to capture exceptions.",
-          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ExceptionAutoCaptureConfig",
+          "type": "boolean | ExceptionAutoCaptureConfig",
           "name": "capture_exceptions"
         },
         {
@@ -3492,12 +3492,12 @@
         },
         {
           "description": "Used to change the behavior of the request queue.\nThis is an advanced feature and should be used with caution.",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").RequestQueueConfig",
+          "type": "RequestQueueConfig",
           "name": "request_queue_config"
         },
         {
           "description": "Used to set-up external integrations with PostHog data - such as session replays, distinct id, etc.",
-          "type": "Record<import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ExternalIntegrationKind, boolean>",
+          "type": "Record<ExternalIntegrationKind, boolean>",
           "name": "integrations"
         },
         {
@@ -3621,12 +3621,12 @@
         },
         {
           "description": "Capture an event.",
-          "type": "(event_name: string, properties?: Properties | null, options?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureOptions) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureResult | undefined",
+          "type": "(event_name: string, properties?: Properties | null, options?: CaptureOptions) => CaptureResult | undefined",
           "name": "capture"
         },
         {
           "description": "Capture an exception.",
-          "type": "(error: unknown, additionalProperties?: Properties) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureResult | undefined",
+          "type": "(error: unknown, additionalProperties?: Properties) => CaptureResult | undefined",
           "name": "captureException"
         },
         {
@@ -3636,12 +3636,12 @@
         },
         {
           "description": "Capture a log entry and send it to the PostHog logs endpoint.",
-          "type": "(options: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture-log\").CaptureLogOptions) => void",
+          "type": "(options: CaptureLogOptions) => void",
           "name": "captureLog"
         },
         {
           "description": "Logger with convenience methods for each severity level.",
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture-log\").Logger",
+          "type": "Logger",
           "name": "logger"
         },
         {
@@ -3671,7 +3671,7 @@
         },
         {
           "description": "Create an alias for the current user.",
-          "type": "(alias: string, original?: string) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureResult | void | number",
+          "type": "(alias: string, original?: string) => CaptureResult | void | number",
           "name": "alias"
         },
         {
@@ -3716,12 +3716,12 @@
         },
         {
           "description": "The feature flags instance. Provides access to feature flag override methods.",
-          "type": "{ overrideFeatureFlags(overrideOptions: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").OverrideFeatureFlagsOptions): void; override(flags: boolean | string[] | Record<string, string | boolean>, suppressWarning?: boolean): void; }",
+          "type": "{ overrideFeatureFlags(overrideOptions: OverrideFeatureFlagsOptions): void; override(flags: boolean | string[] | Record<string, string | boolean>, suppressWarning?: boolean): void; }",
           "name": "featureFlags"
         },
         {
           "description": "Get the value of a feature flag.",
-          "type": "(key: string, options?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagOptions) => boolean | string | undefined",
+          "type": "(key: string, options?: FeatureFlagOptions) => boolean | string | undefined",
           "name": "getFeatureFlag"
         },
         {
@@ -3731,12 +3731,12 @@
         },
         {
           "description": "Get a feature flag evaluation result including both the flag value and payload.\n\nBy default, this method emits the `$feature_flag_called` event.",
-          "type": "(key: string, options?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagOptions) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagResult | undefined",
+          "type": "(key: string, options?: FeatureFlagOptions) => FeatureFlagResult | undefined",
           "name": "getFeatureFlagResult"
         },
         {
           "description": "Check if a feature flag is enabled.",
-          "type": "(key: string, options?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagOptions) => boolean | undefined",
+          "type": "(key: string, options?: FeatureFlagOptions) => boolean | undefined",
           "name": "isFeatureEnabled"
         },
         {
@@ -3751,7 +3751,7 @@
         },
         {
           "description": "Register a callback to be called when feature flags are loaded.",
-          "type": "(callback: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagsCallback) => () => void",
+          "type": "(callback: FeatureFlagsCallback) => () => void",
           "name": "onFeatureFlags"
         },
         {
@@ -3776,12 +3776,12 @@
         },
         {
           "description": "Get the list of early access features.",
-          "type": "(callback: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").EarlyAccessFeatureCallback, forceReload?: boolean, stages?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").EarlyAccessFeatureStage[]) => void",
+          "type": "(callback: EarlyAccessFeatureCallback, forceReload?: boolean, stages?: EarlyAccessFeatureStage[]) => void",
           "name": "getEarlyAccessFeatures"
         },
         {
           "description": "Update enrollment in an early access feature.",
-          "type": "(key: string, isEnrolled: boolean, stage?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").EarlyAccessFeatureStage) => void",
+          "type": "(key: string, isEnrolled: boolean, stage?: EarlyAccessFeatureStage) => void",
           "name": "updateEarlyAccessFeatureEnrollment"
         },
         {
@@ -3826,7 +3826,7 @@
         },
         {
           "description": "Register a callback to be called when the session ID changes.",
-          "type": "(callback: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/session-recording\").SessionIdChangedCallback) => () => void",
+          "type": "(callback: SessionIdChangedCallback) => () => void",
           "name": "onSessionId"
         },
         {
@@ -3906,12 +3906,12 @@
         },
         {
           "description": "Check if a survey can be rendered.",
-          "type": "(surveyId: string) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/survey\").SurveyRenderReason | null",
+          "type": "(surveyId: string) => SurveyRenderReason | null",
           "name": "canRenderSurvey"
         },
         {
           "description": "Check if a survey can be rendered (async version).",
-          "type": "(surveyId: string, forceReload?: boolean) => Promise<import(\"/Users/anna/Develop/posthog-js/packages/types/dist/survey\").SurveyRenderReason>",
+          "type": "(surveyId: string, forceReload?: boolean) => Promise<SurveyRenderReason>",
           "name": "canRenderSurveyAsync"
         },
         {
@@ -3921,7 +3921,7 @@
         },
         {
           "description": "Start automatic exception capture.",
-          "type": "(config?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ExceptionAutoCaptureConfig) => void",
+          "type": "(config?: ExceptionAutoCaptureConfig) => void",
           "name": "startExceptionAutocapture"
         },
         {
@@ -3950,7 +3950,7 @@
           "name": "captureTraceMetric"
         },
         {
-          "type": "{ set: (prop: string | Properties, to?: string, callback?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/request\").RequestCallback) => void; set_once: (prop: string | Properties, to?: string, callback?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/request\").RequestCallback) => void; }",
+          "type": "{ set: (prop: string | Properties, to?: string, callback?: RequestCallback) => void; set_once: (prop: string | Properties, to?: string, callback?: RequestCallback) => void; }",
           "name": "people"
         },
         {

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -2549,7 +2549,7 @@
       "name": "ErrorEventArgs",
       "properties": [],
       "path": "lib/src/types.d.ts",
-      "example": "[\n    event: string | Event, source?: string | undefined, lineno?: number | undefined, colno?: number | undefined, error?: Error | undefined\n]"
+      "example": "[\n    event: string | Event,\n    source?: string | undefined,\n    lineno?: number | undefined,\n    colno?: number | undefined,\n    error?: Error | undefined\n]"
     },
     {
       "id": "ErrorTrackingSuppressionRule",
@@ -2630,9 +2630,17 @@
     {
       "id": "FlagVariant",
       "name": "FlagVariant",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "{\n    flag: string;\n    variant: string;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "flag"
+        },
+        {
+          "type": "string",
+          "name": "variant"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "GetMessagesResponse",
@@ -2843,16 +2851,77 @@
     {
       "id": "NetworkRecordOptions",
       "name": "NetworkRecordOptions",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "{\n    initiatorTypes?: InitiatorType[];\n    maskRequestFn?: (data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined;\n    recordHeaders?: boolean | {\n        request: boolean;\n        response: boolean;\n    };\n    recordBody?: boolean | string[] | {\n        request: boolean | string[];\n        response: boolean | string[];\n    };\n    recordInitialRequests?: boolean;\n    recordPerformance?: boolean;\n    performanceEntryTypeToObserve: string[];\n    payloadSizeLimitBytes: number;\n    streamNetworkBody?: boolean;\n    payloadHostDenyList?: string[];\n}"
+      "properties": [
+        {
+          "type": "InitiatorType[]",
+          "name": "initiatorTypes"
+        },
+        {
+          "type": "(data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined",
+          "name": "maskRequestFn"
+        },
+        {
+          "type": "boolean | { request: boolean; response: boolean; }",
+          "name": "recordHeaders"
+        },
+        {
+          "type": "boolean | string[] | { request: boolean | string[]; response: boolean | string[]; }",
+          "name": "recordBody"
+        },
+        {
+          "type": "boolean",
+          "name": "recordInitialRequests"
+        },
+        {
+          "description": "whether to record PerformanceEntry events for network requests",
+          "type": "boolean",
+          "name": "recordPerformance"
+        },
+        {
+          "description": "the PerformanceObserver will only observe these entry types",
+          "type": "string[]",
+          "name": "performanceEntryTypeToObserve"
+        },
+        {
+          "description": "the maximum size of the request/response body to record\nNB this will be at most 1MB even if set larger",
+          "type": "number",
+          "name": "payloadSizeLimitBytes"
+        },
+        {
+          "description": "when true, read bodies through a streaming reader that stops at payloadSizeLimitBytes\ninstead of buffering the whole body and then enforcing the limit. Reads only a clone of\nthe body, so it never consumes the stream the page itself reads.",
+          "type": "boolean",
+          "name": "streamNetworkBody"
+        },
+        {
+          "description": "some domains we should never record the payload\nfor example other companies session replay ingestion payloads aren't super useful but are gigantic\nif this isn't provided we use a default list\nif this is provided - we add the provided list to the default list\ni.e. we never record the payloads on the default deny list",
+          "type": "string[]",
+          "name": "payloadHostDenyList"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "OverrideConfig",
       "name": "OverrideConfig",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "{\n    sampling: boolean;\n    linked_flag: boolean;\n    url_trigger: boolean;\n    event_trigger: boolean;\n}"
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "sampling"
+        },
+        {
+          "type": "boolean",
+          "name": "linked_flag"
+        },
+        {
+          "type": "boolean",
+          "name": "url_trigger"
+        },
+        {
+          "type": "boolean",
+          "name": "event_trigger"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "PersistentStore",
@@ -2888,16 +2957,1012 @@
     {
       "id": "PostHogConfig",
       "name": "PostHogConfig",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "Omit<BasePostHogConfig, 'loaded'> & {\n    loaded: (posthog: PostHogInterface) => void;\n    disableDeviceModel?: boolean;\n    __extensionClasses?: {\n        exceptions?: ExtensionConstructor<PostHogExceptions>;\n        historyAutocapture?: ExtensionConstructor<HistoryAutocapture>;\n        tracingHeaders?: ExtensionConstructor<TracingHeaders>;\n        siteApps?: ExtensionConstructor<SiteApps>;\n        sessionRecording?: ExtensionConstructor<SessionRecording>;\n        autocapture?: ExtensionConstructor<Autocapture>;\n        productTours?: ExtensionConstructor<PostHogProductTours>;\n        heatmaps?: ExtensionConstructor<Heatmaps>;\n        webVitalsAutocapture?: ExtensionConstructor<WebVitalsAutocapture>;\n        exceptionObserver?: ExtensionConstructor<ExceptionObserver>;\n        deadClicksAutocapture?: ExtensionConstructor<DeadClicksAutocapture>;\n        surveys?: ExtensionConstructor<PostHogSurveys>;\n        toolbar?: ExtensionConstructor<Toolbar>;\n        experiments?: ExtensionConstructor<WebExperiments>;\n        conversations?: ExtensionConstructor<PostHogConversations>;\n        featureFlags?: ExtensionConstructor<PostHogFeatureFlags>;\n        logs?: ExtensionConstructor<PostHogLogs>;\n        metrics?: ExtensionConstructor<PostHogMetrics>;\n    };\n}"
+      "properties": [
+        {
+          "description": "The name this instance will be identified by.\nYou don't need to set this most of the time,\nbut can be useful if you have several Posthog instances running at the same time.",
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "description": "URL of your PostHog instance.",
+          "type": "string",
+          "name": "api_host"
+        },
+        {
+          "description": "URL to use for feature flag requests specifically.\nIf not set, feature flag requests will use the URL derived from `api_host`.\nThis is useful when you want to route feature flag requests to a different endpoint than other analytic APIs.",
+          "type": "string",
+          "name": "flags_api_host"
+        },
+        {
+          "description": "If using a reverse proxy for `api_host` then this should be the actual PostHog app URL (e.g. https://us.posthog.com).\nThis ensures that links to PostHog point to the correct host.",
+          "type": "string",
+          "name": "ui_host"
+        },
+        {
+          "description": "The transport method to use for API requests.",
+          "type": "\"fetch\" | \"XHR\"",
+          "name": "api_transport"
+        },
+        {
+          "description": "The token for your PostHog project.\nIt should NOT be provided manually in the config, but rather passed as the first parameter to `posthog.init()`.",
+          "type": "string",
+          "name": "token"
+        },
+        {
+          "description": "Determines whether PostHog should autocapture events.\nThis setting does not affect capturing pageview events (see `capture_pageview`).\n\nby default autocapture is ignored on elements that match a `ph-no-capture` css class on the element or a parent",
+          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").AutocaptureConfig",
+          "name": "autocapture"
+        },
+        {
+          "description": "Determines whether PostHog should capture rage clicks.\n\nBy default, rage clicks are ignored on elements that match a `ph-no-capture` or `ph-no-rageclick` CSS class on the element or a parent.\nWhen `defaults` is `'2025-11-30'` or later, the default is `{ content_ignorelist: true }`.\nWhen `defaults` is `'2026-05-30'` or later, the default also excludes stepper controls (`+`, `-`, `−`, `–`) and text-selection surfaces.",
+          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").RageclickConfig",
+          "name": "rageclick"
+        },
+        {
+          "description": "Determines if cookie should be set on the top level domain (example.com).\nIf PostHog-js is loaded on a subdomain (test.example.com), and `cross_subdomain_cookie` is set to false,\nit'll set the cookie on the subdomain only (test.example.com).\n\nNOTE: It will be set to `false` if we detect that the domain is a subdomain of a platform that is excluded from cross-subdomain cookie setting.\nThe current list of excluded platforms is `herokuapp.com`, `vercel.app`, and `netlify.app`.",
+          "type": "boolean",
+          "name": "cross_subdomain_cookie"
+        },
+        {
+          "description": "Determines how PostHog stores information about the user. See [persistence](https://posthog.com/docs/libraries/js#persistence) for details.",
+          "type": "\"localStorage\" | \"cookie\" | \"memory\" | \"localStorage+cookie\" | \"sessionStorage\"",
+          "name": "persistence"
+        },
+        {
+          "description": "The name for the super properties persistent store",
+          "type": "string",
+          "name": "persistence_name"
+        },
+        {
+          "type": "string",
+          "name": "cookie_name"
+        },
+        {
+          "description": "List of custom property names that should be stored in cookies (in addition to the default ones)\nwhen using 'localStorage+cookie' persistence mode. This allows these properties to be shared\nacross subdomains when cross_subdomain_cookie is enabled.",
+          "type": "readonly string[]",
+          "name": "cookie_persisted_properties"
+        },
+        {
+          "description": "Determines whether PostHog should strip URL fragments (`#...`) from automatically captured URL fields.\nDisabled by default for backwards compatibility, and enabled automatically when `config.defaults` is\n`'2026-06-25'` or later. Set to `true` to strip hashes from:\n\n- `$current_url` on automatically captured browser events, including `$pageview`\n- `$initial_current_url`\n- `$session_entry_url`\n- `$elements[*].attr__href` and `$external_click_url` for autocapture and dead-click autocapture\n- Next.js Pages Router `$pageview` `$current_url`\n- web vitals `$current_url`\n- logs `url.full`\n- conversations `current_url` and `request_url`\n- session replay rrweb meta/custom-event `href` URLs\n- heatmap data URLs\n\nIf your SPA relies on hash-based routes for analytics, enabling this is a breaking behavior change.\nIf you want to capture hashes selectively, leave this disabled and use `before_send` to remove\nsensitive hash values before events are sent.",
+          "type": "boolean",
+          "name": "disable_capture_url_hashes"
+        },
+        {
+          "description": "Determines whether PostHog should save referrer information.",
+          "type": "boolean",
+          "name": "save_referrer"
+        },
+        {
+          "description": "Determines whether PostHog should save marketing parameters.\nThese are `utm_*` paramaters and friends.",
+          "type": "boolean",
+          "name": "save_campaign_params"
+        },
+        {
+          "type": "boolean",
+          "name": "store_google"
+        },
+        {
+          "description": "Used to extend the list of campaign parameters that are saved by default.",
+          "type": "string[]",
+          "name": "custom_campaign_params"
+        },
+        {
+          "description": "Used to extend the list of user agents that are blocked by default.",
+          "type": "string[]",
+          "name": "custom_blocked_useragents"
+        },
+        {
+          "description": "Determines whether PostHog should be in debug mode.\nYou can enable this to get more detailed logging.\n\nYou can also enable this on your website by appending `?__posthog_debug=true` at the end of your URL\nYou can also call `posthog.debug()` in your code to enable debug mode",
+          "type": "boolean",
+          "name": "debug"
+        },
+        {
+          "type": "boolean",
+          "name": "verbose"
+        },
+        {
+          "description": "Determines whether PostHog should capture pageview events automatically.\nCan be:\n- `true`: Capture regular pageviews (default)\n- `false`: Don't capture any pageviews\n- `'history_change'`: Capture pageviews on the initial page load and on history API changes (pushState, replaceState, popstate)",
+          "type": "boolean | \"history_change\"",
+          "name": "capture_pageview"
+        },
+        {
+          "description": "Determines whether PostHog should capture pageleave events.\nIf set to `true`, it will capture pageleave events for all pages.\nIf set to `'if_capture_pageview'`, it will only capture pageleave events if `capture_pageview` is also set to `true` or `'history_change'`.",
+          "type": "boolean | \"if_capture_pageview\"",
+          "name": "capture_pageleave"
+        },
+        {
+          "description": "Determines the number of days to store cookies for.",
+          "type": "number",
+          "name": "cookie_expiration"
+        },
+        {
+          "description": "Determines whether PostHog should upgrade old cookies.\nIf set to `true`, the library will check for a cookie from our old js library and import super properties from it, then the old cookie is deleted.\nThis option only works in the initialization, so make sure you set it when you create the library.",
+          "type": "boolean",
+          "name": "upgrade"
+        },
+        {
+          "description": "Determines whether PostHog should disable session recording.",
+          "type": "boolean",
+          "name": "disable_session_recording"
+        },
+        {
+          "description": "Determines whether PostHog should disable persistence.\nIf set to `true`, the library will not save any data to the browser. It will also delete any data previously saved to the browser.",
+          "type": "boolean",
+          "name": "disable_persistence"
+        },
+        {
+          "type": "boolean",
+          "name": "disable_cookie"
+        },
+        {
+          "description": "Coalesce rapid `Persistence.save()` calls into a single write.\n\nSet to a positive number (milliseconds) to debounce writes to localStorage / cookie\nby that window. The in-memory `props` object is always updated synchronously so\nwithin-tab reads see the latest values immediately. Cross-tab `storage` events\n(which carry the full persistence value as a payload) are reduced proportionally\nto the debounce window.\n\nPending writes are flushed on `beforeunload` and `pagehide` so no state is lost\non tab close. The cross-tab visibility delay is bounded by the configured window.\n\nDefaults to `0` (no debouncing, write synchronously) for backwards compatibility.\nOn pages that capture many events per second, `250` is a reasonable starting point\nto reduce localStorage write pressure and cross-tab IPC traffic. The `2026-05-30`\nconfig default opts into `250` automatically.",
+          "type": "number",
+          "name": "persistence_save_debounce_ms"
+        },
+        {
+          "description": "Store the feature-flag config cluster and survey config in their own\nlocalStorage entries (`<name>__flags`, `<name>__surveys`) instead of the\nsingle main persistence blob. These payloads are large and change rarely,\nso keeping them out of the main blob stops them riding on every\nhigh-frequency main-blob write and broadcasting cross-tab `storage` events.\n\nOnly applies when persistence resolves to `localStorage` / `localStorage+cookie`\n(the split is pointless for `memory` / `sessionStorage` and impossible for `cookie`).\nOn load the old main-blob location is read once and migrated forward, so\nupgrades never miss a cached flag. The `2026-05-30` config default opts in.",
+          "type": "boolean",
+          "name": "split_storage"
+        },
+        {
+          "description": "Detect the Google Search App (GSA) as its own `$browser` value instead of\nthe underlying webview it embeds — Mobile Safari on iOS, Chrome on Android.\nDetection keys off the `GSA/` marker present in the UA on every platform.\n\nOff by default for backwards-compatibility: enabling it reattributes\nexisting GSA traffic away from Mobile Safari / Chrome, which would\notherwise look like those browsers suddenly losing share. The `2026-05-30`\nconfig default opts in.",
+          "type": "boolean",
+          "name": "detect_google_search_app"
+        },
+        {
+          "description": "Determines whether PostHog should disable all surveys functionality.",
+          "type": "boolean",
+          "name": "disable_surveys"
+        },
+        {
+          "description": "Determines whether PostHog should disable automatic display of surveys. If this is true, popup or widget surveys will not be shown when display conditions are met.",
+          "type": "boolean",
+          "name": "disable_surveys_automatic_display"
+        },
+        {
+          "description": "Determines whether PostHog should disable all product tours functionality.",
+          "type": "boolean",
+          "name": "disable_product_tours"
+        },
+        {
+          "description": "Survey-specific configuration options.",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").SurveyConfig",
+          "name": "surveys"
+        },
+        {
+          "description": "Logs-specific configuration options.",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").LogsConfig",
+          "name": "logs"
+        },
+        {
+          "description": "Metrics-specific configuration options for the posthog.metrics API.",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").MetricsConfig",
+          "name": "metrics"
+        },
+        {
+          "description": "Determines whether PostHog should disable all conversations functionality.",
+          "type": "boolean",
+          "name": "disable_conversations"
+        },
+        {
+          "description": "Verified distinct_id for HMAC-based identity verification.\nWhen both `identity_distinct_id` and `identity_hash` are provided,\nproducts like conversations use server-verified identity instead of\nanonymous session identifiers.\n\nCan be set at init time or later via `posthog.setIdentity()`.",
+          "type": "string",
+          "name": "identity_distinct_id"
+        },
+        {
+          "description": "HMAC-SHA256 of `identity_distinct_id` using the project's API secret.\nMust be provided together with `identity_distinct_id`.",
+          "type": "string",
+          "name": "identity_hash"
+        },
+        {
+          "description": "Determines whether PostHog should disable web experiments.\n\nCurrently disabled while we're in BETA. It will be toggled to `true` in a future release.",
+          "type": "boolean",
+          "name": "disable_web_experiments"
+        },
+        {
+          "description": "Determines whether PostHog should disable any external dependency loading.\nThis will prevent PostHog from requesting any external scripts such as those needed for Session Replay, Surveys or Site Apps.",
+          "type": "boolean",
+          "name": "disable_external_dependency_loading"
+        },
+        {
+          "description": "Determines whether PostHog should load external dependency scripts from\nsemver-qualified asset paths such as /static/1.370.0/recorder.js instead\nof the legacy /static/recorder.js?v=1.370.0 form.",
+          "type": "boolean",
+          "name": "strict_script_versioning"
+        },
+        {
+          "description": "Optional host override for static assets loaded by PostHog, such as\nrecorder.js, surveys.js, or toolbar.js. Only applies to /static/* asset\npaths; dynamic assets like remote config continue to use the regular\nasset host derived from api_host.",
+          "type": "string",
+          "name": "asset_host"
+        },
+        {
+          "description": "A function to be called when a script is being loaded.\nThis can be used to modify the script before it is loaded.\nThis is useful for adding a nonce to the script, for example.",
+          "type": "(script: HTMLScriptElement) => HTMLScriptElement | null",
+          "name": "prepare_external_dependency_script"
+        },
+        {
+          "description": "A function to be called when a stylesheet is being loaded.\nThis can be used to modify the stylesheet before it is loaded.\nThis is useful for adding a nonce to the stylesheet, for example.",
+          "type": "(stylesheet: HTMLStyleElement) => HTMLStyleElement | null",
+          "name": "prepare_external_dependency_stylesheet"
+        },
+        {
+          "description": "Where to inject external dependency scripts (recorder, surveys, etc.) in the DOM.\n- 'body': Injects scripts into document.body (legacy behavior)\n- 'head': Injects scripts into document.head (avoids SSR hydration errors)",
+          "type": "\"body\" | \"head\"",
+          "name": "external_scripts_inject_target"
+        },
+        {
+          "description": "Determines whether PostHog should enable recording console logs.\n\nThis is related to the Session Recording feature. For more session recording\nsettings, see the `session_recording` and `capture_performance` configuration option.\nWhen undefined, it falls back to the remote config setting.",
+          "type": "boolean",
+          "name": "enable_recording_console_log"
+        },
+        {
+          "description": "Determines whether PostHog should use secure cookies.\nIf this is `true`, PostHog cookies will be marked as secure,\nmeaning they will only be transmitted over HTTPS.",
+          "type": "boolean",
+          "name": "secure_cookie"
+        },
+        {
+          "description": "Determines if users should be opted out of PostHog tracking by default,\nrequiring additional logic to opt them into capturing by calling `posthog.opt_in_capturing()`.",
+          "type": "boolean",
+          "name": "opt_out_capturing_by_default"
+        },
+        {
+          "description": "Determines where we'll save the information about whether users are opted out of capturing.",
+          "type": "\"localStorage\" | \"cookie\"",
+          "name": "opt_out_capturing_persistence_type"
+        },
+        {
+          "description": "Determines if users should be opted out of browser data storage by this PostHog instance by default,\nrequiring additional logic to opt them into capturing by calling `posthog.opt_in_capturing()`.",
+          "type": "boolean",
+          "name": "opt_out_persistence_by_default"
+        },
+        {
+          "description": "Determines if users should be opted out of user agent filtering such as googlebot or other bots.\nIf this is set to `true`, PostHog will set `$browser_type` to either `bot` or `browser` for all events,\nbut will process all events as if they were from a browser.",
+          "type": "boolean",
+          "name": "opt_out_useragent_filter"
+        },
+        {
+          "type": "string",
+          "name": "opt_out_capturing_cookie_prefix"
+        },
+        {
+          "description": "Determines the key for the cookie / local storage used to store the information about whether users are opted in/out of capturing.\nWhen `null`, we used a key based on your token.",
+          "type": "string",
+          "name": "consent_persistence_name"
+        },
+        {
+          "description": "Determines if users should be opted in to site apps.",
+          "type": "boolean",
+          "name": "opt_in_site_apps"
+        },
+        {
+          "description": "Determines whether PostHog should respect the Do Not Track header when computing\nconsent in `ConsentManager`.",
+          "type": "boolean",
+          "name": "respect_dnt"
+        },
+        {
+          "description": "A list of properties that should never be sent with capture calls.",
+          "type": "string[]",
+          "name": "property_denylist"
+        },
+        {
+          "type": "string[]",
+          "name": "property_blacklist"
+        },
+        {
+          "description": "A list of headers that should be sent with requests to the PostHog API.",
+          "type": "{ [header_name: string]: string; }",
+          "name": "request_headers"
+        },
+        {
+          "type": "{ [header_name: string]: string; }",
+          "name": "xhr_headers"
+        },
+        {
+          "description": "A function that is called when a request to the PostHog API fails.",
+          "type": "(error: RequestResponse) => void",
+          "name": "on_request_error"
+        },
+        {
+          "type": "(failedRequest: XMLHttpRequest) => void",
+          "name": "on_xhr_error"
+        },
+        {
+          "description": "Determines whether PostHog should batch requests to the PostHog API.",
+          "type": "boolean",
+          "name": "request_batching"
+        },
+        {
+          "description": "Determines the maximum length of the properties string that can be sent with capture calls.",
+          "type": "number",
+          "name": "properties_string_max_length"
+        },
+        {
+          "description": "Configuration defaults for breaking changes. When set to a specific date,\nenables new default behaviors that were introduced on that date.\n\n- `'unset'`: Use legacy default behaviors\n- `'2025-05-24'`: Use updated default behaviors (e.g. capture_pageview defaults to 'history_change')\n- `'2025-11-30'`: Defaults from '2025-05-24' plus additional changes (e.g. strict minimum duration for replay and rageclick content ignore list defaults to active)\n- `'2026-01-30'`: Defaults from '2025-11-30' plus external_scripts_inject_target defaults to 'head' (avoids SSR hydration errors)\n- `'2026-05-30'`: Defaults from '2026-01-30' plus `persistence_save_debounce_ms` defaults to `250`, `split_storage` and `detect_google_search_app` default to `true`, and rageclick defaults also exclude stepper controls and text-selection surfaces\n- `'2026-06-25'`: Defaults from '2026-05-30' plus `session_recording.streamNetworkBody` defaults to `true` (streams network bodies to enforce the payload size limit)",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ConfigDefaults",
+          "name": "defaults"
+        },
+        {
+          "description": "EXPERIMENTAL: Defers initialization of non-critical extensions (autocapture, session recording, etc.)\nto the next event loop tick using setTimeout. This reduces main thread blocking during SDK\ninitialization for better page load performance, while keeping critical functionality\n(persistence, sessions, capture) available immediately.\n\nWhen enabled:\n- Persistence, sessions, and basic capture work immediately\n- Extensions (autocapture, recording, heatmaps, etc.) start after yielding back to the browser",
+          "type": "boolean",
+          "name": "__preview_deferred_init_extensions"
+        },
+        {
+          "description": "In `'localStorage+cookie'` persistence mode, prefer cookie values over localStorage\nwhen both stores carry the same key. Fixes cross-subdomain identify and session\ndisconnects caused by stale per-subdomain localStorage clobbering a fresh shared cookie.\nRead at SDK init; has no effect when toggled via `set_config` or for other persistence modes.",
+          "type": "boolean",
+          "name": "__preview_cookie_wins_on_conflict"
+        },
+        {
+          "description": "Determines the session recording options.\n\nFor more session recording settings, see the `enable_recording_console_log` and `capture_performance` configuration option.\nWhen `defaults` is `'2025-11-30'` or later, `strictMinimumDuration` defaults to `true`.",
+          "type": "SessionRecordingOptions",
+          "name": "session_recording"
+        },
+        {
+          "description": "Determines the error tracking options.",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ErrorTrackingOptions",
+          "name": "error_tracking"
+        },
+        {
+          "description": "Determines the session idle timeout in seconds.\n\nIf no events are captured for this many seconds, the next event starts a\nnew session with a new `$session_id` (and `$window_id`). The SDK may also proactively reset the stored session\nafter the timeout while the page is idle, so the next event creates a new session.\n\nSession recording has a separate idle threshold: `session_recording.session_idle_threshold_ms`. That setting\nonly controls when the user is considered idle, it does not rotate `$session_id`.\n\nMust be between 60 seconds and 10 hours. Values outside this range are clamped.",
+          "type": "number",
+          "name": "session_idle_timeout_seconds"
+        },
+        {
+          "description": "Prevent autocapture from capturing any attribute names on elements.",
+          "type": "boolean",
+          "name": "mask_all_element_attributes"
+        },
+        {
+          "description": "Prevent autocapture from capturing `textContent` on elements.",
+          "type": "boolean",
+          "name": "mask_all_text"
+        },
+        {
+          "description": "Mask personal data properties from the current URL.\nThis will mask personal data properties such as advertising IDs (gclid, fbclid, etc.), and you can also add\ncustom properties to mask with `custom_personal_data_properties`.",
+          "type": "boolean",
+          "name": "mask_personal_data_properties"
+        },
+        {
+          "description": "Custom list of personal data properties to mask.\n\nE.g. if you added `email` to this list, then any `email` property in the URL will be masked.\nhttps://www.example.com/login?email=john.doe%40example.com => https://www.example.com/login?email=<MASKED>",
+          "type": "string[]",
+          "name": "custom_personal_data_properties"
+        },
+        {
+          "description": "One of the very first things the PostHog library does when init() is called\nis make a request to the /flags endpoint on PostHog's backend.\nThis endpoint contains information on how to run the PostHog library\nso events are properly received in the backend, and it also contains\nfeature flag evaluation information for the current user.\n\nThis endpoint is required to run most features of this library.\nHowever, if you're not using any of the described features,\nyou may wish to turn off the call completely to avoid an extra request\nand reduce resource usage on both the client and the server.\n\nWARNING: Disabling this will also prevent remote configuration from loading,\nwhich could mean features like web vitals, surveys, and other features configured\nin PostHog settings are disabled unless explicitly enabled via client-side config.\nWhen setting this to true, make sure to explicitly configure any features you\nwant to use (e.g., capture_performance, autocapture, etc.) in your SDK's init config.",
+          "type": "boolean",
+          "name": "advanced_disable_flags"
+        },
+        {
+          "type": "boolean",
+          "name": "advanced_disable_decide"
+        },
+        {
+          "description": "Will keep /flags running, but without evaluating any feature flags.\nUseful for when you need to load the config data associated with the flags endpoint\n(e.g. /flags?v=2&config=true) without evaluating any feature flags.  Most folks use this\nto save money on feature flag evaluation (by bootstrapping feature flags on the server side).",
+          "type": "boolean",
+          "name": "advanced_disable_feature_flags"
+        },
+        {
+          "description": "Stops from firing feature flag requests on first page load.\nOnly requests feature flags when user identity or properties are updated,\nor you manually request for flags to be loaded.",
+          "type": "boolean",
+          "name": "advanced_disable_feature_flags_on_first_load"
+        },
+        {
+          "description": "Evaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'web', 'checkout']",
+          "type": "readonly string[]",
+          "name": "evaluation_contexts"
+        },
+        {
+          "description": "List of feature flag keys to remotely evaluate for this SDK instance.\nWhen set, only these flags are evaluated by `/flags`; omitted flags are not remotely evaluated.\nDependencies of the requested flags may still be evaluated internally by PostHog.\nIf unset, all eligible flags are evaluated.\n\nExamples: ['checkout-redesign', 'new-onboarding']",
+          "type": "readonly string[]",
+          "name": "flag_keys"
+        },
+        {
+          "description": "Evaluation environments for feature flags.",
+          "type": "readonly string[]",
+          "name": "evaluation_environments"
+        },
+        {
+          "description": "Determines whether PostHog should disable toolbar metrics.\nThis is our internal instrumentation for our toolbar in your website.",
+          "type": "boolean",
+          "name": "advanced_disable_toolbar_metrics"
+        },
+        {
+          "description": "Determines whether PostHog should only evaluate feature flags for surveys.\nUseful for when you want to use this library to evaluate feature flags for surveys only but you have additional feature flags\nthat you evaluate on the server side.",
+          "type": "boolean",
+          "name": "advanced_only_evaluate_survey_feature_flags"
+        },
+        {
+          "description": "When this is enabled, surveys will always be initialized, regardless of the /flags response or remote config settings.\nThis is useful if you want to use surveys but disable all other flag-dependent functionality.\nUsed internally for displaying external surveys without making a /flags request.",
+          "type": "boolean",
+          "name": "advanced_enable_surveys"
+        },
+        {
+          "description": "Sets timeout for fetching feature flags",
+          "type": "number",
+          "name": "feature_flag_request_timeout_ms"
+        },
+        {
+          "description": "Sets the maximum age (in milliseconds) for cached feature flag values.\nWhen the cache is older than this value:\n- `getFeatureFlag()` will return `undefined` instead of stale cached values\n- `$feature/` properties will not be attached to events\n- A background refresh will be triggered automatically\n\nThis prevents stale feature flag values from being used when the `/flags` request\nfails (e.g., due to ad blockers or network issues).\n\nWhen not set or set to `0`, cache expiration is disabled (cached values never expire).",
+          "type": "number",
+          "name": "feature_flag_cache_ttl_ms"
+        },
+        {
+          "description": "When enabled, `$feature_flag_called` event deduplication is scoped to the current session.\n\nBy default, the SDK deduplicates `$feature_flag_called` events globally and only re-emits\nthem when `identify` (with a new distinct ID) or `reset` is called. This can be problematic\nfor experiments: if a flag is checked before an experiment starts, the event is cached and\nwon't fire again for that user until identify/reset, meaning the experiment never sees the event.\n\nWhen this option is `true`, the deduplication cache is keyed on the session ID, so each new\nsession will re-emit `$feature_flag_called` for every flag that is checked.",
+          "type": "boolean",
+          "name": "advanced_feature_flags_dedup_per_session"
+        },
+        {
+          "description": "Sets timeout for fetching surveys",
+          "type": "number",
+          "name": "surveys_request_timeout_ms"
+        },
+        {
+          "description": "Controls how often feature flags are automatically refreshed in long-running sessions after remote configuration has loaded.\n\nBy default, feature flags are refreshed every 5 minutes (300000ms) to pick up server-side\nflag changes without requiring a page reload. This is useful for SPAs and long-running tabs.\n\n**Tradeoffs:**\n- **Shorter intervals**: Feature flag changes propagate faster, but increases network requests and server load.\n- **Longer intervals**: Reduces network traffic (better for mobile/battery), but flag changes take longer to propagate.\n- **Disabled (0)**: No background refreshes. Flags only update on page load or manual `reloadFeatureFlags()` calls.\n  Use this if you control flag updates manually or have infrequent flag changes.\n\nNote: Refreshes are automatically skipped when the browser tab is hidden or no document is available.",
+          "type": "number",
+          "name": "remote_config_refresh_interval_ms"
+        },
+        {
+          "description": "Function to get the device ID.\nThis doesn't usually need to be set, but can be useful if you want to use a custom device ID.",
+          "type": "(uuid: string) => string",
+          "name": "get_device_id"
+        },
+        {
+          "description": "This function or array of functions - if provided - are called immediately before sending data to the server.\nIt allows you to edit data before it is sent, or choose not to send it all.\nif provided as an array the functions are called in the order they are provided\nany one function returning null means the event will not be sent",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").BeforeSendFn | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").BeforeSendFn[]",
+          "name": "before_send"
+        },
+        {
+          "description": "Overrides the URL used for client-side URL targeting: session replay URL triggers, the\nsession replay URL blocklist, survey URL display conditions, product tour URL conditions,\nweb experiment URL conditions, and autocapture URL allow/ignore lists.\n\nThese features match against `window.location.href` directly, which does not reflect\nany `$current_url` you rewrite in `before_send`. In environments where the browser URL\nis not meaningful for targeting — e.g. Electron/desktop apps served from a generated\nhost — return the logical URL you want these features to match against. This does not\nchange the `$current_url` property captured on events (use `before_send` for that).",
+          "type": "(defaultUrl: string) => string",
+          "name": "get_current_url"
+        },
+        {
+          "type": "(properties: Properties, event_name: string) => Properties",
+          "name": "sanitize_properties"
+        },
+        {
+          "type": "(eventName: string, eventData: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureResult) => void",
+          "name": "_onCapture"
+        },
+        {
+          "description": "Determines whether to capture performance metrics.\nThese include Network Timing for Session Replay and Web Vitals.\n\nThe `network_timing` option is only used by the Session Replay feature.\nFor more session recording settings, see the `session_recording` and `enable_recording_console_log` configuration option.\n\nWhen `undefined`, fallback to the remote configuration.\nIf `false`, neither network timing nor web vitals will work.\nIf an object, that will override the remote configuration.",
+          "type": "boolean | PerformanceCaptureConfig",
+          "name": "capture_performance"
+        },
+        {
+          "description": "Determines whether to disable compression when sending events to the server.\nWARNING: Should only be used for testing. Could negatively impact performance.",
+          "type": "boolean",
+          "name": "disable_compression"
+        },
+        {
+          "description": "An object containing the `distinctID`, `isIdentifiedID`, and `featureFlags` keys,\nwhere `distinctID` is a string, and `featureFlags` is an object of key-value pairs.\n\nSince there is a delay between initializing PostHog and fetching feature flags,\nfeature flags are not always available immediately.\nThis makes them unusable if you want to do something like redirecting a user\nto a different page based on a feature flag.\n\nYou can, therefore, fetch the feature flags in your server and pre-fill them here,\nallowing PostHog to know the feature flag values immediately.\n\nAfter the SDK fetches feature flags from PostHog, it will use those flag values instead of bootstrapped ones.",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").BootstrapConfig",
+          "name": "bootstrap"
+        },
+        {
+          "description": "The segment analytics object.",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/segment\").SegmentAnalytics",
+          "name": "segment"
+        },
+        {
+          "description": "Determines whether to capture heatmaps.",
+          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").HeatmapConfig",
+          "name": "capture_heatmaps"
+        },
+        {
+          "type": "boolean",
+          "name": "enable_heatmaps"
+        },
+        {
+          "description": "Determines whether to capture dead clicks.\n\nby default dead clicks are ignored on elements that match a `ph-no-capture` or `ph-no-deadclick` css class on the element or a parent",
+          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").DeadClicksAutoCaptureConfig",
+          "name": "capture_dead_clicks"
+        },
+        {
+          "description": "Determines whether to capture exceptions.",
+          "type": "boolean | import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ExceptionAutoCaptureConfig",
+          "name": "capture_exceptions"
+        },
+        {
+          "description": "Determines whether to disable scroll properties.\nThese allow you to keep track of how far down someone scrolled in your website.",
+          "type": "boolean",
+          "name": "disable_scroll_properties"
+        },
+        {
+          "description": "Let the pageview scroll stats use a custom css selector for the root element, e.g. `main`\nIt will use `window.document.documentElement` if not specified.",
+          "type": "string | string[]",
+          "name": "scroll_root_selector"
+        },
+        {
+          "description": "You can control whether events from PostHog-js have person processing enabled with the `person_profiles` config setting.\nThere are three options:\n- `person_profiles: 'always'` - we will process persons data for all events\n- `person_profiles: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person_profile: False`.\n- `person_profiles: 'identified_only'` _(default)_ - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.unsetPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.",
+          "type": "\"always\" | \"never\" | \"identified_only\"",
+          "name": "person_profiles"
+        },
+        {
+          "type": "\"always\" | \"never\" | \"identified_only\"",
+          "name": "process_person"
+        },
+        {
+          "description": "Client side rate limiting",
+          "type": "{ events_per_second?: number; events_burst_limit?: number; }",
+          "name": "rate_limiting"
+        },
+        {
+          "description": "Used when sending data via `fetch`, use with care.\nThis is intentionally meant to be used with NextJS `fetch`\n\nIncorrect `cache` usage may cause out-of-date data for feature flags, actions tracking, etc.\nSee https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options",
+          "type": "{ cache?: RequestCache; next_options?: { revalidate: false | 0 | number; tags: string[]; }; }",
+          "name": "fetch_options"
+        },
+        {
+          "description": "Used to change the behavior of the request queue.\nThis is an advanced feature and should be used with caution.",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").RequestQueueConfig",
+          "name": "request_queue_config"
+        },
+        {
+          "description": "Used to set-up external integrations with PostHog data - such as session replays, distinct id, etc.",
+          "type": "Record<import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ExternalIntegrationKind, boolean>",
+          "name": "integrations"
+        },
+        {
+          "description": "Enables cookieless mode. In this mode, PostHog will not set any cookies, or use session or local storage. User\nidentity is handled by generating a privacy-preserving hash on PostHog's servers.\n\nWeb Vitals (`capture_performance.web_vitals`) are supported: metrics are sent without client session IDs;\ningestion assigns `$session_id` when cookieless mode is enabled for the project.\n\n- 'always' - enable cookieless mode immediately on startup, use this if you do not intend to show a cookie banner\n- 'on_reject' - enable cookieless mode only if the user rejects cookies, use this if you want to show a cookie banner. If the user accepts cookies, cookieless mode will not be used, and PostHog will use cookies and local storage as usual.\n\nNote that you MUST enable cookieless mode in your PostHog project's settings, otherwise all your cookieless events will be ignored. We plan to remove this requirement in the future.",
+          "type": "\"always\" | \"on_reject\"",
+          "name": "cookieless_mode"
+        },
+        {
+          "description": "A hostname pattern to match test environments. When the current hostname matches,\n`setInternalOrTestUser()` is called automatically on startup, enabling person processing\nand setting `$internal_or_test_user: true`.\n\nCan be a string (exact match) or RegExp (pattern match).\nSet to `null` to explicitly disable (useful when using `defaults: '2026-01-30'`).",
+          "type": "string | RegExp",
+          "name": "internal_or_test_user_hostname"
+        },
+        {
+          "description": "Display language override for Product Tours.\n\nMust be a valid BCP 47 language code.\n\nIn the future this will be used for Surveys and other products that\ndeliver in-app experiences to end-users.",
+          "type": "string",
+          "name": "override_display_language"
+        },
+        {
+          "description": "A list of hostnames for which to inject PostHog tracing headers to all requests\n(X-POSTHOG-DISTINCT-ID, X-POSTHOG-SESSION-ID, X-POSTHOG-WINDOW-ID). Used to link\nfrontend sessions to backend traces (see https://posthog.com/docs/llm-analytics/link-session-replay).",
+          "type": "string[]",
+          "name": "tracing_headers"
+        },
+        {
+          "type": "string[]",
+          "name": "addTracingHeaders"
+        },
+        {
+          "type": "string[]",
+          "name": "__add_tracing_headers"
+        },
+        {
+          "type": "boolean",
+          "name": "__preview_flags_v2"
+        },
+        {
+          "type": "boolean",
+          "name": "__preview_eager_load_replay"
+        },
+        {
+          "description": "Prevents posthog-js from using the `navigator.sendBeacon` API to send events.\nEnabling this option may hurt the reliability of sending $pageleave events.",
+          "type": "boolean",
+          "name": "disable_beacon"
+        },
+        {
+          "type": "boolean",
+          "name": "__preview_disable_beacon"
+        },
+        {
+          "type": "boolean",
+          "name": "__preview_disable_xhr_credentials"
+        },
+        {
+          "type": "string | boolean",
+          "name": "__preview_external_dependency_versioned_paths"
+        },
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION\nEnables collection of bot traffic as $bot_pageview events with detailed bot detection\nproperties instead of dropping them entirely. Use it alongside opt_out_useragent_filter",
+          "type": "boolean",
+          "name": "__preview_capture_bot_pageviews"
+        },
+        {
+          "type": "boolean",
+          "name": "__preview_lazy_load_replay"
+        },
+        {
+          "type": "string",
+          "name": "api_method"
+        },
+        {
+          "type": "string",
+          "name": "inapp_protocol"
+        },
+        {
+          "type": "boolean",
+          "name": "inapp_link_new_window"
+        },
+        {
+          "type": "boolean",
+          "name": "ip"
+        },
+        {
+          "type": "(posthog: PostHogInterface) => void",
+          "name": "loaded"
+        },
+        {
+          "description": "Disables capturing the `$device_model` super-property.\n\nWhen capturing is enabled (the default), PostHog resolves the hardware model once during init\nvia `navigator.userAgentData.getHighEntropyValues(['model'])` and registers it as the raw OEM\ncode (e.g. `Pixel 7`). This is Chromium-only and only meaningful on Android — it resolves to\n`undefined` on Safari/Firefox and to an empty string on desktop, in which cases nothing is\nregistered.\n\nThis opt-out is offered because `getHighEntropyValues` is still experimental and Chromium-only\n(not yet a cross-browser standard); set it to `true` to skip the call entirely.",
+          "type": "boolean",
+          "name": "disableDeviceModel"
+        },
+        {
+          "description": "Internal: Extension class overrides for tree-shaking support.\nWhen provided, these classes are used instead of the default imports.\nThis enables entrypoints to control which extensions are bundled.",
+          "type": "{ exceptions?: ExtensionConstructor<PostHogExceptions>; historyAutocapture?: ExtensionConstructor<HistoryAutocapture>; tracingHeaders?: ExtensionConstructor<TracingHeaders>; siteApps?: ExtensionConstructor<SiteApps>; sessionRecording?: ExtensionConstructor<SessionRecording>; autocapture?: ExtensionConstructor<Autocapture>; productTours?: ExtensionConstructor<PostHogProductTours>; heatmaps?: ExtensionConstructor<Heatmaps>; webVitalsAutocapture?: ExtensionConstructor<WebVitalsAutocapture>; exceptionObserver?: ExtensionConstructor<ExceptionObserver>; deadClicksAutocapture?: ExtensionConstructor<DeadClicksAutocapture>; surveys?: ExtensionConstructor<PostHogSurveys>; toolbar?: ExtensionConstructor<Toolbar>; experiments?: ExtensionConstructor<WebExperiments>; conversations?: ExtensionConstructor<PostHogConversations>; featureFlags?: ExtensionConstructor<PostHogFeatureFlags>; logs?: ExtensionConstructor<PostHogLogs>; metrics?: ExtensionConstructor<PostHogMetrics>; }",
+          "name": "__extensionClasses"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "PostHogInterface",
       "name": "PostHogInterface",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "Omit<BasePostHogInterface, 'config' | 'init' | 'set_config'> & {\n    config: PostHogConfig;\n    set_config(config: Partial<PostHogConfig>): void;\n}"
+      "properties": [
+        {
+          "description": "Enable or disable debug mode.",
+          "type": "(debug?: boolean) => void",
+          "name": "debug"
+        },
+        {
+          "description": "The library version.",
+          "type": "string",
+          "name": "version"
+        },
+        {
+          "description": "Whether the PostHog instance has been loaded.",
+          "type": "boolean",
+          "name": "__loaded"
+        },
+        {
+          "description": "Whether the flags endpoint has been hit.",
+          "type": "boolean",
+          "name": "flagsEndpointWasHit"
+        },
+        {
+          "description": "Capture an event.",
+          "type": "(event_name: string, properties?: Properties | null, options?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureOptions) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureResult | undefined",
+          "name": "capture"
+        },
+        {
+          "description": "Capture an exception.",
+          "type": "(error: unknown, additionalProperties?: Properties) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureResult | undefined",
+          "name": "captureException"
+        },
+        {
+          "description": "Adds a breadcrumb-like step that will be attached to the next captured exception as `$exception_steps`.",
+          "type": "(message: string, properties?: Properties) => void",
+          "name": "addExceptionStep"
+        },
+        {
+          "description": "Capture a log entry and send it to the PostHog logs endpoint.",
+          "type": "(options: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture-log\").CaptureLogOptions) => void",
+          "name": "captureLog"
+        },
+        {
+          "description": "Logger with convenience methods for each severity level.",
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture-log\").Logger",
+          "name": "logger"
+        },
+        {
+          "description": "Identify a user with a distinct ID and optionally set person properties.",
+          "type": "(new_distinct_id?: string, userPropertiesToSet?: Properties, userPropertiesToSetOnce?: Properties) => void",
+          "name": "identify"
+        },
+        {
+          "description": "Set HMAC-based identity verification.",
+          "type": "(distinctId: string, hash: string) => void",
+          "name": "setIdentity"
+        },
+        {
+          "description": "Clear HMAC-based identity verification, reverting to anonymous mode.",
+          "type": "() => void",
+          "name": "clearIdentity"
+        },
+        {
+          "description": "Set properties on the current user.",
+          "type": "(userPropertiesToSet?: Properties, userPropertiesToSetOnce?: Properties) => void",
+          "name": "setPersonProperties"
+        },
+        {
+          "description": "Remove properties from the current user.",
+          "type": "(propertyNames: string | string[]) => void",
+          "name": "unsetPersonProperties"
+        },
+        {
+          "description": "Create an alias for the current user.",
+          "type": "(alias: string, original?: string) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/capture\").CaptureResult | void | number",
+          "name": "alias"
+        },
+        {
+          "description": "Get the current distinct ID.",
+          "type": "() => string",
+          "name": "get_distinct_id"
+        },
+        {
+          "description": "Reset the user's identity and start a new session.",
+          "type": "(reset_device_id?: boolean) => void",
+          "name": "reset"
+        },
+        {
+          "description": "Flush any queued events and gracefully tear down the SDK.",
+          "type": "(shutdownTimeoutMs?: number) => Promise<void>",
+          "name": "shutdown"
+        },
+        {
+          "description": "Create a person profile for the current user.",
+          "type": "() => void",
+          "name": "createPersonProfile"
+        },
+        {
+          "description": "Marks the current user as a test user by setting the `$internal_or_test_user` person property to `true`.\nThis also enables person processing for the current user.\n\nThis is useful for using in a cohort your internal/test filters for your posthog org.",
+          "type": "() => void",
+          "name": "setInternalOrTestUser"
+        },
+        {
+          "description": "Associate the user with a group.",
+          "type": "(groupType: string, groupKey: string, groupPropertiesToSet?: Properties) => void",
+          "name": "group"
+        },
+        {
+          "description": "Get the current groups.",
+          "type": "() => Record<string, any>",
+          "name": "getGroups"
+        },
+        {
+          "description": "Reset all groups for the current user.",
+          "type": "() => void",
+          "name": "resetGroups"
+        },
+        {
+          "description": "The feature flags instance. Provides access to feature flag override methods.",
+          "type": "{ overrideFeatureFlags(overrideOptions: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").OverrideFeatureFlagsOptions): void; override(flags: boolean | string[] | Record<string, string | boolean>, suppressWarning?: boolean): void; }",
+          "name": "featureFlags"
+        },
+        {
+          "description": "Get the value of a feature flag.",
+          "type": "(key: string, options?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagOptions) => boolean | string | undefined",
+          "name": "getFeatureFlag"
+        },
+        {
+          "description": "Get the payload of a feature flag.",
+          "type": "(key: string) => JsonType",
+          "name": "getFeatureFlagPayload"
+        },
+        {
+          "description": "Get a feature flag evaluation result including both the flag value and payload.\n\nBy default, this method emits the `$feature_flag_called` event.",
+          "type": "(key: string, options?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagOptions) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagResult | undefined",
+          "name": "getFeatureFlagResult"
+        },
+        {
+          "description": "Check if a feature flag is enabled.",
+          "type": "(key: string, options?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagOptions) => boolean | undefined",
+          "name": "isFeatureEnabled"
+        },
+        {
+          "description": "Reload feature flags from the server.",
+          "type": "() => void",
+          "name": "reloadFeatureFlags"
+        },
+        {
+          "description": "Manually update feature flag values without making a network request.",
+          "type": "(flags: Record<string, boolean | string>, payloads?: Record<string, JsonType>, options?: { merge?: boolean; }) => void",
+          "name": "updateFlags"
+        },
+        {
+          "description": "Register a callback to be called when feature flags are loaded.",
+          "type": "(callback: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").FeatureFlagsCallback) => () => void",
+          "name": "onFeatureFlags"
+        },
+        {
+          "description": "Set person properties to be used for feature flag evaluation.",
+          "type": "(properties: Properties, reloadFeatureFlags?: boolean) => void",
+          "name": "setPersonPropertiesForFlags"
+        },
+        {
+          "description": "Reset person properties used for feature flag evaluation.",
+          "type": "(reloadFeatureFlags?: boolean) => void",
+          "name": "resetPersonPropertiesForFlags"
+        },
+        {
+          "description": "Set group properties to be used for feature flag evaluation.",
+          "type": "(properties: { [type: string]: Properties; }, reloadFeatureFlags?: boolean) => void",
+          "name": "setGroupPropertiesForFlags"
+        },
+        {
+          "description": "Reset group properties used for feature flag evaluation.",
+          "type": "(group_type?: string) => void",
+          "name": "resetGroupPropertiesForFlags"
+        },
+        {
+          "description": "Get the list of early access features.",
+          "type": "(callback: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").EarlyAccessFeatureCallback, forceReload?: boolean, stages?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").EarlyAccessFeatureStage[]) => void",
+          "name": "getEarlyAccessFeatures"
+        },
+        {
+          "description": "Update enrollment in an early access feature.",
+          "type": "(key: string, isEnrolled: boolean, stage?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/feature-flags\").EarlyAccessFeatureStage) => void",
+          "name": "updateEarlyAccessFeatureEnrollment"
+        },
+        {
+          "description": "Register properties to be sent with every event.",
+          "type": "(properties: Properties, days?: number) => void",
+          "name": "register"
+        },
+        {
+          "description": "Register properties to be sent with every event, but only if they haven't been set before.",
+          "type": "(properties: Properties, default_value?: any, days?: number) => void",
+          "name": "register_once"
+        },
+        {
+          "description": "Register properties for the current session only.",
+          "type": "(properties: Properties) => void",
+          "name": "register_for_session"
+        },
+        {
+          "description": "Unregister a property so it is no longer sent with events.",
+          "type": "(property: string) => void",
+          "name": "unregister"
+        },
+        {
+          "description": "Unregister a session property.",
+          "type": "(property: string) => void",
+          "name": "unregister_for_session"
+        },
+        {
+          "description": "Get a property value from persistence.",
+          "type": "(property_name: string) => any | undefined",
+          "name": "get_property"
+        },
+        {
+          "description": "Get a session property value.",
+          "type": "(property_name: string) => any | undefined",
+          "name": "getSessionProperty"
+        },
+        {
+          "description": "Get the current session ID.",
+          "type": "() => string",
+          "name": "get_session_id"
+        },
+        {
+          "description": "Register a callback to be called when the session ID changes.",
+          "type": "(callback: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/session-recording\").SessionIdChangedCallback) => () => void",
+          "name": "onSessionId"
+        },
+        {
+          "description": "Get the URL to view the current session recording.",
+          "type": "(options?: { withTimestamp?: boolean; timestampLookBack?: number; }) => string",
+          "name": "get_session_replay_url"
+        },
+        {
+          "description": "Start session recording (if not already started).",
+          "type": "(override?: { sampling?: boolean; linked_flag?: boolean; url_trigger?: true; event_trigger?: true; } | true) => void",
+          "name": "startSessionRecording"
+        },
+        {
+          "description": "Stop session recording.",
+          "type": "() => void",
+          "name": "stopSessionRecording"
+        },
+        {
+          "description": "Check if session recording has started.",
+          "type": "() => boolean",
+          "name": "sessionRecordingStarted"
+        },
+        {
+          "description": "The session recording instance. May be undefined if session recording is not initialized.",
+          "type": "{ _forceAllowLocalhostNetworkCapture: boolean; }",
+          "name": "sessionRecording"
+        },
+        {
+          "description": "The session manager instance. May be undefined in cookieless mode.",
+          "type": "{ resetSessionId: () => void; }",
+          "name": "sessionManager"
+        },
+        {
+          "description": "Opt the user into capturing.",
+          "type": "() => void",
+          "name": "opt_in_capturing"
+        },
+        {
+          "description": "Opt the user out of capturing.",
+          "type": "() => void",
+          "name": "opt_out_capturing"
+        },
+        {
+          "description": "Check if the user has opted in to capturing.",
+          "type": "() => boolean",
+          "name": "has_opted_in_capturing"
+        },
+        {
+          "description": "Check if the user has opted out of capturing.",
+          "type": "() => boolean",
+          "name": "has_opted_out_capturing"
+        },
+        {
+          "description": "Get the explicit consent status.",
+          "type": "() => \"granted\" | \"denied\" | \"pending\"",
+          "name": "get_explicit_consent_status"
+        },
+        {
+          "description": "Clear the opt-in/out status.",
+          "type": "() => void",
+          "name": "clear_opt_in_out_capturing"
+        },
+        {
+          "description": "Get the list of surveys.",
+          "type": "(callback: (surveys: any[]) => void, forceReload?: boolean) => void",
+          "name": "getSurveys"
+        },
+        {
+          "description": "Get active surveys that match the current user.",
+          "type": "(callback: (surveys: any[]) => void, forceReload?: boolean) => void",
+          "name": "getActiveMatchingSurveys"
+        },
+        {
+          "description": "Render a survey in a specific container.",
+          "type": "(surveyId: string, selector: string) => void",
+          "name": "renderSurvey"
+        },
+        {
+          "description": "Check if a survey can be rendered.",
+          "type": "(surveyId: string) => import(\"/Users/anna/Develop/posthog-js/packages/types/dist/survey\").SurveyRenderReason | null",
+          "name": "canRenderSurvey"
+        },
+        {
+          "description": "Check if a survey can be rendered (async version).",
+          "type": "(surveyId: string, forceReload?: boolean) => Promise<import(\"/Users/anna/Develop/posthog-js/packages/types/dist/survey\").SurveyRenderReason>",
+          "name": "canRenderSurveyAsync"
+        },
+        {
+          "description": "Register an event listener.",
+          "type": "(event: \"eventCaptured\" | \"featureFlagsReloading\", cb: (...args: any[]) => void) => () => void",
+          "name": "on"
+        },
+        {
+          "description": "Start automatic exception capture.",
+          "type": "(config?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/posthog-config\").ExceptionAutoCaptureConfig) => void",
+          "name": "startExceptionAutocapture"
+        },
+        {
+          "description": "Stop automatic exception capture.",
+          "type": "() => void",
+          "name": "stopExceptionAutocapture"
+        },
+        {
+          "description": "Load the PostHog toolbar.",
+          "type": "(params: ToolbarParams) => boolean",
+          "name": "loadToolbar"
+        },
+        {
+          "description": "Get the current page view ID.",
+          "type": "() => string | undefined",
+          "name": "getPageViewId"
+        },
+        {
+          "description": "Capture written user feedback for a LLM trace.",
+          "type": "(traceId: string | number, userFeedback: string) => void",
+          "name": "captureTraceFeedback"
+        },
+        {
+          "description": "Capture a metric for a LLM trace.",
+          "type": "(traceId: string | number, metricName: string, metricValue: string | number | boolean) => void",
+          "name": "captureTraceMetric"
+        },
+        {
+          "type": "{ set: (prop: string | Properties, to?: string, callback?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/request\").RequestCallback) => void; set_once: (prop: string | Properties, to?: string, callback?: import(\"/Users/anna/Develop/posthog-js/packages/types/dist/request\").RequestCallback) => void; }",
+          "name": "people"
+        },
+        {
+          "type": "boolean",
+          "name": "decideEndpointWasHit"
+        },
+        {
+          "type": "PostHogConfig",
+          "name": "config"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "ProductTour",
@@ -3825,16 +4890,162 @@
     {
       "id": "SessionRecordingPersistedConfig",
       "name": "SessionRecordingPersistedConfig",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "Omit<SessionRecordingRemoteConfig, 'recordCanvas' | 'canvasFps' | 'canvasQuality' | 'networkPayloadCapture' | 'sampleRate' | 'minimumDurationMilliseconds'> & {\n    cache_timestamp?: number;\n    enabled: boolean;\n    networkPayloadCapture: SessionRecordingRemoteConfig['networkPayloadCapture'] & {\n        capturePerformance: RemoteConfig['capturePerformance'];\n    };\n    canvasRecording: {\n        enabled: SessionRecordingRemoteConfig['recordCanvas'];\n        fps: SessionRecordingRemoteConfig['canvasFps'];\n        quality: SessionRecordingRemoteConfig['canvasQuality'];\n    };\n    sampleRate: number | null;\n    minimumDurationMilliseconds: number | null | undefined;\n}"
+      "properties": [
+        {
+          "description": "Config version - defaults to 1 (legacy)\nWhen version is 2, triggerGroups is used instead of individual trigger fields",
+          "type": "1 | 2",
+          "name": "version"
+        },
+        {
+          "type": "string",
+          "name": "endpoint"
+        },
+        {
+          "type": "boolean",
+          "name": "consoleLogRecordingEnabled"
+        },
+        {
+          "type": "string | FlagVariant",
+          "name": "linkedFlag"
+        },
+        {
+          "type": "Pick<SessionRecordingOptions, \"maskAllInputs\" | \"maskTextSelector\" | \"blockSelector\">",
+          "name": "masking"
+        },
+        {
+          "type": "SessionRecordingUrlTrigger[]",
+          "name": "urlTriggers"
+        },
+        {
+          "type": "{ script?: string | undefined; }",
+          "name": "scriptConfig"
+        },
+        {
+          "type": "SessionRecordingUrlTrigger[]",
+          "name": "urlBlocklist"
+        },
+        {
+          "type": "string[]",
+          "name": "eventTriggers"
+        },
+        {
+          "description": "Controls how event, url, sampling, and linked flag triggers are combined\n\n`any` means that if any of the triggers match, the session will be recorded\n`all` means that all the triggers must match for the session to be recorded\n\noriginally it was (event || url) && (sampling || linked flag)\nwhich nobody wanted, now the default is all",
+          "type": "\"any\" | \"all\"",
+          "name": "triggerMatchType"
+        },
+        {
+          "description": "V2 Trigger Groups - multiple named trigger groups with their own conditions and sample rates\nOnly used when version === 2",
+          "type": "SessionRecordingTriggerGroup[]",
+          "name": "triggerGroups"
+        },
+        {
+          "description": "Used to determine if the persisted config is still valid or we need to wait for a new one\nonly accepts undefined since older versions of the library didn't set this.",
+          "type": "number",
+          "name": "cache_timestamp"
+        },
+        {
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "type": "Pick<NetworkRecordOptions, \"recordBody\" | \"recordHeaders\"> & { capturePerformance: RemoteConfig[\"capturePerformance\"]; }",
+          "name": "networkPayloadCapture"
+        },
+        {
+          "type": "{ enabled: SessionRecordingRemoteConfig[\"recordCanvas\"]; fps: SessionRecordingRemoteConfig[\"canvasFps\"]; quality: SessionRecordingRemoteConfig[\"canvasQuality\"]; }",
+          "name": "canvasRecording"
+        },
+        {
+          "type": "number",
+          "name": "sampleRate"
+        },
+        {
+          "type": "number",
+          "name": "minimumDurationMilliseconds"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "SessionRecordingRemoteConfig",
       "name": "SessionRecordingRemoteConfig",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "SessionRecordingCanvasOptions & {\n    endpoint?: string;\n    consoleLogRecordingEnabled?: boolean;\n    sampleRate?: string | null;\n    minimumDurationMilliseconds?: number;\n    linkedFlag?: string | FlagVariant | null;\n    networkPayloadCapture?: Pick<NetworkRecordOptions, 'recordBody' | 'recordHeaders'>;\n    masking?: Pick<SessionRecordingOptions, 'maskAllInputs' | 'maskTextSelector' | 'blockSelector'>;\n    urlTriggers?: SessionRecordingUrlTrigger[];\n    scriptConfig?: {\n        script?: string | undefined;\n    };\n    urlBlocklist?: SessionRecordingUrlTrigger[];\n    eventTriggers?: string[];\n    triggerMatchType?: 'any' | 'all';\n    version?: 1 | 2;\n    triggerGroups?: SessionRecordingTriggerGroup[];\n}"
+      "properties": [
+        {
+          "description": "If set, records the canvas",
+          "type": "boolean",
+          "name": "recordCanvas"
+        },
+        {
+          "description": "If set, records the canvas at the given FPS\nCan be set in the remote configuration\nLimited between 0 and 12\nWhen canvas recording is enabled, if this is not set locally, then remote config sets this as 4",
+          "type": "number",
+          "name": "canvasFps"
+        },
+        {
+          "description": "If set, records the canvas at the given quality\nCan be set in the remote configuration\nMust be a string that is a valid decimal between 0 and 1\nWhen canvas recording is enabled, if this is not set locally, then remote config sets this as \"0.4\"",
+          "type": "string",
+          "name": "canvasQuality"
+        },
+        {
+          "type": "string",
+          "name": "endpoint"
+        },
+        {
+          "type": "boolean",
+          "name": "consoleLogRecordingEnabled"
+        },
+        {
+          "type": "string",
+          "name": "sampleRate"
+        },
+        {
+          "type": "number",
+          "name": "minimumDurationMilliseconds"
+        },
+        {
+          "type": "string | FlagVariant",
+          "name": "linkedFlag"
+        },
+        {
+          "type": "Pick<NetworkRecordOptions, \"recordBody\" | \"recordHeaders\">",
+          "name": "networkPayloadCapture"
+        },
+        {
+          "type": "Pick<SessionRecordingOptions, \"maskAllInputs\" | \"maskTextSelector\" | \"blockSelector\">",
+          "name": "masking"
+        },
+        {
+          "type": "SessionRecordingUrlTrigger[]",
+          "name": "urlTriggers"
+        },
+        {
+          "type": "{ script?: string | undefined; }",
+          "name": "scriptConfig"
+        },
+        {
+          "type": "SessionRecordingUrlTrigger[]",
+          "name": "urlBlocklist"
+        },
+        {
+          "type": "string[]",
+          "name": "eventTriggers"
+        },
+        {
+          "description": "Controls how event, url, sampling, and linked flag triggers are combined\n\n`any` means that if any of the triggers match, the session will be recorded\n`all` means that all the triggers must match for the session to be recorded\n\noriginally it was (event || url) && (sampling || linked flag)\nwhich nobody wanted, now the default is all",
+          "type": "\"any\" | \"all\"",
+          "name": "triggerMatchType"
+        },
+        {
+          "description": "Config version - defaults to 1 (legacy)\nWhen version is 2, triggerGroups is used instead of individual trigger fields",
+          "type": "1 | 2",
+          "name": "version"
+        },
+        {
+          "description": "V2 Trigger Groups - multiple named trigger groups with their own conditions and sample rates\nOnly used when version === 2",
+          "type": "SessionRecordingTriggerGroup[]",
+          "name": "triggerGroups"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "SessionRecordingTriggerGroup",
@@ -3926,23 +5137,63 @@
     {
       "id": "SiteApp",
       "name": "SiteApp",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "{\n    id: string;\n    loaded: boolean;\n    errored: boolean;\n    processedBuffer: boolean;\n    processEvent?: (globals: SiteAppGlobals) => void;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "boolean",
+          "name": "loaded"
+        },
+        {
+          "type": "boolean",
+          "name": "errored"
+        },
+        {
+          "type": "boolean",
+          "name": "processedBuffer"
+        },
+        {
+          "type": "(globals: SiteAppGlobals) => void",
+          "name": "processEvent"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "SiteAppGlobals",
       "name": "SiteAppGlobals",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "{\n    event: {\n        uuid: string;\n        event: EventName;\n        properties: Properties;\n        timestamp?: Date;\n        elements_chain?: string;\n        distinct_id?: string;\n    };\n    person: {\n        properties: Properties;\n    };\n    groups: Record<string, {\n        id: string;\n        type: string;\n        properties: Properties;\n    }>;\n}"
+      "properties": [
+        {
+          "type": "{ uuid: string; event: EventName; properties: Properties; timestamp?: Date; elements_chain?: string; distinct_id?: string; }",
+          "name": "event"
+        },
+        {
+          "type": "{ properties: Properties; }",
+          "name": "person"
+        },
+        {
+          "type": "Record<string, { id: string; type: string; properties: Properties; }>",
+          "name": "groups"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "SiteAppLoader",
       "name": "SiteAppLoader",
-      "properties": [],
-      "path": "lib/src/types.d.ts",
-      "example": "{\n    id: string;\n    init: (config: {\n        posthog: PostHog;\n        callback: (success: boolean) => void;\n    }) => {\n        processEvent?: (globals: SiteAppGlobals) => void;\n    };\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "(config: { posthog: PostHog; callback: (success: boolean) => void; }) => { processEvent?: (globals: SiteAppGlobals) => void; }",
+          "name": "init"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
     },
     {
       "id": "SnippetArrayItem",
@@ -4306,9 +5557,21 @@
     {
       "id": "SurveyWithTypeAndAppearance",
       "name": "SurveyWithTypeAndAppearance",
-      "properties": [],
-      "path": "lib/src/posthog-surveys-types.d.ts",
-      "example": "\"id\" | \"type\" | \"appearance\""
+      "properties": [
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "SurveyType",
+          "name": "type"
+        },
+        {
+          "type": "SurveyAppearance",
+          "name": "appearance"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
     },
     {
       "id": "Ticket",

--- a/packages/browser/scripts/generate-docs.js
+++ b/packages/browser/scripts/generate-docs.js
@@ -11,6 +11,7 @@ const shouldWriteVersionedReferences = process.env.GENERATE_VERSIONED_REFERENCES
 const config = {
     packageDir: path.resolve(__dirname, '..'),  // packages/browser
     apiJsonPath: path.resolve(__dirname, '../docs/posthog-js.api.json'),
+    dtsEntryPath: path.resolve(__dirname, '../lib/src/entrypoints/module.no-external.es.d.ts'),
     outputPath: path.resolve(__dirname, `../references/posthog-js-references-${version}.json`),
     version: version,
     id: 'posthog-js',

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -1602,16 +1602,72 @@
     {
       "id": "ActionStepType",
       "name": "ActionStepType",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    event?: string;\n    selector?: string;\n    text?: string;\n    text_matching?: ActionStepStringMatching;\n    href?: string;\n    href_matching?: ActionStepStringMatching;\n    url?: string;\n    url_matching?: ActionStepStringMatching;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "event"
+        },
+        {
+          "type": "string",
+          "name": "selector"
+        },
+        {
+          "type": "string",
+          "name": "text"
+        },
+        {
+          "type": "ActionStepStringMatching",
+          "name": "text_matching"
+        },
+        {
+          "type": "string",
+          "name": "href"
+        },
+        {
+          "type": "ActionStepStringMatching",
+          "name": "href_matching"
+        },
+        {
+          "type": "string",
+          "name": "url"
+        },
+        {
+          "type": "ActionStepStringMatching",
+          "name": "url_matching"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "AllFlagsOptions",
       "name": "AllFlagsOptions",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "BaseFlagEvaluationOptions & {\n    flagKeys?: string[];\n}"
+      "properties": [
+        {
+          "type": "Record<string, string>",
+          "name": "groups"
+        },
+        {
+          "type": "Record<string, string>",
+          "name": "personProperties"
+        },
+        {
+          "type": "Record<string, Record<string, string>>",
+          "name": "groupProperties"
+        },
+        {
+          "type": "boolean",
+          "name": "onlyEvaluateLocally"
+        },
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "type": "string[]",
+          "name": "flagKeys"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "BaseException",
@@ -1635,16 +1691,80 @@
     {
       "id": "BaseFlagEvaluationOptions",
       "name": "BaseFlagEvaluationOptions",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    groups?: Record<string, string>;\n    personProperties?: Record<string, string>;\n    groupProperties?: Record<string, Record<string, string>>;\n    onlyEvaluateLocally?: boolean;\n    disableGeoip?: boolean;\n}"
+      "properties": [
+        {
+          "type": "Record<string, string>",
+          "name": "groups"
+        },
+        {
+          "type": "Record<string, string>",
+          "name": "personProperties"
+        },
+        {
+          "type": "Record<string, Record<string, string>>",
+          "name": "groupProperties"
+        },
+        {
+          "type": "boolean",
+          "name": "onlyEvaluateLocally"
+        },
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "BasicSurveyQuestion",
       "name": "BasicSurveyQuestion",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Open;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "\"open\"",
+          "name": "type"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "BeforeSendFn_2",
@@ -1663,9 +1783,39 @@
     {
       "id": "CaptureEvent",
       "name": "CaptureEvent",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    uuid?: string;\n    event: string;\n    properties?: PostHogEventProperties;\n    $set?: PostHogEventProperties;\n    $set_once?: PostHogEventProperties;\n    timestamp?: Date;\n}"
+      "properties": [
+        {
+          "description": "UUID for the event (optional to allow compatibility with Node SDK's EventMessage). Must be a valid UUID.",
+          "type": "string",
+          "name": "uuid"
+        },
+        {
+          "description": "The name of the event",
+          "type": "string",
+          "name": "event"
+        },
+        {
+          "description": "Properties associated with the event (optional to allow compatibility with Node SDK's EventMessage)",
+          "type": "PostHogEventProperties",
+          "name": "properties"
+        },
+        {
+          "description": "Properties to set on the person (overrides existing values)",
+          "type": "PostHogEventProperties",
+          "name": "$set"
+        },
+        {
+          "description": "Properties to set on the person only once (does not override existing values)",
+          "type": "PostHogEventProperties",
+          "name": "$set_once"
+        },
+        {
+          "description": "Timestamp for the event",
+          "type": "Date",
+          "name": "timestamp"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "ChunkIdMapType",
@@ -1750,9 +1900,13 @@
     {
       "id": "EndBranching",
       "name": "EndBranching",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: typeof SurveyQuestionBranchingType.End;\n}"
+      "properties": [
+        {
+          "type": "\"end\"",
+          "name": "type"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "ErrorEventLike",
@@ -1820,9 +1974,52 @@
     {
       "id": "EventMessage",
       "name": "EventMessage",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "Omit<IdentifyMessage, 'distinctId'> & {\n    distinctId?: string;\n    event: string;\n    groups?: Record<string, string | number>;\n    flags?: FeatureFlagEvaluations;\n    sendFeatureFlags?: boolean | SendFeatureFlagsOptions;\n    timestamp?: Date;\n    uuid?: string;\n    _originatedFromCaptureException?: boolean;\n}"
+      "properties": [
+        {
+          "type": "Record<string | number, any>",
+          "name": "properties"
+        },
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "string",
+          "name": "event"
+        },
+        {
+          "type": "Record<string, string | number>",
+          "name": "groups"
+        },
+        {
+          "description": "Attach feature flag values evaluated via `posthog.evaluateFlags()` to this event.\nPrefer this over `sendFeatureFlags` — it guarantees the event carries the exact\nvalues the code branched on and avoids a hidden `/flags` request on every capture.",
+          "type": "FeatureFlagEvaluations",
+          "name": "flags"
+        },
+        {
+          "type": "boolean | SendFeatureFlagsOptions",
+          "name": "sendFeatureFlags"
+        },
+        {
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "description": "If provided overrides the auto-generated event UUID. Must be a valid UUID.",
+          "type": "string",
+          "name": "uuid"
+        },
+        {
+          "description": "Internal flag set by captureException() to indicate this $exception\nevent originated from the proper exception capture path. Used to warn users who call\ncapture() with '$exception' directly.",
+          "type": "boolean",
+          "name": "_originatedFromCaptureException"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "EventWithDetailReason",
@@ -1889,21 +2086,38 @@
       "id": "ExceptionList",
       "name": "ExceptionList",
       "properties": [],
-      "path": "../core/src/error-tracking/types.ts"
+      "path": "../core/src/error-tracking/types.ts",
+      "example": "Exception[]"
     },
     {
       "id": "ExceptionStep",
       "name": "ExceptionStep",
-      "properties": [],
-      "path": "../core/src/error-tracking/exception-steps.ts",
-      "example": "{\n    [EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE]: string;\n    [EXCEPTION_STEP_INTERNAL_FIELDS.TIMESTAMP]: string | number;\n    [key: string]: unknown;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "$message"
+        },
+        {
+          "type": "string | number",
+          "name": "$timestamp"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ExceptionStepsConfig",
       "name": "ExceptionStepsConfig",
-      "properties": [],
-      "path": "../core/src/error-tracking/exception-steps.ts",
-      "example": "{\n    enabled?: boolean;\n    max_bytes?: number;\n}"
+      "properties": [
+        {
+          "type": "boolean | undefined",
+          "name": "enabled"
+        },
+        {
+          "type": "number | undefined",
+          "name": "max_bytes"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ExpressErrorMiddleware",
@@ -1929,9 +2143,25 @@
     {
       "id": "FeatureFlagCondition",
       "name": "FeatureFlagCondition",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    properties: FlagProperty[];\n    rollout_percentage?: number;\n    variant?: string;\n    aggregation_group_type_index?: number | null;\n}"
+      "properties": [
+        {
+          "type": "FlagProperty[]",
+          "name": "properties"
+        },
+        {
+          "type": "number",
+          "name": "rollout_percentage"
+        },
+        {
+          "type": "string",
+          "name": "variant"
+        },
+        {
+          "type": "number",
+          "name": "aggregation_group_type_index"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "FeatureFlagDetail",
@@ -1945,7 +2175,7 @@
       "name": "FeatureFlagErrorType",
       "properties": [],
       "path": "../core/src/types.ts",
-      "example": "\"apiError\""
+      "example": "(typeof FeatureFlagError)[Exclude<keyof typeof FeatureFlagError, 'apiError'>] | ReturnType<typeof FeatureFlagError.apiError> | string"
     },
     {
       "id": "FeatureFlagMetadata",
@@ -1957,23 +2187,57 @@
     {
       "id": "FeatureFlagOverrideOptions",
       "name": "FeatureFlagOverrideOptions",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    flags?: false | string[] | Record<string, FeatureFlagValue>;\n    payloads?: false | Record<string, JsonType>;\n}"
+      "properties": [
+        {
+          "description": "Flag overrides. Can be:\n- `false` to clear flag overrides\n- `string[]` to enable a list of flags\n- `Record<string, FeatureFlagValue>` to set specific values/variants",
+          "type": "false | string[] | Record<string, FeatureFlagValue>",
+          "name": "flags"
+        },
+        {
+          "description": "Payload overrides for flags.\n- `false` to clear payload overrides\n- `Record<string, JsonType>` to set specific payloads",
+          "type": "false | Record<string, JsonType>",
+          "name": "payloads"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "FeatureFlagRequestError",
       "name": "FeatureFlagRequestError",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: 'timeout' | 'connection_error' | 'api_error' | 'unknown_error';\n    statusCode?: number;\n}"
+      "properties": [
+        {
+          "type": "\"timeout\" | \"connection_error\" | \"unknown_error\" | \"api_error\"",
+          "name": "type"
+        },
+        {
+          "type": "number",
+          "name": "statusCode"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "FeatureFlagResult",
       "name": "FeatureFlagResult",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    key: string;\n    enabled: boolean;\n    variant: string | undefined;\n    payload: JsonType | undefined;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "key"
+        },
+        {
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "type": "string",
+          "name": "variant"
+        },
+        {
+          "type": "JsonType",
+          "name": "payload"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "FeatureFlagValue",
@@ -2013,16 +2277,64 @@
     {
       "id": "FlagEvaluationOptions",
       "name": "FlagEvaluationOptions",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "BaseFlagEvaluationOptions & {\n    sendFeatureFlagEvents?: boolean;\n}"
+      "properties": [
+        {
+          "type": "Record<string, string>",
+          "name": "groups"
+        },
+        {
+          "type": "Record<string, string>",
+          "name": "personProperties"
+        },
+        {
+          "type": "Record<string, Record<string, string>>",
+          "name": "groupProperties"
+        },
+        {
+          "type": "boolean",
+          "name": "onlyEvaluateLocally"
+        },
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "type": "boolean",
+          "name": "sendFeatureFlagEvents"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "FlagProperty",
       "name": "FlagProperty",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    key: string;\n    type?: string;\n    value: FlagPropertyValue;\n    operator?: string;\n    negation?: boolean;\n    dependency_chain?: string[];\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "key"
+        },
+        {
+          "type": "string",
+          "name": "type"
+        },
+        {
+          "type": "FlagPropertyValue",
+          "name": "value"
+        },
+        {
+          "type": "string",
+          "name": "operator"
+        },
+        {
+          "type": "boolean",
+          "name": "negation"
+        },
+        {
+          "type": "string[]",
+          "name": "dependency_chain"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "FlagPropertyValue",
@@ -2048,16 +2360,48 @@
     {
       "id": "GroupIdentifyMessage",
       "name": "GroupIdentifyMessage",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    groupType: string;\n    groupKey: string;\n    properties?: Record<string | number, any>;\n    distinctId?: string;\n    disableGeoip?: boolean;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "groupType"
+        },
+        {
+          "type": "string",
+          "name": "groupKey"
+        },
+        {
+          "type": "Record<string | number, any>",
+          "name": "properties"
+        },
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "IdentifyMessage",
       "name": "IdentifyMessage",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    distinctId: string;\n    properties?: Record<string | number, any>;\n    disableGeoip?: boolean;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "Record<string | number, any>",
+          "name": "properties"
+        },
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "IPostHog",
@@ -2087,16 +2431,88 @@
     {
       "id": "LinkSurveyQuestion",
       "name": "LinkSurveyQuestion",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Link;\n    link?: string | null;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "\"link\"",
+          "name": "type"
+        },
+        {
+          "type": "string",
+          "name": "link"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "Logger",
       "name": "Logger",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    debug: (...args: any[]) => void;\n    info: (...args: any[]) => void;\n    warn: (...args: any[]) => void;\n    error: (...args: any[]) => void;\n    critical: (...args: any[]) => void;\n    createLogger: (prefix: string) => Logger;\n}"
+      "properties": [
+        {
+          "type": "(...args: any[]) => void",
+          "name": "debug"
+        },
+        {
+          "type": "(...args: any[]) => void",
+          "name": "info"
+        },
+        {
+          "type": "(...args: any[]) => void",
+          "name": "warn"
+        },
+        {
+          "type": "(...args: any[]) => void",
+          "name": "error"
+        },
+        {
+          "type": "(...args: any[]) => void",
+          "name": "critical"
+        },
+        {
+          "type": "(prefix: string) => Logger",
+          "name": "createLogger"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "Mechanism",
@@ -2147,16 +2563,80 @@
     {
       "id": "MultipleSurveyQuestion",
       "name": "MultipleSurveyQuestion",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.SingleChoice | typeof SurveyQuestionType.MultipleChoice;\n    choices: string[];\n    hasOpenChoice?: boolean;\n    shuffleOptions?: boolean;\n    skipSubmitButton?: boolean;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "\"single_choice\" | \"multiple_choice\"",
+          "name": "type"
+        },
+        {
+          "type": "string[]",
+          "name": "choices"
+        },
+        {
+          "type": "boolean",
+          "name": "hasOpenChoice"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleOptions"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "NextQuestionBranching",
       "name": "NextQuestionBranching",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: typeof SurveyQuestionBranchingType.NextQuestion;\n}"
+      "properties": [
+        {
+          "type": "\"next_question\"",
+          "name": "type"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "ObjectLike",
@@ -2238,9 +2718,28 @@
     {
       "id": "PostHogCaptureOptions",
       "name": "PostHogCaptureOptions",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    uuid?: string;\n    timestamp?: Date;\n    disableGeoip?: boolean;\n    _originatedFromCaptureException?: boolean;\n}"
+      "properties": [
+        {
+          "description": "If provided overrides the auto-generated event UUID. Must be a valid UUID.",
+          "type": "string",
+          "name": "uuid"
+        },
+        {
+          "description": "If provided overrides the auto-generated timestamp",
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "description": "Internal flag set by captureException() to indicate this $exception\nevent originated from the proper exception capture path. Used to warn users who call\ncapture('$exception') directly.",
+          "type": "boolean",
+          "name": "_originatedFromCaptureException"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogCookieState",
@@ -2268,9 +2767,154 @@
     {
       "id": "PostHogCoreOptions",
       "name": "PostHogCoreOptions",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    host?: string;\n    flushAt?: number;\n    flushInterval?: number;\n    maxBatchSize?: number;\n    maxQueueSize?: number;\n    disabled?: boolean;\n    defaultOptIn?: boolean;\n    disable_capture_url_hashes?: boolean;\n    sendFeatureFlagEvent?: boolean;\n    preloadFeatureFlags?: boolean;\n    disableRemoteFeatureFlags?: boolean;\n    disableRemoteConfig?: boolean;\n    disableSurveys?: boolean;\n    bootstrap?: {\n        distinctId?: string;\n        isIdentifiedId?: boolean;\n        featureFlags?: Record<string, FeatureFlagValue>;\n        featureFlagPayloads?: Record<string, JsonType>;\n    };\n    fetchRetryCount?: number;\n    fetchRetryDelay?: number;\n    requestTimeout?: number;\n    featureFlagsRequestTimeoutMs?: number;\n    featureFlagsRequestMaxRetries?: number;\n    remoteConfigRequestTimeoutMs?: number;\n    sessionExpirationTimeSeconds?: number;\n    disableCompression?: boolean;\n    disableGeoip?: boolean;\n    historicalMigration?: boolean;\n    evaluationContexts?: readonly string[];\n    evaluationEnvironments?: readonly string[];\n    personProfiles?: 'always' | 'identified_only' | 'never';\n    before_send?: BeforeSendFn | BeforeSendFn[];\n    addTracingHeaders?: string[];\n}"
+      "properties": [
+        {
+          "description": "PostHog API host, usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'",
+          "type": "string",
+          "name": "host"
+        },
+        {
+          "description": "The number of events to queue before sending to PostHog (flushing)",
+          "type": "number",
+          "name": "flushAt"
+        },
+        {
+          "description": "The interval in milliseconds between periodic flushes",
+          "type": "number",
+          "name": "flushInterval"
+        },
+        {
+          "description": "The maximum number of queued messages to be flushed as part of a single batch (must be higher than `flushAt`)",
+          "type": "number",
+          "name": "maxBatchSize"
+        },
+        {
+          "description": "The maximum number of cached messages either in memory or on the local storage (must be higher than `flushAt`)",
+          "type": "number",
+          "name": "maxQueueSize"
+        },
+        {
+          "description": "If set to true the SDK is essentially disabled (useful for local environments where you don't want to track anything)",
+          "type": "boolean",
+          "name": "disabled"
+        },
+        {
+          "description": "If set to false the SDK will not track until the `optIn` function is called.",
+          "type": "boolean",
+          "name": "defaultOptIn"
+        },
+        {
+          "description": "Whether to strip URL fragments (`#...`) from automatically captured URL fields.\nDisabled by default for backwards compatibility. Set to `true` to strip hashes from:\n\n- `$current_url` on automatically captured browser events, including `$pageview`\n- `$initial_current_url`\n- `$session_entry_url`\n- `$elements[*].attr__href` and `$external_click_url` for autocapture and dead-click autocapture\n- Next.js Pages Router `$pageview` `$current_url`\n- web vitals `$current_url`\n- logs `url.full`\n- conversations `current_url` and `request_url`\n- session replay rrweb meta/custom-event `href` URLs\n- heatmap data URLs\n\nIf your SPA relies on hash-based routes for analytics, enabling this is a breaking behavior change.\nIf you want to capture hashes selectively, leave this as `false` and use `before_send` to remove\nsensitive hash values before events are sent.",
+          "type": "boolean",
+          "name": "disable_capture_url_hashes"
+        },
+        {
+          "description": "Whether to track that `getFeatureFlag` was called (used by Experiments)",
+          "type": "boolean",
+          "name": "sendFeatureFlagEvent"
+        },
+        {
+          "description": "Whether to load feature flags when initialized or not",
+          "type": "boolean",
+          "name": "preloadFeatureFlags"
+        },
+        {
+          "description": "Advanced: whether to disable fetching and evaluating feature flags from PostHog entirely.\n\nWhen set to true, `reloadFeatureFlags()` and the reloads triggered by `identify()`,\n`group()`, `setPersonPropertiesForFlags()` and `reset()` become no-ops, and any request\nto the flags endpoint that still goes out (e.g. to fetch remote config or surveys)\ncarries `disable_flags: true` so the server skips flag evaluation. Flag values must be\nsupplied via the `bootstrap` option or `updateFlags()` instead; `getFeatureFlag()` and\nrelated methods keep working against those values. Until `updateFlags()` runs, reads\nreturn their not-loaded defaults, so use `bootstrap` for any flags needed at startup.\nEquivalent to the web SDK's `advanced_disable_feature_flags`.\n\nNote: surveys gated on feature flags will not evaluate unless the survey targeting\nflags are also provided via `updateFlags()`. This option cannot be toggled at runtime.\n`posthog-node` inherits this option but does not implement it (no-op).",
+          "type": "boolean",
+          "name": "disableRemoteFeatureFlags"
+        },
+        {
+          "description": "Whether to load remote config when initialized or not",
+          "type": "boolean",
+          "name": "disableRemoteConfig"
+        },
+        {
+          "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
+          "type": "boolean",
+          "name": "disableSurveys"
+        },
+        {
+          "description": "Option to bootstrap the library with given distinctId and feature flags",
+          "type": "{ distinctId?: string; isIdentifiedId?: boolean; featureFlags?: Record<string, FeatureFlagValue>; featureFlagPayloads?: Record<string, JsonType>; }",
+          "name": "bootstrap"
+        },
+        {
+          "description": "How many times we will retry HTTP requests",
+          "type": "number",
+          "name": "fetchRetryCount"
+        },
+        {
+          "description": "The delay between HTTP request retries in milliseconds",
+          "type": "number",
+          "name": "fetchRetryDelay"
+        },
+        {
+          "description": "Timeout in milliseconds for any calls",
+          "type": "number",
+          "name": "requestTimeout"
+        },
+        {
+          "description": "Timeout in milliseconds for feature flag calls",
+          "type": "number",
+          "name": "featureFlagsRequestTimeoutMs"
+        },
+        {
+          "description": "How many times feature flag requests retry after a transient network error.\nSet to 0 to disable feature flag request retries.",
+          "type": "number",
+          "name": "featureFlagsRequestMaxRetries"
+        },
+        {
+          "description": "Timeout in milliseconds for remote config calls",
+          "type": "number",
+          "name": "remoteConfigRequestTimeoutMs"
+        },
+        {
+          "description": "For Session Analysis how long before we expire a session in seconds",
+          "type": "number",
+          "name": "sessionExpirationTimeSeconds"
+        },
+        {
+          "description": "Whether to disable GZIP compression",
+          "type": "boolean",
+          "name": "disableCompression"
+        },
+        {
+          "description": "Whether to disable GeoIP lookups",
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "description": "Special flag to indicate ingested data is for a historical migration",
+          "type": "boolean",
+          "name": "historicalMigration"
+        },
+        {
+          "description": "Evaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'web', 'mobile']",
+          "type": "readonly string[]",
+          "name": "evaluationContexts"
+        },
+        {
+          "description": "Evaluation environments for feature flags.",
+          "type": "readonly string[]",
+          "name": "evaluationEnvironments"
+        },
+        {
+          "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
+          "type": "\"always\" | \"identified_only\" | \"never\"",
+          "name": "personProfiles"
+        },
+        {
+          "description": "Allows modification or dropping of events before they're sent to PostHog.\nIf an array is provided, the functions are run in order.\nIf a function returns null, the event will be dropped.",
+          "type": "BeforeSendFn | BeforeSendFn[]",
+          "name": "before_send"
+        },
+        {
+          "description": "A list of hostnames for which to inject PostHog tracing headers\n(X-POSTHOG-DISTINCT-ID, X-POSTHOG-SESSION-ID) on outgoing `fetch` requests.\n\nUse this to link requests made from your app to session replays and LLM traces\nin PostHog. When set, the global `fetch` is patched on initialization and the\nheaders are added to requests whose hostname matches one of the entries.\n\nRequires the SDK to wire up `patchFetchForTracingHeaders` against this option\n(currently supported in posthog-react-native).",
+          "type": "string[]",
+          "name": "addTracingHeaders"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogEventProperties",
@@ -2282,58 +2926,553 @@
     {
       "id": "PostHogFeatureFlag",
       "name": "PostHogFeatureFlag",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    id: number;\n    name: string;\n    key: string;\n    bucketing_identifier?: FeatureFlagBucketingIdentifier;\n    filters?: {\n        aggregation_group_type_index?: number;\n        groups?: FeatureFlagCondition[];\n        multivariate?: {\n            variants: {\n                key: string;\n                rollout_percentage: number;\n            }[];\n        };\n        payloads?: Record<string, string>;\n        early_exit?: boolean;\n    };\n    deleted: boolean;\n    active: boolean;\n    rollout_percentage: null | number;\n    ensure_experience_continuity: boolean;\n    experiment_set: number[];\n}"
+      "properties": [
+        {
+          "type": "number",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "string",
+          "name": "key"
+        },
+        {
+          "type": "FeatureFlagBucketingIdentifier",
+          "name": "bucketing_identifier"
+        },
+        {
+          "type": "{ aggregation_group_type_index?: number; groups?: FeatureFlagCondition[]; multivariate?: { variants: { key: string; rollout_percentage: number; }[]; }; payloads?: Record<string, string>; early_exit?: boolean; }",
+          "name": "filters"
+        },
+        {
+          "type": "boolean",
+          "name": "deleted"
+        },
+        {
+          "type": "boolean",
+          "name": "active"
+        },
+        {
+          "type": "number",
+          "name": "rollout_percentage"
+        },
+        {
+          "type": "boolean",
+          "name": "ensure_experience_continuity"
+        },
+        {
+          "type": "number[]",
+          "name": "experiment_set"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "PostHogFeatureFlagDetails",
       "name": "PostHogFeatureFlagDetails",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "\"flags\" | \"featureFlags\" | \"featureFlagPayloads\" | \"requestId\""
+      "properties": [
+        {
+          "type": "{ [key: string]: FeatureFlagDetail; }",
+          "name": "flags"
+        },
+        {
+          "type": "{ [key: string]: FeatureFlagValue; }",
+          "name": "featureFlags"
+        },
+        {
+          "type": "{ [key: string]: JsonType; }",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "string",
+          "name": "requestId"
+        },
+        {
+          "type": "(boolean | { [key: string]: JsonType; }) & (boolean | { [key: string]: JsonType; })",
+          "name": "sessionRecording"
+        },
+        {
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "errorTracking"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "capturePerformance"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "logs"
+        },
+        {
+          "type": "boolean",
+          "name": "errorsWhileComputingFlags"
+        },
+        {
+          "type": "string[]",
+          "name": "quotaLimited"
+        },
+        {
+          "type": "number",
+          "name": "evaluatedAt"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFeatureFlagsResponse",
       "name": "PostHogFeatureFlagsResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "\"flags\" | \"featureFlags\" | \"featureFlagPayloads\" | \"requestId\""
+      "properties": [
+        {
+          "type": "{ [key: string]: FeatureFlagDetail; }",
+          "name": "flags"
+        },
+        {
+          "type": "{ [key: string]: FeatureFlagValue; }",
+          "name": "featureFlags"
+        },
+        {
+          "type": "{ [key: string]: JsonType; }",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "string",
+          "name": "requestId"
+        },
+        {
+          "type": "(boolean | { [key: string]: JsonType; }) & (boolean | { [key: string]: JsonType; })",
+          "name": "sessionRecording"
+        },
+        {
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "errorTracking"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "capturePerformance"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "logs"
+        },
+        {
+          "type": "boolean",
+          "name": "errorsWhileComputingFlags"
+        },
+        {
+          "type": "string[]",
+          "name": "quotaLimited"
+        },
+        {
+          "type": "number",
+          "name": "evaluatedAt"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFetchOptions",
       "name": "PostHogFetchOptions",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    method: 'GET' | 'POST' | 'PUT' | 'PATCH';\n    mode?: 'no-cors';\n    credentials?: 'omit';\n    headers: {\n        [key: string]: string;\n    };\n    body?: string | Blob;\n    signal?: AbortSignal;\n}"
+      "properties": [
+        {
+          "type": "\"GET\" | \"POST\" | \"PUT\" | \"PATCH\"",
+          "name": "method"
+        },
+        {
+          "type": "\"no-cors\"",
+          "name": "mode"
+        },
+        {
+          "type": "\"omit\"",
+          "name": "credentials"
+        },
+        {
+          "type": "{ [key: string]: string; }",
+          "name": "headers"
+        },
+        {
+          "type": "string | Blob",
+          "name": "body"
+        },
+        {
+          "type": "AbortSignal",
+          "name": "signal"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFetchResponse",
       "name": "PostHogFetchResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    status: number;\n    text: () => Promise<string>;\n    json: () => Promise<any>;\n    headers?: {\n        get(name: string): string | null;\n    };\n    body?: ReadableStream<Uint8Array> | null;\n}"
+      "properties": [
+        {
+          "type": "number",
+          "name": "status"
+        },
+        {
+          "type": "() => Promise<string>",
+          "name": "text"
+        },
+        {
+          "type": "() => Promise<any>",
+          "name": "json"
+        },
+        {
+          "type": "{ get(name: string): string | null; }",
+          "name": "headers"
+        },
+        {
+          "type": "ReadableStream<Uint8Array<ArrayBufferLike>>",
+          "name": "body"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFlagsAndPayloadsResponse",
       "name": "PostHogFlagsAndPayloadsResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "\"featureFlags\" | \"featureFlagPayloads\""
+      "properties": [
+        {
+          "type": "{ [key: string]: FeatureFlagValue; }",
+          "name": "featureFlags"
+        },
+        {
+          "type": "{ [key: string]: JsonType; }",
+          "name": "featureFlagPayloads"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFlagsResponse",
       "name": "PostHogFlagsResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "Omit<PostHogRemoteConfig, 'hasFeatureFlags'> & {\n    featureFlags: {\n        [key: string]: FeatureFlagValue;\n    };\n    featureFlagPayloads: {\n        [key: string]: JsonType;\n    };\n    flags: {\n        [key: string]: FeatureFlagDetail;\n    };\n    errorsWhileComputingFlags: boolean;\n    sessionRecording?: boolean | {\n        [key: string]: JsonType;\n    };\n    quotaLimited?: string[];\n    requestId?: string;\n    evaluatedAt?: number;\n}"
+      "properties": [
+        {
+          "type": "(boolean | { [key: string]: JsonType; }) & (boolean | { [key: string]: JsonType; })",
+          "name": "sessionRecording"
+        },
+        {
+          "description": "Supported compression algorithms",
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "description": "Whether surveys are enabled",
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "description": "Error tracking remote config.\nEither a boolean (false = disabled) or a map with configuration.\nWhen a map, `autocaptureExceptions` (boolean) controls whether automatic exception capture is enabled remotely.",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "errorTracking"
+        },
+        {
+          "description": "Capture performance remote config.\nEither a boolean (false = disabled) or a map with configuration.\nWhen a map, `network_timing` (boolean) controls whether network timing capture is enabled remotely.",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "capturePerformance"
+        },
+        {
+          "description": "Logs feature remote config. When a map, `captureConsoleLogs` (boolean)\nis the local opt-in flag for `console.*` autocapture (read by the JS\nSDK's `PostHogLogs` extension to decide whether to load the autocapture\nbundle).",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "logs"
+        },
+        {
+          "type": "{ [key: string]: FeatureFlagValue; }",
+          "name": "featureFlags"
+        },
+        {
+          "type": "{ [key: string]: JsonType; }",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "{ [key: string]: FeatureFlagDetail; }",
+          "name": "flags"
+        },
+        {
+          "type": "boolean",
+          "name": "errorsWhileComputingFlags"
+        },
+        {
+          "type": "string[]",
+          "name": "quotaLimited"
+        },
+        {
+          "type": "string",
+          "name": "requestId"
+        },
+        {
+          "type": "number",
+          "name": "evaluatedAt"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogOptions",
       "name": "PostHogOptions",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "Omit<PostHogCoreOptions, 'before_send' | 'maxQueueSize'> & {\n    persistence?: 'memory';\n    maxQueueSize?: number;\n    metrics?: MetricsConfig;\n    secretKey?: string;\n    personalApiKey?: string;\n    privacyMode?: boolean;\n    enableExceptionAutocapture?: boolean;\n    featureFlagsPollingInterval?: number;\n    maxCacheSize?: number;\n    fetch?: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>;\n    enableLocalEvaluation?: boolean;\n    flagDefinitionCacheProvider?: FlagDefinitionCacheProvider;\n    before_send?: BeforeSendFn | BeforeSendFn[];\n    evaluationContexts?: readonly string[];\n    evaluationEnvironments?: readonly string[];\n    custom_blocked_useragents?: string[];\n    __preview_capture_bot_pageviews?: boolean;\n    strictLocalEvaluation?: boolean;\n    featureFlagsLogWarnings?: boolean;\n    waitUntil?: (promise: Promise<unknown>) => void;\n    waitUntilDebounceMs?: number;\n    waitUntilMaxWaitMs?: number;\n    isServer?: boolean;\n} & ExceptionRateLimiterConfig"
+      "properties": [
+        {
+          "description": "Whether to disable GeoIP lookups",
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "description": "PostHog API host, usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'",
+          "type": "string",
+          "name": "host"
+        },
+        {
+          "description": "The number of events to queue before sending to PostHog (flushing)",
+          "type": "number",
+          "name": "flushAt"
+        },
+        {
+          "description": "The interval in milliseconds between periodic flushes",
+          "type": "number",
+          "name": "flushInterval"
+        },
+        {
+          "description": "The maximum number of queued messages to be flushed as part of a single batch (must be higher than `flushAt`)",
+          "type": "number",
+          "name": "maxBatchSize"
+        },
+        {
+          "description": "If set to true the SDK is essentially disabled (useful for local environments where you don't want to track anything)",
+          "type": "boolean",
+          "name": "disabled"
+        },
+        {
+          "description": "If set to false the SDK will not track until the `optIn` function is called.",
+          "type": "boolean",
+          "name": "defaultOptIn"
+        },
+        {
+          "description": "Whether to strip URL fragments (`#...`) from automatically captured URL fields.\nDisabled by default for backwards compatibility. Set to `true` to strip hashes from:\n\n- `$current_url` on automatically captured browser events, including `$pageview`\n- `$initial_current_url`\n- `$session_entry_url`\n- `$elements[*].attr__href` and `$external_click_url` for autocapture and dead-click autocapture\n- Next.js Pages Router `$pageview` `$current_url`\n- web vitals `$current_url`\n- logs `url.full`\n- conversations `current_url` and `request_url`\n- session replay rrweb meta/custom-event `href` URLs\n- heatmap data URLs\n\nIf your SPA relies on hash-based routes for analytics, enabling this is a breaking behavior change.\nIf you want to capture hashes selectively, leave this as `false` and use `before_send` to remove\nsensitive hash values before events are sent.",
+          "type": "boolean",
+          "name": "disable_capture_url_hashes"
+        },
+        {
+          "description": "Whether to track that `getFeatureFlag` was called (used by Experiments)",
+          "type": "boolean",
+          "name": "sendFeatureFlagEvent"
+        },
+        {
+          "description": "Whether to load feature flags when initialized or not",
+          "type": "boolean",
+          "name": "preloadFeatureFlags"
+        },
+        {
+          "description": "Advanced: whether to disable fetching and evaluating feature flags from PostHog entirely.\n\nWhen set to true, `reloadFeatureFlags()` and the reloads triggered by `identify()`,\n`group()`, `setPersonPropertiesForFlags()` and `reset()` become no-ops, and any request\nto the flags endpoint that still goes out (e.g. to fetch remote config or surveys)\ncarries `disable_flags: true` so the server skips flag evaluation. Flag values must be\nsupplied via the `bootstrap` option or `updateFlags()` instead; `getFeatureFlag()` and\nrelated methods keep working against those values. Until `updateFlags()` runs, reads\nreturn their not-loaded defaults, so use `bootstrap` for any flags needed at startup.\nEquivalent to the web SDK's `advanced_disable_feature_flags`.\n\nNote: surveys gated on feature flags will not evaluate unless the survey targeting\nflags are also provided via `updateFlags()`. This option cannot be toggled at runtime.\n`posthog-node` inherits this option but does not implement it (no-op).",
+          "type": "boolean",
+          "name": "disableRemoteFeatureFlags"
+        },
+        {
+          "description": "Whether to load remote config when initialized or not",
+          "type": "boolean",
+          "name": "disableRemoteConfig"
+        },
+        {
+          "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
+          "type": "boolean",
+          "name": "disableSurveys"
+        },
+        {
+          "description": "Option to bootstrap the library with given distinctId and feature flags",
+          "type": "{ distinctId?: string; isIdentifiedId?: boolean; featureFlags?: Record<string, FeatureFlagValue>; featureFlagPayloads?: Record<string, JsonType>; }",
+          "name": "bootstrap"
+        },
+        {
+          "description": "How many times we will retry HTTP requests",
+          "type": "number",
+          "name": "fetchRetryCount"
+        },
+        {
+          "description": "The delay between HTTP request retries in milliseconds",
+          "type": "number",
+          "name": "fetchRetryDelay"
+        },
+        {
+          "description": "Timeout in milliseconds for any calls",
+          "type": "number",
+          "name": "requestTimeout"
+        },
+        {
+          "description": "Timeout in milliseconds for feature flag calls",
+          "type": "number",
+          "name": "featureFlagsRequestTimeoutMs"
+        },
+        {
+          "description": "How many times feature flag requests retry after a transient network error.\nSet to 0 to disable feature flag request retries.",
+          "type": "number",
+          "name": "featureFlagsRequestMaxRetries"
+        },
+        {
+          "description": "Timeout in milliseconds for remote config calls",
+          "type": "number",
+          "name": "remoteConfigRequestTimeoutMs"
+        },
+        {
+          "description": "For Session Analysis how long before we expire a session in seconds",
+          "type": "number",
+          "name": "sessionExpirationTimeSeconds"
+        },
+        {
+          "description": "Whether to disable GZIP compression",
+          "type": "boolean",
+          "name": "disableCompression"
+        },
+        {
+          "description": "Special flag to indicate ingested data is for a historical migration",
+          "type": "boolean",
+          "name": "historicalMigration"
+        },
+        {
+          "description": "Evaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'web', 'mobile']\nEvaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'backend', 'api']",
+          "type": "readonly string[]",
+          "name": "evaluationContexts"
+        },
+        {
+          "description": "Evaluation environments for feature flags.",
+          "type": "readonly string[]",
+          "name": "evaluationEnvironments"
+        },
+        {
+          "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
+          "type": "\"always\" | \"identified_only\" | \"never\"",
+          "name": "personProfiles"
+        },
+        {
+          "description": "A list of hostnames for which to inject PostHog tracing headers\n(X-POSTHOG-DISTINCT-ID, X-POSTHOG-SESSION-ID) on outgoing `fetch` requests.\n\nUse this to link requests made from your app to session replays and LLM traces\nin PostHog. When set, the global `fetch` is patched on initialization and the\nheaders are added to requests whose hostname matches one of the entries.\n\nRequires the SDK to wire up `patchFetchForTracingHeaders` against this option\n(currently supported in posthog-react-native).",
+          "type": "string[]",
+          "name": "addTracingHeaders"
+        },
+        {
+          "type": "\"memory\"",
+          "name": "persistence"
+        },
+        {
+          "description": "The maximum number of cached messages either in memory or on the local storage (must be higher than `flushAt`)",
+          "type": "number",
+          "name": "maxQueueSize"
+        },
+        {
+          "description": "Configuration for the `posthog.metrics` API (count, gauge, histogram).\nSet `serviceName` so series can be filtered per service in the Metrics UI.",
+          "type": "MetricsConfig",
+          "name": "metrics"
+        },
+        {
+          "description": "Credential that enables local feature flag evaluation and remote config.\n\nAccepts either a Personal API Key (`phx_...`) or a Project Secret API Key (`phs_...`).\nWhen provided, the client can evaluate feature flags locally and decrypt remote\nconfig payloads via `getRemoteConfigPayload`. Prefer this over the deprecated\n`personalApiKey` option; when both are set, `secretKey` takes precedence.",
+          "type": "string",
+          "name": "secretKey"
+        },
+        {
+          "type": "string",
+          "name": "personalApiKey"
+        },
+        {
+          "type": "boolean",
+          "name": "privacyMode"
+        },
+        {
+          "type": "boolean",
+          "name": "enableExceptionAutocapture"
+        },
+        {
+          "type": "number",
+          "name": "featureFlagsPollingInterval"
+        },
+        {
+          "type": "number",
+          "name": "maxCacheSize"
+        },
+        {
+          "type": "(url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>",
+          "name": "fetch"
+        },
+        {
+          "type": "boolean",
+          "name": "enableLocalEvaluation"
+        },
+        {
+          "description": "Optional cache provider for feature flag definitions.\n\nAllows custom caching strategies (Redis, database, etc.) for flag definitions\nin multi-worker environments. If not provided, defaults to in-memory cache.\n\nThis enables distributed coordination where only one worker fetches flags while\nothers use cached data, reducing API calls and improving performance.",
+          "type": "FlagDefinitionCacheProvider",
+          "name": "flagDefinitionCacheProvider"
+        },
+        {
+          "description": "Allows modification or dropping of events before they're sent to PostHog.\nIf an array is provided, the functions are run in order.\nIf a function returns null, the event will be dropped.",
+          "type": "BeforeSendFn | BeforeSendFn[]",
+          "name": "before_send"
+        },
+        {
+          "description": "Additional user agent strings to block from being tracked.\nThese are combined with the default list of blocked user agents.",
+          "type": "string[]",
+          "name": "custom_blocked_useragents"
+        },
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION\nEnables collection of bot traffic as $bot_pageview events instead of dropping them.\nWhen enabled, events with a $raw_user_agent property that matches the bot detection list\nwill have their $pageview event renamed to $bot_pageview.\n\nTo use this feature, pass the user agent in event properties:\n```ts\nclient.capture({\n  distinctId: 'user_123',\n  event: '$pageview',\n  properties: {\n    $raw_user_agent: req.headers['user-agent']\n  }\n})\n```",
+          "type": "boolean",
+          "name": "__preview_capture_bot_pageviews"
+        },
+        {
+          "description": "When enabled, all feature flag evaluations will use local evaluation only,\nnever falling back to server-side evaluation. This prevents unexpected server\nrequests and associated costs when using local evaluation.\n\nFlags that cannot be evaluated locally (e.g., those with experience continuity)\nwill return `undefined` instead of making a server request.",
+          "type": "boolean",
+          "name": "strictLocalEvaluation"
+        },
+        {
+          "description": "Controls whether `FeatureFlagEvaluations` filter helpers (`onlyAccessed()` and\n`only()`) log warnings when their input is unexpected — for example, calling\n`onlyAccessed()` before accessing any flags, or passing unknown keys to `only()`.",
+          "type": "boolean",
+          "name": "featureFlagsLogWarnings"
+        },
+        {
+          "description": "Provides the API to extend the lifetime of a serverless invocation until\nbackground work (like flushing analytics events) completes after the response\nis sent.",
+          "type": "(promise: Promise<unknown>) => void",
+          "name": "waitUntil"
+        },
+        {
+          "description": "Debounce interval in milliseconds for the `waitUntil`-based flush.\nAfter the last event is enqueued, the SDK waits this long before flushing.",
+          "type": "number",
+          "name": "waitUntilDebounceMs"
+        },
+        {
+          "description": "Maximum time in milliseconds to debounce before forcing a flush.\nPrevents starvation from rapid concurrent captures.",
+          "type": "number",
+          "name": "waitUntilMaxWaitMs"
+        },
+        {
+          "description": "Whether to attach the `$is_server: true` property to every captured event.",
+          "type": "boolean",
+          "name": "isServer"
+        },
+        {
+          "description": "ADVANCED: alters the refill rate for the error tracking rate limiter's token bucket.\nNormally only altered alongside PostHog support guidance.\nAccepts values between 0 and 100.",
+          "type": "number",
+          "name": "exceptionRateLimiterRefillRate"
+        },
+        {
+          "description": "ADVANCED: alters the bucket size for the error tracking rate limiter's token bucket.\nNormally only altered alongside PostHog support guidance.\nAccepts values between 0 and 100.",
+          "type": "number",
+          "name": "exceptionRateLimiterBucketSize"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "PostHogPersistedProperty",
@@ -2469,9 +3608,43 @@
     {
       "id": "PostHogRemoteConfig",
       "name": "PostHogRemoteConfig",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    sessionRecording?: boolean | {\n        [key: string]: JsonType;\n    };\n    supportedCompression?: Compression[];\n    surveys?: boolean | Survey[];\n    hasFeatureFlags?: boolean;\n    errorTracking?: boolean | {\n        [key: string]: JsonType;\n    };\n    capturePerformance?: boolean | {\n        [key: string]: JsonType;\n    };\n    logs?: boolean | {\n        [key: string]: JsonType;\n    };\n}"
+      "properties": [
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "sessionRecording"
+        },
+        {
+          "description": "Supported compression algorithms",
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "description": "Whether surveys are enabled",
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "description": "Indicates if the team has any flags enabled (if not we don't need to load them)",
+          "type": "boolean",
+          "name": "hasFeatureFlags"
+        },
+        {
+          "description": "Error tracking remote config.\nEither a boolean (false = disabled) or a map with configuration.\nWhen a map, `autocaptureExceptions` (boolean) controls whether automatic exception capture is enabled remotely.",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "errorTracking"
+        },
+        {
+          "description": "Capture performance remote config.\nEither a boolean (false = disabled) or a map with configuration.\nWhen a map, `network_timing` (boolean) controls whether network timing capture is enabled remotely.",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "capturePerformance"
+        },
+        {
+          "description": "Logs feature remote config. When a map, `captureConsoleLogs` (boolean)\nis the local opt-in flag for `console.*` autocapture (read by the JS\nSDK's `PostHogLogs` extension to decide whether to load the autocapture\nbundle).",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "logs"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PreviouslyCapturedError",
@@ -2505,16 +3678,88 @@
     {
       "id": "PropertyGroup",
       "name": "PropertyGroup",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    type: 'AND' | 'OR';\n    values: PropertyGroup[] | FlagProperty[];\n}"
+      "properties": [
+        {
+          "type": "\"AND\" | \"OR\"",
+          "name": "type"
+        },
+        {
+          "type": "FlagProperty[] | PropertyGroup[]",
+          "name": "values"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "RatingSurveyQuestion",
       "name": "RatingSurveyQuestion",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Rating;\n    display: SurveyRatingDisplay;\n    scale: 2 | 3 | 5 | 7 | 10;\n    lowerBoundLabel: string;\n    upperBoundLabel: string;\n    skipSubmitButton?: boolean;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "\"rating\"",
+          "name": "type"
+        },
+        {
+          "type": "SurveyRatingDisplay",
+          "name": "display"
+        },
+        {
+          "type": "2 | 3 | 5 | 7 | 10",
+          "name": "scale"
+        },
+        {
+          "type": "string",
+          "name": "lowerBoundLabel"
+        },
+        {
+          "type": "string",
+          "name": "upperBoundLabel"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "RejectionLike",
@@ -2526,16 +3771,32 @@
     {
       "id": "ResolvedExceptionStepsConfig",
       "name": "ResolvedExceptionStepsConfig",
-      "properties": [],
-      "path": "../core/src/error-tracking/exception-steps.ts",
-      "example": "{\n    enabled: boolean;\n    max_bytes: number;\n}"
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "type": "number",
+          "name": "max_bytes"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ResponseBasedBranching",
       "name": "ResponseBasedBranching",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: typeof SurveyQuestionBranchingType.ResponseBased;\n    responseValues: Record<string, any>;\n}"
+      "properties": [
+        {
+          "type": "\"response_based\"",
+          "name": "type"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "responseValues"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "RetriableOptions",
@@ -2559,9 +3820,25 @@
     {
       "id": "SendFeatureFlagsOptions",
       "name": "SendFeatureFlagsOptions",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    onlyEvaluateLocally?: boolean;\n    personProperties?: Record<string, any>;\n    groupProperties?: Record<string, Record<string, any>>;\n    flagKeys?: string[];\n}"
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "onlyEvaluateLocally"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "personProperties"
+        },
+        {
+          "type": "Record<string, Record<string, any>>",
+          "name": "groupProperties"
+        },
+        {
+          "type": "string[]",
+          "name": "flagKeys"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "SendLogsBatchOutcome",
@@ -2580,16 +3857,48 @@
     {
       "id": "SentryIntegrationOptions",
       "name": "SentryIntegrationOptions",
-      "properties": [],
-      "path": "src/extensions/sentry-integration.ts",
-      "example": "{\n    organization?: string;\n    projectId?: number;\n    prefix?: string;\n    severityAllowList?: CoreErrorTracking.SeverityLevel[] | '*';\n    sendExceptionsToPostHog?: boolean;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "organization"
+        },
+        {
+          "type": "number",
+          "name": "projectId"
+        },
+        {
+          "type": "string",
+          "name": "prefix"
+        },
+        {
+          "type": "(\"fatal\" | \"error\" | \"warning\" | \"log\" | \"info\" | \"debug\")[] | \"*\"",
+          "name": "severityAllowList"
+        },
+        {
+          "type": "boolean",
+          "name": "sendExceptionsToPostHog"
+        }
+      ],
+      "path": "src/extensions/sentry-integration.ts"
     },
     {
       "id": "SetPersonPropertiesMessage",
       "name": "SetPersonPropertiesMessage",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    distinctId: string;\n    properties?: Record<string | number, any>;\n    propertiesOnce?: Record<string | number, any>;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "Record<string | number, any>",
+          "name": "properties"
+        },
+        {
+          "type": "Record<string | number, any>",
+          "name": "propertiesOnce"
+        }
+      ],
+      "path": "src/types.ts"
     },
     {
       "id": "SeverityLevel",
@@ -2601,9 +3910,17 @@
     {
       "id": "SpecificQuestionBranching",
       "name": "SpecificQuestionBranching",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: typeof SurveyQuestionBranchingType.SpecificQuestion;\n    index: number;\n}"
+      "properties": [
+        {
+          "type": "\"specific_question\"",
+          "name": "type"
+        },
+        {
+          "type": "number",
+          "name": "index"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "StackFrame",
@@ -2696,23 +4013,207 @@
     {
       "id": "Survey",
       "name": "Survey",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    id: string;\n    name: string;\n    description?: string;\n    type: SurveyType;\n    translations?: Record<string, SurveyTranslation>;\n    feature_flag_keys?: {\n        key: string;\n        value?: string;\n    }[];\n    linked_flag_key?: string;\n    targeting_flag_key?: string;\n    internal_targeting_flag_key?: string;\n    questions: SurveyQuestion[];\n    appearance?: SurveyAppearance;\n    conditions?: {\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: SurveyMatchType;\n        events?: {\n            repeatedActivation?: boolean;\n            values?: {\n                name: string;\n            }[];\n        };\n        actions?: {\n            values: SurveyActionType[];\n        };\n        deviceTypes?: string[];\n        deviceTypesMatchType?: SurveyMatchType;\n        linkedFlagVariant?: string;\n    };\n    start_date?: string;\n    end_date?: string;\n    current_iteration?: number | null;\n    current_iteration_start_date?: string | null;\n    schedule?: SurveySchedule | null;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyType",
+          "name": "type"
+        },
+        {
+          "type": "Record<string, SurveyTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "{ key: string; value?: string; }[]",
+          "name": "feature_flag_keys"
+        },
+        {
+          "type": "string",
+          "name": "linked_flag_key"
+        },
+        {
+          "type": "string",
+          "name": "targeting_flag_key"
+        },
+        {
+          "type": "string",
+          "name": "internal_targeting_flag_key"
+        },
+        {
+          "type": "SurveyQuestion[]",
+          "name": "questions"
+        },
+        {
+          "type": "SurveyAppearance",
+          "name": "appearance"
+        },
+        {
+          "type": "{ url?: string; selector?: string; seenSurveyWaitPeriodInDays?: number; urlMatchType?: SurveyMatchType; events?: { repeatedActivation?: boolean; values?: { name: string; }[]; }; actions?: { values: SurveyActionType[]; }; deviceTypes?: string[]; deviceTypesMatchType?: SurveyMatchType; linkedFlagVariant?: string; }",
+          "name": "conditions"
+        },
+        {
+          "type": "string",
+          "name": "start_date"
+        },
+        {
+          "type": "string",
+          "name": "end_date"
+        },
+        {
+          "type": "number",
+          "name": "current_iteration"
+        },
+        {
+          "type": "string",
+          "name": "current_iteration_start_date"
+        },
+        {
+          "type": "SurveySchedule",
+          "name": "schedule"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyActionType",
       "name": "SurveyActionType",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    id: number;\n    name?: string;\n    steps?: ActionStepType[];\n}"
+      "properties": [
+        {
+          "type": "number",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "ActionStepType[]",
+          "name": "steps"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyAppearance",
       "name": "SurveyAppearance",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    backgroundColor?: string;\n    textColor?: string;\n    submitButtonColor?: string;\n    submitButtonText?: string;\n    submitButtonTextColor?: string;\n    ratingButtonColor?: string;\n    ratingButtonActiveColor?: string;\n    inputBackground?: string;\n    inputTextColor?: string;\n    autoDisappear?: boolean;\n    displayThankYouMessage?: boolean;\n    thankYouMessageHeader?: string;\n    thankYouMessageDescription?: string;\n    thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType;\n    thankYouMessageCloseButtonText?: string;\n    borderColor?: string;\n    position?: SurveyPosition;\n    placeholder?: string;\n    shuffleQuestions?: boolean;\n    surveyPopupDelaySeconds?: number;\n    allowGoBack?: boolean;\n    backButtonText?: string;\n    widgetType?: SurveyWidgetType;\n    widgetSelector?: string;\n    widgetLabel?: string;\n    widgetColor?: string;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "backgroundColor"
+        },
+        {
+          "type": "string",
+          "name": "textColor"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonText"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonTextColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonActiveColor"
+        },
+        {
+          "type": "string",
+          "name": "inputBackground"
+        },
+        {
+          "type": "string",
+          "name": "inputTextColor"
+        },
+        {
+          "type": "boolean",
+          "name": "autoDisappear"
+        },
+        {
+          "type": "boolean",
+          "name": "displayThankYouMessage"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageHeader"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageDescription"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "thankYouMessageDescriptionContentType"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageCloseButtonText"
+        },
+        {
+          "type": "string",
+          "name": "borderColor"
+        },
+        {
+          "type": "SurveyPosition",
+          "name": "position"
+        },
+        {
+          "type": "string",
+          "name": "placeholder"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleQuestions"
+        },
+        {
+          "type": "number",
+          "name": "surveyPopupDelaySeconds"
+        },
+        {
+          "type": "boolean",
+          "name": "allowGoBack"
+        },
+        {
+          "type": "string",
+          "name": "backButtonText"
+        },
+        {
+          "type": "SurveyWidgetType",
+          "name": "widgetType"
+        },
+        {
+          "type": "string",
+          "name": "widgetSelector"
+        },
+        {
+          "type": "string",
+          "name": "widgetLabel"
+        },
+        {
+          "type": "string",
+          "name": "widgetColor"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyMatchType",
@@ -2738,9 +4239,49 @@
     {
       "id": "SurveyQuestionBase",
       "name": "SurveyQuestionBase",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    question: string;\n    id: string;\n    description?: string | null;\n    descriptionContentType?: SurveyQuestionDescriptionContentType;\n    optional?: boolean;\n    buttonText?: string;\n    originalQuestionIndex: number;\n    branching?: NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching;\n    validation?: SurveyValidationRule[];\n    translations?: Record<string, SurveyQuestionTranslation>;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyQuestionBranchingType",
@@ -2808,9 +4349,13 @@
     {
       "id": "SurveyResponse",
       "name": "SurveyResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    surveys: Survey[];\n}"
+      "properties": [
+        {
+          "type": "Survey[]",
+          "name": "surveys"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveySchedule",
@@ -2893,9 +4438,17 @@
     {
       "id": "UnsetPersonPropertiesMessage",
       "name": "UnsetPersonPropertiesMessage",
-      "properties": [],
-      "path": "src/types.ts",
-      "example": "{\n    distinctId: string;\n    properties: string | string[];\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "string | string[]",
+          "name": "properties"
+        }
+      ],
+      "path": "src/types.ts"
     }
   ],
   "categories": [

--- a/packages/node/scripts/generate-docs.mjs
+++ b/packages/node/scripts/generate-docs.mjs
@@ -38,6 +38,7 @@ const NODE_TYPE_EXAMPLES = {
 const config = {
   packageDir: path.resolve(import.meta.dirname, '..'), // packages/node
   apiJsonPath: path.resolve(import.meta.dirname, '../docs/posthog-node.api.json'),
+  dtsEntryPath: path.resolve(import.meta.dirname, '../dist/entrypoints/index.node.d.ts'),
   outputPath: path.resolve(import.meta.dirname, `../references/posthog-node-references-${version}.json`),
   version: version,
   id: NODE_SPEC_INFO.id,

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -3887,12 +3887,12 @@
       "name": "PostHogReactNativePluginExtended",
       "properties": [
         {
-          "type": "((sessionId: string, sdkOptions: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap, pluginConfig?: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginConfig) => Promise<void>) & ((sessionId: string, sdkOptions: { [key: string]: any; }, pluginConfig: { [key: string]: any; }) => Promise<void>)",
+          "type": "((sessionId: string, sdkOptions: PostHogReactNativePluginMap, pluginConfig?: PostHogReactNativePluginConfig) => Promise<void>) & ((sessionId: string, sdkOptions: { [key: string]: any; }, pluginConfig: { [key: string]: any; }) => Promise<void>)",
           "name": "setup"
         },
         {
           "description": "Legacy session replay setup entrypoint. Prefer setup() for new native features.",
-          "type": "(sessionId: string, sdkOptions: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap, sdkReplayConfig: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap, decideReplayConfig: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap) => Promise<void>",
+          "type": "(sessionId: string, sdkOptions: PostHogReactNativePluginMap, sdkReplayConfig: PostHogReactNativePluginMap, decideReplayConfig: PostHogReactNativePluginMap) => Promise<void>",
           "name": "start"
         },
         {
@@ -3920,7 +3920,7 @@
           "name": "stopRecording"
         },
         {
-          "type": "((message: string, properties?: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap) => Promise<void>) & ((message: string, properties?: { [key: string]: any; }) => Promise<void>)",
+          "type": "((message: string, properties?: PostHogReactNativePluginMap) => Promise<void>) & ((message: string, properties?: { [key: string]: any; }) => Promise<void>)",
           "name": "addExceptionStep"
         }
       ],
@@ -4607,7 +4607,7 @@
           "name": "borderColor"
         },
         {
-          "type": "import(\"/Users/anna/Develop/posthog-js/packages/core/dist/types\").SurveyPosition",
+          "type": "SurveyPosition",
           "name": "position"
         },
         {

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2088,9 +2088,41 @@
     {
       "id": "ActionStepType",
       "name": "ActionStepType",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    event?: string;\n    selector?: string;\n    text?: string;\n    text_matching?: ActionStepStringMatching;\n    href?: string;\n    href_matching?: ActionStepStringMatching;\n    url?: string;\n    url_matching?: ActionStepStringMatching;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "event"
+        },
+        {
+          "type": "string",
+          "name": "selector"
+        },
+        {
+          "type": "string",
+          "name": "text"
+        },
+        {
+          "type": "ActionStepStringMatching",
+          "name": "text_matching"
+        },
+        {
+          "type": "string",
+          "name": "href"
+        },
+        {
+          "type": "ActionStepStringMatching",
+          "name": "href_matching"
+        },
+        {
+          "type": "string",
+          "name": "url"
+        },
+        {
+          "type": "ActionStepStringMatching",
+          "name": "url_matching"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "AutocaptureOptions",
@@ -2138,9 +2170,53 @@
     {
       "id": "BasicSurveyQuestion",
       "name": "BasicSurveyQuestion",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Open;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "\"open\"",
+          "name": "type"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "BeforeSendFn",
@@ -2152,9 +2228,39 @@
     {
       "id": "CaptureEvent",
       "name": "CaptureEvent",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    uuid?: string;\n    event: string;\n    properties?: PostHogEventProperties;\n    $set?: PostHogEventProperties;\n    $set_once?: PostHogEventProperties;\n    timestamp?: Date;\n}"
+      "properties": [
+        {
+          "description": "UUID for the event (optional to allow compatibility with Node SDK's EventMessage). Must be a valid UUID.",
+          "type": "string",
+          "name": "uuid"
+        },
+        {
+          "description": "The name of the event",
+          "type": "string",
+          "name": "event"
+        },
+        {
+          "description": "Properties associated with the event (optional to allow compatibility with Node SDK's EventMessage)",
+          "type": "PostHogEventProperties",
+          "name": "properties"
+        },
+        {
+          "description": "Properties to set on the person (overrides existing values)",
+          "type": "PostHogEventProperties",
+          "name": "$set"
+        },
+        {
+          "description": "Properties to set on the person only once (does not override existing values)",
+          "type": "PostHogEventProperties",
+          "name": "$set_once"
+        },
+        {
+          "description": "Timestamp for the event",
+          "type": "Date",
+          "name": "timestamp"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "CaptureLogger",
@@ -2208,9 +2314,13 @@
     {
       "id": "EndBranching",
       "name": "EndBranching",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: typeof SurveyQuestionBranchingType.End;\n}"
+      "properties": [
+        {
+          "type": "\"end\"",
+          "name": "type"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "ErrorEventLike",
@@ -2355,21 +2465,38 @@
       "id": "ExceptionList",
       "name": "ExceptionList",
       "properties": [],
-      "path": "../core/src/error-tracking/types.ts"
+      "path": "../core/src/error-tracking/types.ts",
+      "example": "Exception[]"
     },
     {
       "id": "ExceptionStep",
       "name": "ExceptionStep",
-      "properties": [],
-      "path": "../core/src/error-tracking/exception-steps.ts",
-      "example": "{\n    [EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE]: string;\n    [EXCEPTION_STEP_INTERNAL_FIELDS.TIMESTAMP]: string | number;\n    [key: string]: unknown;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "$message"
+        },
+        {
+          "type": "string | number",
+          "name": "$timestamp"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ExceptionStepsConfig",
       "name": "ExceptionStepsConfig",
-      "properties": [],
-      "path": "../core/src/error-tracking/exception-steps.ts",
-      "example": "{\n    enabled?: boolean;\n    max_bytes?: number;\n}"
+      "properties": [
+        {
+          "type": "boolean | undefined",
+          "name": "enabled"
+        },
+        {
+          "type": "number | undefined",
+          "name": "max_bytes"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ExceptionStepsOptions",
@@ -2405,23 +2532,52 @@
     {
       "id": "FeatureFlagRequestError",
       "name": "FeatureFlagRequestError",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: 'timeout' | 'connection_error' | 'api_error' | 'unknown_error';\n    statusCode?: number;\n}"
+      "properties": [
+        {
+          "type": "\"timeout\" | \"connection_error\" | \"api_error\" | \"unknown_error\"",
+          "name": "type"
+        },
+        {
+          "type": "number",
+          "name": "statusCode"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "FeatureFlagResult",
       "name": "FeatureFlagResult",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    readonly key: string;\n    readonly enabled: boolean;\n    readonly variant?: string;\n    readonly payload?: JsonType;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "readonly key"
+        },
+        {
+          "type": "boolean",
+          "name": "readonly enabled"
+        },
+        {
+          "type": "string | undefined",
+          "name": "readonly variant"
+        },
+        {
+          "type": "JsonType | undefined",
+          "name": "readonly payload"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "FeatureFlagResultOptions",
       "name": "FeatureFlagResultOptions",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    sendEvent?: boolean;\n}"
+      "properties": [
+        {
+          "description": "Whether to send a $feature_flag_called event. Defaults to true.",
+          "type": "boolean",
+          "name": "sendEvent"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "FeatureFlagValue",
@@ -2480,16 +2636,88 @@
     {
       "id": "LinkSurveyQuestion",
       "name": "LinkSurveyQuestion",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Link;\n    link?: string | null;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "\"link\"",
+          "name": "type"
+        },
+        {
+          "type": "string",
+          "name": "link"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "Logger",
       "name": "Logger",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    debug: (...args: any[]) => void;\n    info: (...args: any[]) => void;\n    warn: (...args: any[]) => void;\n    error: (...args: any[]) => void;\n    critical: (...args: any[]) => void;\n    createLogger: (prefix: string) => Logger;\n}"
+      "properties": [
+        {
+          "type": "(...args: any[]) => void",
+          "name": "debug"
+        },
+        {
+          "type": "(...args: any[]) => void",
+          "name": "info"
+        },
+        {
+          "type": "(...args: any[]) => void",
+          "name": "warn"
+        },
+        {
+          "type": "(...args: any[]) => void",
+          "name": "error"
+        },
+        {
+          "type": "(...args: any[]) => void",
+          "name": "critical"
+        },
+        {
+          "type": "(prefix: string) => Logger",
+          "name": "createLogger"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "LogLevel",
@@ -2524,16 +2752,80 @@
     {
       "id": "MultipleSurveyQuestion",
       "name": "MultipleSurveyQuestion",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.SingleChoice | typeof SurveyQuestionType.MultipleChoice;\n    choices: string[];\n    hasOpenChoice?: boolean;\n    shuffleOptions?: boolean;\n    skipSubmitButton?: boolean;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "\"single_choice\" | \"multiple_choice\"",
+          "name": "type"
+        },
+        {
+          "type": "string[]",
+          "name": "choices"
+        },
+        {
+          "type": "boolean",
+          "name": "hasOpenChoice"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleOptions"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "NextQuestionBranching",
       "name": "NextQuestionBranching",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: typeof SurveyQuestionBranchingType.NextQuestion;\n}"
+      "properties": [
+        {
+          "type": "\"next_question\"",
+          "name": "type"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "ObjectLike",
@@ -2608,37 +2900,278 @@
     {
       "id": "PostHogAutocaptureElement",
       "name": "PostHogAutocaptureElement",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    $el_text?: string;\n    tag_name: string;\n    href?: string;\n    nth_child?: number;\n    nth_of_type?: number;\n    order?: number;\n} & PostHogEventProperties"
+      "properties": [
+        {
+          "type": "string",
+          "name": "$el_text"
+        },
+        {
+          "type": "string",
+          "name": "tag_name"
+        },
+        {
+          "type": "string",
+          "name": "href"
+        },
+        {
+          "type": "number",
+          "name": "nth_child"
+        },
+        {
+          "type": "number",
+          "name": "nth_of_type"
+        },
+        {
+          "type": "number",
+          "name": "order"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogAutocaptureNavigationTrackerOptions",
       "name": "PostHogAutocaptureNavigationTrackerOptions",
-      "properties": [],
-      "path": "dist/types.d.ts",
-      "example": "{\n    routeToName?: (name: string, params: any) => string;\n    routeToProperties?: (name: string, params: any) => Record<string, any>;\n}"
+      "properties": [
+        {
+          "type": "(name: string, params: any) => string",
+          "name": "routeToName"
+        },
+        {
+          "type": "(name: string, params: any) => Record<string, any>",
+          "name": "routeToProperties"
+        }
+      ],
+      "path": "dist/types.d.ts"
     },
     {
       "id": "PostHogAutocaptureOptions",
       "name": "PostHogAutocaptureOptions",
-      "properties": [],
-      "path": "dist/types.d.ts",
-      "example": "{\n    captureTouches?: boolean;\n    customLabelProp?: string;\n    noCaptureProp?: string;\n    maxElementsCaptured?: number;\n    ignoreLabels?: string[];\n    propsToCapture?: string[];\n    captureScreens?: boolean;\n    navigation?: PostHogAutocaptureNavigationTrackerOptions;\n    navigationRef?: PostHogNavigationRef;\n}"
+      "properties": [
+        {
+          "description": "Enable autocapture of touch events",
+          "type": "boolean",
+          "name": "captureTouches"
+        },
+        {
+          "description": "Custom prop name used to label elements for autocapture",
+          "type": "string",
+          "name": "customLabelProp"
+        },
+        {
+          "description": "Prop name used to prevent autocapture on an element and its children",
+          "type": "string",
+          "name": "noCaptureProp"
+        },
+        {
+          "description": "Maximum number of elements to capture in the component tree hierarchy",
+          "type": "number",
+          "name": "maxElementsCaptured"
+        },
+        {
+          "description": "List of element labels to ignore during autocapture",
+          "type": "string[]",
+          "name": "ignoreLabels"
+        },
+        {
+          "description": "List of prop names to capture from elements",
+          "type": "string[]",
+          "name": "propsToCapture"
+        },
+        {
+          "description": "Capture the screen name (or route name) and properties\n\nOnly used for expo-router,",
+          "type": "boolean",
+          "name": "captureScreens"
+        },
+        {
+          "description": "Used for mutating the screen name and properties\nOnly used if captureScreens is true",
+          "type": "PostHogAutocaptureNavigationTrackerOptions",
+          "name": "navigation"
+        },
+        {
+          "description": "If you create a navigation ref with createNavigationContainerRef, you need to pass the navigation ref\nOnly used for expo-router and",
+          "type": "PostHogNavigationRef",
+          "name": "navigationRef"
+        }
+      ],
+      "path": "dist/types.d.ts"
     },
     {
       "id": "PostHogCaptureOptions",
       "name": "PostHogCaptureOptions",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    uuid?: string;\n    timestamp?: Date;\n    disableGeoip?: boolean;\n    _originatedFromCaptureException?: boolean;\n}"
+      "properties": [
+        {
+          "description": "If provided overrides the auto-generated event UUID. Must be a valid UUID.",
+          "type": "string",
+          "name": "uuid"
+        },
+        {
+          "description": "If provided overrides the auto-generated timestamp",
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "description": "Internal flag set by captureException() to indicate this $exception\nevent originated from the proper exception capture path. Used to warn users who call\ncapture('$exception') directly.",
+          "type": "boolean",
+          "name": "_originatedFromCaptureException"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogCoreOptions",
       "name": "PostHogCoreOptions",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    host?: string;\n    flushAt?: number;\n    flushInterval?: number;\n    maxBatchSize?: number;\n    maxQueueSize?: number;\n    disabled?: boolean;\n    defaultOptIn?: boolean;\n    disable_capture_url_hashes?: boolean;\n    sendFeatureFlagEvent?: boolean;\n    preloadFeatureFlags?: boolean;\n    disableRemoteFeatureFlags?: boolean;\n    disableRemoteConfig?: boolean;\n    disableSurveys?: boolean;\n    bootstrap?: {\n        distinctId?: string;\n        isIdentifiedId?: boolean;\n        featureFlags?: Record<string, FeatureFlagValue>;\n        featureFlagPayloads?: Record<string, JsonType>;\n    };\n    fetchRetryCount?: number;\n    fetchRetryDelay?: number;\n    requestTimeout?: number;\n    featureFlagsRequestTimeoutMs?: number;\n    featureFlagsRequestMaxRetries?: number;\n    remoteConfigRequestTimeoutMs?: number;\n    sessionExpirationTimeSeconds?: number;\n    disableCompression?: boolean;\n    disableGeoip?: boolean;\n    historicalMigration?: boolean;\n    evaluationContexts?: readonly string[];\n    evaluationEnvironments?: readonly string[];\n    personProfiles?: 'always' | 'identified_only' | 'never';\n    before_send?: BeforeSendFn | BeforeSendFn[];\n    addTracingHeaders?: string[];\n}"
+      "properties": [
+        {
+          "description": "PostHog API host, usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'",
+          "type": "string",
+          "name": "host"
+        },
+        {
+          "description": "The number of events to queue before sending to PostHog (flushing)",
+          "type": "number",
+          "name": "flushAt"
+        },
+        {
+          "description": "The interval in milliseconds between periodic flushes",
+          "type": "number",
+          "name": "flushInterval"
+        },
+        {
+          "description": "The maximum number of queued messages to be flushed as part of a single batch (must be higher than `flushAt`)",
+          "type": "number",
+          "name": "maxBatchSize"
+        },
+        {
+          "description": "The maximum number of cached messages either in memory or on the local storage (must be higher than `flushAt`)",
+          "type": "number",
+          "name": "maxQueueSize"
+        },
+        {
+          "description": "If set to true the SDK is essentially disabled (useful for local environments where you don't want to track anything)",
+          "type": "boolean",
+          "name": "disabled"
+        },
+        {
+          "description": "If set to false the SDK will not track until the `optIn` function is called.",
+          "type": "boolean",
+          "name": "defaultOptIn"
+        },
+        {
+          "description": "Whether to strip URL fragments (`#...`) from automatically captured URL fields.\nDisabled by default for backwards compatibility. Set to `true` to strip hashes from:\n\n- `$current_url` on automatically captured browser events, including `$pageview`\n- `$initial_current_url`\n- `$session_entry_url`\n- `$elements[*].attr__href` and `$external_click_url` for autocapture and dead-click autocapture\n- Next.js Pages Router `$pageview` `$current_url`\n- web vitals `$current_url`\n- logs `url.full`\n- conversations `current_url` and `request_url`\n- session replay rrweb meta/custom-event `href` URLs\n- heatmap data URLs\n\nIf your SPA relies on hash-based routes for analytics, enabling this is a breaking behavior change.\nIf you want to capture hashes selectively, leave this as `false` and use `before_send` to remove\nsensitive hash values before events are sent.",
+          "type": "boolean",
+          "name": "disable_capture_url_hashes"
+        },
+        {
+          "description": "Whether to track that `getFeatureFlag` was called (used by Experiments)",
+          "type": "boolean",
+          "name": "sendFeatureFlagEvent"
+        },
+        {
+          "description": "Whether to load feature flags when initialized or not",
+          "type": "boolean",
+          "name": "preloadFeatureFlags"
+        },
+        {
+          "description": "Advanced: whether to disable fetching and evaluating feature flags from PostHog entirely.\n\nWhen set to true, `reloadFeatureFlags()` and the reloads triggered by `identify()`,\n`group()`, `setPersonPropertiesForFlags()` and `reset()` become no-ops, and any request\nto the flags endpoint that still goes out (e.g. to fetch remote config or surveys)\ncarries `disable_flags: true` so the server skips flag evaluation. Flag values must be\nsupplied via the `bootstrap` option or `updateFlags()` instead; `getFeatureFlag()` and\nrelated methods keep working against those values. Until `updateFlags()` runs, reads\nreturn their not-loaded defaults, so use `bootstrap` for any flags needed at startup.\nEquivalent to the web SDK's `advanced_disable_feature_flags`.\n\nNote: surveys gated on feature flags will not evaluate unless the survey targeting\nflags are also provided via `updateFlags()`. This option cannot be toggled at runtime.\n`posthog-node` inherits this option but does not implement it (no-op).",
+          "type": "boolean",
+          "name": "disableRemoteFeatureFlags"
+        },
+        {
+          "description": "Whether to load remote config when initialized or not",
+          "type": "boolean",
+          "name": "disableRemoteConfig"
+        },
+        {
+          "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
+          "type": "boolean",
+          "name": "disableSurveys"
+        },
+        {
+          "description": "Option to bootstrap the library with given distinctId and feature flags",
+          "type": "{ distinctId?: string; isIdentifiedId?: boolean; featureFlags?: Record<string, FeatureFlagValue>; featureFlagPayloads?: Record<string, JsonType>; }",
+          "name": "bootstrap"
+        },
+        {
+          "description": "How many times we will retry HTTP requests",
+          "type": "number",
+          "name": "fetchRetryCount"
+        },
+        {
+          "description": "The delay between HTTP request retries in milliseconds",
+          "type": "number",
+          "name": "fetchRetryDelay"
+        },
+        {
+          "description": "Timeout in milliseconds for any calls",
+          "type": "number",
+          "name": "requestTimeout"
+        },
+        {
+          "description": "Timeout in milliseconds for feature flag calls",
+          "type": "number",
+          "name": "featureFlagsRequestTimeoutMs"
+        },
+        {
+          "description": "How many times feature flag requests retry after a transient network error.\nSet to 0 to disable feature flag request retries.",
+          "type": "number",
+          "name": "featureFlagsRequestMaxRetries"
+        },
+        {
+          "description": "Timeout in milliseconds for remote config calls",
+          "type": "number",
+          "name": "remoteConfigRequestTimeoutMs"
+        },
+        {
+          "description": "For Session Analysis how long before we expire a session in seconds",
+          "type": "number",
+          "name": "sessionExpirationTimeSeconds"
+        },
+        {
+          "description": "Whether to disable GZIP compression",
+          "type": "boolean",
+          "name": "disableCompression"
+        },
+        {
+          "description": "Whether to disable GeoIP lookups",
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "description": "Special flag to indicate ingested data is for a historical migration",
+          "type": "boolean",
+          "name": "historicalMigration"
+        },
+        {
+          "description": "Evaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'web', 'mobile']",
+          "type": "readonly string[]",
+          "name": "evaluationContexts"
+        },
+        {
+          "description": "Evaluation environments for feature flags.",
+          "type": "readonly string[]",
+          "name": "evaluationEnvironments"
+        },
+        {
+          "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
+          "type": "\"always\" | \"identified_only\" | \"never\"",
+          "name": "personProfiles"
+        },
+        {
+          "description": "Allows modification or dropping of events before they're sent to PostHog.\nIf an array is provided, the functions are run in order.\nIf a function returns null, the event will be dropped.",
+          "type": "BeforeSendFn | BeforeSendFn[]",
+          "name": "before_send"
+        },
+        {
+          "description": "A list of hostnames for which to inject PostHog tracing headers\n(X-POSTHOG-DISTINCT-ID, X-POSTHOG-SESSION-ID) on outgoing `fetch` requests.\n\nUse this to link requests made from your app to session replays and LLM traces\nin PostHog. When set, the global `fetch` is patched on initialization and the\nheaders are added to requests whose hostname matches one of the entries.\n\nRequires the SDK to wire up `patchFetchForTracingHeaders` against this option\n(currently supported in posthog-react-native).",
+          "type": "string[]",
+          "name": "addTracingHeaders"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogCustomAppProperties",
@@ -2730,23 +3263,51 @@
     {
       "id": "PostHogErrorBoundaryFallbackProps",
       "name": "PostHogErrorBoundaryFallbackProps",
-      "properties": [],
-      "path": "dist/PostHogErrorBoundary.d.ts",
-      "example": "{\n    error: unknown;\n    componentStack: string;\n}"
+      "properties": [
+        {
+          "type": "unknown",
+          "name": "error"
+        },
+        {
+          "type": "string",
+          "name": "componentStack"
+        }
+      ],
+      "path": "dist/PostHogErrorBoundary.d.ts"
     },
     {
       "id": "PostHogErrorBoundaryProps",
       "name": "PostHogErrorBoundaryProps",
-      "properties": [],
-      "path": "dist/PostHogErrorBoundary.d.ts",
-      "example": "{\n    children?: React.ReactNode | (() => React.ReactNode);\n    fallback?: React.ReactNode | FunctionComponent<PostHogErrorBoundaryFallbackProps>;\n    additionalProperties?: Properties | ((error: unknown) => Properties);\n}"
+      "properties": [
+        {
+          "type": "any",
+          "name": "children"
+        },
+        {
+          "type": "any",
+          "name": "fallback"
+        },
+        {
+          "type": "Properties | ((error: unknown) => Properties)",
+          "name": "additionalProperties"
+        }
+      ],
+      "path": "dist/PostHogErrorBoundary.d.ts"
     },
     {
       "id": "PostHogErrorBoundaryState",
       "name": "PostHogErrorBoundaryState",
-      "properties": [],
-      "path": "dist/PostHogErrorBoundary.d.ts",
-      "example": "{\n    componentStack: string | null;\n    error: unknown;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "componentStack"
+        },
+        {
+          "type": "unknown",
+          "name": "error"
+        }
+      ],
+      "path": "dist/PostHogErrorBoundary.d.ts"
     },
     {
       "id": "PostHogEventProperties",
@@ -2758,37 +3319,242 @@
     {
       "id": "PostHogFeatureFlagDetails",
       "name": "PostHogFeatureFlagDetails",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "\"flags\" | \"featureFlags\" | \"featureFlagPayloads\" | \"requestId\""
+      "properties": [
+        {
+          "type": "{ [key: string]: FeatureFlagDetail; }",
+          "name": "flags"
+        },
+        {
+          "type": "{ [key: string]: FeatureFlagValue; }",
+          "name": "featureFlags"
+        },
+        {
+          "type": "{ [key: string]: JsonType; }",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "string",
+          "name": "requestId"
+        },
+        {
+          "type": "(boolean | { [key: string]: JsonType; }) & (boolean | { [key: string]: JsonType; })",
+          "name": "sessionRecording"
+        },
+        {
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "errorTracking"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "capturePerformance"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "logs"
+        },
+        {
+          "type": "boolean",
+          "name": "errorsWhileComputingFlags"
+        },
+        {
+          "type": "string[]",
+          "name": "quotaLimited"
+        },
+        {
+          "type": "number",
+          "name": "evaluatedAt"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFeatureFlagsResponse",
       "name": "PostHogFeatureFlagsResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "\"flags\" | \"featureFlags\" | \"featureFlagPayloads\" | \"requestId\""
+      "properties": [
+        {
+          "type": "{ [key: string]: FeatureFlagDetail; }",
+          "name": "flags"
+        },
+        {
+          "type": "{ [key: string]: FeatureFlagValue; }",
+          "name": "featureFlags"
+        },
+        {
+          "type": "{ [key: string]: JsonType; }",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "string",
+          "name": "requestId"
+        },
+        {
+          "type": "(boolean | { [key: string]: JsonType; }) & (boolean | { [key: string]: JsonType; })",
+          "name": "sessionRecording"
+        },
+        {
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "errorTracking"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "capturePerformance"
+        },
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "logs"
+        },
+        {
+          "type": "boolean",
+          "name": "errorsWhileComputingFlags"
+        },
+        {
+          "type": "string[]",
+          "name": "quotaLimited"
+        },
+        {
+          "type": "number",
+          "name": "evaluatedAt"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFetchOptions",
       "name": "PostHogFetchOptions",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    method: 'GET' | 'POST' | 'PUT' | 'PATCH';\n    mode?: 'no-cors';\n    credentials?: 'omit';\n    headers: {\n        [key: string]: string;\n    };\n    body?: string | Blob;\n    signal?: AbortSignal;\n}"
+      "properties": [
+        {
+          "type": "\"GET\" | \"POST\" | \"PUT\" | \"PATCH\"",
+          "name": "method"
+        },
+        {
+          "type": "\"no-cors\"",
+          "name": "mode"
+        },
+        {
+          "type": "\"omit\"",
+          "name": "credentials"
+        },
+        {
+          "type": "{ [key: string]: string; }",
+          "name": "headers"
+        },
+        {
+          "type": "string | Blob",
+          "name": "body"
+        },
+        {
+          "type": "AbortSignal",
+          "name": "signal"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFetchResponse",
       "name": "PostHogFetchResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    status: number;\n    text: () => Promise<string>;\n    json: () => Promise<any>;\n    headers?: {\n        get(name: string): string | null;\n    };\n    body?: ReadableStream<Uint8Array> | null;\n}"
+      "properties": [
+        {
+          "type": "number",
+          "name": "status"
+        },
+        {
+          "type": "() => Promise<string>",
+          "name": "text"
+        },
+        {
+          "type": "() => Promise<any>",
+          "name": "json"
+        },
+        {
+          "type": "{ get(name: string): string | null; }",
+          "name": "headers"
+        },
+        {
+          "type": "ReadableStream<Uint8Array<ArrayBuffer>>",
+          "name": "body"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogFlagsResponse",
       "name": "PostHogFlagsResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "Omit<PostHogRemoteConfig, 'hasFeatureFlags'> & {\n    featureFlags: {\n        [key: string]: FeatureFlagValue;\n    };\n    featureFlagPayloads: {\n        [key: string]: JsonType;\n    };\n    flags: {\n        [key: string]: FeatureFlagDetail;\n    };\n    errorsWhileComputingFlags: boolean;\n    sessionRecording?: boolean | {\n        [key: string]: JsonType;\n    };\n    quotaLimited?: string[];\n    requestId?: string;\n    evaluatedAt?: number;\n}"
+      "properties": [
+        {
+          "type": "(boolean | { [key: string]: JsonType; }) & (boolean | { [key: string]: JsonType; })",
+          "name": "sessionRecording"
+        },
+        {
+          "description": "Supported compression algorithms",
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "description": "Whether surveys are enabled",
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "description": "Error tracking remote config.\nEither a boolean (false = disabled) or a map with configuration.\nWhen a map, `autocaptureExceptions` (boolean) controls whether automatic exception capture is enabled remotely.",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "errorTracking"
+        },
+        {
+          "description": "Capture performance remote config.\nEither a boolean (false = disabled) or a map with configuration.\nWhen a map, `network_timing` (boolean) controls whether network timing capture is enabled remotely.",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "capturePerformance"
+        },
+        {
+          "description": "Logs feature remote config. When a map, `captureConsoleLogs` (boolean)\nis the local opt-in flag for `console.*` autocapture (read by the JS\nSDK's `PostHogLogs` extension to decide whether to load the autocapture\nbundle).",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "logs"
+        },
+        {
+          "type": "{ [key: string]: FeatureFlagValue; }",
+          "name": "featureFlags"
+        },
+        {
+          "type": "{ [key: string]: JsonType; }",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "{ [key: string]: FeatureFlagDetail; }",
+          "name": "flags"
+        },
+        {
+          "type": "boolean",
+          "name": "errorsWhileComputingFlags"
+        },
+        {
+          "type": "string[]",
+          "name": "quotaLimited"
+        },
+        {
+          "type": "string",
+          "name": "requestId"
+        },
+        {
+          "type": "number",
+          "name": "evaluatedAt"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogGroupProperties",
@@ -2864,9 +3630,17 @@
     {
       "id": "PostHogNavigationRef",
       "name": "PostHogNavigationRef",
-      "properties": [],
-      "path": "dist/types.d.ts",
-      "example": "{\n    getCurrentRoute(): any | undefined;\n    isReady: () => boolean;\n    current?: PostHogNavigationRef | any | undefined;\n}"
+      "properties": [
+        {
+          "type": "() => boolean",
+          "name": "isReady"
+        },
+        {
+          "type": "any",
+          "name": "current"
+        }
+      ],
+      "path": "dist/types.d.ts"
     },
     {
       "id": "PostHogOptions",
@@ -3111,30 +3885,174 @@
     {
       "id": "PostHogReactNativePluginExtended",
       "name": "PostHogReactNativePluginExtended",
-      "properties": [],
-      "path": "dist/optional/OptionalPlugin.d.ts",
-      "example": "typeof PostHogReactNativePlugin & {\n    setup?: (sessionId: string, sdkOptions: {\n        [key: string]: any;\n    }, pluginConfig: {\n        [key: string]: any;\n    }) => Promise<void>;\n    startRecording?: (resumeCurrent: boolean) => Promise<void>;\n    stopRecording?: () => Promise<void>;\n    addExceptionStep?: (message: string, properties?: {\n        [key: string]: any;\n    }) => Promise<void>;\n}"
+      "properties": [
+        {
+          "type": "((sessionId: string, sdkOptions: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap, pluginConfig?: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginConfig) => Promise<void>) & ((sessionId: string, sdkOptions: { [key: string]: any; }, pluginConfig: { [key: string]: any; }) => Promise<void>)",
+          "name": "setup"
+        },
+        {
+          "description": "Legacy session replay setup entrypoint. Prefer setup() for new native features.",
+          "type": "(sessionId: string, sdkOptions: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap, sdkReplayConfig: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap, decideReplayConfig: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap) => Promise<void>",
+          "name": "start"
+        },
+        {
+          "type": "(sessionId: string) => Promise<void>",
+          "name": "startSession"
+        },
+        {
+          "type": "() => Promise<void>",
+          "name": "endSession"
+        },
+        {
+          "type": "() => Promise<boolean>",
+          "name": "isEnabled"
+        },
+        {
+          "type": "(distinctId: string, anonymousId: string) => Promise<void>",
+          "name": "identify"
+        },
+        {
+          "type": "((resumeCurrent: boolean) => Promise<void>) & ((resumeCurrent: boolean) => Promise<void>)",
+          "name": "startRecording"
+        },
+        {
+          "type": "(() => Promise<void>) & (() => Promise<void>)",
+          "name": "stopRecording"
+        },
+        {
+          "type": "((message: string, properties?: import(\"/Users/anna/Develop/posthog-js/packages/react-native-plugin/lib/typescript/module/src/index\").PostHogReactNativePluginMap) => Promise<void>) & ((message: string, properties?: { [key: string]: any; }) => Promise<void>)",
+          "name": "addExceptionStep"
+        }
+      ],
+      "path": "dist/optional/OptionalPlugin.d.ts"
     },
     {
       "id": "PostHogRemoteConfig",
       "name": "PostHogRemoteConfig",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    sessionRecording?: boolean | {\n        [key: string]: JsonType;\n    };\n    supportedCompression?: Compression[];\n    surveys?: boolean | Survey[];\n    hasFeatureFlags?: boolean;\n    errorTracking?: boolean | {\n        [key: string]: JsonType;\n    };\n    capturePerformance?: boolean | {\n        [key: string]: JsonType;\n    };\n    logs?: boolean | {\n        [key: string]: JsonType;\n    };\n}"
+      "properties": [
+        {
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "sessionRecording"
+        },
+        {
+          "description": "Supported compression algorithms",
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "description": "Whether surveys are enabled",
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "description": "Indicates if the team has any flags enabled (if not we don't need to load them)",
+          "type": "boolean",
+          "name": "hasFeatureFlags"
+        },
+        {
+          "description": "Error tracking remote config.\nEither a boolean (false = disabled) or a map with configuration.\nWhen a map, `autocaptureExceptions` (boolean) controls whether automatic exception capture is enabled remotely.",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "errorTracking"
+        },
+        {
+          "description": "Capture performance remote config.\nEither a boolean (false = disabled) or a map with configuration.\nWhen a map, `network_timing` (boolean) controls whether network timing capture is enabled remotely.",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "capturePerformance"
+        },
+        {
+          "description": "Logs feature remote config. When a map, `captureConsoleLogs` (boolean)\nis the local opt-in flag for `console.*` autocapture (read by the JS\nSDK's `PostHogLogs` extension to decide whether to load the autocapture\nbundle).",
+          "type": "boolean | { [key: string]: JsonType; }",
+          "name": "logs"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "PostHogSessionReplayConfig",
       "name": "PostHogSessionReplayConfig",
-      "properties": [],
-      "path": "dist/types.d.ts",
-      "example": "{\n    maskAllTextInputs?: boolean;\n    maskAllImages?: boolean;\n    maskAllSandboxedViews?: boolean;\n    captureLog?: boolean;\n    iOSdebouncerDelayMs?: number;\n    androidDebouncerDelayMs?: number;\n    throttleDelayMs?: number;\n    captureNetworkTelemetry?: boolean;\n    screenshotModeBackgroundCapture?: boolean;\n    sampleRate?: number;\n}"
+      "properties": [
+        {
+          "description": "Enable masking of all text and text input fields",
+          "type": "boolean",
+          "name": "maskAllTextInputs"
+        },
+        {
+          "description": "Enable masking of all images to a placeholder",
+          "type": "boolean",
+          "name": "maskAllImages"
+        },
+        {
+          "description": "Enable masking of all sandboxed system views\nThese may include UIImagePickerController, PHPickerViewController and CNContactPickerViewController\niOS only",
+          "type": "boolean",
+          "name": "maskAllSandboxedViews"
+        },
+        {
+          "description": "Enable capturing of logs as console events",
+          "type": "boolean",
+          "name": "captureLog"
+        },
+        {
+          "description": "Deboucer delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a screenshot\nThe lower the number more snapshots will be captured but higher the performance impact",
+          "type": "number",
+          "name": "iOSdebouncerDelayMs"
+        },
+        {
+          "description": "Deboucer delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a screenshot\nThe lower the number more snapshots will be captured but higher the performance impact\nPs: it was 500ms (0.5s) by default until version 3.3.7",
+          "type": "number",
+          "name": "androidDebouncerDelayMs"
+        },
+        {
+          "description": "Throttling delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a wireframe or screenshot\nThe lower the number more snapshots will be captured but higher the performance impact\n\nThis value has precedence over iOSdebouncerDelayMs and androidDebouncerDelayMs\nIf this is not set, we will take the max number between iOSdebouncerDelayMs and androidDebouncerDelayMs for back compatibility",
+          "type": "number",
+          "name": "throttleDelayMs"
+        },
+        {
+          "description": "Enable capturing network telemetry\niOS only",
+          "type": "boolean",
+          "name": "captureNetworkTelemetry"
+        },
+        {
+          "description": "Schedule screenshot image capture on a background queue.\niOS only\nExperimental support\n\nWarning: Enabling this option will trigger Main Thread Checker warnings and may\nbriefly freeze the app the first time a screenshot is captured. Consider disabling\nMain Thread Checker in your scheme's run diagnostics when enabling this.",
+          "type": "boolean",
+          "name": "screenshotModeBackgroundCapture"
+        },
+        {
+          "description": "Session replay sample rate between 0 and 1\nLocal config has precedence over remote config when both are set.\nIf undefined, sampling is controlled by remote config (when available).",
+          "type": "number",
+          "name": "sampleRate"
+        }
+      ],
+      "path": "dist/types.d.ts"
     },
     {
       "id": "PostHogSurveyProviderProps",
       "name": "PostHogSurveyProviderProps",
-      "properties": [],
-      "path": "dist/surveys/PostHogSurveyProvider.d.ts",
-      "example": "{\n    defaultSurveyAppearance?: SurveyAppearance;\n    overrideAppearanceWithDefault?: boolean;\n    androidKeyboardBehavior?: 'padding' | 'height';\n    client?: PostHog;\n    children: React.ReactNode;\n}"
+      "properties": [
+        {
+          "description": "The default appearance for surveys when not specified in PostHog.",
+          "type": "SurveyAppearance",
+          "name": "defaultSurveyAppearance"
+        },
+        {
+          "description": "If true, PosHog appearance will be ignored and defaultSurveyAppearance is always used.",
+          "type": "boolean",
+          "name": "overrideAppearanceWithDefault"
+        },
+        {
+          "description": "The keyboard avoiding behavior for the survey modal (KeyboardAvoidingView), applied only to Android devices.\n- 'padding': Adds padding to avoid keyboard (recommended)\n- 'height': Resizes the view height (default, for legacy - may cause flickering on some Android devices)",
+          "type": "\"padding\" | \"height\"",
+          "name": "androidKeyboardBehavior"
+        },
+        {
+          "type": "PostHog",
+          "name": "client"
+        },
+        {
+          "type": "React.ReactNode",
+          "name": "children"
+        }
+      ],
+      "path": "dist/surveys/PostHogSurveyProvider.d.ts"
     },
     {
       "id": "PreviouslyCapturedError",
@@ -3175,9 +4093,73 @@
     {
       "id": "RatingSurveyQuestion",
       "name": "RatingSurveyQuestion",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "SurveyQuestionBase & {\n    type: typeof SurveyQuestionType.Rating;\n    display: SurveyRatingDisplay;\n    scale: 2 | 3 | 5 | 7 | 10;\n    lowerBoundLabel: string;\n    upperBoundLabel: string;\n    skipSubmitButton?: boolean;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "\"rating\"",
+          "name": "type"
+        },
+        {
+          "type": "SurveyRatingDisplay",
+          "name": "display"
+        },
+        {
+          "type": "2 | 3 | 5 | 7 | 10",
+          "name": "scale"
+        },
+        {
+          "type": "string",
+          "name": "lowerBoundLabel"
+        },
+        {
+          "type": "string",
+          "name": "upperBoundLabel"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "RejectionLike",
@@ -3189,16 +4171,32 @@
     {
       "id": "ResolvedExceptionStepsConfig",
       "name": "ResolvedExceptionStepsConfig",
-      "properties": [],
-      "path": "../core/src/error-tracking/exception-steps.ts",
-      "example": "{\n    enabled: boolean;\n    max_bytes: number;\n}"
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "type": "number",
+          "name": "max_bytes"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ResponseBasedBranching",
       "name": "ResponseBasedBranching",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: typeof SurveyQuestionBranchingType.ResponseBased;\n    responseValues: Record<string, any>;\n}"
+      "properties": [
+        {
+          "type": "\"response_based\"",
+          "name": "type"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "responseValues"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "RetriableOptions",
@@ -3243,9 +4241,17 @@
     {
       "id": "SpecificQuestionBranching",
       "name": "SpecificQuestionBranching",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    type: typeof SurveyQuestionBranchingType.SpecificQuestion;\n    index: number;\n}"
+      "properties": [
+        {
+          "type": "\"specific_question\"",
+          "name": "type"
+        },
+        {
+          "type": "number",
+          "name": "index"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "StackFrame",
@@ -3338,30 +4344,298 @@
     {
       "id": "Survey",
       "name": "Survey",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    id: string;\n    name: string;\n    description?: string;\n    type: SurveyType;\n    translations?: Record<string, SurveyTranslation>;\n    feature_flag_keys?: {\n        key: string;\n        value?: string;\n    }[];\n    linked_flag_key?: string;\n    targeting_flag_key?: string;\n    internal_targeting_flag_key?: string;\n    questions: SurveyQuestion[];\n    appearance?: SurveyAppearance;\n    conditions?: {\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: SurveyMatchType;\n        events?: {\n            repeatedActivation?: boolean;\n            values?: {\n                name: string;\n            }[];\n        };\n        actions?: {\n            values: SurveyActionType[];\n        };\n        deviceTypes?: string[];\n        deviceTypesMatchType?: SurveyMatchType;\n        linkedFlagVariant?: string;\n    };\n    start_date?: string;\n    end_date?: string;\n    current_iteration?: number | null;\n    current_iteration_start_date?: string | null;\n    schedule?: SurveySchedule | null;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyType",
+          "name": "type"
+        },
+        {
+          "type": "Record<string, SurveyTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "{ key: string; value?: string; }[]",
+          "name": "feature_flag_keys"
+        },
+        {
+          "type": "string",
+          "name": "linked_flag_key"
+        },
+        {
+          "type": "string",
+          "name": "targeting_flag_key"
+        },
+        {
+          "type": "string",
+          "name": "internal_targeting_flag_key"
+        },
+        {
+          "type": "SurveyQuestion[]",
+          "name": "questions"
+        },
+        {
+          "type": "SurveyAppearance",
+          "name": "appearance"
+        },
+        {
+          "type": "{ url?: string; selector?: string; seenSurveyWaitPeriodInDays?: number; urlMatchType?: SurveyMatchType; events?: { repeatedActivation?: boolean; values?: { name: string; }[]; }; actions?: { values: SurveyActionType[]; }; deviceTypes?: string[]; deviceTypesMatchType?: SurveyMatchType; linkedFlagVariant?: string; }",
+          "name": "conditions"
+        },
+        {
+          "type": "string",
+          "name": "start_date"
+        },
+        {
+          "type": "string",
+          "name": "end_date"
+        },
+        {
+          "type": "number",
+          "name": "current_iteration"
+        },
+        {
+          "type": "string",
+          "name": "current_iteration_start_date"
+        },
+        {
+          "type": "SurveySchedule",
+          "name": "schedule"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyActionType",
       "name": "SurveyActionType",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    id: number;\n    name?: string;\n    steps?: ActionStepType[];\n}"
+      "properties": [
+        {
+          "type": "number",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "ActionStepType[]",
+          "name": "steps"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyAppearance",
       "name": "SurveyAppearance",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    backgroundColor?: string;\n    textColor?: string;\n    submitButtonColor?: string;\n    submitButtonText?: string;\n    submitButtonTextColor?: string;\n    ratingButtonColor?: string;\n    ratingButtonActiveColor?: string;\n    inputBackground?: string;\n    inputTextColor?: string;\n    autoDisappear?: boolean;\n    displayThankYouMessage?: boolean;\n    thankYouMessageHeader?: string;\n    thankYouMessageDescription?: string;\n    thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType;\n    thankYouMessageCloseButtonText?: string;\n    borderColor?: string;\n    position?: SurveyPosition;\n    placeholder?: string;\n    shuffleQuestions?: boolean;\n    surveyPopupDelaySeconds?: number;\n    allowGoBack?: boolean;\n    backButtonText?: string;\n    widgetType?: SurveyWidgetType;\n    widgetSelector?: string;\n    widgetLabel?: string;\n    widgetColor?: string;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "backgroundColor"
+        },
+        {
+          "type": "string",
+          "name": "textColor"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonText"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonTextColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonActiveColor"
+        },
+        {
+          "type": "string",
+          "name": "inputBackground"
+        },
+        {
+          "type": "string",
+          "name": "inputTextColor"
+        },
+        {
+          "type": "boolean",
+          "name": "autoDisappear"
+        },
+        {
+          "type": "boolean",
+          "name": "displayThankYouMessage"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageHeader"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageDescription"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "thankYouMessageDescriptionContentType"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageCloseButtonText"
+        },
+        {
+          "type": "string",
+          "name": "borderColor"
+        },
+        {
+          "type": "SurveyPosition",
+          "name": "position"
+        },
+        {
+          "type": "string",
+          "name": "placeholder"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleQuestions"
+        },
+        {
+          "type": "number",
+          "name": "surveyPopupDelaySeconds"
+        },
+        {
+          "type": "boolean",
+          "name": "allowGoBack"
+        },
+        {
+          "type": "string",
+          "name": "backButtonText"
+        },
+        {
+          "type": "SurveyWidgetType",
+          "name": "widgetType"
+        },
+        {
+          "type": "string",
+          "name": "widgetSelector"
+        },
+        {
+          "type": "string",
+          "name": "widgetLabel"
+        },
+        {
+          "type": "string",
+          "name": "widgetColor"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyAppearanceTheme",
       "name": "SurveyAppearanceTheme",
-      "properties": [],
-      "path": "dist/surveys/surveys-utils.d.ts",
-      "example": "Omit<Required<SurveyAppearance>, 'widgetSelector' | 'widgetType' | 'widgetColor' | 'widgetLabel' | 'shuffleQuestions' | 'textColor' | 'inputTextColor'> & {\n    textColor?: string;\n    inputTextColor?: string;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "backgroundColor"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonText"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonTextColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonActiveColor"
+        },
+        {
+          "type": "string",
+          "name": "inputBackground"
+        },
+        {
+          "type": "boolean",
+          "name": "autoDisappear"
+        },
+        {
+          "type": "boolean",
+          "name": "displayThankYouMessage"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageHeader"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageDescription"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "thankYouMessageDescriptionContentType"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageCloseButtonText"
+        },
+        {
+          "type": "string",
+          "name": "borderColor"
+        },
+        {
+          "type": "import(\"/Users/anna/Develop/posthog-js/packages/core/dist/types\").SurveyPosition",
+          "name": "position"
+        },
+        {
+          "type": "string",
+          "name": "placeholder"
+        },
+        {
+          "type": "number",
+          "name": "surveyPopupDelaySeconds"
+        },
+        {
+          "type": "boolean",
+          "name": "allowGoBack"
+        },
+        {
+          "type": "string",
+          "name": "backButtonText"
+        },
+        {
+          "type": "string",
+          "name": "textColor"
+        },
+        {
+          "type": "string",
+          "name": "inputTextColor"
+        }
+      ],
+      "path": "dist/surveys/surveys-utils.d.ts"
     },
     {
       "id": "SurveyMatchType",
@@ -3373,9 +4647,33 @@
     {
       "id": "SurveyModalProps",
       "name": "SurveyModalProps",
-      "properties": [],
-      "path": "dist/surveys/components/SurveyModal.d.ts",
-      "example": "{\n    survey: Survey;\n    surveyLanguage: string | null;\n    appearance: SurveyAppearanceTheme;\n    onShow: () => void;\n    onClose: (submitted: boolean, responses: SurveyResponses) => void;\n    androidKeyboardBehavior?: 'padding' | 'height';\n}"
+      "properties": [
+        {
+          "type": "Survey",
+          "name": "survey"
+        },
+        {
+          "type": "string",
+          "name": "surveyLanguage"
+        },
+        {
+          "type": "SurveyAppearanceTheme",
+          "name": "appearance"
+        },
+        {
+          "type": "() => void",
+          "name": "onShow"
+        },
+        {
+          "type": "(submitted: boolean, responses: SurveyResponses) => void",
+          "name": "onClose"
+        },
+        {
+          "type": "\"padding\" | \"height\"",
+          "name": "androidKeyboardBehavior"
+        }
+      ],
+      "path": "dist/surveys/components/SurveyModal.d.ts"
     },
     {
       "id": "SurveyPosition",
@@ -3394,9 +4692,49 @@
     {
       "id": "SurveyQuestionBase",
       "name": "SurveyQuestionBase",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    question: string;\n    id: string;\n    description?: string | null;\n    descriptionContentType?: SurveyQuestionDescriptionContentType;\n    optional?: boolean;\n    buttonText?: string;\n    originalQuestionIndex: number;\n    branching?: NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching;\n    validation?: SurveyValidationRule[];\n    translations?: Record<string, SurveyQuestionTranslation>;\n}"
+      "properties": [
+        {
+          "type": "string",
+          "name": "question"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "descriptionContentType"
+        },
+        {
+          "type": "boolean",
+          "name": "optional"
+        },
+        {
+          "type": "string",
+          "name": "buttonText"
+        },
+        {
+          "type": "number",
+          "name": "originalQuestionIndex"
+        },
+        {
+          "type": "NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching",
+          "name": "branching"
+        },
+        {
+          "type": "SurveyValidationRule[]",
+          "name": "validation"
+        },
+        {
+          "type": "Record<string, SurveyQuestionTranslation>",
+          "name": "translations"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyQuestionBranchingType",
@@ -3464,9 +4802,13 @@
     {
       "id": "SurveyResponse",
       "name": "SurveyResponse",
-      "properties": [],
-      "path": "../core/src/types.ts",
-      "example": "{\n    surveys: Survey[];\n}"
+      "properties": [
+        {
+          "type": "Survey[]",
+          "name": "surveys"
+        }
+      ],
+      "path": "../core/src/types.ts"
     },
     {
       "id": "SurveyResponses",

--- a/packages/react-native/scripts/generate-docs.js
+++ b/packages/react-native/scripts/generate-docs.js
@@ -37,6 +37,7 @@ const REACT_NATIVE_TYPE_EXAMPLES = {
 const config = {
     packageDir: path.resolve(__dirname, '..'),  // packages/react-native
     apiJsonPath: path.resolve(__dirname, '../docs/posthog-react-native.api.json'),
+    dtsEntryPath: path.resolve(__dirname, '../dist/index.d.ts'),
     outputPath: path.resolve(__dirname, `../references/posthog-react-native-references-${version}.json`),
     version: version,
     id: REACT_NATIVE_SPEC_INFO.id,

--- a/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
@@ -1,0 +1,116 @@
+/**
+ * Base configuration shared by all clients
+ *
+ * @public
+ */
+export interface BaseConfig {
+    /** URL of the API host */
+    api_host: string;
+    /** Called when the client is ready */
+    loaded: (client: unknown) => void;
+    /** Optional project token */
+    token?: string;
+}
+
+/**
+ * Object-shaped alias built from Omit and an intersection
+ *
+ * @public
+ */
+export type Config = Omit<BaseConfig, 'loaded'> & {
+    /** Called with the initialized client */
+    loaded: (client: BaseConfig) => void;
+    debug?: boolean;
+};
+
+/**
+ * Plain object literal alias
+ *
+ * @public
+ */
+export type FlagVariant = {
+    flag: string;
+    variant: string;
+};
+
+/**
+ * Genuine callback alias
+ *
+ * @public
+ */
+export type LoadedCallback = (client: BaseConfig) => void;
+
+/**
+ * String literal union alias
+ *
+ * @public
+ */
+export type Fruit = 'apple' | 'banana' | 'cherry';
+
+/**
+ * Alias with only an index signature
+ *
+ * @public
+ */
+export type PropertyFilters = {
+    [propertyName: string]: {
+        values: string[];
+    };
+};
+
+/**
+ * @public
+ */
+export interface QuestionA {
+    kind: string;
+    a: string;
+}
+
+/**
+ * @public
+ */
+export interface QuestionB {
+    kind: string;
+    b: string;
+}
+
+/**
+ * Union of interfaces
+ *
+ * @public
+ */
+export type Question = QuestionA | QuestionB;
+
+/**
+ * Generic alias, not resolvable without type arguments
+ *
+ * @public
+ */
+export type WithoutKind<T> = Omit<T, 'kind'>;
+
+/**
+ * Tuple alias
+ *
+ * @public
+ */
+export type Pair = [name: string, value: number];
+
+/**
+ * Union that the checker collapses to plain string
+ *
+ * @public
+ */
+export type LooseId = 'special' | string;
+
+/**
+ * Referenced by the public API but not exported
+ */
+type HiddenOptions = {
+    /** Enables verbose output */
+    verbose: boolean;
+};
+
+/**
+ * @public
+ */
+export declare function configure(options: HiddenOptions): void;

--- a/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
@@ -1,3 +1,6 @@
+import type { RemoteBase } from './other';
+import type { ThirdBase } from './third';
+
 /**
  * Base configuration shared by all clients
  *
@@ -101,6 +104,17 @@ export type Pair = [name: string, value: number];
  * @public
  */
 export type LooseId = 'special' | string;
+
+/**
+ * Intersection mixing a lexically imported property type with one that is only
+ * reachable through the checker
+ *
+ * @public
+ */
+export type Remote = RemoteBase & {
+    local?: string;
+    extra?: ThirdBase;
+};
 
 /**
  * Referenced by the public API but not exported

--- a/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
@@ -117,6 +117,17 @@ export type Remote = RemoteBase & {
 };
 
 /**
+ * Callable object: a call signature alongside named properties
+ *
+ * @public
+ */
+export type CallableWithProps = {
+    (input: string): boolean;
+    /** Human-readable label */
+    label: string;
+};
+
+/**
  * Referenced by the public API but not exported
  */
 type HiddenOptions = {

--- a/scripts/docs/__tests__/fixtures/reference-types/other.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/other.d.ts
@@ -1,0 +1,30 @@
+/**
+ * @public
+ */
+export interface RemoteOptions {
+    deep: boolean;
+}
+
+/**
+ * @public
+ */
+export interface RemoteBase {
+    /** Options resolved from another file */
+    options?: RemoteOptions;
+}
+
+/**
+ * Alias that never reaches the entry point's exports
+ *
+ * @public
+ */
+export type RemoteMode = {
+    fast: boolean;
+};
+
+/**
+ * Collides with the declaration in third.d.ts
+ */
+type Dup = {
+    fromOther: string;
+};

--- a/scripts/docs/__tests__/fixtures/reference-types/package.json
+++ b/scripts/docs/__tests__/fixtures/reference-types/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "reference-types-fixture",
+    "version": "0.0.0",
+    "private": true,
+    "types": "index.d.ts"
+}

--- a/scripts/docs/__tests__/fixtures/reference-types/third.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/third.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @public
+ */
+export interface ThirdBase {
+    tag?: string;
+}
+
+/**
+ * Collides with the declaration in other.d.ts
+ */
+type Dup = {
+    fromThird: string;
+};

--- a/scripts/docs/__tests__/type-resolution.test.js
+++ b/scripts/docs/__tests__/type-resolution.test.js
@@ -68,6 +68,10 @@ describe('createTypeResolver classification', () => {
         assert.equal(typeResolver.resolveTypeAlias('LoadedCallback').kind, 'function');
     });
 
+    test('callable types with members keep their full signature', () => {
+        assert.equal(typeResolver.resolveTypeAlias('CallableWithProps').kind, 'signature');
+    });
+
     test('classifies unions', () => {
         assert.equal(typeResolver.resolveTypeAlias('Fruit').kind, 'union');
         assert.equal(typeResolver.resolveTypeAlias('Question').kind, 'union');
@@ -148,6 +152,13 @@ describe('resolveTypeDefinitions with type resolver', () => {
         const filters = byName(types, 'PropertyFilters');
         assert.deepEqual(filters.properties, []);
         assert.match(filters.example, /^\{/);
+    });
+
+    test('callable-with-members aliases publish the call signature via example', () => {
+        const callable = byName(types, 'CallableWithProps');
+        assert.deepEqual(callable.properties, []);
+        assert.match(callable.example, /\(input: string\): boolean/);
+        assert.match(callable.example, /label: string/);
     });
 
     test('keeps unions of interfaces as union examples', () => {

--- a/scripts/docs/__tests__/type-resolution.test.js
+++ b/scripts/docs/__tests__/type-resolution.test.js
@@ -1,0 +1,199 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
+const { ApiPackage } = require('@microsoft/api-extractor-model');
+const { resolveTypeDefinitions } = require('../types');
+const { createTypeResolver } = require('../type-resolver');
+
+const fixtureDir = path.join(__dirname, 'fixtures', 'reference-types');
+const entryPath = path.join(fixtureDir, 'index.d.ts');
+
+function buildApiPackage() {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-reference-types-'));
+    const apiJsonPath = path.join(tmpDir, 'reference-types-fixture.api.json');
+
+    const extractorConfig = ExtractorConfig.prepare({
+        configObject: {
+            projectFolder: fixtureDir,
+            mainEntryPointFilePath: entryPath,
+            compiler: {
+                overrideTsconfig: { compilerOptions: { skipLibCheck: true, types: [] } },
+            },
+            docModel: { enabled: true, apiJsonFilePath: apiJsonPath },
+            apiReport: { enabled: false },
+            dtsRollup: { enabled: false },
+            tsdocMetadata: { enabled: false },
+        },
+        configObjectFullPath: undefined,
+        packageJsonFullPath: path.join(fixtureDir, 'package.json'),
+    });
+
+    const result = Extractor.invoke(extractorConfig, {
+        localBuild: true,
+        messageCallback: (message) => {
+            message.handled = true;
+        },
+    });
+    assert.ok(result.succeeded, 'api-extractor run on the fixture failed');
+
+    return ApiPackage.loadFromJsonFile(apiJsonPath);
+}
+
+const apiPackage = buildApiPackage();
+const typeResolver = createTypeResolver(entryPath);
+
+const byName = (types, name) => {
+    const found = types.find((t) => t.name === name);
+    assert.ok(found, `type ${name} missing from resolved definitions`);
+    return found;
+};
+
+const propByName = (type, name) => {
+    const found = type.properties.find((p) => p.name === name);
+    assert.ok(found, `property ${name} missing from ${type.name}`);
+    return found;
+};
+
+describe('createTypeResolver classification', () => {
+    test('classifies object-shaped aliases, including Omit intersections', () => {
+        assert.equal(typeResolver.resolveTypeAlias('Config').kind, 'object');
+        assert.equal(typeResolver.resolveTypeAlias('FlagVariant').kind, 'object');
+    });
+
+    test('classifies function aliases', () => {
+        assert.equal(typeResolver.resolveTypeAlias('LoadedCallback').kind, 'function');
+    });
+
+    test('classifies unions', () => {
+        assert.equal(typeResolver.resolveTypeAlias('Fruit').kind, 'union');
+        assert.equal(typeResolver.resolveTypeAlias('Question').kind, 'union');
+    });
+
+    test('classifies index-signature-only aliases and tuples as raw signatures', () => {
+        assert.equal(typeResolver.resolveTypeAlias('PropertyFilters').kind, 'signature');
+        assert.equal(typeResolver.resolveTypeAlias('Pair').kind, 'signature');
+    });
+
+    test('unions collapsed to a primitive are not objects', () => {
+        assert.equal(typeResolver.resolveTypeAlias('LooseId').kind, 'other');
+    });
+
+    test('resolves aliases referenced by the public API but not exported', () => {
+        const hidden = typeResolver.resolveTypeAlias('HiddenOptions');
+        assert.equal(hidden.kind, 'object');
+        assert.deepEqual(hidden.properties, [
+            { name: 'verbose', type: 'boolean', description: 'Enables verbose output' },
+        ]);
+    });
+
+    test('returns null for interfaces, generic aliases and unknown names', () => {
+        assert.equal(typeResolver.resolveTypeAlias('BaseConfig'), null);
+        assert.equal(typeResolver.resolveTypeAlias('WithoutKind'), null);
+        assert.equal(typeResolver.resolveTypeAlias('DoesNotExist'), null);
+    });
+});
+
+describe('resolveTypeDefinitions with type resolver', () => {
+    const types = resolveTypeDefinitions(apiPackage, typeResolver);
+
+    test('flattens Omit + intersection aliases to their effective members', () => {
+        const config = byName(types, 'Config');
+        const names = config.properties.map((p) => p.name).sort();
+        assert.deepEqual(names, ['api_host', 'debug', 'loaded', 'token']);
+        assert.equal(config.example, undefined);
+
+        assert.equal(propByName(config, 'api_host').type, 'string');
+        assert.equal(propByName(config, 'api_host').description, 'URL of the API host');
+        assert.equal(propByName(config, 'token').description, 'Optional project token');
+        assert.match(propByName(config, 'loaded').type, /=>/);
+        assert.equal(propByName(config, 'loaded').description, 'Called with the initialized client');
+    });
+
+    test('extracts properties of plain object literal aliases', () => {
+        const flagVariant = byName(types, 'FlagVariant');
+        assert.deepEqual(
+            flagVariant.properties.map(({ name, type }) => ({ name, type })),
+            [
+                { name: 'flag', type: 'string' },
+                { name: 'variant', type: 'string' },
+            ]
+        );
+    });
+
+    test('keeps callback aliases as signature examples', () => {
+        const callback = byName(types, 'LoadedCallback');
+        assert.deepEqual(callback.properties, []);
+        assert.match(callback.example, /=>/);
+    });
+
+    test('keeps string literal unions as examples', () => {
+        const fruit = byName(types, 'Fruit');
+        assert.deepEqual(fruit.properties, []);
+        assert.equal(fruit.example, '"apple" | "banana" | "cherry"');
+    });
+
+    test('keeps index-signature aliases as signature examples without garbage properties', () => {
+        const filters = byName(types, 'PropertyFilters');
+        assert.deepEqual(filters.properties, []);
+        assert.match(filters.example, /^\{/);
+    });
+
+    test('keeps unions of interfaces as union examples', () => {
+        const question = byName(types, 'Question');
+        assert.deepEqual(question.properties, []);
+        assert.equal(question.example, 'QuestionA | QuestionB');
+    });
+
+    test('tuples keep their signature as example, without numeric index properties', () => {
+        const pair = byName(types, 'Pair');
+        assert.deepEqual(pair.properties, []);
+        assert.equal(pair.example, '[name: string, value: number]');
+    });
+
+    test('unions collapsed to string still surface their known literals', () => {
+        const looseId = byName(types, 'LooseId');
+        assert.deepEqual(looseId.properties, []);
+        assert.equal(looseId.example, '"special"');
+    });
+
+    test('generic aliases fall back to their signature, not quoted type arguments', () => {
+        const withoutKind = byName(types, 'WithoutKind');
+        assert.deepEqual(withoutKind.properties, []);
+        assert.equal(withoutKind.example, "Omit<T, 'kind'>");
+    });
+
+    test('interfaces keep their members', () => {
+        const base = byName(types, 'BaseConfig');
+        assert.deepEqual(base.properties.map((p) => p.name), ['api_host', 'loaded', 'token']);
+    });
+});
+
+describe('resolveTypeDefinitions without type resolver (fallback)', () => {
+    const types = resolveTypeDefinitions(apiPackage, null);
+
+    test('object literal aliases are not misclassified as callbacks', () => {
+        const flagVariant = byName(types, 'FlagVariant');
+        assert.deepEqual(flagVariant.properties.map((p) => p.name), ['flag', 'variant']);
+    });
+
+    test('Omit intersections degrade to a signature example, not a bogus literal union', () => {
+        const config = byName(types, 'Config');
+        assert.deepEqual(config.properties, []);
+        assert.match(config.example, /^Omit<BaseConfig/);
+    });
+
+    test('callback aliases are still detected via top-level arrow', () => {
+        const callback = byName(types, 'LoadedCallback');
+        assert.deepEqual(callback.properties, []);
+        assert.match(callback.example, /=>/);
+    });
+
+    test('string literal unions still produce examples', () => {
+        const fruit = byName(types, 'Fruit');
+        assert.equal(fruit.example, '"apple" | "banana" | "cherry"');
+    });
+});

--- a/scripts/docs/__tests__/type-resolution.test.js
+++ b/scripts/docs/__tests__/type-resolution.test.js
@@ -82,6 +82,14 @@ describe('createTypeResolver classification', () => {
         assert.equal(typeResolver.resolveTypeAlias('LooseId').kind, 'other');
     });
 
+    test('returns null when the same alias name is declared differently in several files', () => {
+        assert.equal(typeResolver.resolveTypeAlias('Dup'), null);
+    });
+
+    test('resolves aliases declared outside the entry point', () => {
+        assert.equal(typeResolver.resolveTypeAlias('RemoteMode').kind, 'object');
+    });
+
     test('resolves aliases referenced by the public API but not exported', () => {
         const hidden = typeResolver.resolveTypeAlias('HiddenOptions');
         assert.equal(hidden.kind, 'object');
@@ -169,6 +177,19 @@ describe('resolveTypeDefinitions with type resolver', () => {
     test('interfaces keep their members', () => {
         const base = byName(types, 'BaseConfig');
         assert.deepEqual(base.properties.map((p) => p.name), ['api_host', 'loaded', 'token']);
+    });
+
+    test('cross-file property types render bare names, never import("...") qualifiers', () => {
+        const remote = byName(types, 'Remote');
+        assert.deepEqual(
+            remote.properties.map(({ name, type }) => ({ name, type })),
+            [
+                { name: 'options', type: 'RemoteOptions' },
+                { name: 'local', type: 'string' },
+                { name: 'extra', type: 'ThirdBase' },
+            ]
+        );
+        assert.doesNotMatch(JSON.stringify(types), /import\("/);
     });
 });
 

--- a/scripts/docs/parser.js
+++ b/scripts/docs/parser.js
@@ -3,6 +3,7 @@ const documentation = require('./documentation');
 const examples = require('./examples');
 const methods = require('./methods');
 const types = require('./types');
+const { createTypeResolver } = require('./type-resolver');
 const { writeFileSync, readFileSync } = require('fs');
 const path = require('path');
 
@@ -93,9 +94,10 @@ const composeOutput = (posthogClass, functions, types, config) => ({
 const generateApiSpecs = (config) => {
     const apiPackage = loadApiPackage(config.apiJsonPath);
     const posthogClass = findPostHogClass(apiPackage, config.parentClass);
-    
+    const typeResolver = config.dtsEntryPath ? createTypeResolver(config.dtsEntryPath) : null;
+
     const resolvedTypes = types
-        .resolveTypeDefinitions(apiPackage)
+        .resolveTypeDefinitions(apiPackage, typeResolver)
         .map(type => enhanceTypeWithExample(type, config));
     
     const methods = filterPublicMethods(posthogClass, config.parentClass);

--- a/scripts/docs/type-resolver.js
+++ b/scripts/docs/type-resolver.js
@@ -1,0 +1,113 @@
+const path = require('path');
+const ts = require('typescript');
+
+// Resolves exported type aliases against the same .d.ts entry point that api-extractor
+// analyzes, using the TypeScript checker so that Omit<>, intersections and cross-package
+// references flatten to their effective members.
+function createTypeResolver(dtsEntryPath) {
+    const entryPath = path.resolve(dtsEntryPath);
+    const program = ts.createProgram([entryPath], {
+        skipLibCheck: true,
+        moduleResolution: ts.ModuleResolutionKind.Node10,
+        types: [],
+    });
+    const checker = program.getTypeChecker();
+    const sourceFile = program.getSourceFile(entryPath);
+    if (!sourceFile) {
+        throw new Error(`type-resolver: could not load entry point ${entryPath}`);
+    }
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+    if (!moduleSymbol) {
+        throw new Error(`type-resolver: no exports found in ${entryPath}`);
+    }
+
+    const aliasDeclarations = new Map();
+    for (const exportSymbol of checker.getExportsOfModule(moduleSymbol)) {
+        const symbol =
+            exportSymbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exportSymbol) : exportSymbol;
+        const declaration = symbol.declarations?.find(ts.isTypeAliasDeclaration);
+        if (declaration) {
+            aliasDeclarations.set(exportSymbol.name, declaration);
+        }
+    }
+
+    // api-extractor also documents aliases that are referenced by the public API without
+    // being exported from the entry point, so index every top-level alias in the program.
+    // Entry-point exports win; a name declared differently in several files stays unresolved.
+    const exportedNames = new Set(aliasDeclarations.keys());
+    const ambiguousNames = new Set();
+    for (const file of program.getSourceFiles()) {
+        if (program.isSourceFileDefaultLibrary(file)) continue;
+        for (const statement of file.statements) {
+            if (!ts.isTypeAliasDeclaration(statement)) continue;
+            const name = statement.name.text;
+            if (exportedNames.has(name)) continue;
+            const existing = aliasDeclarations.get(name);
+            if (existing && existing !== statement) {
+                ambiguousNames.add(name);
+                continue;
+            }
+            aliasDeclarations.set(name, statement);
+        }
+    }
+
+    return {
+        resolveTypeAlias: (name) =>
+            ambiguousNames.has(name) ? null : classifyAlias(checker, aliasDeclarations.get(name)),
+    };
+}
+
+// Classifies a type alias declaration as one of:
+//   { kind: 'function' }                       - callable with no members
+//   { kind: 'object', properties: [...] }      - object shape with named members
+//   { kind: 'signature' }                      - render the raw signature (tuples, index-only objects)
+//   { kind: 'union' }                          - any union
+//   { kind: 'other' }                          - primitives and everything else
+// Returns null for unknown names and generic aliases, which keeps them on the
+// token-based fallback path.
+function classifyAlias(checker, declaration) {
+    if (!declaration || declaration.typeParameters?.length) {
+        return null;
+    }
+
+    const type = checker.getTypeFromTypeNode(declaration.type);
+    if (type.isUnion()) {
+        return { kind: 'union' };
+    }
+    if (checker.isTupleType(type) || checker.isArrayType(type)) {
+        return { kind: 'signature' };
+    }
+    if (!(type.flags & (ts.TypeFlags.Object | ts.TypeFlags.Intersection))) {
+        return { kind: 'other' };
+    }
+
+    const properties = type.getProperties().filter((prop) => !(prop.flags & ts.SymbolFlags.Method));
+    if (type.getCallSignatures().length > 0 && properties.length === 0) {
+        return { kind: 'function' };
+    }
+    if (properties.length > 0) {
+        return {
+            kind: 'object',
+            properties: properties.map((prop) => describeProperty(checker, prop, declaration)),
+        };
+    }
+    if (checker.getIndexInfosOfType(type).length > 0) {
+        return { kind: 'signature' };
+    }
+    return { kind: 'other' };
+}
+
+function describeProperty(checker, prop, location) {
+    const propType = checker.getTypeOfSymbolAtLocation(prop, location);
+    const description = ts.displayPartsToString(prop.getDocumentationComment(checker)).trim();
+
+    return {
+        name: prop.getName(),
+        type: checker.typeToString(propType, location, ts.TypeFormatFlags.NoTruncation),
+        description: description || undefined,
+    };
+}
+
+module.exports = {
+    createTypeResolver,
+};

--- a/scripts/docs/type-resolver.js
+++ b/scripts/docs/type-resolver.js
@@ -82,8 +82,10 @@ function classifyAlias(checker, declaration) {
     }
 
     const properties = type.getProperties().filter((prop) => !(prop.flags & ts.SymbolFlags.Method));
-    if (type.getCallSignatures().length > 0 && properties.length === 0) {
-        return { kind: 'function' };
+    if (type.getCallSignatures().length > 0) {
+        // a callable type with members would lose its call signature as an object,
+        // so publish the full raw signature instead
+        return properties.length === 0 ? { kind: 'function' } : { kind: 'signature' };
     }
     if (properties.length > 0) {
         return {

--- a/scripts/docs/type-resolver.js
+++ b/scripts/docs/type-resolver.js
@@ -101,9 +101,15 @@ function describeProperty(checker, prop, location) {
     const propType = checker.getTypeOfSymbolAtLocation(prop, location);
     const description = ts.displayPartsToString(prop.getDocumentationComment(checker)).trim();
 
+    // typeToString qualifies symbols not lexically visible at the alias declaration as
+    // import("<absolute path>").Name — machine-specific and unfit for published output
+    const typeText = checker
+        .typeToString(propType, location, ts.TypeFormatFlags.NoTruncation)
+        .replace(/import\("[^"]*"\)\./g, '');
+
     return {
         name: prop.getName(),
-        type: checker.typeToString(propType, location, ts.TypeFormatFlags.NoTruncation),
+        type: typeText,
         description: description || undefined,
     };
 }

--- a/scripts/docs/types.js
+++ b/scripts/docs/types.js
@@ -5,9 +5,9 @@ const documentation = require('./documentation');
 // TypeDefinition structure: { name, id, params?, path?, example? }
 // TypeToken structure: { kind, text, canonicalReference? }
 
-function resolveTypeDefinitions(apiPackage) {
+function resolveTypeDefinitions(apiPackage, typeResolver) {
     const allMembers = getAllTypeMembers(apiPackage);
-    const typeDefinitions = allMembers.map((member) => createInitialTypeDef(member, apiPackage));
+    const typeDefinitions = allMembers.map((member) => createInitialTypeDef(member, apiPackage, typeResolver));
     
     const resolvedTypeDefinitions = resolveObjectTypes(
         resolveUnionTypes(typeDefinitions)
@@ -42,7 +42,7 @@ function getAllTypeMembers(apiPackage) {
 }
 
 // Create initial type definition
-function createInitialTypeDef(member, apiPackage) {
+function createInitialTypeDef(member, apiPackage, typeResolver) {
     const typeDef = {
         name: member.name,
         id: member.name,
@@ -53,7 +53,7 @@ function createInitialTypeDef(member, apiPackage) {
     const processor = {
         [ApiItemKind.Enum]: () => processEnumMember(member, typeDef),
         [ApiItemKind.Interface]: () => processInterfaceMember(member, typeDef),
-        [ApiItemKind.TypeAlias]: () => processTypeAliasMember(member, typeDef, apiPackage)
+        [ApiItemKind.TypeAlias]: () => processTypeAliasMember(member, typeDef, apiPackage, typeResolver)
     }[member.kind];
 
     processor?.();
@@ -82,19 +82,38 @@ function processInterfaceMember(member, typeDef) {
 }
 
 // Process type alias members
-function processTypeAliasMember(member, typeDef, apiPackage) {
+function processTypeAliasMember(member, typeDef, apiPackage, typeResolver) {
     const detailedType = extractDetailedTypeInfo(member);
     if (!detailedType) return;
 
-    // Check if this is a callback type and extract full signature
-    const callbackSignature = extractCallbackSignature(detailedType, member);
-    if (callbackSignature) {
-        typeDef.example = callbackSignature;
+    const resolved = typeResolver?.resolveTypeAlias(member.name);
+
+    if (resolved?.kind === 'object') {
+        typeDef.params = resolved.properties;
+        return;
+    }
+
+    if (resolved?.kind === 'signature') {
+        typeDef.example = detailedType.signature;
         typeDef.params = [];
         return;
     }
 
-    const literalValues = extractLiteralValues(member, apiPackage);
+    const isFunctionType = resolved
+        ? resolved.kind === 'function'
+        : hasTopLevelArrow(detailedType.signature) ||
+          utils.isCallbackType(member.name) ||
+          member.name.includes('Callback');
+
+    if (isFunctionType) {
+        typeDef.example = extractCallbackSignature(detailedType);
+        typeDef.params = [];
+        return;
+    }
+
+    // Quoted strings inside object literals, intersections or type arguments
+    // (e.g. Omit<T, 'key'>) are not string-literal union members
+    const literalValues = /[{&<]/.test(detailedType.signature) ? [] : extractLiteralValues(member, apiPackage);
     if (literalValues.length > 0) {
         // For string literal unions, create an example instead of properties
         const literalTypes = literalValues.map(v => v.type).join(' | ');
@@ -108,32 +127,37 @@ function processTypeAliasMember(member, typeDef, apiPackage) {
     }
 }
 
-// Extract callback signature from type alias
-function extractCallbackSignature(detailedType, member) {
-    const signature = detailedType.signature;
-    
-    // Check if this is a function type by looking for function patterns
-    const isFunctionPattern = signature.includes('=>') || 
-                             signature.includes(': ') || 
-                             utils.isCallbackType(member.name) ||
-                             member.name.includes('Callback');
-    
-    if (!isFunctionPattern) {
-        return null;
+// Detects a function type at the top level of a signature, ignoring arrows nested
+// inside object literals, parameter lists, generics or arrays
+function hasTopLevelArrow(signature) {
+    let depth = 0;
+    for (let i = 0; i < signature.length; i++) {
+        const char = signature[i];
+        if (char === '=' && signature[i + 1] === '>') {
+            if (depth === 0) {
+                return true;
+            }
+            i++;
+        } else if ('({[<'.includes(char)) {
+            depth++;
+        } else if (')}]>'.includes(char)) {
+            depth--;
+        }
     }
-    
-    // Extract function signature from the tokens
+    return false;
+}
+
+// Extract callback signature from a type alias already known to be a function type
+function extractCallbackSignature(detailedType) {
     const functionSignature = extractFunctionFromTokens(detailedType.tokens);
     if (functionSignature) {
         return functionSignature;
     }
-    
-    // For known callback patterns, extract the full signature
-    if (signature.includes('=>')) {
-        return signature.trim();
+
+    if (detailedType.signature.includes('=>')) {
+        return detailedType.signature.trim();
     }
-    
-    // Fallback to generic callback for simple function types
+
     return '() => {}';
 }
 

--- a/scripts/docs/utils.js
+++ b/scripts/docs/utils.js
@@ -171,6 +171,7 @@ const splitObjectProperties = (content) => {
  * @returns {{name: string, type: string, description: string} | null} - Parsed property
  */
 const parseProperty = (part) => {
+  if (part.startsWith('[')) return null; // index signatures are not named properties
   const colonIndex = part.indexOf(':');
   if (colonIndex === -1) return null;
 


### PR DESCRIPTION
## Problem

The generated SDK references published `"properties": []` for object-shaped type aliases — including `PostHogConfig`, the most-used type in the SDK — so posthog.com rendered nothing for them (fixes #4162, reported by @ryanwaits).

Root cause: `extractCallbackSignature` in `scripts/docs/types.js` treated any signature containing `': '` as a function type. Every object literal contains `': '`, so all object-shaped aliases took the callback path: raw signature into `example`, early return, property extraction skipped. Interfaces use a different path, which is why only aliases were affected. The parser is shared, so browser, node, and react-native references all had the gap (52/107, 95/124, 85/116 types with empty properties respectively).

This also unblocks PostHog/posthog.com#18577: the generated reference can now serve as the full `PostHogConfig` documentation source.

## Changes

- **New `scripts/docs/type-resolver.js`** — builds a TypeScript program over the same `.d.ts` entry point api-extractor analyzes and classifies each documented alias via the checker: `function`, `object` (flattened properties with JSDoc descriptions — this resolves `Omit<>`, intersections, and cross-package references, which token-based parsing can't), `signature` (tuples, index-signature-only objects), `union`, or `other`. Indexes entry-point exports plus every top-level alias in the program (api-extractor documents referenced-but-unexported aliases too); duplicate names across files resolve to `null` rather than guessing. `import("<abs path>").Name` qualifiers emitted by `typeToString` for non-lexically-visible symbols are stripped — they leak machine paths and would churn on every CI regeneration.
- **`scripts/docs/types.js`** — consults the resolver first; the `': '` heuristic is replaced with a top-level-arrow check on the fallback path; string-literal extraction no longer treats quoted strings inside `{ } & <` signatures (e.g. `Omit<T, 'key'>`) as union members.
- **`scripts/docs/utils.js`** — the fallback object parser skips index-signature parts instead of emitting `"[key"`-style property names.
- **`packages/{browser,node,react-native}/scripts/generate-docs.*`** — pass `dtsEntryPath` (identical to each package's api-extractor `mainEntryPointFilePath`).
- **Regenerated references**: `PostHogConfig` 0 → 132 properties with descriptions; empty-property types drop from 52→41 (browser), 95→49 (node), 85→43 (react-native). Remaining empties are string unions / interface unions rendered via `example`, unchanged from before.
- **Tests**: `scripts/docs/__tests__/` runs a fixture package through real api-extractor and the parser (24 node:test tests) covering object aliases, `Omit`+intersection, callbacks, string unions, tuples, index signatures, unions of interfaces, generic aliases, cross-file/unexported aliases, name collisions, import-qualifier stripping, and the resolver-less fallback. Wired into CI (`pnpm test:docs-scripts` in the unit job).

Reviewer-relevant verification: schema of the reference JSONs is unchanged (same keys); scripted before/after audit shows no type lost properties or example and no garbage property names; `packages/*/docs/*.api.json` and `.api.md` regenerate byte-identical; regeneration is deterministic (node's JSON byte-identical across runs). Union aliases still render as raw examples — expanding those via the checker is a possible follow-up, not a regression.

## Release info Sub-libraries affected

### Libraries affected

None — this is docs-generation tooling plus regenerated reference JSONs; no published package code changes, so no version bumps.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

No changeset: nothing is released; docs tooling and generated reference files only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. Investigated #4162 against source, confirmed the reporter's root-cause analysis, and implemented the checker-based approach they proposed (thanks @ryanwaits).
- Considered `bundledPackages` in api-extractor config instead of a checker — rejected because it would rewrite the committed `.api.md`/`.api.json` public-API reports; the checker leaves those untouched.
- A pre-PR review loop (independent reviewer → skeptical triage → fix) caught two issues before this PR: `typeToString` leaking absolute local paths as `import("/Users/…")` qualifiers into the JSONs, and missing test coverage for duplicate-alias ambiguity. Both fixed; regeneration audits (schema keys, lost content, garbage names, determinism) ran after each cycle.
