### PR TITLE
fix(docs): publish deprecated underscore members and strip leaked JSDoc asterisks

### DIFF
--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -3204,7 +3204,7 @@
           "name": "opt_out_useragent_filter"
         },
         {
-          "description": "Deprecated: Use `consent_persistence_name` instead. This will be removed in a future major version. *",
+          "description": "Deprecated: Use `consent_persistence_name` instead. This will be removed in a future major version.",
           "type": "string",
           "name": "opt_out_capturing_cookie_prefix",
           "releaseTag": "deprecated"
@@ -3406,6 +3406,12 @@
           "releaseTag": "deprecated"
         },
         {
+          "description": "Deprecated: - use `before_send` instead",
+          "type": "(eventName: string, eventData: CaptureResult) => void",
+          "name": "_onCapture",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Determines whether to capture performance metrics.\nThese include Network Timing for Session Replay and Web Vitals.\n\nThe `network_timing` option is only used by the Session Replay feature.\nFor more session recording settings, see the `session_recording` and `enable_recording_console_log` configuration option.\n\nWhen `undefined`, fallback to the remote configuration.\nIf `false`, neither network timing nor web vitals will work.\nIf an object, that will override the remote configuration.",
           "type": "boolean | PerformanceCaptureConfig",
           "name": "capture_performance"
@@ -3514,9 +3520,51 @@
           "releaseTag": "deprecated"
         },
         {
+          "description": "Deprecated: Use {@link tracing_headers} instead. Kept for backwards compatibility.",
+          "type": "string[]",
+          "name": "__add_tracing_headers",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: This option is a no-op. The browser SDK already uses the `/flags/?v=2` endpoint.",
+          "type": "boolean",
+          "name": "__preview_flags_v2",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: This option is a no-op. Session replay is lazy-loaded by default.",
+          "type": "boolean",
+          "name": "__preview_eager_load_replay",
+          "releaseTag": "deprecated"
+        },
+        {
           "description": "Prevents posthog-js from using the `navigator.sendBeacon` API to send events.\nEnabling this option may hurt the reliability of sending $pageleave events.",
           "type": "boolean",
           "name": "disable_beacon"
+        },
+        {
+          "description": "Deprecated: Use `disable_beacon` instead.",
+          "type": "boolean",
+          "name": "__preview_disable_beacon",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: This option is a no-op. The browser SDK no longer sets `XMLHttpRequest.withCredentials`.",
+          "type": "boolean",
+          "name": "__preview_disable_xhr_credentials",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: Use {@link strict_script_versioning} and {@link asset_host} instead.\nWhen set to true, this is equivalent to strict_script_versioning: true.\nWhen set to a string, this is equivalent to strict_script_versioning: true\nand asset_host set to that string.",
+          "type": "string | boolean",
+          "name": "__preview_external_dependency_versioned_paths",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Deprecated: - does nothing\nwas present only for PostHog testing of replay lazy loading",
+          "type": "boolean",
+          "name": "__preview_lazy_load_replay",
+          "releaseTag": "deprecated"
         },
         {
           "description": "Deprecated: - NOT USED ANYMORE, kept here for backwards compatibility reasons",

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -182,7 +182,7 @@ export interface BootstrapConfig {
      * - a valid UUID v7
      * - the timestamp part must be <= the timestamp of the first event in the session
      * - the timestamp of the last event in the session must be < the timestamp part + 24 hours
-     * **/
+     */
     sessionID?: string
 }
 
@@ -1345,7 +1345,7 @@ export interface PostHogConfig {
      */
     opt_out_useragent_filter: boolean
 
-    /** @deprecated Use `consent_persistence_name` instead. This will be removed in a future major version. **/
+    /** @deprecated Use `consent_persistence_name` instead. This will be removed in a future major version. */
     opt_out_capturing_cookie_prefix: string | null
 
     /**

--- a/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
@@ -147,6 +147,10 @@ export interface DeprecationShapes {
     legacy_timeout?: number;
     /** @deprecated */
     retired?: boolean;
+    /** @deprecated Gone. Use current **/
+    legacy_typo?: string;
+    /** @deprecated Use current instead */
+    __legacy_flag?: boolean;
 }
 
 /**

--- a/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
+++ b/scripts/docs/__tests__/fixtures/reference-types/index.d.ts
@@ -149,6 +149,8 @@ export interface DeprecationShapes {
     retired?: boolean;
     /** @deprecated Gone. Use current **/
     legacy_typo?: string;
+    /** This is **important** */
+    emphasized?: string;
     /** @deprecated Use current instead */
     __legacy_flag?: boolean;
 }

--- a/scripts/docs/__tests__/type-resolution.test.js
+++ b/scripts/docs/__tests__/type-resolution.test.js
@@ -224,6 +224,27 @@ describe('resolveTypeDefinitions with type resolver', () => {
         }
     });
 
