### PR TITLE
feat(consent): add respect_gpc option honoring Global Privacy Control

### DIFF
--- a/.changeset/tidy-donuts-behave.md
+++ b/.changeset/tidy-donuts-behave.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+Added the `respect_gpc` config option. When `true`, users whose browser sends the Global Privacy Control signal (`navigator.globalPrivacyControl`) are treated as opted out of capturing, like `respect_dnt` does for the deprecated Do Not Track signal. Defaults to `false`.

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -3220,9 +3220,14 @@
           "name": "opt_in_site_apps"
         },
         {
-          "description": "Determines whether PostHog should respect the Do Not Track header when computing\nconsent in `ConsentManager`.",
+          "description": "Determines whether PostHog should respect the Do Not Track header when computing\nconsent in `ConsentManager`.\n\nNote the Do Not Track signal is deprecated and not sent by all modern browsers;\nsee `respect_gpc` for its successor.",
           "type": "boolean",
           "name": "respect_dnt"
+        },
+        {
+          "description": "Determines whether PostHog should respect the Global Privacy Control signal\n(`navigator.globalPrivacyControl`) when computing consent in `ConsentManager`.\nWhen `true`, users whose browser sends the GPC signal are treated as opted out.\n\nGPC is the successor to Do Not Track and is recognized as a valid opt-out\nsignal under privacy regulations such as CCPA/CPRA.",
+          "type": "boolean",
+          "name": "respect_gpc"
         },
         {
           "description": "A list of properties that should never be sent with capture calls.",

--- a/packages/browser/src/__tests__/consent.test.ts
+++ b/packages/browser/src/__tests__/consent.test.ts
@@ -200,12 +200,40 @@ describe('consentManager', () => {
             ;(navigator as any).doNotTrack = '1'
         })
 
+        afterEach(() => {
+            delete (navigator as any).doNotTrack
+        })
+
         it('should respect it if explicitly set', async () => {
             posthog = await createPostHog({ respect_dnt: true })
             expect(posthog.has_opted_in_capturing()).toBe(false)
         })
 
         it('should not respect it if not explicitly set', () => {
+            expect(posthog.has_opted_in_capturing()).toBe(true)
+        })
+    })
+
+    describe('with global privacy control setting', () => {
+        beforeEach(() => {
+            ;(navigator as any).globalPrivacyControl = true
+        })
+
+        afterEach(() => {
+            delete (navigator as any).globalPrivacyControl
+        })
+
+        it('should respect it if explicitly set', async () => {
+            posthog = await createPostHog({ respect_gpc: true })
+            expect(posthog.has_opted_in_capturing()).toBe(false)
+        })
+
+        it('should not respect it if not explicitly set', () => {
+            expect(posthog.has_opted_in_capturing()).toBe(true)
+        })
+
+        it('should not be respected by respect_dnt', async () => {
+            posthog = await createPostHog({ respect_dnt: true })
             expect(posthog.has_opted_in_capturing()).toBe(true)
         })
     })

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -27,7 +27,7 @@ export class ConsentManager {
     }
 
     public get consent(): ConsentStatus {
-        if (this._getDnt()) {
+        if (this._getDnt() || this._getGpc()) {
             return ConsentStatus.DENIED
         }
 
@@ -128,5 +128,12 @@ export class ConsentManager {
             (navigator as any)?.['msDoNotTrack'],
             assignableWindow['doNotTrack'],
         ].some((dntValue) => isYesLike(dntValue))
+    }
+
+    private _getGpc(): boolean {
+        if (!this._config.respect_gpc) {
+            return false
+        }
+        return isYesLike((navigator as any)?.['globalPrivacyControl'])
     }
 }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -271,6 +271,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     opt_in_site_apps: false,
     property_denylist: [],
     respect_dnt: false,
+    respect_gpc: false,
     sanitize_properties: null,
     request_headers: {}, // { header: value, header2: value }
     request_batching: true,

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1368,10 +1368,26 @@ export interface PostHogConfig {
      * Determines whether PostHog should respect the Do Not Track header when computing
      * consent in `ConsentManager`.
      *
+     * Note the Do Not Track signal is deprecated and not sent by all modern browsers;
+     * see `respect_gpc` for its successor.
+     *
      * @see `ConsentManager`
      * @default false
      */
     respect_dnt: boolean
+
+    /**
+     * Determines whether PostHog should respect the Global Privacy Control signal
+     * (`navigator.globalPrivacyControl`) when computing consent in `ConsentManager`.
+     * When `true`, users whose browser sends the GPC signal are treated as opted out.
+     *
+     * GPC is the successor to Do Not Track and is recognized as a valid opt-out
+     * signal under privacy regulations such as CCPA/CPRA.
+     *
+     * @see `ConsentManager`
+     * @default false
+     */
+    respect_gpc: boolean
 
     /**
      * A list of properties that should never be sent with capture calls.


### PR DESCRIPTION
## Problem

`respect_dnt: true` reads the Do Not Track signal (`navigator.doNotTrack` and legacy variants), but DNT is deprecated as a web standard and no longer sent by all modern browsers. Its successor, Global Privacy Control (`navigator.globalPrivacyControl`), is what privacy-conscious users actually send today (Firefox setting, Brave, DuckDuckGo, extensions) — and unlike DNT it carries legal weight as a recognized opt-out signal under CCPA/CPRA. The SDK currently ignores it, so developers who enable `respect_dnt` for compliance reasonably believe they honor user opt-out signals but miss the one that matters now.

Surfaced by @dustinbyrne's review comment on PostHog/posthog.com#18601.

## Changes

- New `respect_gpc` config option (default `false`): when `true`, `ConsentManager` treats users whose browser sends the GPC signal as opted out — a `_getGpc()` check alongside the existing `_getDnt()`.
- Deliberately a **separate option** rather than folding GPC into `respect_dnt`: extending the existing option would silently change opt-out behavior (and event volume) for every current `respect_dnt` user. Separate and additive means zero behavior change unless explicitly enabled; the `respect_dnt` JSDoc now cross-references it.
- Never-throw: the check is a single optional-chained property read through `isYesLike`; absent/undefined resolves to `false`.
- Tests: GPC respected when enabled, ignored when not, and `respect_dnt` does not react to the GPC signal (28 consent tests pass).
- JSDoc flows into the generated `PostHogConfig` reference automatically (regenerated here) — no api.json churn since the property lives in `@posthog/types`, resolved cross-package by the reference pipeline.

Draft for the consent-behavior design review: mainly whether a separate `respect_gpc` (this PR) or extending `respect_dnt` is preferred, and whether other SDK platforms need parity (GPC is browser-only, so likely not).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code from a review comment on the docs PR: while adding a DNT-deprecation caveat to the `respect_dnt` docs row, we checked `consent.ts` and found GPC unsupported. Chose the additive option over extending `respect_dnt` to avoid changing behavior for existing users; the PR is a draft to let the team weigh that trade-off.
