### PR TITLE
feat(ai): route span processor through AI gateway

### DIFF
--- a/.changeset/tidy-otters-trace.md
+++ b/.changeset/tidy-otters-trace.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': minor
+---
+
+Allow the recommended PostHog span processor to authenticate through the AI gateway.

--- a/.changeset/tidy-otters-trace.md
+++ b/.changeset/tidy-otters-trace.md
@@ -2,4 +2,4 @@
 '@posthog/ai': minor
 ---
 
-Allow the recommended PostHog span processor to authenticate through the AI gateway.
+Allow the recommended PostHog span processor to select AI Gateway routing with a `phs_` project secret.

--- a/.changeset/tidy-otters-trace.md
+++ b/.changeset/tidy-otters-trace.md
@@ -2,4 +2,4 @@
 '@posthog/ai': minor
 ---
 
-Allow the recommended PostHog span processor to select AI Gateway routing with a `phs_` project secret.
+Allow the recommended PostHog span processor to route through AI Gateway with an explicit `aiGateway` option and a `phs_` project secret.

--- a/examples/example-convex/convex/aiSdk/openTelemetry.ts
+++ b/examples/example-convex/convex/aiSdk/openTelemetry.ts
@@ -3,33 +3,29 @@
 import '../polyfills.js'
 
 import { trace } from '@opentelemetry/api'
-import { BasicTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import { generateText } from 'ai'
 import { openai } from '@ai-sdk/openai'
-import { PostHogTraceExporter } from '@posthog/ai/otel'
+import { PostHogSpanProcessor } from '@posthog/ai/otel'
 import { action } from '../_generated/server'
 import { v } from 'convex/values'
 
-// PostHogTraceExporter is a standard OTEL SpanExporter — add it as a span
-// processor alongside any other exporters in your OTEL setup.
 const provider = new BasicTracerProvider({
     resource: resourceFromAttributes({
         'service.name': 'example-convex',
     }),
     spanProcessors: [
-        new SimpleSpanProcessor(
-            new PostHogTraceExporter({
-                projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
-                host: process.env.POSTHOG_HOST,
-            })
-        ),
+        new PostHogSpanProcessor({
+            projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
+            host: process.env.POSTHOG_HOST,
+        }),
     ],
 })
 trace.setGlobalTracerProvider(provider)
 
 // Demonstrates using the Vercel AI SDK's experimental_telemetry with
-// PostHog's PostHogTraceExporter to automatically capture $ai_generation events.
+// PostHog's PostHogSpanProcessor to automatically capture $ai_generation events.
 export const generate = action({
     args: {
         prompt: v.string(),
@@ -49,6 +45,8 @@ export const generate = action({
                 },
             },
         })
+
+        await provider.forceFlush()
 
         return { text: result.text, usage: result.usage }
     },

--- a/examples/example-convex/convex/aiSdk/openTelemetry.ts
+++ b/examples/example-convex/convex/aiSdk/openTelemetry.ts
@@ -46,7 +46,11 @@ export const generate = action({
             },
         })
 
-        await provider.forceFlush()
+        try {
+            await provider.forceFlush()
+        } catch (error) {
+            console.error('Failed to flush PostHog telemetry', error)
+        }
 
         return { text: result.text, usage: result.usage }
     },

--- a/examples/example-convex/convex/convexAgent/openTelemetry.ts
+++ b/examples/example-convex/convex/convexAgent/openTelemetry.ts
@@ -55,7 +55,11 @@ export const generate = action({
             },
         })
 
