### PR TITLE
fix(docs): exclude internal members and tag deprecated ones in SDK references

### DIFF
--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -2372,6 +2372,12 @@
           "name": "selector"
         },
         {
+          "description": "Deprecated: Only `selector` should be used now.",
+          "type": "string",
+          "name": "tag_name",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "StringMatching.Exact",
           "type": "ActionStepStringMatching | null",
           "name": "text_matching"
@@ -2984,6 +2990,12 @@
           "name": "persistence_name"
         },
         {
+          "description": "Deprecated: - Use 'persistence_name' instead",
+          "type": "string",
+          "name": "cookie_name",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "List of custom property names that should be stored in cookies (in addition to the default ones)\nwhen using 'localStorage+cookie' persistence mode. This allows these properties to be shared\nacross subdomains when cross_subdomain_cookie is enabled.",
           "type": "readonly string[]",
           "name": "cookie_persisted_properties"
@@ -3004,6 +3016,12 @@
           "name": "save_campaign_params"
         },
         {
+          "description": "Deprecated: - Use `save_campaign_params` instead",
+          "type": "boolean",
+          "name": "store_google",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Used to extend the list of campaign parameters that are saved by default.",
           "type": "string[]",
           "name": "custom_campaign_params"
@@ -3017,6 +3035,12 @@
           "description": "Determines whether PostHog should be in debug mode.\nYou can enable this to get more detailed logging.\n\nYou can also enable this on your website by appending `?__posthog_debug=true` at the end of your URL\nYou can also call `posthog.debug()` in your code to enable debug mode",
           "type": "boolean",
           "name": "debug"
+        },
+        {
+          "description": "Deprecated: Use `debug` instead",
+          "type": "boolean",
+          "name": "verbose",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Determines whether PostHog should capture pageview events automatically.\nCan be:\n- `true`: Capture regular pageviews (default)\n- `false`: Don't capture any pageviews\n- `'history_change'`: Capture pageviews on the initial page load and on history API changes (pushState, replaceState, popstate)",
@@ -3047,6 +3071,12 @@
           "description": "Determines whether PostHog should disable persistence.\nIf set to `true`, the library will not save any data to the browser. It will also delete any data previously saved to the browser.",
           "type": "boolean",
           "name": "disable_persistence"
+        },
+        {
+          "description": "Deprecated: - use `disable_persistence` instead",
+          "type": "boolean",
+          "name": "disable_cookie",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Coalesce rapid `Persistence.save()` calls into a single write.\n\nSet to a positive number (milliseconds) to debounce writes to localStorage / cookie\nby that window. The in-memory `props` object is always updated synchronously so\nwithin-tab reads see the latest values immediately. Cross-tab `storage` events\n(which carry the full persistence value as a payload) are reduced proportionally\nto the debounce window.\n\nPending writes are flushed on `beforeunload` and `pagehide` so no state is lost\non tab close. The cross-tab visibility delay is bounded by the configured window.\n\nDefaults to `0` (no debouncing, write synchronously) for backwards compatibility.\nOn pages that capture many events per second, `250` is a reasonable starting point\nto reduce localStorage write pressure and cross-tab IPC traffic. The `2026-05-30`\nconfig default opts into `250` automatically.",
@@ -3174,6 +3204,12 @@
           "name": "opt_out_useragent_filter"
         },
         {
+          "description": "Deprecated: Use `consent_persistence_name` instead. This will be removed in a future major version. *",
+          "type": "string",
+          "name": "opt_out_capturing_cookie_prefix",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Determines the key for the cookie / local storage used to store the information about whether users are opted in/out of capturing.\nWhen `null`, we used a key based on your token.",
           "type": "string",
           "name": "consent_persistence_name"
@@ -3194,14 +3230,32 @@
           "name": "property_denylist"
         },
         {
+          "description": "Deprecated: - use `property_denylist` instead",
+          "type": "string[]",
+          "name": "property_blacklist",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "A list of headers that should be sent with requests to the PostHog API.",
           "type": "{ [header_name: string]: string; }",
           "name": "request_headers"
         },
         {
+          "description": "Deprecated: - use `request_headers` instead",
+          "type": "{ [header_name: string]: string; }",
+          "name": "xhr_headers",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "A function that is called when a request to the PostHog API fails.",
           "type": "(error: RequestResponse) => void",
           "name": "on_request_error"
+        },
+        {
+          "description": "Deprecated: - use `on_request_error` instead",
+          "type": "(failedRequest: XMLHttpRequest) => void",
+          "name": "on_xhr_error",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Determines whether PostHog should batch requests to the PostHog API.",
@@ -3259,6 +3313,12 @@
           "name": "advanced_disable_flags"
         },
         {
+          "description": "Deprecated: Use `advanced_disable_flags` instead. This will be removed in a future major version.\n\nOne of the very first things the PostHog library does when init() is called\nis make a request to the /decide endpoint on PostHog's backend.\nThis endpoint contains information on how to run the PostHog library\nso events are properly received in the backend.\n\nThis endpoint is required to run most features of the library.\nHowever, if you're not using any of the described features,\nyou may wish to turn off the call completely to avoid an extra request\nand reduce resource usage on both the client and the server.",
+          "type": "boolean",
+          "name": "advanced_disable_decide",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Will keep /flags running, but without evaluating any feature flags.\nUseful for when you need to load the config data associated with the flags endpoint\n(e.g. /flags?v=2&config=true) without evaluating any feature flags.  Most folks use this\nto save money on feature flag evaluation (by bootstrapping feature flags on the server side).",
           "type": "boolean",
           "name": "advanced_disable_feature_flags"
@@ -3277,6 +3337,12 @@
           "description": "List of feature flag keys to remotely evaluate for this SDK instance.\nWhen set, only these flags are evaluated by `/flags`; omitted flags are not remotely evaluated.\nDependencies of the requested flags may still be evaluated internally by PostHog.\nIf unset, all eligible flags are evaluated.\n\nExamples: ['checkout-redesign', 'new-onboarding']",
           "type": "readonly string[]",
           "name": "flag_keys"
+        },
+        {
+          "description": "Evaluation environments for feature flags.\nDeprecated: Use evaluation_contexts instead. This property will be removed in a future version.",
+          "type": "readonly string[]",
+          "name": "evaluation_environments",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Determines whether PostHog should disable toolbar metrics.\nThis is our internal instrumentation for our toolbar in your website.",
@@ -3334,6 +3400,12 @@
           "name": "get_current_url"
         },
         {
+          "description": "Deprecated: - use `before_send` instead",
+          "type": "(properties: Properties, event_name: string) => Properties",
+          "name": "sanitize_properties",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Determines whether to capture performance metrics.\nThese include Network Timing for Session Replay and Web Vitals.\n\nThe `network_timing` option is only used by the Session Replay feature.\nFor more session recording settings, see the `session_recording` and `enable_recording_console_log` configuration option.\n\nWhen `undefined`, fallback to the remote configuration.\nIf `false`, neither network timing nor web vitals will work.\nIf an object, that will override the remote configuration.",
           "type": "boolean | PerformanceCaptureConfig",
           "name": "capture_performance"
@@ -3359,6 +3431,12 @@
           "name": "capture_heatmaps"
         },
         {
+          "description": "Deprecated: Use `capture_heatmaps` instead.",
+          "type": "boolean",
+          "name": "enable_heatmaps",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Determines whether to capture dead clicks.\n\nby default dead clicks are ignored on elements that match a `ph-no-capture` or `ph-no-deadclick` css class on the element or a parent",
           "type": "boolean | DeadClicksAutoCaptureConfig",
           "name": "capture_dead_clicks"
@@ -3382,6 +3460,12 @@
           "description": "You can control whether events from PostHog-js have person processing enabled with the `person_profiles` config setting.\nThere are three options:\n- `person_profiles: 'always'` - we will process persons data for all events\n- `person_profiles: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person_profile: False`.\n- `person_profiles: 'identified_only'` _(default)_ - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.unsetPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.",
           "type": "\"always\" | \"never\" | \"identified_only\"",
           "name": "person_profiles"
+        },
+        {
+          "description": "Deprecated: - use `person_profiles` instead",
+          "type": "\"always\" | \"never\" | \"identified_only\"",
+          "name": "process_person",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Client side rate limiting",
@@ -3424,9 +3508,39 @@
           "name": "tracing_headers"
         },
         {
+          "description": "Deprecated: Use {@link tracing_headers} instead. Kept for backwards compatibility.",
+          "type": "string[]",
+          "name": "addTracingHeaders",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Prevents posthog-js from using the `navigator.sendBeacon` API to send events.\nEnabling this option may hurt the reliability of sending $pageleave events.",
           "type": "boolean",
           "name": "disable_beacon"
+        },
+        {
+          "description": "Deprecated: - NOT USED ANYMORE, kept here for backwards compatibility reasons",
+          "type": "string",
+          "name": "api_method",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: - NOT USED ANYMORE, kept here for backwards compatibility reasons",
+          "type": "string",
+          "name": "inapp_protocol",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: - NOT USED ANYMORE, kept here for backwards compatibility reasons",
+          "type": "boolean",
+          "name": "inapp_link_new_window",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: - THIS OPTION HAS NO EFFECT, kept here for backwards compatibility reasons.\nUse a custom transformation or \"Discard IP data\" project setting instead:",
+          "type": "boolean",
+          "name": "ip",
+          "releaseTag": "deprecated"
         },
         {
           "type": "(posthog: PostHogInterface) => void",
@@ -3563,6 +3677,12 @@
           "description": "Get the value of a feature flag.",
           "type": "(key: string, options?: FeatureFlagOptions) => boolean | string | undefined",
           "name": "getFeatureFlag"
+        },
+        {
+          "description": "Get the payload of a feature flag.\nDeprecated: Use `getFeatureFlagResult()` instead which properly tracks the feature flag call.",
+          "type": "(key: string) => JsonType",
+          "name": "getFeatureFlagPayload",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Get a feature flag evaluation result including both the flag value and payload.\n\nBy default, this method emits the `$feature_flag_called` event.",
@@ -3783,6 +3903,18 @@
           "description": "Capture a metric for a LLM trace.",
           "type": "(traceId: string | number, metricName: string, metricValue: string | number | boolean) => void",
           "name": "captureTraceMetric"
+        },
+        {
+          "description": "Deprecated: Use `setPersonProperties` instead",
+          "type": "{ set: (prop: string | Properties, to?: string, callback?: RequestCallback) => void; set_once: (prop: string | Properties, to?: string, callback?: RequestCallback) => void; }",
+          "name": "people",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: Use `flagsEndpointWasHit` instead",
+          "type": "boolean",
+          "name": "decideEndpointWasHit",
+          "releaseTag": "deprecated"
         },
         {
           "type": "PostHogConfig",
@@ -4366,6 +4498,12 @@
           "description": "Whether to only capture identified users by default",
           "type": "boolean",
           "name": "defaultIdentifiedOnly"
+        },
+        {
+          "description": "Deprecated: renamed to toolbarParams, still present on older API responses",
+          "type": "ToolbarParams",
+          "name": "editorParams",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Whether the `$elements_chain` property should be sent as a string or as an array\nfalse",
@@ -5131,6 +5269,12 @@
           "name": "boxPadding"
         },
         {
+          "description": "Deprecated: - not currently used",
+          "type": "string",
+          "name": "descriptionTextColor",
+          "releaseTag": "deprecated"
+        },
+        {
           "type": "boolean",
           "name": "disableAutofocus"
         },
