### PR TITLE
fix(next): preserve dynamic rendering bailouts

### DIFF
--- a/.changeset/fuzzy-pandas-render.md
+++ b/.changeset/fuzzy-pandas-render.md
@@ -1,0 +1,5 @@
+---
+'@posthog/next': patch
+---
+
+Let Next.js dynamic rendering bailouts propagate when bootstrapping flags.

--- a/packages/next/src/app/PostHogProvider.tsx
+++ b/packages/next/src/app/PostHogProvider.tsx
@@ -96,8 +96,12 @@ export async function PostHogProvider({
     let bootstrap: BootstrapConfig | undefined
 
     if (bootstrapFlags) {
+        // Keep Next.js dynamic-rendering control flow outside our error handler.
+        // During static generation, cookies() throws a framework signal that must reach Next.js.
+        const cookieStore = await cookies()
+
         try {
-            bootstrap = await evaluateFlags(apiKey, resolvedOptions, bootstrapFlags, serverOptions)
+            bootstrap = await evaluateFlags(cookieStore, apiKey, resolvedOptions, bootstrapFlags, serverOptions)
 
             // Only disable the first-load fetch when we actually have bootstrap data.
             // If evaluateFlags returned undefined (no cookie, opted-out), the client
@@ -154,13 +158,12 @@ function mergeBootstrap(
 }
 
 async function evaluateFlags(
+    cookieStore: Awaited<ReturnType<typeof cookies>>,
     apiKey: string,
     options: Partial<PostHogConfig> | undefined,
     bootstrapFlags: boolean | BootstrapFlagsConfig,
     serverOptions?: Partial<PostHogOptions>
 ): Promise<BootstrapConfig | undefined> {
-    const cookieStore = await cookies()
-
     if (isOptedOut(cookieStore, apiKey, options)) {
         return undefined
     }

--- a/packages/next/tests/PostHogProvider.test.tsx
+++ b/packages/next/tests/PostHogProvider.test.tsx
@@ -473,6 +473,27 @@ describe('PostHogProvider', () => {
             )
         })
 
+        it('propagates errors from cookies() so Next.js can handle dynamic rendering control flow', async () => {
+            const { cookies } = require('next/headers.js')
+            const dynamicUsageError = Object.assign(new Error('Dynamic server usage'), {
+                digest: 'DYNAMIC_SERVER_USAGE',
+            })
+            cookies.mockRejectedValueOnce(dynamicUsageError)
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+            await expect(
+                PostHogProvider({
+                    apiKey: 'phc_test123',
+                    bootstrapFlags: true,
+                    children: <div>Child</div>,
+                })
+            ).rejects.toBe(dynamicUsageError)
+
+            expect(mockGetAllFlagsAndPayloads).not.toHaveBeenCalled()
+            expect(warnSpy).not.toHaveBeenCalled()
+            warnSpy.mockRestore()
+        })
+
         it('renders without bootstrap when flag evaluation fails', async () => {
             mockGetAllFlagsAndPayloads.mockRejectedValue(new Error('network timeout'))
             const warnSpy = jest.spyOn(console, 'warn').mockImplementation()


### PR DESCRIPTION
## Problem

During `next build`, Next.js probes routes for static rendering. When `<PostHogProvider bootstrapFlags>` calls `cookies()`, Next.js throws an internal control-flow signal to classify the route as dynamic.

The provider currently catches that signal as though feature flag evaluation failed and logs:

```text
[PostHog Next.js] Failed to evaluate bootstrap flags: Error: Dynamic server usage
```

The build succeeds and the route is correctly classified as dynamic, but the warning is misleading and can obscure genuine evaluation failures. It appears for every route under a bootstrap-enabled root provider, including `/` and `/_not-found`.

## Changes

- Resolve `cookies()` before entering the flag-evaluation error handler so Next.js dynamic-rendering control flow reaches the framework.
- Continue catching genuine PostHog flag evaluation failures so pages render without bootstrap data when PostHog is unavailable.
- Add a regression test proving cookie errors propagate unchanged without logging a flag-evaluation warning or attempting flag evaluation.
- Add a patch changeset for `@posthog/next`.

Validation:

- All 253 `@posthog/next` tests pass.
- `@posthog/next` lint and package build pass.
- A packed-package Next.js 15.5.9 production build keeps `/` and `/_not-found` dynamically rendered and emits no `Failed to evaluate bootstrap flags` or `Dynamic server usage` warning.
- Independent SDK review verdict: `APPROVE`, with no findings.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This was implemented with the Pi coding agent and independently reviewed with the SDK review criteria. We considered Next.js 15's `unstable_rethrow`, but kept compatibility with the package's Next.js 13+ peer range by moving the dynamic API call outside the broad error handler instead.

The packed-package smoke test reproduces Next.js's static/dynamic build analysis without contacting a real PostHog project.
