### PR TITLE
feat(autoresearch): shrink array.js via terser and rollup treeshake tuning

### DIFF
--- a/.changeset/heavy-moons-scream.md
+++ b/.changeset/heavy-moons-scream.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Shrink bundle sizes through build tuning: enable terser's `unsafe_arrows` and a third compress pass, and align rollup tree-shaking purity assumptions with terser's existing `pure_getters` posture

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -114,8 +114,9 @@ const plugins = (es5, noExternal) => [
         toplevel: true,
         compress: {
             ecma: es5 ? 5 : 6,
-            passes: 2,
+            passes: 3,
             pure_getters: true,
+            unsafe_arrows: !es5,
             unsafe_methods: true,
             unsafe_comps: true,
             unsafe_math: true,
@@ -366,6 +367,14 @@ const entrypointTargets = entrypoints.map((file) => {
     /** @type {import('rollup').RollupOptions} */
     return {
         input: `src/entrypoints/${file}`,
+        treeshake: {
+            // Match the purity assumptions terser already applies below (pure_getters etc.):
+            // treat property reads as side-effect free, and don't retain otherwise-unused code
+            // just because it sits inside one of our many defensive try/catch blocks.
+            propertyReadSideEffects: false,
+            tryCatchDeoptimization: false,
+            unknownGlobalSideEffects: false,
+        },
         output: [
             {
                 file: `dist/${fileName}.js`,


### PR DESCRIPTION
## Problem

`array.js` (the snippet bundle every posthog-js web user downloads) carries avoidable weight: the build config left some safe minifier and tree-shaking capacity unused. This PR is the outcome of an iterative size-optimization loop over the bundle build. Created with Autoresearch.

## Changes

Three focused changes to `packages/browser/rollup.config.mjs`, each measured individually:

1. **terser `compress.unsafe_arrows` (non-es5 bundles only)** — converts eligible function expressions to arrows. Safe here because babel's browser targets already keep classes/arrows native, and terser only converts functions that don't rely on `this`/construction. The es5/IE11 bundle is excluded.
2. **rollup `treeshake` options** (`propertyReadSideEffects`, `tryCatchDeoptimization`, `unknownGlobalSideEffects` all `false`) — aligns rollup's tree-shaking purity assumptions with what terser already assumes for the same output (`pure_getters` etc.), so code retained only because it sits inside the SDK's many defensive try/catch blocks can be dropped.
3. **terser `compress.passes: 2 → 3`** — the extra pass folds structures the first two passes exposed.

Measured on the full build (`gzip -9`): `array.js` **227,426 → 226,614 bytes raw (−812)** and **73,063 → 72,906 bytes gzipped (−157)**.

Notable experiments rejected along the way (details in commit history of the loop): `passes: 4` and excluding babel's template-literal transform both *regressed* gzip size; terser's `compress.module` shaved 10 bytes but silently strips the bundle's `"use strict"` directive (a semantics change), so it was rejected.

Verification:
- Full `turbo build --filter=posthog-js` passes (all 11 tasks, including the cross-bundle mangled-property consistency check; `terser-mangled-names.json` has no drift)
- CI gates reproduced locally: `es-check es5 dist/array.full.es5.js` and `es-check es6 dist/array.full.js` both pass
- Unit tests: 120 suites / 4,946 tests pass; functional tests pass

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [ ] Tests for new code (build-config only; covered by existing suites and es-check gates)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude Code (PostHog Code) running an autoresearch optimization loop: establish baseline → one measured change per iteration → keep wins, revert regressions.
- Each candidate was rebuilt and measured (`stat` + `gzip -9` on `dist/array.js`); risky-looking wins were inspected in the emitted output before acceptance, which is how the `compress.module` semantics regression was caught and rejected despite measuring smaller.
- No source code changed — build configuration only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