@@ -5145,6 +5289,12 @@
         {
           "type": "boolean",
           "name": "hideCancelButton"
+        },
+        {
+          "description": "Deprecated: Use inputBackground instead (inherited from core)",
+          "type": "string",
+          "name": "inputBackgroundColor",
+          "releaseTag": "deprecated"
         },
         {
           "type": "string",
@@ -5188,6 +5338,18 @@
       "id": "SurveyConfig",
       "name": "SurveyConfig",
       "properties": [
+        {
+          "description": "Deprecated: No longer used. Pre-filled responses are now sent immediately when partial responses are enabled, or all required questions have been pre-filled.",
+          "type": "number",
+          "name": "autoSubmitDelay",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: No longer used. Surveys will automatically advance past prefilled questions with skipSubmitButton enabled. If partial response collection is enabled, partial responses for pre-filled questions will be submitted automatically on page load.",
+          "type": "boolean",
+          "name": "autoSubmitIfComplete",
+          "releaseTag": "deprecated"
+        },
         {
           "description": "Prefill survey responses from matching URL parameters.\nundefined",
           "type": "boolean",

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -2372,11 +2372,6 @@
           "name": "selector"
         },
         {
-          "description": "",
-          "type": "string",
-          "name": "tag_name"
-        },
-        {
           "description": "StringMatching.Exact",
           "type": "ActionStepStringMatching | null",
           "name": "text_matching"
@@ -2926,32 +2921,7 @@
     {
       "id": "PersistentStore",
       "name": "PersistentStore",
-      "properties": [
-        {
-          "type": "(error: any) => void",
-          "name": "_error"
-        },
-        {
-          "type": "(name: string) => any",
-          "name": "_get"
-        },
-        {
-          "type": "() => boolean",
-          "name": "_is_supported"
-        },
-        {
-          "type": "(name: string) => any",
-          "name": "_parse"
-        },
-        {
-          "type": "(name: string, cross_subdomain?: boolean) => void",
-          "name": "_remove"
-        },
-        {
-          "type": "(name: string, value: any, expire_days?: number | null, cross_subdomain?: boolean, secure?: boolean, debug?: boolean) => boolean",
-          "name": "_set"
-        }
-      ],
+      "properties": [],
       "path": "lib/src/types.d.ts"
     },
     {
@@ -3014,10 +2984,6 @@
           "name": "persistence_name"
         },
         {
-          "type": "string",
-          "name": "cookie_name"
-        },
-        {
           "description": "List of custom property names that should be stored in cookies (in addition to the default ones)\nwhen using 'localStorage+cookie' persistence mode. This allows these properties to be shared\nacross subdomains when cross_subdomain_cookie is enabled.",
           "type": "readonly string[]",
           "name": "cookie_persisted_properties"
@@ -3038,10 +3004,6 @@
           "name": "save_campaign_params"
         },
         {
-          "type": "boolean",
-          "name": "store_google"
-        },
-        {
           "description": "Used to extend the list of campaign parameters that are saved by default.",
           "type": "string[]",
           "name": "custom_campaign_params"
@@ -3055,10 +3017,6 @@
           "description": "Determines whether PostHog should be in debug mode.\nYou can enable this to get more detailed logging.\n\nYou can also enable this on your website by appending `?__posthog_debug=true` at the end of your URL\nYou can also call `posthog.debug()` in your code to enable debug mode",
           "type": "boolean",
           "name": "debug"
-        },
-        {
-          "type": "boolean",
-          "name": "verbose"
         },
         {
           "description": "Determines whether PostHog should capture pageview events automatically.\nCan be:\n- `true`: Capture regular pageviews (default)\n- `false`: Don't capture any pageviews\n- `'history_change'`: Capture pageviews on the initial page load and on history API changes (pushState, replaceState, popstate)",
@@ -3089,10 +3047,6 @@
           "description": "Determines whether PostHog should disable persistence.\nIf set to `true`, the library will not save any data to the browser. It will also delete any data previously saved to the browser.",
           "type": "boolean",
           "name": "disable_persistence"
-        },
-        {
-          "type": "boolean",
-          "name": "disable_cookie"
         },
         {
           "description": "Coalesce rapid `Persistence.save()` calls into a single write.\n\nSet to a positive number (milliseconds) to debounce writes to localStorage / cookie\nby that window. The in-memory `props` object is always updated synchronously so\nwithin-tab reads see the latest values immediately. Cross-tab `storage` events\n(which carry the full persistence value as a payload) are reduced proportionally\nto the debounce window.\n\nPending writes are flushed on `beforeunload` and `pagehide` so no state is lost\non tab close. The cross-tab visibility delay is bounded by the configured window.\n\nDefaults to `0` (no debouncing, write synchronously) for backwards compatibility.\nOn pages that capture many events per second, `250` is a reasonable starting point\nto reduce localStorage write pressure and cross-tab IPC traffic. The `2026-05-30`\nconfig default opts into `250` automatically.",
@@ -3220,10 +3174,6 @@
           "name": "opt_out_useragent_filter"
         },
         {
-          "type": "string",
-          "name": "opt_out_capturing_cookie_prefix"
-        },
-        {
           "description": "Determines the key for the cookie / local storage used to store the information about whether users are opted in/out of capturing.\nWhen `null`, we used a key based on your token.",
           "type": "string",
           "name": "consent_persistence_name"
@@ -3244,26 +3194,14 @@
           "name": "property_denylist"
         },
         {
-          "type": "string[]",
-          "name": "property_blacklist"
-        },
-        {
           "description": "A list of headers that should be sent with requests to the PostHog API.",
           "type": "{ [header_name: string]: string; }",
           "name": "request_headers"
         },
         {
-          "type": "{ [header_name: string]: string; }",
-          "name": "xhr_headers"
-        },
-        {
           "description": "A function that is called when a request to the PostHog API fails.",
           "type": "(error: RequestResponse) => void",
           "name": "on_request_error"
-        },
-        {
-          "type": "(failedRequest: XMLHttpRequest) => void",
-          "name": "on_xhr_error"
         },
         {
           "description": "Determines whether PostHog should batch requests to the PostHog API.",
@@ -3279,16 +3217,6 @@
           "description": "Configuration defaults for breaking changes. When set to a specific date,\nenables new default behaviors that were introduced on that date.\n\n- `'unset'`: Use legacy default behaviors\n- `'2025-05-24'`: Use updated default behaviors (e.g. capture_pageview defaults to 'history_change')\n- `'2025-11-30'`: Defaults from '2025-05-24' plus additional changes (e.g. strict minimum duration for replay and rageclick content ignore list defaults to active)\n- `'2026-01-30'`: Defaults from '2025-11-30' plus external_scripts_inject_target defaults to 'head' (avoids SSR hydration errors)\n- `'2026-05-30'`: Defaults from '2026-01-30' plus `persistence_save_debounce_ms` defaults to `250`, `split_storage` and `detect_google_search_app` default to `true`, and rageclick defaults also exclude stepper controls and text-selection surfaces\n- `'2026-06-25'`: Defaults from '2026-05-30' plus `session_recording.streamNetworkBody` defaults to `true` (streams network bodies to enforce the payload size limit)",
           "type": "ConfigDefaults",
           "name": "defaults"
-        },
-        {
-          "description": "EXPERIMENTAL: Defers initialization of non-critical extensions (autocapture, session recording, etc.)\nto the next event loop tick using setTimeout. This reduces main thread blocking during SDK\ninitialization for better page load performance, while keeping critical functionality\n(persistence, sessions, capture) available immediately.\n\nWhen enabled:\n- Persistence, sessions, and basic capture work immediately\n- Extensions (autocapture, recording, heatmaps, etc.) start after yielding back to the browser",
-          "type": "boolean",
-          "name": "__preview_deferred_init_extensions"
-        },
-        {
-          "description": "In `'localStorage+cookie'` persistence mode, prefer cookie values over localStorage\nwhen both stores carry the same key. Fixes cross-subdomain identify and session\ndisconnects caused by stale per-subdomain localStorage clobbering a fresh shared cookie.\nRead at SDK init; has no effect when toggled via `set_config` or for other persistence modes.",
-          "type": "boolean",
-          "name": "__preview_cookie_wins_on_conflict"
         },
         {
           "description": "Determines the session recording options.\n\nFor more session recording settings, see the `enable_recording_console_log` and `capture_performance` configuration option.\nWhen `defaults` is `'2025-11-30'` or later, `strictMinimumDuration` defaults to `true`.",
@@ -3331,10 +3259,6 @@
           "name": "advanced_disable_flags"
         },
         {
-          "type": "boolean",
-          "name": "advanced_disable_decide"
-        },
-        {
           "description": "Will keep /flags running, but without evaluating any feature flags.\nUseful for when you need to load the config data associated with the flags endpoint\n(e.g. /flags?v=2&config=true) without evaluating any feature flags.  Most folks use this\nto save money on feature flag evaluation (by bootstrapping feature flags on the server side).",
           "type": "boolean",
           "name": "advanced_disable_feature_flags"
@@ -3353,11 +3277,6 @@
           "description": "List of feature flag keys to remotely evaluate for this SDK instance.\nWhen set, only these flags are evaluated by `/flags`; omitted flags are not remotely evaluated.\nDependencies of the requested flags may still be evaluated internally by PostHog.\nIf unset, all eligible flags are evaluated.\n\nExamples: ['checkout-redesign', 'new-onboarding']",
           "type": "readonly string[]",
           "name": "flag_keys"
-        },
-        {
-          "description": "Evaluation environments for feature flags.",
-          "type": "readonly string[]",
-          "name": "evaluation_environments"
         },
         {
           "description": "Determines whether PostHog should disable toolbar metrics.\nThis is our internal instrumentation for our toolbar in your website.",
@@ -3415,14 +3334,6 @@
           "name": "get_current_url"
         },
         {
-          "type": "(properties: Properties, event_name: string) => Properties",
-          "name": "sanitize_properties"
-        },
-        {
-          "type": "(eventName: string, eventData: CaptureResult) => void",
-          "name": "_onCapture"
-        },
-        {
           "description": "Determines whether to capture performance metrics.\nThese include Network Timing for Session Replay and Web Vitals.\n\nThe `network_timing` option is only used by the Session Replay feature.\nFor more session recording settings, see the `session_recording` and `enable_recording_console_log` configuration option.\n\nWhen `undefined`, fallback to the remote configuration.\nIf `false`, neither network timing nor web vitals will work.\nIf an object, that will override the remote configuration.",
           "type": "boolean | PerformanceCaptureConfig",
           "name": "capture_performance"
@@ -3448,10 +3359,6 @@
           "name": "capture_heatmaps"
         },
         {
-          "type": "boolean",
-          "name": "enable_heatmaps"
-        },
-        {
           "description": "Determines whether to capture dead clicks.\n\nby default dead clicks are ignored on elements that match a `ph-no-capture` or `ph-no-deadclick` css class on the element or a parent",
           "type": "boolean | DeadClicksAutoCaptureConfig",
           "name": "capture_dead_clicks"
@@ -3475,10 +3382,6 @@
           "description": "You can control whether events from PostHog-js have person processing enabled with the `person_profiles` config setting.\nThere are three options:\n- `person_profiles: 'always'` - we will process persons data for all events\n- `person_profiles: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person_profile: False`.\n- `person_profiles: 'identified_only'` _(default)_ - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.unsetPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.",
           "type": "\"always\" | \"never\" | \"identified_only\"",
           "name": "person_profiles"
-        },
-        {
-          "type": "\"always\" | \"never\" | \"identified_only\"",
-          "name": "process_person"
         },
         {
           "description": "Client side rate limiting",
@@ -3521,62 +3424,9 @@
           "name": "tracing_headers"
         },
         {
-          "type": "string[]",
-          "name": "addTracingHeaders"
-        },
-        {
-          "type": "string[]",
-          "name": "__add_tracing_headers"
-        },
-        {
-          "type": "boolean",
-          "name": "__preview_flags_v2"
-        },
-        {
-          "type": "boolean",
-          "name": "__preview_eager_load_replay"
-        },
-        {
           "description": "Prevents posthog-js from using the `navigator.sendBeacon` API to send events.\nEnabling this option may hurt the reliability of sending $pageleave events.",
           "type": "boolean",
           "name": "disable_beacon"
-        },
-        {
-          "type": "boolean",
-          "name": "__preview_disable_beacon"
-        },
-        {
-          "type": "boolean",
-          "name": "__preview_disable_xhr_credentials"
-        },
-        {
-          "type": "string | boolean",
-          "name": "__preview_external_dependency_versioned_paths"
-        },
-        {
-          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION\nEnables collection of bot traffic as $bot_pageview events with detailed bot detection\nproperties instead of dropping them entirely. Use it alongside opt_out_useragent_filter",
-          "type": "boolean",
-          "name": "__preview_capture_bot_pageviews"
-        },
-        {
-          "type": "boolean",
-          "name": "__preview_lazy_load_replay"
-        },
-        {
-          "type": "string",
-          "name": "api_method"
-        },
-        {
-          "type": "string",
-          "name": "inapp_protocol"
-        },
-        {
-          "type": "boolean",
-          "name": "inapp_link_new_window"
-        },
-        {
-          "type": "boolean",
-          "name": "ip"
         },
         {
           "type": "(posthog: PostHogInterface) => void",
@@ -3586,11 +3436,6 @@
           "description": "Disables capturing the `$device_model` super-property.\n\nWhen capturing is enabled (the default), PostHog resolves the hardware model once during init\nvia `navigator.userAgentData.getHighEntropyValues(['model'])` and registers it as the raw OEM\ncode (e.g. `Pixel 7`). This is Chromium-only and only meaningful on Android — it resolves to\n`undefined` on Safari/Firefox and to an empty string on desktop, in which cases nothing is\nregistered.\n\nThis opt-out is offered because `getHighEntropyValues` is still experimental and Chromium-only\n(not yet a cross-browser standard); set it to `true` to skip the call entirely.",
           "type": "boolean",
           "name": "disableDeviceModel"
-        },
-        {
-          "description": "Internal: Extension class overrides for tree-shaking support.\nWhen provided, these classes are used instead of the default imports.\nThis enables entrypoints to control which extensions are bundled.",
-          "type": "{ exceptions?: ExtensionConstructor<PostHogExceptions>; historyAutocapture?: ExtensionConstructor<HistoryAutocapture>; tracingHeaders?: ExtensionConstructor<TracingHeaders>; siteApps?: ExtensionConstructor<SiteApps>; sessionRecording?: ExtensionConstructor<SessionRecording>; autocapture?: ExtensionConstructor<Autocapture>; productTours?: ExtensionConstructor<PostHogProductTours>; heatmaps?: ExtensionConstructor<Heatmaps>; webVitalsAutocapture?: ExtensionConstructor<WebVitalsAutocapture>; exceptionObserver?: ExtensionConstructor<ExceptionObserver>; deadClicksAutocapture?: ExtensionConstructor<DeadClicksAutocapture>; surveys?: ExtensionConstructor<PostHogSurveys>; toolbar?: ExtensionConstructor<Toolbar>; experiments?: ExtensionConstructor<WebExperiments>; conversations?: ExtensionConstructor<PostHogConversations>; featureFlags?: ExtensionConstructor<PostHogFeatureFlags>; logs?: ExtensionConstructor<PostHogLogs>; metrics?: ExtensionConstructor<PostHogMetrics>; }",
-          "name": "__extensionClasses"
         }
       ],
       "path": "lib/src/types.d.ts"
@@ -3608,11 +3453,6 @@
           "description": "The library version.",
           "type": "string",
           "name": "version"
-        },
-        {
-          "description": "Whether the PostHog instance has been loaded.",
-          "type": "boolean",
-          "name": "__loaded"
         },
         {
           "description": "Whether the flags endpoint has been hit.",
@@ -3723,11 +3563,6 @@
           "description": "Get the value of a feature flag.",
           "type": "(key: string, options?: FeatureFlagOptions) => boolean | string | undefined",
           "name": "getFeatureFlag"
-        },
-        {
-          "description": "Get the payload of a feature flag.",
-          "type": "(key: string) => JsonType",
-          "name": "getFeatureFlagPayload"
         },
         {
           "description": "Get a feature flag evaluation result including both the flag value and payload.\n\nBy default, this method emits the `$feature_flag_called` event.",
@@ -3948,14 +3783,6 @@
           "description": "Capture a metric for a LLM trace.",
           "type": "(traceId: string | number, metricName: string, metricValue: string | number | boolean) => void",
           "name": "captureTraceMetric"
-        },
-        {
-          "type": "{ set: (prop: string | Properties, to?: string, callback?: RequestCallback) => void; set_once: (prop: string | Properties, to?: string, callback?: RequestCallback) => void; }",
-          "name": "people"
-        },
-        {
-          "type": "boolean",
-          "name": "decideEndpointWasHit"
         },
         {
           "type": "PostHogConfig",
@@ -4539,11 +4366,6 @@
           "description": "Whether to only capture identified users by default",
           "type": "boolean",
           "name": "defaultIdentifiedOnly"
-        },
-        {
-          "description": "",
-          "type": "ToolbarParams",
-          "name": "editorParams"
         },
         {
           "description": "Whether the `$elements_chain` property should be sent as a string or as an array\nfalse",
@@ -5309,11 +5131,6 @@
           "name": "boxPadding"
         },
         {
-          "description": "",
-          "type": "string",
-          "name": "descriptionTextColor"
-        },
-        {
           "type": "boolean",
           "name": "disableAutofocus"
         },
@@ -5328,11 +5145,6 @@
         {
           "type": "boolean",
           "name": "hideCancelButton"
-        },
-        {
-          "description": "",
-          "type": "string",
-          "name": "inputBackgroundColor"
         },
         {
           "type": "string",
@@ -5376,16 +5188,6 @@
       "id": "SurveyConfig",
       "name": "SurveyConfig",
       "properties": [
-        {
-          "description": "",
-          "type": "number",
-          "name": "autoSubmitDelay"
-        },
-        {
-          "description": "",
-          "type": "boolean",
-          "name": "autoSubmitIfComplete"
-        },
         {
           "description": "Prefill survey responses from matching URL parameters.\nundefined",
           "type": "boolean",

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -2001,10 +2001,6 @@
           "name": "flags"
         },
         {
-          "type": "boolean | SendFeatureFlagsOptions",
-          "name": "sendFeatureFlags"
-        },
-        {
           "type": "Date",
           "name": "timestamp"
         },
@@ -2012,11 +2008,6 @@
           "description": "If provided overrides the auto-generated event UUID. Must be a valid UUID.",
           "type": "string",
           "name": "uuid"
-        },
-        {
-          "description": "Internal flag set by captureException() to indicate this $exception\nevent originated from the proper exception capture path. Used to warn users who call\ncapture() with '$exception' directly.",
-          "type": "boolean",
-          "name": "_originatedFromCaptureException"
         }
       ],
       "path": "src/types.ts"
@@ -2732,11 +2723,6 @@
         {
           "type": "boolean",
           "name": "disableGeoip"
-        },
-        {
-          "description": "Internal flag set by captureException() to indicate this $exception\nevent originated from the proper exception capture path. Used to warn users who call\ncapture('$exception') directly.",
-          "type": "boolean",
-          "name": "_originatedFromCaptureException"
         }
       ],
       "path": "../core/src/types.ts"