-        await provider.forceFlush()
+        try {
+            await provider.forceFlush()
+        } catch (error) {
+            console.error('Failed to flush PostHog telemetry', error)
+        }
 
         return {
             text: result.text,

--- a/examples/example-convex/convex/convexAgent/openTelemetry.ts
+++ b/examples/example-convex/convex/convexAgent/openTelemetry.ts
@@ -3,34 +3,30 @@
 import '../polyfills.js'
 
 import { trace } from '@opentelemetry/api'
-import { BasicTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import { Agent } from '@convex-dev/agent'
 import { openai } from '@ai-sdk/openai'
-import { PostHogTraceExporter } from '@posthog/ai/otel'
+import { PostHogSpanProcessor } from '@posthog/ai/otel'
 import { components } from '../_generated/api'
 import { action } from '../_generated/server'
 import { v } from 'convex/values'
 
-// PostHogTraceExporter is a standard OTEL SpanExporter — add it as a span
-// processor alongside any other exporters in your OTEL setup.
 const provider = new BasicTracerProvider({
     resource: resourceFromAttributes({
         'service.name': 'example-convex',
     }),
     spanProcessors: [
-        new SimpleSpanProcessor(
-            new PostHogTraceExporter({
-                projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
-                host: process.env.POSTHOG_HOST,
-            })
-        ),
+        new PostHogSpanProcessor({
+            projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
+            host: process.env.POSTHOG_HOST,
+        }),
     ],
 })
 trace.setGlobalTracerProvider(provider)
 
 // Demonstrates using @convex-dev/agent with the Vercel AI SDK's
-// experimental_telemetry and PostHog's PostHogTraceExporter to
+// experimental_telemetry and PostHog's PostHogSpanProcessor to
 // automatically capture $ai_generation events.
 export const generate = action({
     args: {
@@ -58,6 +54,8 @@ export const generate = action({
                 },
             },
         })
+
+        await provider.forceFlush()
 
         return {
             text: result.text,

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -11,6 +11,8 @@ SDK usage examples and code snippets live in the official documentation so they 
 
 ## AI gateway tracing
 
+Pass a PostHog project secret (`phs_...`) as `projectSecret` to send AI telemetry through PostHog AI Gateway. This selects the gateway automatically and defaults to `https://ai-gateway.us.posthog.com`; you do not need to set `host`.
+
 ```ts
 import { PostHogSpanProcessor } from '@posthog/ai/otel'
 import { NodeSDK } from '@opentelemetry/sdk-node'
@@ -26,7 +28,7 @@ const sdk = new NodeSDK({
 sdk.start()
 ```
 
-`PostHogSpanProcessor` is the recommended tracing integration. `PostHogTraceExporter` remains available for frameworks that only accept a trace exporter. Evaluation logs use the standard OpenTelemetry logs pipeline.
+Using `projectToken: 'phc_...'` instead sends traces directly to PostHog's OTLP ingestion endpoint and does not use AI Gateway. `PostHogSpanProcessor` is the recommended tracing integration. `PostHogTraceExporter` remains available for frameworks that only accept a trace exporter. Evaluation logs use the standard OpenTelemetry logs pipeline.
 
 ## Questions?
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -11,7 +11,7 @@ SDK usage examples and code snippets live in the official documentation so they 
 
 ## AI gateway tracing
 
-Set `aiGateway` with a PostHog project secret (`phs_...`) to send AI telemetry through PostHog AI Gateway. Gateway routing is explicit at the call site and defaults to `https://ai-gateway.us.posthog.com`; you do not need to set `host`.
+Set `aiGateway` with a PostHog project secret (`phs_...`) to send AI telemetry through PostHog AI Gateway. Gateway routing is explicit at the call site. Its host defaults to `https://ai-gateway.us.posthog.com`; set `aiGateway.host` to `https://ai-gateway.eu.posthog.com` for EU or to your development or self-hosted gateway URL.
 
 ```ts
 import { PostHogSpanProcessor } from '@posthog/ai/otel'
@@ -22,6 +22,7 @@ const sdk = new NodeSDK({
     new PostHogSpanProcessor({
       aiGateway: {
         projectSecret: process.env.POSTHOG_PROJECT_SECRET_KEY!,
+        host: process.env.POSTHOG_AI_GATEWAY_HOST,
       },
     }),
   ],

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -9,6 +9,25 @@ SDK usage examples and code snippets live in the official documentation so they 
 - [AI observability installation docs](https://posthog.com/docs/ai-observability/installation)
 - [AI observability docs](https://posthog.com/docs/ai-observability)
 
+## AI gateway tracing
+
+```ts
+import { PostHogSpanProcessor } from '@posthog/ai/otel'
+import { NodeSDK } from '@opentelemetry/sdk-node'
+
+const sdk = new NodeSDK({
+  spanProcessors: [
+    new PostHogSpanProcessor({
+      projectSecret: process.env.POSTHOG_PROJECT_SECRET_KEY!,
+    }),
+  ],
+})
+
+sdk.start()
+```
+
+`PostHogSpanProcessor` is the recommended tracing integration. `PostHogTraceExporter` remains available for frameworks that only accept a trace exporter. Evaluation logs use the standard OpenTelemetry logs pipeline.
+
 ## Questions?
 
 ### [Check out our community page.](https://posthog.com/posts)

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -11,7 +11,7 @@ SDK usage examples and code snippets live in the official documentation so they 
 
 ## AI gateway tracing
 
-Pass a PostHog project secret (`phs_...`) as `projectSecret` to send AI telemetry through PostHog AI Gateway. This selects the gateway automatically and defaults to `https://ai-gateway.us.posthog.com`; you do not need to set `host`.
+Set `aiGateway` with a PostHog project secret (`phs_...`) to send AI telemetry through PostHog AI Gateway. Gateway routing is explicit at the call site and defaults to `https://ai-gateway.us.posthog.com`; you do not need to set `host`.
 
 ```ts
 import { PostHogSpanProcessor } from '@posthog/ai/otel'
@@ -20,7 +20,9 @@ import { NodeSDK } from '@opentelemetry/sdk-node'
 const sdk = new NodeSDK({
   spanProcessors: [
     new PostHogSpanProcessor({
-      projectSecret: process.env.POSTHOG_PROJECT_SECRET_KEY!,
+      aiGateway: {
+        projectSecret: process.env.POSTHOG_PROJECT_SECRET_KEY!,
+      },
     }),
   ],
 })
@@ -28,7 +30,7 @@ const sdk = new NodeSDK({
 sdk.start()
 ```
 
-Using `projectToken: 'phc_...'` instead sends traces directly to PostHog's OTLP ingestion endpoint and does not use AI Gateway. `PostHogSpanProcessor` is the recommended tracing integration. `PostHogTraceExporter` remains available for frameworks that only accept a trace exporter. Evaluation logs use the standard OpenTelemetry logs pipeline.
+Using `projectToken: 'phc_...'` sends traces directly to PostHog's OTLP ingestion endpoint and does not use AI Gateway. `PostHogSpanProcessor` is the recommended tracing integration. `PostHogTraceExporter` remains available for frameworks that only accept a trace exporter. Evaluation logs use the standard OpenTelemetry logs pipeline.
 
 ## Questions?
 

--- a/packages/ai/src/otel/processor.ts
+++ b/packages/ai/src/otel/processor.ts
@@ -7,6 +7,7 @@ import { isAISpan } from './spans'
 import { warnIfPostHogAiGatewayOtelAttributes } from '../gatewayWarning'
 
 const DEFAULT_OTEL_HOST = 'https://us.i.posthog.com'
+const DEFAULT_AI_GATEWAY_HOST = 'https://ai-gateway.us.posthog.com'
 
 function normalizeToken(value?: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
@@ -17,15 +18,10 @@ function normalizeHost(value?: unknown): string {
   return normalizedValue || DEFAULT_OTEL_HOST
 }
 
-export interface PostHogSpanProcessorOptions {
+interface PostHogSpanProcessorBaseOptions {
   /**
-   * Your PostHog project token (the `phc_...` key). Required; a blank token disables the
-   * processor as a defensive no-op.
-   */
-  projectToken: string
-
-  /**
-   * PostHog host URL. Defaults to `https://us.i.posthog.com`.
+   * PostHog host URL. Defaults to `https://us.i.posthog.com` for project tokens
+   * and `https://ai-gateway.us.posthog.com` for project secrets.
    */
   host?: string
 
@@ -33,6 +29,29 @@ export interface PostHogSpanProcessorOptions {
    * @internal Injected processor for testing — bypasses exporter creation.
    */
   _spanProcessor?: SpanProcessor
+}
+
+export type PostHogSpanProcessorOptions = PostHogSpanProcessorBaseOptions &
+  (
+    | {
+        /** Your PostHog project token (the `phc_...` key). */
+        projectToken: string
+        projectSecret?: never
+      }
+    | {
+        /** Your AI gateway project secret (the `phs_...` key). */
+        projectSecret: string
+        projectToken?: never
+      }
+  )
+
+interface PostHogSpanProcessorRuntimeOptions extends PostHogSpanProcessorBaseOptions {
+  /**
+   * Your PostHog project token (the `phc_...` key).
+   */
+  projectToken?: string
+  /** Your AI gateway project secret (the `phs_...` key). */
+  projectSecret?: string
 }
 
 class NoopSpanProcessor implements SpanProcessor {
@@ -53,7 +72,9 @@ class NoopSpanProcessor implements SpanProcessor {
 /**
  * An OpenTelemetry `SpanProcessor` that sends AI traces to PostHog.
  *
- * `projectToken` is required; a blank token disables the processor as a defensive no-op.
+ * Provide either a `projectToken` for direct PostHog ingestion or a
+ * `projectSecret` for AI gateway ingestion. A blank credential disables the
+ * processor as a defensive no-op.
  *
  * Internally batches spans and exports them to PostHog's OTLP ingestion
  * endpoint. Only AI-related spans (those whose name or attribute keys
@@ -79,17 +100,26 @@ export class PostHogSpanProcessor implements SpanProcessor {
   private readonly inner: SpanProcessor
 
   constructor(options: PostHogSpanProcessorOptions) {
-    const token = normalizeToken(options.projectToken)
+    const runtimeOptions = options as PostHogSpanProcessorRuntimeOptions
+    const projectToken = normalizeToken(runtimeOptions.projectToken)
+    const projectSecret = normalizeToken(runtimeOptions.projectSecret)
+    const token = projectSecret || projectToken
     if (!token) {
-      console.warn('[PostHogSpanProcessor] projectToken is missing or blank; the processor will be disabled.')
+      console.warn(
+        '[PostHogSpanProcessor] projectToken or projectSecret is missing or blank; the processor will be disabled.'
+      )
       this.inner = new NoopSpanProcessor()
       return
     }
+    if (projectToken && projectSecret) {
+      throw new TypeError('[PostHogSpanProcessor] provide either projectToken or projectSecret, not both.')
+    }
 
-    if (options._spanProcessor) {
-      this.inner = options._spanProcessor
+    if (runtimeOptions._spanProcessor) {
+      this.inner = runtimeOptions._spanProcessor
     } else {
-      const host = new URL(normalizeHost(options.host)).origin
+      const defaultHost = projectSecret ? DEFAULT_AI_GATEWAY_HOST : DEFAULT_OTEL_HOST
+      const host = new URL(normalizeHost(runtimeOptions.host || defaultHost)).origin
       const exporter = new OTLPTraceExporter({
         url: `${host}/i/v0/ai/otel`,
         headers: {

--- a/packages/ai/src/otel/processor.ts
+++ b/packages/ai/src/otel/processor.ts
@@ -39,7 +39,10 @@ export type PostHogSpanProcessorOptions = PostHogSpanProcessorBaseOptions &
         projectSecret?: never
       }
     | {
-        /** Your AI gateway project secret (the `phs_...` key). */
+        /**
+         * Your PostHog project secret (the `phs_...` key). Selecting this
+         * credential routes telemetry through PostHog AI Gateway.
+         */
         projectSecret: string
         projectToken?: never
       }
@@ -50,7 +53,7 @@ interface PostHogSpanProcessorRuntimeOptions extends PostHogSpanProcessorBaseOpt
    * Your PostHog project token (the `phc_...` key).
    */
   projectToken?: string
-  /** Your AI gateway project secret (the `phs_...` key). */
+  /** Your PostHog project secret (the `phs_...` key). */
   projectSecret?: string
 }
 
@@ -72,9 +75,10 @@ class NoopSpanProcessor implements SpanProcessor {
 /**
  * An OpenTelemetry `SpanProcessor` that sends AI traces to PostHog.
  *
- * Provide either a `projectToken` for direct PostHog ingestion or a
- * `projectSecret` for AI gateway ingestion. A blank credential disables the
- * processor as a defensive no-op.
+ * Credential choice controls the route: `projectSecret: 'phs_...'` sends
+ * telemetry through PostHog AI Gateway, while `projectToken: 'phc_...'` sends
+ * directly to PostHog's OTLP ingestion endpoint. A blank credential disables
+ * the processor as a defensive no-op.
  *
  * Internally batches spans and exports them to PostHog's OTLP ingestion
  * endpoint. Only AI-related spans (those whose name or attribute keys

--- a/packages/ai/src/otel/processor.ts
+++ b/packages/ai/src/otel/processor.ts
@@ -20,8 +20,8 @@ function normalizeHost(value: unknown, defaultHost: string): string {
 
 interface PostHogSpanProcessorBaseOptions {
   /**
-   * PostHog host URL. Defaults to `https://us.i.posthog.com` for project tokens
-   * and `https://ai-gateway.us.posthog.com` for project secrets.
+   * PostHog host URL. Defaults to `https://us.i.posthog.com` for direct
+   * ingestion and `https://ai-gateway.us.posthog.com` for AI Gateway.
    */
   host?: string
 
@@ -36,14 +36,16 @@ export type PostHogSpanProcessorOptions = PostHogSpanProcessorBaseOptions &
     | {
         /** Your PostHog project token (the `phc_...` key). */
         projectToken: string
-        projectSecret?: never
+        aiGateway?: never
       }
     | {
         /**
-         * Your PostHog project secret (the `phs_...` key). Selecting this
-         * credential routes telemetry through PostHog AI Gateway.
+         * Route telemetry through PostHog AI Gateway.
          */
-        projectSecret: string
+        aiGateway: {
+          /** Your PostHog project secret (the `phs_...` key). */
+          projectSecret: string
+        }
         projectToken?: never
       }
   )
@@ -53,8 +55,7 @@ interface PostHogSpanProcessorRuntimeOptions extends PostHogSpanProcessorBaseOpt
    * Your PostHog project token (the `phc_...` key).
    */
   projectToken?: string
-  /** Your PostHog project secret (the `phs_...` key). */
-  projectSecret?: string
+  aiGateway?: { projectSecret?: unknown }
 }
 
 class NoopSpanProcessor implements SpanProcessor {
@@ -75,10 +76,10 @@ class NoopSpanProcessor implements SpanProcessor {
 /**
  * An OpenTelemetry `SpanProcessor` that sends AI traces to PostHog.
  *
- * Credential choice controls the route: `projectSecret: 'phs_...'` sends
- * telemetry through PostHog AI Gateway, while `projectToken: 'phc_...'` sends
- * directly to PostHog's OTLP ingestion endpoint. A blank credential disables
- * the processor as a defensive no-op.
+ * Set `aiGateway: { projectSecret: 'phs_...' }` to send telemetry through
+ * PostHog AI Gateway. Set `projectToken: 'phc_...'` to send directly to
+ * PostHog's OTLP ingestion endpoint. A blank credential disables the processor
+ * as a defensive no-op.
  *
  * Internally batches spans and exports them to PostHog's OTLP ingestion
  * endpoint. Only AI-related spans (those whose name or attribute keys
@@ -106,17 +107,17 @@ export class PostHogSpanProcessor implements SpanProcessor {
   constructor(options: PostHogSpanProcessorOptions) {
     const runtimeOptions = options as PostHogSpanProcessorRuntimeOptions
     const projectToken = normalizeToken(runtimeOptions.projectToken)
-    const projectSecret = normalizeToken(runtimeOptions.projectSecret)
+    const projectSecret = normalizeToken(runtimeOptions.aiGateway?.projectSecret)
     const token = projectSecret || projectToken
     if (!token) {
       console.warn(
-        '[PostHogSpanProcessor] projectToken or projectSecret is missing or blank; the processor will be disabled.'
+        '[PostHogSpanProcessor] projectToken or aiGateway.projectSecret is missing or blank; the processor will be disabled.'
       )
       this.inner = new NoopSpanProcessor()
       return
     }
     if (projectToken && projectSecret) {
-      throw new TypeError('[PostHogSpanProcessor] provide either projectToken or projectSecret, not both.')
+      throw new TypeError('[PostHogSpanProcessor] provide either projectToken or aiGateway, not both.')
     }
 
     if (runtimeOptions._spanProcessor) {

--- a/packages/ai/src/otel/processor.ts
+++ b/packages/ai/src/otel/processor.ts
@@ -20,12 +20,6 @@ function normalizeHost(value: unknown, defaultHost: string): string {
 
 interface PostHogSpanProcessorBaseOptions {
   /**
-   * PostHog host URL. Defaults to `https://us.i.posthog.com` for direct
-   * ingestion and `https://ai-gateway.us.posthog.com` for AI Gateway.
-   */
-  host?: string
-
-  /**
    * @internal Injected processor for testing — bypasses exporter creation.
    */
   _spanProcessor?: SpanProcessor
@@ -36,6 +30,8 @@ export type PostHogSpanProcessorOptions = PostHogSpanProcessorBaseOptions &
     | {
         /** Your PostHog project token (the `phc_...` key). */
         projectToken: string
+        /** PostHog ingestion host. Defaults to `https://us.i.posthog.com`. */
+        host?: string
         aiGateway?: never
       }
     | {
@@ -45,8 +41,11 @@ export type PostHogSpanProcessorOptions = PostHogSpanProcessorBaseOptions &
         aiGateway: {
           /** Your PostHog project secret (the `phs_...` key). */
           projectSecret: string
+          /** AI Gateway host. Defaults to `https://ai-gateway.us.posthog.com`. */
+          host?: string
         }
         projectToken?: never
+        host?: never
       }
   )
 
@@ -55,7 +54,8 @@ interface PostHogSpanProcessorRuntimeOptions extends PostHogSpanProcessorBaseOpt
    * Your PostHog project token (the `phc_...` key).
    */
   projectToken?: string
-  aiGateway?: { projectSecret?: unknown }
+  host?: unknown
+  aiGateway?: { projectSecret?: unknown; host?: unknown }
 }
 
 class NoopSpanProcessor implements SpanProcessor {
@@ -76,10 +76,11 @@ class NoopSpanProcessor implements SpanProcessor {
 /**
  * An OpenTelemetry `SpanProcessor` that sends AI traces to PostHog.
  *
- * Set `aiGateway: { projectSecret: 'phs_...' }` to send telemetry through
- * PostHog AI Gateway. Set `projectToken: 'phc_...'` to send directly to
- * PostHog's OTLP ingestion endpoint. A blank credential disables the processor
- * as a defensive no-op.
+ * Set `aiGateway: { projectSecret: 'phs_...', host: '...' }` to send telemetry
+ * through a PostHog AI Gateway deployment. The gateway host defaults to US;
+ * set it for EU, development, or self-hosted deployments. Set
+ * `projectToken: 'phc_...'` to send directly to PostHog's OTLP ingestion
+ * endpoint. A blank credential disables the processor as a defensive no-op.
  *
  * Internally batches spans and exports them to PostHog's OTLP ingestion
  * endpoint. Only AI-related spans (those whose name or attribute keys
@@ -124,7 +125,8 @@ export class PostHogSpanProcessor implements SpanProcessor {
       this.inner = runtimeOptions._spanProcessor
     } else {
       const defaultHost = projectSecret ? DEFAULT_AI_GATEWAY_HOST : DEFAULT_OTEL_HOST
-      const host = new URL(normalizeHost(runtimeOptions.host, defaultHost)).origin
+      const configuredHost = projectSecret ? runtimeOptions.aiGateway?.host : runtimeOptions.host
+      const host = new URL(normalizeHost(configuredHost, defaultHost)).origin
       const exporter = new OTLPTraceExporter({
         url: `${host}/i/v0/ai/otel`,
         headers: {

--- a/packages/ai/src/otel/processor.ts
+++ b/packages/ai/src/otel/processor.ts
@@ -13,9 +13,9 @@ function normalizeToken(value?: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function normalizeHost(value?: unknown): string {
+function normalizeHost(value: unknown, defaultHost: string): string {
   const normalizedValue = typeof value === 'string' ? value.trim() : ''
-  return normalizedValue || DEFAULT_OTEL_HOST
+  return normalizedValue || defaultHost
 }
 
 interface PostHogSpanProcessorBaseOptions {
@@ -119,7 +119,7 @@ export class PostHogSpanProcessor implements SpanProcessor {
       this.inner = runtimeOptions._spanProcessor
     } else {
       const defaultHost = projectSecret ? DEFAULT_AI_GATEWAY_HOST : DEFAULT_OTEL_HOST
-      const host = new URL(normalizeHost(runtimeOptions.host || defaultHost)).origin
+      const host = new URL(normalizeHost(runtimeOptions.host, defaultHost)).origin
       const exporter = new OTLPTraceExporter({
         url: `${host}/i/v0/ai/otel`,
         headers: {

--- a/packages/ai/tests/processor.test.ts
+++ b/packages/ai/tests/processor.test.ts
@@ -84,6 +84,16 @@ describe('PostHogSpanProcessor', () => {
     expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object))
   })
 
+  it('routes project secrets through the AI gateway when host is blank', () => {
+    new PostHogSpanProcessor({ projectSecret: 'phs_test123', host: '  \n\t ' })
+
+    expect(OTLPTraceExporter).toHaveBeenCalledWith({
+      url: 'https://ai-gateway.us.posthog.com/i/v0/ai/otel',
+      headers: { Authorization: 'Bearer phs_test123' },
+    })
+    expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object))
+  })
+
   it.each([
     ['missing', {}],
     ['empty', { projectToken: '' }],

--- a/packages/ai/tests/processor.test.ts
+++ b/packages/ai/tests/processor.test.ts
@@ -74,21 +74,16 @@ describe('PostHogSpanProcessor', () => {
     expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object))
   })
 
-  it('routes project secrets through the AI gateway', () => {
-    new PostHogSpanProcessor({ aiGateway: { projectSecret: '  phs_test123  ' } })
+  it.each([
+    ['US default', undefined, 'https://ai-gateway.us.posthog.com/i/v0/ai/otel'],
+    ['EU', 'https://ai-gateway.eu.posthog.com', 'https://ai-gateway.eu.posthog.com/i/v0/ai/otel'],
+    ['self-hosted', 'https://gateway.example.com/', 'https://gateway.example.com/i/v0/ai/otel'],
+    ['blank host', '  \n\t ', 'https://ai-gateway.us.posthog.com/i/v0/ai/otel'],
+  ])('routes project secrets through the %s AI gateway', (_name, host, expectedUrl) => {
+    new PostHogSpanProcessor({ aiGateway: { projectSecret: '  phs_test123  ', host } })
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
-      url: 'https://ai-gateway.us.posthog.com/i/v0/ai/otel',
-      headers: { Authorization: 'Bearer phs_test123' },
-    })
-    expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object))
-  })
-
-  it('routes project secrets through the AI gateway when host is blank', () => {
-    new PostHogSpanProcessor({ aiGateway: { projectSecret: 'phs_test123' }, host: '  \n\t ' })
-
-    expect(OTLPTraceExporter).toHaveBeenCalledWith({
-      url: 'https://ai-gateway.us.posthog.com/i/v0/ai/otel',
+      url: expectedUrl,
       headers: { Authorization: 'Bearer phs_test123' },
     })
     expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object))

--- a/packages/ai/tests/processor.test.ts
+++ b/packages/ai/tests/processor.test.ts
@@ -74,6 +74,16 @@ describe('PostHogSpanProcessor', () => {
     expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object))
   })
 
+  it('routes project secrets through the AI gateway', () => {
+    new PostHogSpanProcessor({ projectSecret: '  phs_test123  ' })
+
+    expect(OTLPTraceExporter).toHaveBeenCalledWith({
+      url: 'https://ai-gateway.us.posthog.com/i/v0/ai/otel',
+      headers: { Authorization: 'Bearer phs_test123' },
+    })
+    expect(BatchSpanProcessor).toHaveBeenCalledWith(expect.any(Object))
+  })
+
   it.each([
     ['missing', {}],
     ['empty', { projectToken: '' }],
@@ -90,7 +100,7 @@ describe('PostHogSpanProcessor', () => {
     expect(OTLPTraceExporter).not.toHaveBeenCalled()
     expect(BatchSpanProcessor).not.toHaveBeenCalled()
     expect(warnSpy).toHaveBeenCalledWith(
-      '[PostHogSpanProcessor] projectToken is missing or blank; the processor will be disabled.'
+      '[PostHogSpanProcessor] projectToken or projectSecret is missing or blank; the processor will be disabled.'
     )
     warnSpy.mockRestore()
   })

--- a/packages/ai/tests/processor.test.ts
+++ b/packages/ai/tests/processor.test.ts
@@ -75,7 +75,7 @@ describe('PostHogSpanProcessor', () => {
   })
 
   it('routes project secrets through the AI gateway', () => {
-    new PostHogSpanProcessor({ projectSecret: '  phs_test123  ' })
+    new PostHogSpanProcessor({ aiGateway: { projectSecret: '  phs_test123  ' } })
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
       url: 'https://ai-gateway.us.posthog.com/i/v0/ai/otel',
@@ -85,7 +85,7 @@ describe('PostHogSpanProcessor', () => {
   })
 
   it('routes project secrets through the AI gateway when host is blank', () => {
-    new PostHogSpanProcessor({ projectSecret: 'phs_test123', host: '  \n\t ' })
+    new PostHogSpanProcessor({ aiGateway: { projectSecret: 'phs_test123' }, host: '  \n\t ' })
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
       url: 'https://ai-gateway.us.posthog.com/i/v0/ai/otel',
@@ -98,6 +98,7 @@ describe('PostHogSpanProcessor', () => {
     ['missing', {}],
     ['empty', { projectToken: '' }],
     ['blank', { projectToken: '  \n\t ' }],
+    ['empty AI Gateway secret', { aiGateway: { projectSecret: '' } }],
   ])('disables and no-ops when projectToken is %s', async (_case, options) => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     const processor = new PostHogSpanProcessor(options as any)
@@ -110,7 +111,7 @@ describe('PostHogSpanProcessor', () => {
     expect(OTLPTraceExporter).not.toHaveBeenCalled()
     expect(BatchSpanProcessor).not.toHaveBeenCalled()
     expect(warnSpy).toHaveBeenCalledWith(
-      '[PostHogSpanProcessor] projectToken or projectSecret is missing or blank; the processor will be disabled.'
+      '[PostHogSpanProcessor] projectToken or aiGateway.projectSecret is missing or blank; the processor will be disabled.'
     )
     warnSpy.mockRestore()
   })

--- a/packages/ai/tests/processor.test.ts
+++ b/packages/ai/tests/processor.test.ts
@@ -111,6 +111,19 @@ describe('PostHogSpanProcessor', () => {
     warnSpy.mockRestore()
   })
 
+  it('rejects conflicting direct and AI gateway credentials', () => {
+    expect(
+      () =>
+        new PostHogSpanProcessor({
+          projectToken: 'phc_test',
+          aiGateway: { projectSecret: 'phs_test' },
+        } as any)
+    ).toThrow('[PostHogSpanProcessor] provide either projectToken or aiGateway, not both.')
+
+    expect(OTLPTraceExporter).not.toHaveBeenCalled()
+    expect(BatchSpanProcessor).not.toHaveBeenCalled()
+  })
+
   it('delegates onStart to the inner processor', () => {
     const inner = mockProcessor()
     const processor = new PostHogSpanProcessor({ projectToken: 'phc_test', _spanProcessor: inner })


### PR DESCRIPTION
## Problem

AI Gateway users need one recommended span processor without making the gateway implicit for existing direct-ingestion users.

## Changes

`PostHogSpanProcessor` makes the route explicit: `aiGateway: { projectSecret: 'phs_...' }` sends traces through PostHog AI Gateway, while `projectToken: 'phc_...'` keeps direct OTLP ingestion. Blank hosts use the matching route-specific default, and `PostHogTraceExporter` remains available for exporter-only frameworks. Supplying both credential routes fails before constructing an exporter.

Hold merge and release until the capture changes are deployed and the relay routes are live in US and EU. The explicit `aiGateway` option is the SDK-side gate.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code handled the implementation and review fixes. Gateway routing remains explicitly opt-in through `aiGateway`, neutral examples keep direct ingestion, and the processor tests cover regional hosts, blank credentials, and conflicting routes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*