### PR TITLE
fix(autocapture): keep server opt-out when remote config fetch fails

### DIFF
--- a/.changeset/autocapture-optout-config-failure.md
+++ b/.changeset/autocapture-optout-config-failure.md
@@ -2,4 +2,4 @@
 'posthog-js': patch
 ---
 
-fix: honour the project-level autocapture opt-out when the remote config request fails. Previously a failed config fetch (network error, timeout, blocked request) enabled autocapture on opted-out projects and persisted that state for later page loads. Autocapture now keeps the last successfully received server value, and stays off until the first successful config response.
+Honour the project-level autocapture opt-out when the remote config request fails. Previously a failed config fetch (network error, timeout, blocked request) enabled autocapture on opted-out projects and persisted that state for later page loads. Autocapture now keeps the last successfully received server value, and stays off until the first successful config response.

--- a/.changeset/autocapture-optout-config-failure.md
+++ b/.changeset/autocapture-optout-config-failure.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: honour the project-level autocapture opt-out when the remote config request fails. Previously a failed config fetch (network error, timeout, blocked request) enabled autocapture on opted-out projects and persisted that state for later page loads. Autocapture now keeps the last successfully received server value, and stays off until the first successful config response.

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -8,7 +8,8 @@ import {
     previousElementSibling,
 } from '../autocapture'
 import { DEFAULT_CONTENT_IGNORELIST_WITH_STEPPERS, shouldCaptureDomEvent } from '../autocapture-utils'
-import { AutocaptureConfig, FlagsResponse, PostHogConfig, RageclickConfig } from '../types'
+import { AutocaptureConfig, FlagsResponse, PostHogConfig, RageclickConfig, RemoteConfig } from '../types'
+import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from '../constants'
 import { PostHog } from '../posthog-core'
 import { window } from '../utils/globals'
 import { createPosthogInstance } from './helpers/posthog-instance'
@@ -1400,6 +1401,32 @@ describe('Autocapture system', () => {
         it('should be disabled before the flags response if client side opted out', () => {
             posthog.config.autocapture = false
             expect(autocapture.isEnabled).toBe(false)
+        })
+
+        describe('when the remote config fetch fails', () => {
+            beforeEach(() => {
+                autocapture['_isDisabledServerSide'] = null
+                posthog.persistence!.unregister(AUTOCAPTURE_DISABLED_SERVER_SIDE)
+            })
+
+            it('stays disabled when there has never been a successful config response', () => {
+                autocapture.onRemoteConfig({ _configLoadFailed: true } as RemoteConfig)
+                expect(autocapture.isEnabled).toBe(false)
+                expect(posthog.persistence!.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]).toBeUndefined()
+            })
+
+            it('keeps a persisted server-side opt-out', () => {
+                posthog.persistence!.register({ [AUTOCAPTURE_DISABLED_SERVER_SIDE]: true })
+                autocapture.onRemoteConfig({ _configLoadFailed: true } as RemoteConfig)
+                expect(autocapture.isEnabled).toBe(false)
+                expect(posthog.persistence!.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]).toBe(true)
+            })
+
+            it('keeps a persisted enabled state', () => {
+                posthog.persistence!.register({ [AUTOCAPTURE_DISABLED_SERVER_SIDE]: false })
+                autocapture.onRemoteConfig({ _configLoadFailed: true } as RemoteConfig)
+                expect(autocapture.isEnabled).toBe(true)
+            })
         })
 
         it.each([

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -8,7 +8,7 @@ import {
     previousElementSibling,
 } from '../autocapture'
 import { DEFAULT_CONTENT_IGNORELIST_WITH_STEPPERS, shouldCaptureDomEvent } from '../autocapture-utils'
-import { AutocaptureConfig, FlagsResponse, PostHogConfig, RageclickConfig, RemoteConfig } from '../types'
+import { AutocaptureConfig, FlagsResponse, PostHogConfig, RageclickConfig } from '../types'
 import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from '../constants'
 import { PostHog } from '../posthog-core'
 import { window } from '../utils/globals'
@@ -1410,21 +1410,21 @@ describe('Autocapture system', () => {
             })
 
             it('stays disabled when there has never been a successful config response', () => {
-                autocapture.onRemoteConfig({ _configLoadFailed: true } as RemoteConfig)
+                autocapture.onRemoteConfigFailed()
                 expect(autocapture.isEnabled).toBe(false)
                 expect(posthog.persistence!.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]).toBeUndefined()
             })
 
             it('keeps a persisted server-side opt-out', () => {
                 posthog.persistence!.register({ [AUTOCAPTURE_DISABLED_SERVER_SIDE]: true })
-                autocapture.onRemoteConfig({ _configLoadFailed: true } as RemoteConfig)
+                autocapture.onRemoteConfigFailed()
                 expect(autocapture.isEnabled).toBe(false)
                 expect(posthog.persistence!.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]).toBe(true)
             })
 
             it('keeps a persisted enabled state', () => {
                 posthog.persistence!.register({ [AUTOCAPTURE_DISABLED_SERVER_SIDE]: false })
-                autocapture.onRemoteConfig({ _configLoadFailed: true } as RemoteConfig)
+                autocapture.onRemoteConfigFailed()
                 expect(autocapture.isEnabled).toBe(true)
             })
         })