@@ -2824,11 +2810,6 @@
           "name": "disableRemoteFeatureFlags"
         },
         {
-          "description": "Whether to load remote config when initialized or not",
-          "type": "boolean",
-          "name": "disableRemoteConfig"
-        },
-        {
           "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
           "type": "boolean",
           "name": "disableSurveys"
@@ -2892,11 +2873,6 @@
           "description": "Evaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'web', 'mobile']",
           "type": "readonly string[]",
           "name": "evaluationContexts"
-        },
-        {
-          "description": "Evaluation environments for feature flags.",
-          "type": "readonly string[]",
-          "name": "evaluationEnvironments"
         },
         {
           "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
@@ -3285,11 +3261,6 @@
           "name": "disableRemoteFeatureFlags"
         },
         {
-          "description": "Whether to load remote config when initialized or not",
-          "type": "boolean",
-          "name": "disableRemoteConfig"
-        },
-        {
           "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
           "type": "boolean",
           "name": "disableSurveys"
@@ -3350,11 +3321,6 @@
           "name": "evaluationContexts"
         },
         {
-          "description": "Evaluation environments for feature flags.",
-          "type": "readonly string[]",
-          "name": "evaluationEnvironments"
-        },
-        {
           "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
           "type": "\"always\" | \"identified_only\" | \"never\"",
           "name": "personProfiles"
@@ -3382,10 +3348,6 @@
           "description": "Credential that enables local feature flag evaluation and remote config.\n\nAccepts either a Personal API Key (`phx_...`) or a Project Secret API Key (`phs_...`).\nWhen provided, the client can evaluate feature flags locally and decrypt remote\nconfig payloads via `getRemoteConfigPayload`. Prefer this over the deprecated\n`personalApiKey` option; when both are set, `secretKey` takes precedence.",
           "type": "string",
           "name": "secretKey"
-        },
-        {
-          "type": "string",
-          "name": "personalApiKey"
         },
         {
           "type": "boolean",
@@ -3425,11 +3387,6 @@
           "description": "Additional user agent strings to block from being tracked.\nThese are combined with the default list of blocked user agents.",
           "type": "string[]",
           "name": "custom_blocked_useragents"
-        },
-        {
-          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION\nEnables collection of bot traffic as $bot_pageview events instead of dropping them.\nWhen enabled, events with a $raw_user_agent property that matches the bot detection list\nwill have their $pageview event renamed to $bot_pageview.\n\nTo use this feature, pass the user agent in event properties:\n```ts\nclient.capture({\n  distinctId: 'user_123',\n  event: '$pageview',\n  properties: {\n    $raw_user_agent: req.headers['user-agent']\n  }\n})\n```",
-          "type": "boolean",
-          "name": "__preview_capture_bot_pageviews"
         },
         {
           "description": "When enabled, all feature flag evaluations will use local evaluation only,\nnever falling back to server-side evaluation. This prevents unexpected server\nrequests and associated costs when using local evaluation.\n\nFlags that cannot be evaluated locally (e.g., those with experience continuity)\nwill return `undefined` instead of making a server request.",
@@ -3649,12 +3606,7 @@
     {
       "id": "PreviouslyCapturedError",
       "name": "PreviouslyCapturedError",
-      "properties": [
-        {
-          "type": "boolean",
-          "name": "__posthog_previously_captured_error"
-        }
-      ],
+      "properties": [],
       "path": "../core/src/error-tracking/types.ts"
     },
     {

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -2001,6 +2001,12 @@
           "name": "flags"
         },
         {
+          "description": "Deprecated: Use the `flags` option with a `FeatureFlagEvaluations` object obtained\nfrom `posthog.evaluateFlags()` instead. `sendFeatureFlags` fires a separate `/flags`\nrequest on capture and may return different values than the ones the code branched on.",
+          "type": "boolean | SendFeatureFlagsOptions",
+          "name": "sendFeatureFlags",
+          "releaseTag": "deprecated"
+        },
+        {
           "type": "Date",
           "name": "timestamp"
         },
@@ -2810,6 +2816,12 @@
           "name": "disableRemoteFeatureFlags"
         },
         {
+          "description": "Whether to load remote config when initialized or not\nDeprecated: Remote config is now always loaded and this option is a no-op. It will be removed in a future version.",
+          "type": "boolean",
+          "name": "disableRemoteConfig",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
           "type": "boolean",
           "name": "disableSurveys"
@@ -2873,6 +2885,12 @@
           "description": "Evaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'web', 'mobile']",
           "type": "readonly string[]",
           "name": "evaluationContexts"
+        },
+        {
+          "description": "Evaluation environments for feature flags.\nDeprecated: Use evaluationContexts instead. This property will be removed in a future version.",
+          "type": "readonly string[]",
+          "name": "evaluationEnvironments",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
@@ -3261,6 +3279,12 @@
           "name": "disableRemoteFeatureFlags"
         },
         {
+          "description": "Whether to load remote config when initialized or not\nDeprecated: Remote config is now always loaded and this option is a no-op. It will be removed in a future version.",
+          "type": "boolean",
+          "name": "disableRemoteConfig",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
           "type": "boolean",
           "name": "disableSurveys"
@@ -3321,6 +3345,12 @@
           "name": "evaluationContexts"
         },
         {
+          "description": "Evaluation environments for feature flags.\nDeprecated: Use evaluationContexts instead. This property will be removed in a future version.",
+          "type": "readonly string[]",
+          "name": "evaluationEnvironments",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
           "type": "\"always\" | \"identified_only\" | \"never\"",
           "name": "personProfiles"
@@ -3348,6 +3378,12 @@
           "description": "Credential that enables local feature flag evaluation and remote config.\n\nAccepts either a Personal API Key (`phx_...`) or a Project Secret API Key (`phs_...`).\nWhen provided, the client can evaluate feature flags locally and decrypt remote\nconfig payloads via `getRemoteConfigPayload`. Prefer this over the deprecated\n`personalApiKey` option; when both are set, `secretKey` takes precedence.",
           "type": "string",
           "name": "secretKey"
+        },
+        {
+          "description": "Deprecated: Use `secretKey` instead.",
+          "type": "string",
+          "name": "personalApiKey",
+          "releaseTag": "deprecated"
         },
         {
           "type": "boolean",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2986,11 +2986,6 @@
           "description": "Used for mutating the screen name and properties\nOnly used if captureScreens is true",
           "type": "PostHogAutocaptureNavigationTrackerOptions",
           "name": "navigation"
-        },
-        {
-          "description": "If you create a navigation ref with createNavigationContainerRef, you need to pass the navigation ref\nOnly used for expo-router and",
-          "type": "PostHogNavigationRef",
-          "name": "navigationRef"
         }
       ],
       "path": "dist/types.d.ts"
