### PR TITLE
feat: publish browser-common

### DIFF
--- a/.changeset/bright-browsers-build.md
+++ b/.changeset/bright-browsers-build.md
@@ -1,0 +1,5 @@
+---
+'@posthog/browser-common': minor
+---
+
+Initial publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,7 @@ jobs:
                     - name: posthog-node
                     - name: posthog-js-lite
                     - name: posthog-js
+                    - name: '@posthog/browser-common'
                     - name: '@posthog/core'
                     - name: '@posthog/react'
                     - name: '@posthog/ai'

--- a/packages/browser-common/README.md
+++ b/packages/browser-common/README.md
@@ -1,8 +1,13 @@
 # @posthog/browser-common
 
-The shared contract for PostHog browser-SDK extensions: the interface an
-extension implements (`Extension`), the host capabilities it is handed
-(`Client`), and small shared runtime primitives such as `Publisher`.
+Internal shared browser utilities and extension primitives for PostHog JavaScript
+SDKs. This package is published so unbundled SDK outputs can resolve it at
+runtime, but it is not a public API surface and does not provide compatibility
+guarantees outside PostHog SDK packages.
+
+The shared extension contract includes the interface an extension implements
+(`Extension`), the host capabilities it is handed (`Client`), and small shared
+runtime primitives such as `Publisher`.
 
 An extension written against this contract runs unchanged across major versions of the web SDK:
 
@@ -11,9 +16,6 @@ An extension written against this contract runs unchanged across major versions 
 
 Each SDK provides a _client adapter_ that implements `Client` over its own
 internals, so extension code never depends on a specific SDK.
-
-This is a source-only package: it does not publish built output. Consumers are
-responsible for bundling/transpiling the TypeScript sources they import.
 
 ## Concepts
 
@@ -110,7 +112,7 @@ v1 → `Client` porting map.
 
 ## Status
 
-Early. The package currently defines the extension contract and the shared
-`Publisher` helper. Additional shared runtime helpers — key-value stores, the
-registry implementation, and a test `Client` — will land alongside the first
-ported extension.
+Early and internal. The package currently defines the extension contract and
+the shared `Publisher` helper. Additional shared runtime helpers — key-value
+stores, the registry implementation, and a test `Client` — will land alongside
+the first ported extension.

--- a/packages/browser-common/jest.config.cjs
+++ b/packages/browser-common/jest.config.cjs
@@ -9,7 +9,6 @@ module.exports = {
                     module: 'CommonJS',
                     moduleResolution: 'node',
                     target: 'ES2022',
-                    ignoreDeprecations: '6.0',
                     esModuleInterop: true,
                     verbatimModuleSyntax: false,
                 },

--- a/packages/browser-common/package.json
+++ b/packages/browser-common/package.json
@@ -1,39 +1,47 @@
 {
     "name": "@posthog/browser-common",
     "version": "0.0.0",
-    "private": true,
-    "description": "Shared browser extension primitives for PostHog JavaScript SDKs",
+    "description": "Internal shared browser utilities and extension primitives for PostHog Browser SDKs",
     "license": "MIT",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/PostHog/posthog-js.git",
         "directory": "packages/browser-common"
     },
-    "type": "module",
     "sideEffects": false,
-    "main": "./src/index.ts",
-    "types": "./src/index.ts",
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "main": "dist/index.js",
+    "module": "dist/index.mjs",
+    "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "types": "./src/index.ts",
-            "import": "./src/index.ts"
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.js",
+            "import": "./dist/index.mjs"
         }
     },
     "scripts": {
+        "clean": "rimraf dist",
         "lint": "eslint src tests",
         "lint:fix": "eslint src tests --fix",
-        "build": "tsc -p tsconfig.json --noEmit",
+        "build": "rslib build",
+        "dev": "rslib build -w",
         "test:unit": "jest -c jest.config.cjs",
-        "check-types": "pnpm build"
+        "check-types": "pnpm build",
+        "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
     },
     "dependencies": {
         "@posthog/core": "workspace:^"
     },
     "devDependencies": {
         "@posthog-tooling/tsconfig-base": "workspace:*",
+        "@rslib/core": "catalog:",
         "@types/jest": "catalog:",
         "jest": "catalog:",
         "ts-jest": "catalog:",
-        "typescript": "^6.0.3"
+        "typescript": "catalog:"
     }
 }

--- a/packages/browser-common/rslib.config.ts
+++ b/packages/browser-common/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core'
+
+export default defineConfig({
+    lib: [
+        { format: 'esm', syntax: 'es2023', dts: true, bundle: false },
+        { format: 'cjs', syntax: 'es2023', dts: true, bundle: false },
+    ],
+    source: {
+        entry: {
+            index: ['src/**/*', '!src/__tests__/**/*', '!src/**/*.spec.ts'],
+        },
+        tsconfigPath: './tsconfig.build.json',
+    },
+})

--- a/packages/browser-common/tsconfig.build.json
+++ b/packages/browser-common/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src/**/*"],
+    "exclude": ["src/__tests__/**/*", "src/**/*.spec.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,18 +503,21 @@ importers:
       '@posthog-tooling/tsconfig-base':
         specifier: workspace:*
         version: link:../../tooling/tsconfig-base
+      '@rslib/core':
+        specifier: 'catalog:'
+        version: 0.10.6(@microsoft/api-extractor@7.58.9(@types/node@26.0.1))(typescript@5.8.2)
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@26.0.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@26.0.1)(typescript@6.0.3))
+        version: 29.7.0(@types/node@26.0.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@26.0.1)(typescript@5.8.2))
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.11(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.0.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@26.0.1)(typescript@6.0.3)))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.0.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@26.0.1)(typescript@5.8.2)))(typescript@5.8.2)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 5.8.2
 
   packages/convex:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -41,6 +41,11 @@
             "env": ["PACKAGE_DEST"],
             "cache": false
         },
+        "@posthog/browser-common#build": {
+            "dependsOn": ["^build"],
+            "inputs": ["src/**", "tsconfig.json", "tsconfig.build.json", "package.json", "rslib.config.ts"],
+            "outputs": ["dist/**"]
+        },
         "lint": {
             "dependsOn": []
         },


### PR DESCRIPTION
## Problem

`@posthog/browser-common` needs to be resolvable as a runtime dependency when shared browser code is moved out of `posthog-js`. The package is currently private and exposes TypeScript source files, so unbundled Node output cannot install or load it from npm.

Version `0.0.0` was published manually to configure npm trusted publishing. This PR prepares the first automated release through the normal release workflow.

## Changes

- Build and publish CommonJS, ES module, and TypeScript declaration outputs with Rslib.
- Package only compiled output and documentation, with Node-compatible conditional exports.
- Add package, clean, and development scripts plus Turbo build inputs.
- Add `@posthog/browser-common` to the release matrix.
- Add a minor changeset for `0.1.0`.
- Document that the published package remains an internal SDK dependency rather than a supported public API.

Validated the package build, lint, unit tests, frozen lockfile install, tarball smoke check, and CJS, ESM, and TypeScript resolution from a fresh consumer installation.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent, using scout and reviewer subagents to verify repository release conventions and the final package configuration. The package follows the repository's existing Rslib dual-module convention and stays on the workspace TypeScript version because the current Rslib release supports TypeScript 5.