--- a/packages/browser/src/__tests__/deferred-init-extensions.test.ts
+++ b/packages/browser/src/__tests__/deferred-init-extensions.test.ts
@@ -56,10 +56,10 @@ describe('deferred extension initialization', () => {
             })
 
             // Simulate remote config arriving synchronously before extensions init
-            posthog._onRemoteConfig(remoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: remoteConfig })
 
             // The config should be stored in _pendingRemoteConfig
-            expect((posthog as any)._pendingRemoteConfig).toEqual(remoteConfig)
+            expect((posthog as any)._pendingRemoteConfig).toEqual({ ok: true, config: remoteConfig })
 
             // Wait for extensions to initialize (time-sliced, may take multiple ticks)
             await new Promise((resolve) => setTimeout(resolve, 200))
@@ -87,10 +87,10 @@ describe('deferred extension initialization', () => {
             await new Promise((resolve) => setTimeout(resolve, 200))
 
             // Now send remote config after extensions are ready
-            posthog._onRemoteConfig(remoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: remoteConfig })
 
             // Config should be stored
-            expect((posthog as any)._pendingRemoteConfig).toEqual(remoteConfig)
+            expect((posthog as any)._pendingRemoteConfig).toEqual({ ok: true, config: remoteConfig })
         })
 
         it('should not store pending config when deferred init is disabled', async () => {
@@ -107,7 +107,7 @@ describe('deferred extension initialization', () => {
             })
 
             // With sync init, extensions are already ready, no need to store config
-            posthog._onRemoteConfig(remoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: remoteConfig })
 
             // Config should NOT be stored when deferred init is disabled
             expect((posthog as any)._pendingRemoteConfig).toBeUndefined()
@@ -127,8 +127,8 @@ describe('deferred extension initialization', () => {
             })
 
             // Call _onRemoteConfig before extensions are ready
-            posthog._onRemoteConfig(remoteConfig)
-            expect((posthog as any)._pendingRemoteConfig).toEqual(remoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: remoteConfig })
+            expect((posthog as any)._pendingRemoteConfig).toEqual({ ok: true, config: remoteConfig })
 
             // Spy on _onRemoteConfig to see if it gets called again during replay
             const onRemoteConfigSpy = jest.spyOn(posthog as any, '_onRemoteConfig')