@@ -3012,11 +3007,6 @@
         {
           "type": "boolean",
           "name": "disableGeoip"
-        },
-        {
-          "description": "Internal flag set by captureException() to indicate this $exception\nevent originated from the proper exception capture path. Used to warn users who call\ncapture('$exception') directly.",
-          "type": "boolean",
-          "name": "_originatedFromCaptureException"
         }
       ],
       "path": "../core/src/types.ts"
@@ -3079,11 +3069,6 @@
           "description": "Advanced: whether to disable fetching and evaluating feature flags from PostHog entirely.\n\nWhen set to true, `reloadFeatureFlags()` and the reloads triggered by `identify()`,\n`group()`, `setPersonPropertiesForFlags()` and `reset()` become no-ops, and any request\nto the flags endpoint that still goes out (e.g. to fetch remote config or surveys)\ncarries `disable_flags: true` so the server skips flag evaluation. Flag values must be\nsupplied via the `bootstrap` option or `updateFlags()` instead; `getFeatureFlag()` and\nrelated methods keep working against those values. Until `updateFlags()` runs, reads\nreturn their not-loaded defaults, so use `bootstrap` for any flags needed at startup.\nEquivalent to the web SDK's `advanced_disable_feature_flags`.\n\nNote: surveys gated on feature flags will not evaluate unless the survey targeting\nflags are also provided via `updateFlags()`. This option cannot be toggled at runtime.\n`posthog-node` inherits this option but does not implement it (no-op).",
           "type": "boolean",
           "name": "disableRemoteFeatureFlags"