+    test('deprecated underscore members win over the underscore exclusion in both paths', () => {
+        for (const typeName of ['DeprecationShapes', 'DeprecationShapesAlias']) {
+            const prop = byName(types, typeName).properties.find((p) => p.name === '__legacy_flag');
+            assert.ok(prop, `${typeName}.__legacy_flag should be published`);
+            assert.equal(prop.releaseTag, 'deprecated');
+            assert.match(prop.description, /Deprecated: Use current instead/);
+        }
+    });
+
+    test('malformed JSDoc closers do not leak asterisks into descriptions', () => {
+        for (const typeName of ['DeprecationShapes', 'DeprecationShapesAlias']) {
+            const prop = byName(types, typeName).properties.find((p) => p.name === 'legacy_typo');
+            assert.equal(prop.description, 'Deprecated: Gone. Use current', `${typeName}.legacy_typo`);
+        }
+        for (const t of types) {
+            for (const p of t.properties || []) {
+                assert.ok(!/\s\*+$/.test(p.description || ''), `${t.name}.${p.name} has a dangling asterisk`);
+            }
+        }
+    });
+
     test('deprecated enum members are tagged', () => {
         const mode = byName(types, 'Mode');
         const legacy = mode.properties.find((p) => p.name === 'Legacy');

--- a/scripts/docs/__tests__/type-resolution.test.js
+++ b/scripts/docs/__tests__/type-resolution.test.js
@@ -233,6 +233,13 @@ describe('resolveTypeDefinitions with type resolver', () => {
         }
     });
 
+    test('descriptions ending in markdown emphasis keep their closing markers', () => {
+        for (const typeName of ['DeprecationShapes', 'DeprecationShapesAlias']) {
+            const prop = byName(types, typeName).properties.find((p) => p.name === 'emphasized');
+            assert.equal(prop.description, 'This is **important**', `${typeName}.emphasized`);
+        }
+    });
+
     test('malformed JSDoc closers do not leak asterisks into descriptions', () => {
         for (const typeName of ['DeprecationShapes', 'DeprecationShapesAlias']) {
             const prop = byName(types, typeName).properties.find((p) => p.name === 'legacy_typo');

--- a/scripts/docs/type-resolver.js
+++ b/scripts/docs/type-resolver.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const ts = require('typescript');
+const utils = require('./utils');
 
 // Resolves exported type aliases against the same .d.ts entry point that api-extractor
 // analyzes, using the TypeScript checker so that Omit<>, intersections and cross-package
@@ -81,7 +82,7 @@ function classifyAlias(checker, declaration) {
         return { kind: 'other' };
     }
 
-    const properties = type.getProperties().filter(isDocumentedProperty);
+    const properties = type.getProperties().filter((prop) => isDocumentedProperty(checker, prop));
     if (type.getCallSignatures().length > 0) {
         // a callable type with members would lose its call signature as an object,
         // so publish the full raw signature instead
@@ -100,17 +101,29 @@ function classifyAlias(checker, declaration) {
 }
 
 // Underscore-prefixed members are internal surface and stay out of the published
-// reference; methods mirror the interface rendering, which lists only property
+// reference unless they are deprecated, in which case the migration note is worth
+// publishing; methods mirror the interface rendering, which lists only property
 // signatures
-function isDocumentedProperty(prop) {
-    return !(prop.flags & ts.SymbolFlags.Method) && !prop.getName().startsWith('_');
+function isDocumentedProperty(checker, prop) {
+    if (prop.flags & ts.SymbolFlags.Method) {
+        return false;
+    }
+    return isDeprecated(checker, prop) || !prop.getName().startsWith('_');
+}
+
+function isDeprecated(checker, prop) {
+    return prop.getJsDocTags(checker).some((tag) => tag.name === 'deprecated');
 }
 
 function describeProperty(checker, prop, location) {
     const propType = checker.getTypeOfSymbolAtLocation(prop, location);
-    const description = ts.displayPartsToString(prop.getDocumentationComment(checker)).trim();
+    const description = utils.trimDanglingAsterisks(
+        ts.displayPartsToString(prop.getDocumentationComment(checker))
+    ).trim();
     const deprecatedTag = prop.getJsDocTags(checker).find((tag) => tag.name === 'deprecated');
-    const deprecatedText = deprecatedTag ? ts.displayPartsToString(deprecatedTag.text).trim() : '';
+    const deprecatedText = deprecatedTag
+        ? utils.trimDanglingAsterisks(ts.displayPartsToString(deprecatedTag.text)).trim()
+        : '';
 
     // typeToString qualifies symbols not lexically visible at the alias declaration as
     // import("<absolute path>").Name — machine-specific and unfit for published output

--- a/scripts/docs/types.js
+++ b/scripts/docs/types.js
@@ -64,13 +64,14 @@ function createInitialTypeDef(member, apiPackage, typeResolver) {
 // Create member descriptor for enum/interface items
 const createMemberDescriptor = (member, defaultType) => {
     const deprecatedText = methods.isMethodDeprecated(member)
-        ? utils.renderDocNodeToText(member.tsdocComment.deprecatedBlock.content)
+        ? utils.trimDanglingAsterisks(utils.renderDocNodeToText(member.tsdocComment.deprecatedBlock.content)).trim()
         : '';
+    const summary = documentation.getDocComment(member);
 
     return {
         name: member.name,
         type: member.initializerExcerpt?.text || member.propertyTypeExcerpt?.text || defaultType,
-        description: [documentation.getDocComment(member), deprecatedText && `Deprecated: ${deprecatedText}`]
+        description: [summary && utils.trimDanglingAsterisks(summary), deprecatedText && `Deprecated: ${deprecatedText}`]
             .filter(Boolean).join('\n') || undefined,
         releaseTag: methods.isMethodDeprecated(member) ? 'deprecated' : undefined
     };
@@ -87,7 +88,7 @@ function processEnumMember(member, typeDef) {
 function processInterfaceMember(member, typeDef) {
     typeDef.params = member.members
         .filter((prop) => prop.kind === ApiItemKind.PropertySignature)
-        .filter((prop) => !prop.name.startsWith('_'))
+        .filter((prop) => methods.isMethodDeprecated(prop) || !prop.name.startsWith('_'))
         .map((prop) => createMemberDescriptor(prop, 'any'));
 }
 

--- a/scripts/docs/utils.js
+++ b/scripts/docs/utils.js
@@ -244,8 +244,17 @@ const generateExampleCode = (methodName, paramList) =>
  * @param {any[]} array - Array to check
  * @returns {boolean} - Whether array has items
  */
-const hasItems = (array) => 
+const hasItems = (array) =>
   array && array.length > 0;
+
+/**
+ * to strip asterisks leaked into extracted text by malformed JSDoc closers like "**\/"
+ * (only when whitespace-separated, so markdown emphasis at the end of a sentence survives)
+ * @param {string} text - Extracted doc text
+ * @returns {string} - Cleaned text
+ */
+const trimDanglingAsterisks = (text) =>
+  text.replace(/\s+\*+\s*$/, '');
 
 /**
  * to create string literal descriptor
@@ -267,6 +276,7 @@ module.exports = {
   generateCallbackExample,
   isCallbackType,
   textToId,
+  trimDanglingAsterisks,
   formatParameterList,
   generateExampleCode,
   hasItems,


### PR DESCRIPTION
## Problem

Follow-up to #4166, addressing @ioannisj's post-merge review comments:

1. `_onCapture` was excluded by the underscore rule even though it's `@deprecated` — so its migration note (`use before_send instead`) was invisible, along with 7 other deprecated `__preview_*`/underscore aliases.
2. `opt_out_capturing_cookie_prefix`'s description ended with a stray `*` — the source JSDoc closes with `**/` instead of `*/`, and the extra asterisk leaked into the extracted tag text.

## Changes

- **Deprecation wins over the underscore exclusion** in both pipeline paths (checker-resolved aliases and interfaces): an underscore-prefixed member that is `@deprecated` is now published with `releaseTag: "deprecated"` and its migration text, instead of silently dropped. Non-deprecated underscore members stay excluded. Browser `PostHogConfig`: 120 → 128 options (the 8 returning members are all underscore+deprecated; node/RN unchanged).
- **Stray asterisks eliminated**: fixed the two `**/` typos in `packages/types/src/posthog-config.ts` (comment-only change), and the pipeline now defensively trims whitespace-separated trailing asterisks from extracted doc text in both paths — so a future typo can't leak either. Trailing markdown emphasis (`...ends with **bold**`) is unaffected since it isn't whitespace-separated.
- Audit vs main: zero property removals; the only additions are the 8 underscore+deprecated members; zero dangling asterisks remain in any published type property.
- Tests: 34 total; new coverage for deprecated-underscore members through both paths and for malformed `**/` closers (a deliberate typo in the fixture proves the trim end-to-end through real api-extractor + checker).

Known pre-existing issue, not addressed here: some *method* descriptions in the node/RN references carry banner-comment garbage (`"* ** SURVEYS *"`) — that comes from the methods path picking up section banner comments and predates this series.

## Release info Sub-libraries affected

### Libraries affected

None — docs tooling, regenerated reference JSONs, and a comment-only typo fix in `@posthog/types` source; no behavior changes, no version bumps.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

No changeset: the only shipped-package change is a JSDoc comment typo fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directly addressing the two inline comments @ioannisj left on #4166 after merge. The deprecated-wins ordering was flagged as a possible follow-up in #4166's review discussion; the asterisk turned out to be a source typo (`**/`) fixed at the source plus a defensive pipeline trim.