@@ -137,7 +137,7 @@ describe('deferred extension initialization', () => {
             await new Promise((resolve) => setTimeout(resolve, 200))
 
             // _onRemoteConfig should have been called again with the pending config during replay
-            expect(onRemoteConfigSpy).toHaveBeenCalledWith(remoteConfig)
+            expect(onRemoteConfigSpy).toHaveBeenCalledWith({ ok: true, config: remoteConfig })
             // Extensions should be initialized, proving the replay worked
             expect(posthog.sessionRecording).toBeDefined()
             expect(posthog.autocapture).toBeDefined()

--- a/packages/browser/src/__tests__/extension-classes.test.ts
+++ b/packages/browser/src/__tests__/extension-classes.test.ts
@@ -243,7 +243,7 @@ describe('extension lifecycle', () => {
             onRemoteConfigSpy.mockClear()
 
             const remoteConfig = { supportedCompression: [] } as unknown as RemoteConfig
-            posthog._onRemoteConfig(remoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: remoteConfig })
 
             // Two extensions, each should get onRemoteConfig called once
             expect(onRemoteConfigSpy).toHaveBeenCalledTimes(2)

--- a/packages/browser/src/__tests__/personProcessing.test.ts
+++ b/packages/browser/src/__tests__/personProcessing.test.ts
@@ -804,7 +804,7 @@ describe('person processing', () => {
             posthog.capture('startup page view')
 
             // act
-            posthog._onRemoteConfig({} as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             posthog.capture('custom event')
 
             // assert
@@ -819,7 +819,7 @@ describe('person processing', () => {
             posthog.capture('startup page view')
 
             // act
-            posthog._onRemoteConfig({ defaultIdentifiedOnly: false } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { defaultIdentifiedOnly: false } as RemoteConfig })
             posthog.capture('custom event')
 
             // assert

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -396,6 +396,21 @@ describe('posthog core', () => {
         })
     })
 
+    describe('_onRemoteConfig failure dispatch', () => {
+        it('routes failure to onRemoteConfigFailed and gives other extensions an empty config', async () => {
+            const posthog = await createPosthogInstance()
+            const autocaptureFailed = jest.spyOn(posthog.autocapture!, 'onRemoteConfigFailed')
+            const autocaptureConfig = jest.spyOn(posthog.autocapture!, 'onRemoteConfig')
+            const heatmapsConfig = jest.spyOn(posthog.heatmaps!, 'onRemoteConfig')
+
+            posthog._onRemoteConfig({ ok: false })
+
+            expect(autocaptureFailed).toHaveBeenCalledTimes(1)
+            expect(autocaptureConfig).not.toHaveBeenCalled()
+            expect(heatmapsConfig).toHaveBeenCalledWith(expect.objectContaining({ supportedCompression: [] }))
+        })
+    })
+
     describe('_afterFlagsResponse', () => {
         it('enables compression from flags response', () => {
             const posthog = posthogWith({})

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -337,7 +337,7 @@ describe('posthog core', () => {
 
         it('sends payloads to alternative endpoint if given', () => {
             const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
-            posthog._onRemoteConfig({ analytics: { endpoint: '/i/v0/e/' } } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { analytics: { endpoint: '/i/v0/e/' } } as RemoteConfig })
 
             posthog.capture('event-name', { foo: 'bar', length: 0 })
 
@@ -362,7 +362,7 @@ describe('posthog core', () => {
 
         it('sends payloads to overriden _url, even if alternative endpoint is set', () => {
             const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
-            posthog._onRemoteConfig({ analytics: { endpoint: '/i/v0/e/' } } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { analytics: { endpoint: '/i/v0/e/' } } as RemoteConfig })
 
             posthog.capture('event-name', { foo: 'bar', length: 0 }, { _url: 'https://app.posthog.com/s/' })
 
@@ -400,32 +400,32 @@ describe('posthog core', () => {
         it('enables compression from flags response', () => {
             const posthog = posthogWith({})
 
-            posthog._onRemoteConfig({ supportedCompression: ['gzip-js', 'base64'] } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { supportedCompression: ['gzip-js', 'base64'] } as RemoteConfig })
 
             expect(posthog.compression).toEqual('gzip-js')
         })
         it('ignores legacy field defaultIdentifiedOnly from flags response', () => {
             const posthog = posthogWith({})
 
-            posthog._onRemoteConfig({ defaultIdentifiedOnly: true } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { defaultIdentifiedOnly: true } as RemoteConfig })
             expect(posthog.config.person_profiles).toEqual('identified_only')
 
-            posthog._onRemoteConfig({ defaultIdentifiedOnly: false } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { defaultIdentifiedOnly: false } as RemoteConfig })
             expect(posthog.config.person_profiles).toEqual('identified_only')
 
-            posthog._onRemoteConfig({} as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             expect(posthog.config.person_profiles).toEqual('identified_only')
         })
         it('defaultIdentifiedOnly does not override person_profiles if already set', () => {
             const posthog = posthogWith({ person_profiles: 'always' })
-            posthog._onRemoteConfig({ defaultIdentifiedOnly: true } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { defaultIdentifiedOnly: true } as RemoteConfig })
             expect(posthog.config.person_profiles).toEqual('always')
         })
 
         it('enables compression from flags response when only one received', () => {
             const posthog = posthogWith({})
 
-            posthog._onRemoteConfig({ supportedCompression: ['base64'] } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { supportedCompression: ['base64'] } as RemoteConfig })
 
             expect(posthog.compression).toEqual('base64')
         })
@@ -433,7 +433,7 @@ describe('posthog core', () => {
         it('does not enable compression from flags response if compression is disabled', () => {
             const posthog = posthogWith({ disable_compression: true, persistence: 'memory' })
 
-            posthog._onRemoteConfig({ supportedCompression: ['gzip-js', 'base64'] } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { supportedCompression: ['gzip-js', 'base64'] } as RemoteConfig })
 
             expect(posthog.compression).toEqual(undefined)
         })
@@ -441,7 +441,7 @@ describe('posthog core', () => {
         it('defaults to /e if no endpoint is given', () => {
             const posthog = posthogWith({})
 
-            posthog._onRemoteConfig({} as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             expect(posthog.analyticsDefaultEndpoint).toEqual('/e/')
         })
@@ -449,7 +449,7 @@ describe('posthog core', () => {
         it('uses the specified analytics endpoint if given', () => {
             const posthog = posthogWith({})
 
-            posthog._onRemoteConfig({ analytics: { endpoint: '/i/v0/e/' } } as RemoteConfig)
+            posthog._onRemoteConfig({ ok: true, config: { analytics: { endpoint: '/i/v0/e/' } } as RemoteConfig })
 
             expect(posthog.analyticsDefaultEndpoint).toEqual('/i/v0/e/')
         })

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -400,7 +400,10 @@ describe('posthog core', () => {
         it('enables compression from flags response', () => {
             const posthog = posthogWith({})
 
-            posthog._onRemoteConfig({ ok: true, config: { supportedCompression: ['gzip-js', 'base64'] } as RemoteConfig })
+            posthog._onRemoteConfig({
+                ok: true,
+                config: { supportedCompression: ['gzip-js', 'base64'] } as RemoteConfig,
+            })
 
             expect(posthog.compression).toEqual('gzip-js')
         })
@@ -433,7 +436,10 @@ describe('posthog core', () => {
         it('does not enable compression from flags response if compression is disabled', () => {
             const posthog = posthogWith({ disable_compression: true, persistence: 'memory' })
 
-            posthog._onRemoteConfig({ ok: true, config: { supportedCompression: ['gzip-js', 'base64'] } as RemoteConfig })
+            posthog._onRemoteConfig({
+                ok: true,
+                config: { supportedCompression: ['gzip-js', 'base64'] } as RemoteConfig,
+            })
 
             expect(posthog.compression).toEqual(undefined)
         })

--- a/packages/browser/src/__tests__/remote-config.test.ts
+++ b/packages/browser/src/__tests__/remote-config.test.ts
@@ -155,7 +155,10 @@ describe('RemoteConfigLoader', () => {
 
             new RemoteConfigLoader(posthog).load()
 
-            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ ok: true, config: { ...config, hasFeatureFlags: true } })
+            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({
+                ok: true,
+                config: { ...config, hasFeatureFlags: true },
+            })
             expect(posthog.featureFlags.ensureFlagsLoaded).not.toHaveBeenCalled()
         })
     })

--- a/packages/browser/src/__tests__/remote-config.test.ts
+++ b/packages/browser/src/__tests__/remote-config.test.ts
@@ -73,7 +73,7 @@ describe('RemoteConfigLoader', () => {
             expect(assignableWindow.__PosthogExtensions__.loadExternalDependency).not.toHaveBeenCalled()
             expect(posthog._send_request).not.toHaveBeenCalled()
 
-            expect(posthog._onRemoteConfig).toHaveBeenCalledWith(config)
+            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ ok: true, config })
         })
 
         it('loads the script if window config not set', () => {
@@ -85,7 +85,7 @@ describe('RemoteConfigLoader', () => {
                 expect.any(Function)
             )
             expect(posthog._send_request).not.toHaveBeenCalled()
-            expect(posthog._onRemoteConfig).toHaveBeenCalledWith(config)
+            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ ok: true, config })
         })
 
         it('loads the json if window config not set and js failed', () => {
@@ -103,7 +103,7 @@ describe('RemoteConfigLoader', () => {
                 url: 'https://test.com/array/testtoken/config',
                 callback: expect.any(Function),
             })
-            expect(posthog._onRemoteConfig).toHaveBeenCalledWith(config)
+            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ ok: true, config })
         })
 
         it.each([
@@ -138,7 +138,7 @@ describe('RemoteConfigLoader', () => {
             new RemoteConfigLoader(posthog).load()
 
             // Should still call _onRemoteConfig, marked as failed, so extensions start
-            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ _configLoadFailed: true })
+            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ ok: false })
             // Should still attempt to load flags
             expect(posthog.featureFlags.ensureFlagsLoaded).toHaveBeenCalled()
         })
@@ -155,7 +155,7 @@ describe('RemoteConfigLoader', () => {
 
             new RemoteConfigLoader(posthog).load()
 
-            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ ...config, hasFeatureFlags: true })
+            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ ok: true, config: { ...config, hasFeatureFlags: true } })
             expect(posthog.featureFlags.ensureFlagsLoaded).not.toHaveBeenCalled()
         })
     })

--- a/packages/browser/src/__tests__/remote-config.test.ts
+++ b/packages/browser/src/__tests__/remote-config.test.ts
@@ -137,8 +137,8 @@ describe('RemoteConfigLoader', () => {
 
             new RemoteConfigLoader(posthog).load()
 
-            // Should still call _onRemoteConfig with empty object so extensions start
-            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({})
+            // Should still call _onRemoteConfig, marked as failed, so extensions start
+            expect(posthog._onRemoteConfig).toHaveBeenCalledWith({ _configLoadFailed: true })
             // Should still attempt to load flags
             expect(posthog.featureFlags.ensureFlagsLoaded).toHaveBeenCalled()
         })

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -347,11 +347,9 @@ export class Autocapture implements Extension {
             this._elementsChainAsString = response.elementsChainAsString
         }
 
-        // A failed config fetch means the opt-out state is unknown: keep the last
-        // known server value (in-memory and persisted) rather than defaulting to
-        // enabled, so a network error cannot turn autocapture on for an opted-out
-        // project. isEnabled falls back to the persisted value, or stays off when
-        // there has never been a successful config response.
+        // Failed fetch = opt-out unknown: keep the last known server value instead
+        // of defaulting to enabled, so a network error cannot turn autocapture on
+        // for an opted-out project.
         if (response._configLoadFailed) {
             this.startIfEnabled()
             return

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -347,9 +347,20 @@ export class Autocapture implements Extension {
             this._elementsChainAsString = response.elementsChainAsString
         }
 
+        // A failed config fetch means the opt-out state is unknown: keep the last
+        // known server value (in-memory and persisted) rather than defaulting to
+        // enabled, so a network error cannot turn autocapture on for an opted-out
+        // project. isEnabled falls back to the persisted value, or stays off when
+        // there has never been a successful config response.
+        if (response._configLoadFailed) {
+            this.startIfEnabled()
+            return
+        }
+
         // NOTE: Unlike other extensions (heatmaps, web-vitals, etc.), we intentionally
-        // DO NOT guard against missing autocapture_opt_out key here. Autocapture uses
-        // a "wait for server, then enable unless explicitly opted out" model:
+        // DO NOT guard against missing autocapture_opt_out key on a successful
+        // response. Autocapture uses a "wait for server, then enable unless
+        // explicitly opted out" model:
         // - Before remote config: autocapture disabled (isEnabled returns false)
         // - After remote config: enabled unless autocapture_opt_out is explicitly true
         // Missing/undefined key → !!undefined = false → autocapture enabled

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -342,17 +342,16 @@ export class Autocapture implements Extension {
         }
     }
 
+    // Failed fetch = opt-out unknown: keep the last known server value instead
+    // of defaulting to enabled, so a network error cannot turn autocapture on
+    // for an opted-out project.
+    public onRemoteConfigFailed(): void {
+        this.startIfEnabled()
+    }
+
     public onRemoteConfig(response: RemoteConfig) {
         if (response.elementsChainAsString) {
             this._elementsChainAsString = response.elementsChainAsString
-        }
-
-        // Failed fetch = opt-out unknown: keep the last known server value instead
-        // of defaulting to enabled, so a network error cannot turn autocapture on
-        // for an opted-out project.
-        if (response._configLoadFailed) {
-            this.startIfEnabled()
-            return
         }
 
         // NOTE: Unlike other extensions (heatmaps, web-vitals, etc.), we intentionally

--- a/packages/browser/src/extensions/types.ts
+++ b/packages/browser/src/extensions/types.ts
@@ -6,4 +6,10 @@ export type ExtensionConstructor<T extends Extension> = new (instance: PostHog, 
 export interface Extension {
     initialize?(): boolean | void
     onRemoteConfig?(config: RemoteConfig): void
+    /**
+     * Called instead of onRemoteConfig when the remote config could not be fetched.
+     * Implement when a server-controlled setting must not fall back to its default
+     * on failure; extensions without it receive onRemoteConfig with an empty config.
+     */
+    onRemoteConfigFailed?(): void
 }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -68,6 +68,7 @@ import {
     Property,
     QueuedRequestWithOptions,
     RemoteConfig,
+    RemoteConfigResult,
     RequestCallback,
     SessionIdChangedCallback,
     SnippetArrayItem,
@@ -435,7 +436,7 @@ export class PostHog implements PostHogInterface {
     _triggered_notifs: any
     compression?: Compression
     __request_queue: QueuedRequestWithOptions[]
-    _pendingRemoteConfig?: RemoteConfig
+    _pendingRemoteConfig?: RemoteConfigResult
     _lastRemoteConfig?: RemoteConfig
     _remoteConfigLoader?: RemoteConfigLoader
     analyticsDefaultEndpoint: string
@@ -940,9 +941,9 @@ export class PostHog implements PostHogInterface {
         // Replay any pending remote config that arrived before extensions were ready
         initTasks.push(() => {
             if (this._pendingRemoteConfig) {
-                const config = this._pendingRemoteConfig
+                const result = this._pendingRemoteConfig
                 this._pendingRemoteConfig = undefined // Clear before replaying to avoid re-storing
-                this._onRemoteConfig(config)
+                this._onRemoteConfig(result)
             }
         })
 
@@ -995,19 +996,31 @@ export class PostHog implements PostHogInterface {
         }
     }
 
-    _onRemoteConfig(config: RemoteConfig) {
+    _onRemoteConfig(result: RemoteConfigResult) {
         if (!(document && document.body)) {
             logger.info('document not ready yet, trying again in 500 milliseconds...')
             setTimeout(() => {
-                this._onRemoteConfig(config)
+                this._onRemoteConfig(result)
             }, 500)
             return
         }
 
         // Store config in case extensions aren't initialized yet (only needed for deferred init)
         if (this.config.__preview_deferred_init_extensions) {
-            this._pendingRemoteConfig = config
+            this._pendingRemoteConfig = result
         }
+
+        // On failure, extensions without onRemoteConfigFailed still initialize with
+        // their defaults from an empty config, as they would for absent keys.
+        const config: RemoteConfig = result.ok
+            ? result.config
+            : {
+                  supportedCompression: [],
+                  toolbarParams: {},
+                  toolbarVersion: 'toolbar',
+                  isAuthenticated: false,
+                  siteApps: [],
+              }
 
         // Cache the latest remote config so extensions that are created later
         // (e.g. sessionRecording after opt_in_capturing from cookieless mode) can
@@ -1033,7 +1046,13 @@ export class PostHog implements PostHogInterface {
                 : PERSON_PROFILES_IDENTIFIED_ONLY,
         })
 
-        this._extensions.forEach((ext) => ext.onRemoteConfig?.(config))
+        this._extensions.forEach((ext) => {
+            if (!result.ok && ext.onRemoteConfigFailed) {
+                ext.onRemoteConfigFailed()
+            } else {
+                ext.onRemoteConfig?.(config)
+            }
+        })
     }
 
     _loaded(): void {

--- a/packages/browser/src/remote-config.ts
+++ b/packages/browser/src/remote-config.ts
@@ -126,10 +126,9 @@ export class RemoteConfigLoader {
         // whether to show a survey), not during config processing. By the time a linked
         // flag is evaluated, flags have already loaded.
         //
-        // Even when config fails, we still notify extensions so they can initialize
-        // with their defaults, but the payload is marked as failed so extensions whose
-        // server setting must not fall back to a default (e.g. autocapture's opt-out)
-        // can keep their last known value instead.
+        // Even when config fails, we notify extensions so they initialize with their
+        // defaults — marked as failed so settings that must not fail open (e.g.
+        // autocapture's opt-out) can keep their last known value.
         this._instance._onRemoteConfig(config ?? ({ _configLoadFailed: true } as RemoteConfig))
 
         if (config?.hasFeatureFlags !== false) {

--- a/packages/browser/src/remote-config.ts
+++ b/packages/browser/src/remote-config.ts
@@ -127,9 +127,9 @@ export class RemoteConfigLoader {
         // flag is evaluated, flags have already loaded.
         //
         // Even when config fails, we notify extensions so they initialize with their
-        // defaults — marked as failed so settings that must not fail open (e.g.
-        // autocapture's opt-out) can keep their last known value.
-        this._instance._onRemoteConfig(config ?? ({ _configLoadFailed: true } as RemoteConfig))
+        // defaults — as an explicit failure, so settings that must not fail open
+        // (e.g. autocapture's opt-out) can keep their last known value.
+        this._instance._onRemoteConfig(config ? { ok: true, config } : { ok: false })
 
         if (config?.hasFeatureFlags !== false) {
             if (!this._instance.config.advanced_disable_feature_flags_on_first_load) {

--- a/packages/browser/src/remote-config.ts
+++ b/packages/browser/src/remote-config.ts
@@ -126,9 +126,11 @@ export class RemoteConfigLoader {
         // whether to show a survey), not during config processing. By the time a linked
         // flag is evaluated, flags have already loaded.
         //
-        // Even when config fails, we pass an empty object so extensions (autocapture,
-        // session recording, etc.) still initialize with their defaults.
-        this._instance._onRemoteConfig(config ?? ({} as RemoteConfig))
+        // Even when config fails, we still notify extensions so they can initialize
+        // with their defaults, but the payload is marked as failed so extensions whose
+        // server setting must not fall back to a default (e.g. autocapture's opt-out)
+        // can keep their last known value instead.
+        this._instance._onRemoteConfig(config ?? ({ _configLoadFailed: true } as RemoteConfig))
 
         if (config?.hasFeatureFlags !== false) {
             if (!this._instance.config.advanced_disable_feature_flags_on_first_load) {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -329,6 +329,14 @@ export type SessionRecordingRemoteConfig = SessionRecordingCanvasOptions & {
  */
 export interface RemoteConfig {
     /**
+     * Internal: set by the SDK, never by the server, when the remote config
+     * could not be fetched. Extensions whose server setting must not fall back
+     * to a default on failure (e.g. autocapture) check this.
+     * @internal
+     */
+    _configLoadFailed?: boolean
+
+    /**
      * Supported compression algorithms
      */
     supportedCompression: Compression[]

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -329,9 +329,7 @@ export type SessionRecordingRemoteConfig = SessionRecordingCanvasOptions & {
  */
 export interface RemoteConfig {
     /**
-     * Internal: set by the SDK, never by the server, when the remote config
-     * could not be fetched. Extensions whose server setting must not fall back
-     * to a default on failure (e.g. autocapture) check this.
+     * Set by the SDK, never by the server, when the remote config could not be fetched.
      * @internal
      */
     _configLoadFailed?: boolean

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -322,17 +322,17 @@ export type SessionRecordingRemoteConfig = SessionRecordingCanvasOptions & {
 }
 
 /**
- * Remote configuration for the PostHog instance
- *
- * All of these settings can be configured directly in your PostHog instance
- * Any configuration set in the client overrides the information from the server
- */
-/**
  * Outcome of a remote config fetch: the config, or an explicit failure.
  * @internal
  */
 export type RemoteConfigResult = { ok: true; config: RemoteConfig } | { ok: false }
 
+/**
+ * Remote configuration for the PostHog instance
+ *
+ * All of these settings can be configured directly in your PostHog instance
+ * Any configuration set in the client overrides the information from the server
+ */
 export interface RemoteConfig {
     /**
      * Supported compression algorithms

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -327,13 +327,13 @@ export type SessionRecordingRemoteConfig = SessionRecordingCanvasOptions & {
  * All of these settings can be configured directly in your PostHog instance
  * Any configuration set in the client overrides the information from the server
  */
-export interface RemoteConfig {
-    /**
-     * Set by the SDK, never by the server, when the remote config could not be fetched.
-     * @internal
-     */
-    _configLoadFailed?: boolean
+/**
+ * Outcome of a remote config fetch: the config, or an explicit failure.
+ * @internal
+ */
+export type RemoteConfigResult = { ok: true; config: RemoteConfig } | { ok: false }
 
+export interface RemoteConfig {
     /**
      * Supported compression algorithms
      */

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -105,7 +105,6 @@
         "_compressionQueueGeneration",
         "_computeShowTicketList",
         "_config",
-        "_configLoadFailed",
         "_consecutiveFlushFailures",
         "_consecutivePollingStatusZeroFailures",
         "_consecutiveStatusZeroFailures",

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -105,6 +105,7 @@
         "_compressionQueueGeneration",
         "_computeShowTicketList",
         "_config",
+        "_configLoadFailed",
         "_consecutiveFlushFailures",
         "_consecutivePollingStatusZeroFailures",
         "_consecutiveStatusZeroFailures",


### PR DESCRIPTION
## Problem

Customer report ([Zendesk #62711](https://posthoghelp.zendesk.com/agent/tickets/62711)): projects with the project-level autocapture opt-out enabled (`autocapture_opt_out: true`) still received `$autocapture`/`$rageclick` events from some clients on 1.402.3/1.404.0.

Root cause: when the remote config request fails (network error, timeout, non-200 — both the `config.js` script and the JSON fallback), `RemoteConfigLoader` substitutes an empty config so extensions can initialize with defaults (#2895, shipped in 1.350.0; before that the failure path returned early). Autocapture reads the missing `autocapture_opt_out` key as "not opted out" (`!!undefined`), starts capturing, and persists `$autocapture_disabled_server_side: false` — so one failed fetch enables autocapture for the whole page *and* arms the next page load to capture from init. There is no in-session recovery because the refresh interval only reloads flags.

Confirmed in the customer's data: all offending events carry `$autocapture_disabled_server_side: false`, and the burst client had sent events with `true` earlier the same day — only the failed-fetch path can flip a persisted `true` back to `false`.

## Changes

- The config fetch outcome is now an explicit discriminated union (per review): `PostHog._onRemoteConfig` takes `RemoteConfigResult = { ok: true; config: RemoteConfig } | { ok: false }` — no more `{} as RemoteConfig` cast on the failure path.
- Extensions opt into failure semantics via an optional `Extension.onRemoteConfigFailed()`. Autocapture implements it: no key coercion, no persistence write, so `isEnabled` falls back to the last successfully received server value, or stays off if there has never been one. The intentional "missing key on a *successful* response = enabled" semantics are unchanged.
- Extensions without `onRemoteConfigFailed` receive `onRemoteConfig` with a structurally valid empty config, preserving their existing initialize-with-defaults failure behavior (verified: no handler distinguishes absent keys from the empty values).

Behavior matrix on config fetch failure:

| Persisted state | Before | After |
|---|---|---|
| never had a successful config | autocapture **on**, `false` persisted | stays **off**, nothing persisted |
| `$autocapture_disabled_server_side: true` (opted out) | flipped to **on**, `false` persisted | stays **off**, value kept |
| `$autocapture_disabled_server_side: false` (not opted out) | on | on (last known good — unchanged) |

**Trade-off (deliberate):** a *first-time* visitor on a project that is **not** opted out loses autocapture for the whole session if their config fetch transiently fails — there is no persisted last-known-good yet, and the refresh interval only reloads flags, never the config. Returning visitors are unaffected (persisted value wins). We prefer failing closed for one session over capturing on opted-out projects.

Verified with unit tests and an end-to-end Playwright repro against the built `array.js` using the customer's init config: config fetch blocked → clicks produced `$autocapture` before the fix, produce nothing and persist nothing after; opt-out-honoured control path unchanged.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Investigated and authored with Claude Code (Fable 5): code/history tracing in this repo, a Playwright repro harness against the built bundle, and read-only verification of the affected project's events (via impersonated support session, plain GETs only).
- Considered guarding inside `Autocapture.onRemoteConfig` against any empty response instead of a marker; rejected because a legitimately empty successful config should keep the documented "enabled unless explicitly opted out" behavior — only genuine fetch failure must be treated as unknown.
- Repro gotchas for anyone extending the tests: Playwright's `navigator.webdriver` trips the bot filter (init with `opt_out_useragent_filter: true`) and events batch for ~3s (`request_batching: false` or wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