-        },
-        {
-          "description": "Whether to load remote config when initialized or not",
-          "type": "boolean",
-          "name": "disableRemoteConfig"
         },
         {
           "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
@@ -3149,11 +3134,6 @@
           "description": "Evaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'web', 'mobile']",
           "type": "readonly string[]",
           "name": "evaluationContexts"
-        },
-        {
-          "description": "Evaluation environments for feature flags.",
-          "type": "readonly string[]",
-          "name": "evaluationEnvironments"
         },
         {
           "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
@@ -3992,16 +3972,6 @@
           "name": "captureLog"
         },
         {
-          "description": "Deboucer delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a screenshot\nThe lower the number more snapshots will be captured but higher the performance impact",
-          "type": "number",
-          "name": "iOSdebouncerDelayMs"
-        },
-        {
-          "description": "Deboucer delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a screenshot\nThe lower the number more snapshots will be captured but higher the performance impact\nPs: it was 500ms (0.5s) by default until version 3.3.7",
-          "type": "number",
-          "name": "androidDebouncerDelayMs"
-        },
-        {
           "description": "Throttling delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a wireframe or screenshot\nThe lower the number more snapshots will be captured but higher the performance impact\n\nThis value has precedence over iOSdebouncerDelayMs and androidDebouncerDelayMs\nIf this is not set, we will take the max number between iOSdebouncerDelayMs and androidDebouncerDelayMs for back compatibility",
           "type": "number",
           "name": "throttleDelayMs"
@@ -4057,12 +4027,7 @@
     {
       "id": "PreviouslyCapturedError",
       "name": "PreviouslyCapturedError",
-      "properties": [
-        {
-          "type": "boolean",
-          "name": "__posthog_previously_captured_error"
-        }
-      ],
+      "properties": [],
       "path": "../core/src/error-tracking/types.ts"
     },
     {

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2986,6 +2986,12 @@
           "description": "Used for mutating the screen name and properties\nOnly used if captureScreens is true",
           "type": "PostHogAutocaptureNavigationTrackerOptions",
           "name": "navigation"
+        },
+        {
+          "description": "If you create a navigation ref with createNavigationContainerRef, you need to pass the navigation ref\nOnly used for expo-router and\nDeprecated: this is deprecated since it didn't work as expected, check out the `captureScreens` comments for capturing screen views semi-automatically",
+          "type": "PostHogNavigationRef",
+          "name": "navigationRef",
+          "releaseTag": "deprecated"
         }
       ],
       "path": "dist/types.d.ts"
@@ -3071,6 +3077,12 @@
           "name": "disableRemoteFeatureFlags"
         },
         {
+          "description": "Whether to load remote config when initialized or not\nDeprecated: Remote config is now always loaded and this option is a no-op. It will be removed in a future version.",
+          "type": "boolean",
+          "name": "disableRemoteConfig",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Whether to load surveys when initialized or not\nRequires the `PostHogSurveyProvider` to be used",
           "type": "boolean",
           "name": "disableSurveys"
@@ -3134,6 +3146,12 @@
           "description": "Evaluation contexts for feature flags.\nWhen set, only feature flags that have at least one matching evaluation tag\nwill be evaluated for this SDK instance. Feature flags with no evaluation tags\nwill always be evaluated.\n\nExamples: ['production', 'web', 'mobile']",
           "type": "readonly string[]",
           "name": "evaluationContexts"
+        },
+        {
+          "description": "Evaluation environments for feature flags.\nDeprecated: Use evaluationContexts instead. This property will be removed in a future version.",
+          "type": "readonly string[]",
+          "name": "evaluationEnvironments",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Determines when to create Person Profiles for users.\n\n- 'always': Always create a person profile for every user (anonymous and identified).\n- 'identified_only': Only create a person profile when the user is identified via identify(), alias(), or group().\n  Events captured before identification will NOT have person profiles and will be anonymous events.\n- 'never': Never create person profiles. identify(), alias(), and group() will be no-ops.",
@@ -3970,6 +3988,18 @@
           "description": "Enable capturing of logs as console events",
           "type": "boolean",
           "name": "captureLog"
+        },
+        {
+          "description": "Deboucer delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a screenshot\nThe lower the number more snapshots will be captured but higher the performance impact\nDeprecated: please use throttleDelayMs instead",
+          "type": "number",
+          "name": "iOSdebouncerDelayMs",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deboucer delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a screenshot\nThe lower the number more snapshots will be captured but higher the performance impact\nPs: it was 500ms (0.5s) by default until version 3.3.7\nDeprecated: please use throttleDelayMs instead",
+          "type": "number",
+          "name": "androidDebouncerDelayMs",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Throttling delay used to reduce the number of snapshots captured and reduce performance impact\nThis is used for capturing the view as a wireframe or screenshot\nThe lower the number more snapshots will be captured but higher the performance impact\n\nThis value has precedence over iOSdebouncerDelayMs and androidDebouncerDelayMs\nIf this is not set, we will take the max number between iOSdebouncerDelayMs and androidDebouncerDelayMs for back compatibility",

--- a/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
@@ -132,6 +132,43 @@ export type CallableWithProps = {
 };
 
 /**
+ * Members in every deprecation shape
+ *
+ * @public
+ */
+export interface DeprecationShapes {
+    /** Current option */
+    current: string;
+    /**
+     * Legacy timeout in ms.
+     *
+     * @deprecated Use current instead
+     */
+    legacy_timeout?: number;
+    /** @deprecated */
+    retired?: boolean;
+}
+
+/**
+ * Alias flattening the same members through the checker path
+ *
+ * @public
+ */
+export type DeprecationShapesAlias = DeprecationShapes & {
+    extra?: string;
+};
+
+/**
+ * @public
+ */
+export declare enum Mode {
+    /** Standard mode */
+    Standard = "standard",
+    /** @deprecated Use Standard */
+    Legacy = "legacy"
+}
+
+/**
  * Referenced by the public API but not exported
  */
 type HiddenOptions = {

--- a/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
@@ -13,6 +13,10 @@ export interface BaseConfig {
     loaded: (client: unknown) => void;
     /** Optional project token */
     token?: string;
+    /** @deprecated Use api_host */
+    old_host?: string;
+    /** Internal preview toggle */
+    __internal_flag?: boolean;
 }
 
 /**

--- a/scripts/docs/__tests__/type-resolution.test.js
+++ b/scripts/docs/__tests__/type-resolution.test.js
@@ -115,7 +115,7 @@ describe('resolveTypeDefinitions with type resolver', () => {
     test('flattens Omit + intersection aliases to their effective members', () => {
         const config = byName(types, 'Config');
         const names = config.properties.map((p) => p.name).sort();
-        assert.deepEqual(names, ['api_host', 'debug', 'loaded', 'token']);
+        assert.deepEqual(names, ['api_host', 'debug', 'loaded', 'old_host', 'token']);
         assert.equal(config.example, undefined);
 
         assert.equal(propByName(config, 'api_host').type, 'string');
@@ -187,15 +187,67 @@ describe('resolveTypeDefinitions with type resolver', () => {
 
     test('interfaces keep their members', () => {
         const base = byName(types, 'BaseConfig');
-        assert.deepEqual(base.properties.map((p) => p.name), ['api_host', 'loaded', 'token']);
+        assert.deepEqual(base.properties.map((p) => p.name), ['api_host', 'loaded', 'old_host', 'token']);
     });
 
-    test('underscore-prefixed and deprecated members are excluded from both paths', () => {
+    test('underscore-prefixed members are excluded from both paths', () => {
         const published = (type) => type.properties.map((p) => p.name);
-        assert.ok(!published(byName(types, 'BaseConfig')).includes('old_host'));
         assert.ok(!published(byName(types, 'BaseConfig')).includes('__internal_flag'));
-        assert.ok(!published(byName(types, 'Config')).includes('old_host'));
         assert.ok(!published(byName(types, 'Config')).includes('__internal_flag'));
+    });
+
+    test('deprecated members are tagged and carry their migration text in both paths', () => {
+        const oldHostVia = (name) => byName(types, name).properties.find((p) => p.name === 'old_host');
+        for (const typeName of ['BaseConfig', 'Config']) {
+            const prop = oldHostVia(typeName);
+            assert.equal(prop.releaseTag, 'deprecated', `${typeName}.old_host releaseTag`);
+            assert.match(prop.description, /Deprecated: Use api_host/);
+        }
+        const apiHost = byName(types, 'Config').properties.find((p) => p.name === 'api_host');
+        assert.equal(apiHost.releaseTag, undefined);
+    });
+
+    test('deprecation text is appended to an existing summary in both paths', () => {
+        for (const typeName of ['DeprecationShapes', 'DeprecationShapesAlias']) {
+            const prop = byName(types, typeName).properties.find((p) => p.name === 'legacy_timeout');
+            assert.equal(prop.releaseTag, 'deprecated', `${typeName}.legacy_timeout releaseTag`);
+            assert.match(prop.description, /^Legacy timeout in ms\./, `${typeName} keeps the summary`);
+            assert.match(prop.description, /Deprecated: Use current instead$/, `${typeName} appends the tag text`);
+        }
+    });
+
+    test('bare @deprecated without a message still tags, with no fabricated description', () => {
+        for (const typeName of ['DeprecationShapes', 'DeprecationShapesAlias']) {
+            const prop = byName(types, typeName).properties.find((p) => p.name === 'retired');
+            assert.equal(prop.releaseTag, 'deprecated', `${typeName}.retired releaseTag`);
+            assert.equal(prop.description, undefined, `${typeName}.retired description`);
+        }
+    });
+
+    test('deprecated enum members are tagged', () => {
+        const mode = byName(types, 'Mode');
+        const legacy = mode.properties.find((p) => p.name === 'Legacy');
+        const standard = mode.properties.find((p) => p.name === 'Standard');
+        assert.equal(legacy.releaseTag, 'deprecated');
+        assert.match(legacy.description, /Deprecated: Use Standard/);
+        assert.equal(standard.releaseTag, undefined);
+        assert.equal(standard.description, 'Standard mode');
+    });
+
+    test('serialized output carries releaseTag only on deprecated members', () => {
+        const serialized = JSON.parse(JSON.stringify(types));
+        const tagged = [];
+        for (const t of serialized) {
+            for (const p of t.properties || []) {
+                if ('releaseTag' in p) {
+                    assert.equal(p.releaseTag, 'deprecated', `${t.name}.${p.name} has unexpected releaseTag`);
+                    tagged.push(`${t.name}.${p.name}`);
+                }
+            }
+        }
+        assert.ok(tagged.includes('Config.old_host'));
+        const current = serialized.find((t) => t.name === 'DeprecationShapes').properties.find((p) => p.name === 'current');
+        assert.ok(!('releaseTag' in current), 'non-deprecated properties must not serialize a releaseTag key');
     });
 
     test('cross-file property types render bare names, never import("...") qualifiers', () => {

--- a/scripts/docs/__tests__/type-resolution.test.js
+++ b/scripts/docs/__tests__/type-resolution.test.js
@@ -190,6 +190,14 @@ describe('resolveTypeDefinitions with type resolver', () => {
         assert.deepEqual(base.properties.map((p) => p.name), ['api_host', 'loaded', 'token']);
     });
 
+    test('underscore-prefixed and deprecated members are excluded from both paths', () => {
+        const published = (type) => type.properties.map((p) => p.name);
+        assert.ok(!published(byName(types, 'BaseConfig')).includes('old_host'));
+        assert.ok(!published(byName(types, 'BaseConfig')).includes('__internal_flag'));
+        assert.ok(!published(byName(types, 'Config')).includes('old_host'));
+        assert.ok(!published(byName(types, 'Config')).includes('__internal_flag'));
+    });
+
     test('cross-file property types render bare names, never import("...") qualifiers', () => {
         const remote = byName(types, 'Remote');
         assert.deepEqual(

--- a/scripts/docs/type-resolver.js
+++ b/scripts/docs/type-resolver.js
@@ -81,7 +81,7 @@ function classifyAlias(checker, declaration) {
         return { kind: 'other' };
     }
 
-    const properties = type.getProperties().filter((prop) => isDocumentedProperty(checker, prop));
+    const properties = type.getProperties().filter(isDocumentedProperty);
     if (type.getCallSignatures().length > 0) {
         // a callable type with members would lose its call signature as an object,
         // so publish the full raw signature instead
@@ -99,20 +99,18 @@ function classifyAlias(checker, declaration) {
     return { kind: 'other' };
 }
 
-// Underscore-prefixed and @deprecated members are internal surface and stay out of
-// the published reference; methods mirror the interface rendering, which lists only
-// property signatures
-function isDocumentedProperty(checker, prop) {
-    return (
-        !(prop.flags & ts.SymbolFlags.Method) &&
-        !prop.getName().startsWith('_') &&
-        !prop.getJsDocTags(checker).some((tag) => tag.name === 'deprecated')
-    );
+// Underscore-prefixed members are internal surface and stay out of the published
+// reference; methods mirror the interface rendering, which lists only property
+// signatures
+function isDocumentedProperty(prop) {
+    return !(prop.flags & ts.SymbolFlags.Method) && !prop.getName().startsWith('_');
 }
 
 function describeProperty(checker, prop, location) {
     const propType = checker.getTypeOfSymbolAtLocation(prop, location);
     const description = ts.displayPartsToString(prop.getDocumentationComment(checker)).trim();
+    const deprecatedTag = prop.getJsDocTags(checker).find((tag) => tag.name === 'deprecated');
+    const deprecatedText = deprecatedTag ? ts.displayPartsToString(deprecatedTag.text).trim() : '';
 
     // typeToString qualifies symbols not lexically visible at the alias declaration as
     // import("<absolute path>").Name — machine-specific and unfit for published output
@@ -123,7 +121,8 @@ function describeProperty(checker, prop, location) {
     return {
         name: prop.getName(),
         type: typeText,
-        description: description || undefined,
+        description: [description, deprecatedText && `Deprecated: ${deprecatedText}`].filter(Boolean).join('\n') || undefined,
+        ...(deprecatedTag && { releaseTag: 'deprecated' }),
     };
 }
 

--- a/scripts/docs/type-resolver.js
+++ b/scripts/docs/type-resolver.js
@@ -81,7 +81,7 @@ function classifyAlias(checker, declaration) {
         return { kind: 'other' };
     }
 
-    const properties = type.getProperties().filter((prop) => !(prop.flags & ts.SymbolFlags.Method));
+    const properties = type.getProperties().filter((prop) => isDocumentedProperty(checker, prop));
     if (type.getCallSignatures().length > 0) {
         // a callable type with members would lose its call signature as an object,
         // so publish the full raw signature instead
@@ -97,6 +97,17 @@ function classifyAlias(checker, declaration) {
         return { kind: 'signature' };
     }
     return { kind: 'other' };
+}
+
+// Underscore-prefixed and @deprecated members are internal surface and stay out of
+// the published reference; methods mirror the interface rendering, which lists only
+// property signatures
+function isDocumentedProperty(checker, prop) {
+    return (
+        !(prop.flags & ts.SymbolFlags.Method) &&
+        !prop.getName().startsWith('_') &&
+        !prop.getJsDocTags(checker).some((tag) => tag.name === 'deprecated')
+    );
 }
 
 function describeProperty(checker, prop, location) {

--- a/scripts/docs/types.js
+++ b/scripts/docs/types.js
@@ -19,8 +19,8 @@ function resolveTypeDefinitions(apiPackage, typeResolver) {
         const result = {
             id: type.id,
             name: type.name,
-            properties: (type.params || []).map(({ description, type: paramType, name }) => ({
-                description, type: paramType, name
+            properties: (type.params || []).map(({ description, type: paramType, name, releaseTag }) => ({
+                description, type: paramType, name, releaseTag
             }))
         };
         
@@ -62,11 +62,19 @@ function createInitialTypeDef(member, apiPackage, typeResolver) {
 }
 
 // Create member descriptor for enum/interface items
-const createMemberDescriptor = (member, defaultType) => ({
-    name: member.name,
-    type: member.initializerExcerpt?.text || member.propertyTypeExcerpt?.text || defaultType,
-    description: documentation.getDocComment(member)
-});
+const createMemberDescriptor = (member, defaultType) => {
+    const deprecatedText = methods.isMethodDeprecated(member)
+        ? utils.renderDocNodeToText(member.tsdocComment.deprecatedBlock.content)
+        : '';
+
+    return {
+        name: member.name,
+        type: member.initializerExcerpt?.text || member.propertyTypeExcerpt?.text || defaultType,
+        description: [documentation.getDocComment(member), deprecatedText && `Deprecated: ${deprecatedText}`]
+            .filter(Boolean).join('\n') || undefined,
+        releaseTag: methods.isMethodDeprecated(member) ? 'deprecated' : undefined
+    };
+};
 
 // Process enum members
 function processEnumMember(member, typeDef) {
@@ -79,7 +87,7 @@ function processEnumMember(member, typeDef) {
 function processInterfaceMember(member, typeDef) {
     typeDef.params = member.members
         .filter((prop) => prop.kind === ApiItemKind.PropertySignature)
-        .filter((prop) => !prop.name.startsWith('_') && !methods.isMethodDeprecated(prop))
+        .filter((prop) => !prop.name.startsWith('_'))
         .map((prop) => createMemberDescriptor(prop, 'any'));
 }
 

--- a/scripts/docs/types.js
+++ b/scripts/docs/types.js
@@ -1,6 +1,7 @@
 const { ApiItemKind } = require('@microsoft/api-extractor-model');
 const utils = require('./utils');
 const documentation = require('./documentation');
+const methods = require('./methods');
 
 // TypeDefinition structure: { name, id, params?, path?, example? }
 // TypeToken structure: { kind, text, canonicalReference? }
@@ -78,6 +79,7 @@ function processEnumMember(member, typeDef) {
 function processInterfaceMember(member, typeDef) {
     typeDef.params = member.members
         .filter((prop) => prop.kind === ApiItemKind.PropertySignature)
+        .filter((prop) => !prop.name.startsWith('_') && !methods.isMethodDeprecated(prop))
         .map((prop) => createMemberDescriptor(prop, 'any'));
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #4165 (and PostHog/posthog.com#18577): the generated references published every member of object-shaped types as first-class options — `__`-prefixed internals and `@deprecated` members included, with no signal distinguishing them. A reader could pick `enable_heatmaps` with no hint that `capture_heatmaps` replaces it, or build on a `__preview_*` flag that may vanish in a patch release. The `@deprecated` migration text in the source JSDoc was dropped entirely by the pipeline.

## Changes

Two commits, second refines the first:

1. `60edb6ba5` excluded both categories.
2. `1ce63f145` (final behavior) keeps deprecated members but **tags** them, which preserves discoverability for people maintaining older integrations:

- **`__`/`_`-prefixed members are excluded** from both pipeline paths (checker-resolved aliases and interfaces). Internal surface shouldn't be documented at all.
- **`@deprecated` members stay, annotated**: they gain `releaseTag: "deprecated"` (the same field methods already carry) and their `@deprecated` tag text is appended to the description, e.g.:

  ```json
  {
    "name": "enable_heatmaps",
    "type": "boolean",
    "description": "Deprecated: Use `capture_heatmaps` instead.",
    "releaseTag": "deprecated"
  }
  ```

  The deprecation is visible as plain text today with no docs-site changes; `releaseTag` gives posthog.com a hook for strikethrough/badge rendering later.

- Regenerated references: browser `PostHogConfig` publishes 120 options (102 current + 18 tagged deprecated; 12 underscore internals removed). Tagged counts: 27 browser / 6 node / 5 react-native. Audit vs the pre-filter output: zero non-underscore members removed, schema change is the single additive `releaseTag` key.
- Every underscore/deprecated classification was verified against source JSDoc — including subtleties like `SurveyConfig.autoSubmit*` (deprecated only in the browser-local declaration, not the `@posthog/types` one of the same name).
- Tests (32 total) cover: tagging through both paths, summary + tag text combining, bare `@deprecated` with no message, deprecated enum members, underscore exclusion, and that `releaseTag` serializes only on deprecated members.

## Release info Sub-libraries affected

### Libraries affected

None — docs-generation tooling and regenerated reference JSONs only; no published package code changes, no version bumps.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

No changeset: docs tooling and generated files only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as a follow-up to #4165, prompted by the public/internal/deprecated split in PostHog/posthog.com#18577. We first implemented exclusion for both categories, then prototyped tagging locally and compared real outputs; tagging won because the migration text (previously dropped) becomes visible with zero docs-site changes while keeping deprecated options discoverable. Every filtered/tagged member was individually verified against source JSDoc before committing.
