### PR TITLE
chore: ban object-literal type assertions in package sources

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -102,6 +102,20 @@ module.exports = {
             },
         },
         {
+            // Object-literal type assertions (`{...} as T`) silently fabricate values that are
+            // missing required fields — prefer `const x: T = {...}` or `satisfies T`, which keep
+            // the compiler checking the literal. Enforced for shipped source only; tests may
+            // still build partial fixtures with casts.
+            files: ['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'],
+            excludedFiles: ['**/__tests__/**', '**/__mocks__/**', '**/*.spec.*', '**/*.test.*'],
+            rules: {
+                '@typescript-eslint/consistent-type-assertions': [
+                    'error',
+                    { assertionStyle: 'as', objectLiteralTypeAssertions: 'never' },
+                ],
+            },
+        },
+        {
             // @posthog/core is shared by browser and React Native — Web API globals
             // like Event, ErrorEvent, etc. don't exist in Hermes/JSC and referencing
             // them as values throws a ReferenceError at runtime.

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -315,7 +315,7 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
       name: runName,
       input,
       startTime: Date.now(),
-    } as SpanMetadata
+    }
   }
 
   private _setLLMMetadata(

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -13,7 +13,7 @@ import type { APIPromise } from 'openai'
 import type { Stream } from 'openai/streaming'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
 import type { ResponseCreateParamsWithTools, ExtractParsedContentFromParams } from 'openai/lib/ResponsesParser'
-import type { FormattedMessage, FormattedContent, FormattedFunctionCall } from '../types'
+import type { FormattedMessage, FormattedContent } from '../types'
 import { sanitizeOpenAI } from '../sanitization'
 import { extractPosthogParams } from '../utils'
 import { isResponseTokenChunk, extractRequestId, buildProviderMetadata } from './utils'
@@ -219,7 +219,7 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                       name: toolCall.name,
                       arguments: toolCall.arguments,
                     },
-                  } as FormattedFunctionCall)
+                  })
                 }
               }
 

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -15,7 +15,7 @@ import type { APIPromise } from 'openai'
 import type { Stream } from 'openai/streaming'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
 import type { ResponseCreateParamsWithTools, ExtractParsedContentFromParams } from 'openai/lib/ResponsesParser'
-import type { FormattedMessage, FormattedContent, FormattedFunctionCall } from '../types'
+import type { FormattedMessage, FormattedContent } from '../types'
 import { sanitizeOpenAI, sanitizeOpenAIResponse } from '../sanitization'
 import { extractPosthogParams } from '../utils'
 import { isResponseTokenChunk, extractRequestId, buildProviderMetadata } from './utils'
@@ -74,6 +74,9 @@ function preserveAPIPromiseHelpers<Input, Output>(
   if (typeof parentPromise.withResponse === 'function') {
     apiPromise.withResponse = async () => {
       const [response, data] = await Promise.all([parentPromise.withResponse(), wrappedPromise])
+      // swaps the `data` payload inside the SDK's generic withResponse shape; the compiler
+      // cannot relate the Input- and Output-instantiated conditional types
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       return { ...response, data } as APIPromiseWithResponse<Output>
     }
   }
@@ -294,7 +297,7 @@ export class WrappedCompletions extends Completions {
                       name: toolCall.name,
                       arguments: toolCall.arguments,
                     },
-                  } as FormattedFunctionCall)
+                  })
                 }
               }
 

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -684,6 +684,7 @@ function elementsToString(elements: PHElement[]): string {
 
 function extractElements(elements: Properties[]): PHElement[] {
     return elements.map((el) => {
+        const attributes: { [id: string]: any } = {}
         const response = {
             text: el['$el_text']?.slice(0, 400),
             tag_name: el['tag_name'],
@@ -692,7 +693,7 @@ function extractElements(elements: Properties[]): PHElement[] {
             attr_id: el['attr__id'],
             nth_child: el['nth_child'],
             nth_of_type: el['nth_of_type'],
-            attributes: {} as { [id: string]: any },
+            attributes,
         }
 
         entries(el)

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -296,9 +296,9 @@ const stringifyArgsSafely = (
 ): { body: string; truncated: boolean; attributes: Record<string, any> } => {
     const parts: string[] = []
     const budget = { remaining: sizeLimit, truncated: false }
-    const attributeCollector = isObject(args[0])
+    const attributeCollector: AttributeCollector | undefined = isObject(args[0])
         ? {
-              result: {} as Record<string, any>,
+              result: {},
               keysRemaining: LOG_ATTRIBUTES_LIMIT,
               sizeRemaining: LOG_BODY_SIZE_LIMIT,
               truncated: false,

--- a/packages/browser/src/entrypoints/tracing-headers.ts
+++ b/packages/browser/src/entrypoints/tracing-headers.ts
@@ -77,7 +77,7 @@ const createFetchInitWithHeaders = (init: RequestInit | undefined, headers: Head
         return initWithHeaders
     }
 
-    const target = { headers } as RequestInit & Record<PropertyKey, unknown>
+    const target: RequestInit & Record<PropertyKey, unknown> = { headers }
 
     return new Proxy(target, {
         get(target, property) {

--- a/packages/browser/src/extensions/replay/external/config.ts
+++ b/packages/browser/src/extensions/replay/external/config.ts
@@ -296,6 +296,8 @@ export const buildNetworkRequestOptions = (
     if (hasDeprecatedMaskFunction) {
         instanceConfig.session_recording.maskCapturedNetworkRequestFn = (data: CapturedNetworkRequest) => {
             const cleanedURL = instanceConfig.session_recording.maskNetworkRequestFn!({ url: data.name })
+            // the deprecated mask fn can suppress the URL, leaving `name` undefined on purpose
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             return {
                 ...data,
                 name: cleanedURL?.url,

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -3,6 +3,7 @@ import {
     type customEvent,
     EventType,
     eventWithTime,
+    type fullSnapshotEvent,
     IncrementalSource,
     type listenerHandler,
     RecordPlugin,
@@ -307,18 +308,24 @@ function compressedResult(event: compressedEventWithTime): CompressedEventResult
     return { event, size: estimateCompressedEventSize(event) }
 }
 
-function buildCompressedFullSnapshotEvent(event: eventWithTime, data: string): compressedEventWithTime {
+function buildCompressedFullSnapshotEvent(
+    event: fullSnapshotEvent & { timestamp: number; delay?: number },
+    data: string
+): compressedEventWithTime {
     return {
         ...event,
         data,
-        cv: '2024-10' as const,
-    } as compressedEventWithTime
+        cv: '2024-10',
+    }
 }
 
 function buildCompressedIncrementalEvent(
     event: eventWithTime,
     fields: CompressedMutationFields | CompressedStyleFields
 ): compressedEventWithTime {
+    // reshapes rrweb incremental `data` into its compressed string-field variant — the
+    // compiler cannot relate the incoming union member to the matching compressed member
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return {
         ...event,
         cv: '2024-10' as const,

--- a/packages/browser/src/extensions/replay/external/recording-strategies.ts
+++ b/packages/browser/src/extensions/replay/external/recording-strategies.ts
@@ -28,7 +28,6 @@ import {
     allMatchSessionRecordingStatus,
     anyMatchSessionRecordingStatus,
     triggerGroupsMatchSessionRecordingStatus,
-    RecordingTriggersStatusV2,
     TriggerType,
     AndTriggerMatching,
     OrTriggerMatching,
@@ -373,7 +372,7 @@ export class V2TriggerGroupStrategy implements RecordingStrategy {
             triggerGroupMatchers: this._triggerGroupMatchers,
             triggerGroupSamplingResults: this._triggerGroupSamplingResults,
             minimumDuration: this.getMinimumDuration(context.sessionId),
-        } as RecordingTriggersStatusV2)
+        })
     }
 
     getMinimumDuration(sessionId: string): number | null {

--- a/packages/browser/src/extensions/surveys/action-matcher.ts
+++ b/packages/browser/src/extensions/surveys/action-matcher.ts
@@ -57,7 +57,7 @@ export class ActionMatcher {
             return
         }
 
-        if (!this._actionEvents.has(eventName) && !this._actionEvents.has(<string>eventPayload?.event)) {
+        if (!this._actionEvents.has(eventName) && !this._actionEvents.has(eventPayload.event)) {
             return
         }
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -639,7 +639,7 @@ export class PostHog implements PostHogInterface {
         }
 
         this.__loaded = true
-        this.config = {} as PostHogConfig // will be set right below
+        this.config = defaultConfig(config.defaults) // fully overwritten by set_config right below
         config.debug = this._checkLocalStorageForDebug(config.debug)
         this._originalUserConfig = config // Store original user config for migration
 

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -495,10 +495,7 @@ export class PostHogPersistence {
 
     private _partitionProps(): { main: Properties; groups: Record<PersistenceStorageGroup, Properties> } {
         const main: Properties = {}
-        const groups = {} as Record<PersistenceStorageGroup, Properties>
-        for (const group of PERSISTENCE_STORAGE_GROUPS) {
-            groups[group] = {}
-        }
+        const groups: Record<PersistenceStorageGroup, Properties> = { flags: {}, surveys: {} }
         each(this.props, (value, key) => {
             const group = getPersistenceKeyPolicy(key)?.storageGroup
             if (group) {

--- a/packages/browser/src/remote-config.ts
+++ b/packages/browser/src/remote-config.ts
@@ -127,7 +127,11 @@ export class RemoteConfigLoader {
         // flag is evaluated, flags have already loaded.
         //
         // Even when config fails, we pass an empty object so extensions (autocapture,
-        // session recording, etc.) still initialize with their defaults.
+        // session recording, etc.) still initialize with their defaults. The empty object
+        // is deliberately missing required RemoteConfig fields: every consumer treats an
+        // absent field as "use my default", and supplying real values here (e.g.
+        // supportedCompression: []) would change behavior (that example disables compression).
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         this._instance._onRemoteConfig(config ?? ({} as RemoteConfig))
 
         if (config?.hasFeatureFlags !== false) {

--- a/packages/browser/src/utils/index.ts
+++ b/packages/browser/src/utils/index.ts
@@ -130,12 +130,13 @@ function deepCircularCopy<T extends Record<string, any> = Record<string, any>>(
                 result.push(internalDeepCircularCopy(it))
             })
         } else {
-            result = {} as T
+            const copy: Record<string, any> = {}
             each(value, (val, key) => {
                 if (!COPY_IN_PROGRESS_SET.has(val)) {
-                    ;(result as any)[key] = internalDeepCircularCopy(val, key)
+                    copy[key] = internalDeepCircularCopy(val, key)
                 }
             })
+            result = copy as T
         }
         return result
     }

--- a/packages/core/src/error-tracking/error-properties-builder.ts
+++ b/packages/core/src/error-tracking/error-properties-builder.ts
@@ -129,10 +129,10 @@ export class ErrorPropertiesBuilder {
   }
 
   private buildParsingContext(hint: EventHint): ParsingContext {
-    const context = {
+    const context: ParsingContext = {
       chunkIdMap: getFilenameToChunkIdMap(this.stackParser),
       skipFirstLines: hint.skipFirstLines ?? 1,
-    } as ParsingContext
+    }
     return context
   }
 
@@ -145,18 +145,20 @@ export class ErrorPropertiesBuilder {
         return undefined
       }
     }
-    const context = {
+    const context: CoercingContext = {
       ...hint,
       // Do not propagate synthetic exception as it doesn't make sense
       syntheticException: depth == 0 ? hint.syntheticException : undefined,
       mechanism,
+      // `coerce` only widens to `undefined` past MAX_CAUSE_RECURSION; `apply` reuses this
+      // context's depth, which was already validated when the context was built
       apply: (input: unknown) => {
-        return coerce(input, depth)
+        return coerce(input, depth) as ExceptionLike
       },
       next: (input: unknown) => {
         return coerce(input, depth + 1)
       },
-    } as CoercingContext
+    }
     return context
   }
 }

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -182,7 +182,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       // clear cached person properties
       this._cachedPersonProperties = null
 
-      for (const key of <(keyof typeof PostHogPersistedProperty)[]>Object.keys(PostHogPersistedProperty)) {
+      for (const key of Object.keys(PostHogPersistedProperty) as (keyof typeof PostHogPersistedProperty)[]) {
         if (!allPropertiesToKeep.includes(PostHogPersistedProperty[key])) {
           this.setPersistedProperty((PostHogPersistedProperty as any)[key], null)
         }
@@ -1651,7 +1651,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
     // Apply modifications from CaptureEvent back to internal message
     // Put $set/$set_once back into properties where they belong
-    const resultProps = { ...(result.properties ?? props) } as PostHogEventProperties
+    const resultProps: PostHogEventProperties = { ...(result.properties ?? props) }
     if (result.$set !== undefined) {
       resultProps.$set = result.$set as JsonType
     } else {

--- a/packages/mcp/src/extensions/instrument-highlevel.ts
+++ b/packages/mcp/src/extensions/instrument-highlevel.ts
@@ -4,7 +4,13 @@
 // Licensed under the MIT License: https://github.com/agentcathq/agentcat-typescript-sdk/blob/main/LICENSE
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import type { CompatibleRequestHandlerExtra, HighLevelMCPServerLike, MCPServerLike, RegisteredTool } from '../types'
+import type {
+  CompatibleRequestHandlerExtra,
+  HighLevelMCPServerLike,
+  MCPServerLike,
+  RegisteredTool,
+  ToolCallback,
+} from '../types'
 import { stripConversationId } from './conversation-id'
 import { MCPAnalyticsEventType } from './event-types'
 import { getServerTrackingData } from './internal'
@@ -34,7 +40,7 @@ type ProcessedRegisteredTool = RegisteredTool & {
   [MCP_ANALYTICS_PROCESSED]?: boolean
 }
 
-function isCallbackUpdate(value: unknown): value is { callback: unknown } {
+function isCallbackUpdate(value: unknown): value is { callback: ToolCallback } {
   return !!value && typeof value === 'object' && 'callback' in value && typeof value.callback === 'function'
 }
 
@@ -81,7 +87,7 @@ function setupListenerToRegisteredTools(server: HighLevelMCPServerLike): void {
                   const updateObj = updateArgs[0]
                   if (isCallbackUpdate(updateObj)) {
                     const wrappedTool = addTracingToToolCallbackInternal(
-                      { callback: updateObj.callback } as RegisteredTool,
+                      { callback: updateObj.callback },
                       property,
                       server
                     )

--- a/packages/mcp/src/extensions/mcp-sdk-compat.ts
+++ b/packages/mcp/src/extensions/mcp-sdk-compat.ts
@@ -64,7 +64,7 @@ export function createWrappedTool(originalTool: RegisteredTool, wrappedFunction:
   return {
     ...originalTool,
     [key]: wrappedFunction,
-  } as RegisteredTool
+  }
 }
 
 // --- Zod schema internal property helpers ---

--- a/packages/next/src/server/clientCache.ts
+++ b/packages/next/src/server/clientCache.ts
@@ -36,6 +36,9 @@ export async function getOrCreatePostHogClient<TClient, TOptions extends Cacheab
     let client = cache.get(key)
     if (!client) {
         const waitUntil = options?.waitUntil ?? (await autoDetectedWaitUntil)
+        // TOptions may declare `waitUntil` narrower than the cacheable base type, so the
+        // compiler cannot prove the injected base-typed waitUntil assignable to Partial<TOptions>
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         const mergedOptions = {
             ...(waitUntil ? { waitUntil } : {}),
             ...options,

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2859,7 +2859,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         // Something went wrong getting the flag info - we should capture the event anyways
         return {}
       })
-      .then((additionalProperties) => {
+      .then((additionalProperties): PostHogEventProperties => {
         // No matter what - capture the event
         const resolvedGroups = eventMessage.groups || groups
 
@@ -2871,7 +2871,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           ...(resolvedGroups !== undefined && Object.keys(resolvedGroups).length > 0
             ? { $groups: resolvedGroups }
             : {}),
-        } as PostHogEventProperties
+        }
       })
 
     // Handle bot pageview collection based on preview flag

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -672,9 +672,9 @@ class FeatureFlagsPoller {
    */
   private updateFlagState(flagData: FlagDefinitionCacheData): void {
     this.featureFlags = flagData.flags
-    this.featureFlagsByKey = flagData.flags.reduce(
+    this.featureFlagsByKey = flagData.flags.reduce<Record<string, PostHogFeatureFlag>>(
       (acc, curr) => ((acc[curr.key] = curr), acc),
-      <Record<string, PostHogFeatureFlag>>{}
+      {}
     )
     this.groupTypeMapping = flagData.groupTypeMapping
     this.cohorts = flagData.cohorts

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -6,9 +6,15 @@ import fs from 'node:fs/promises'
 // Re-export for backward compatibility
 export type PostHogRollupPluginOptions = PluginConfig
 
-export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOptions) {
+// The `config` hook is Vite-specific: Vite runs it before the build to force sourcemap
+// generation, while Rollup ignores unknown hooks.
+type PostHogRollupPlugin = Plugin & {
+    config: () => { build: { sourcemap: boolean | 'hidden' } } | undefined
+}
+
+export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOptions): Plugin {
     const posthogOptions = resolveConfig(userOptions)
-    return {
+    const plugin: PostHogRollupPlugin = {
         name: 'posthog-rollup-plugin',
 
         config() {
@@ -79,5 +85,6 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
                 )
             },
         },
-    } as Plugin
+    }
+    return plugin
 }


### PR DESCRIPTION
## Problem

In #4191, `{} as RemoteConfig` silently fabricated an object missing required fields, and the reviewer asked for a guard: [it'd be nice to ban explicit unsafe casts like this in eslint, because this shouldn't have gotten in to begin with](https://github.com/PostHog/posthog-js/pull/4191#discussion_r3604768627).

Object-literal type assertions (`{...} as T`) disable both missing-property and excess-property checking on the literal, so the compiler happily accepts values that don't satisfy `T`. Nothing stopped new ones from landing in shipped source.

## Changes

Adds a root ESLint override enforcing `@typescript-eslint/consistent-type-assertions`:

```js
{
    files: ['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'],
    excludedFiles: ['**/__tests__/**', '**/__mocks__/**', '**/*.spec.*', '**/*.test.*'],
    rules: {
        '@typescript-eslint/consistent-type-assertions': [
            'error',
            { assertionStyle: 'as', objectLiteralTypeAssertions: 'never' },
        ],
    },
}
```

- `error` for every package's production source (`packages/*/src`), test files excluded — tests build partial fixtures with casts constantly (323 occurrences) and rewriting them isn't worth the churn in this PR.
- `assertionStyle: 'as'` also converts the two remaining angle-bracket assertions to `as` style.
- `as const`, `as any`, and `as unknown` are exempt by the rule's design; only literal-to-concrete-type assertions are banned.
- `packages/nuxt` uses its own flat config and is untouched.

### Violation survey (what justified the scope)

Running the rule repo-wide found **349** violations: **26 in production src**, **323 in test files**.

| Package | src | tests |
| --- | --- | --- |
| posthog-js (browser) | 12 | 251 |
| @posthog/ai | 4 | 31 |
| @posthog/core | 4 | 6 |
| @posthog/mcp | 2 | 9 |
| posthog-node | 2 | 3 |
| @posthog/next | 1 | 0 |
| @posthog/rollup-plugin | 1 | 3 |
| posthog-react-native | 0 | 14 |
| @posthog/convex | 0 | 5 |
| @posthog/browser-common | 0 | 1 |

### Production fixes (21 of 26 sites)

All behavior-preserving — mostly replacing casts with type annotations the compiler actually checks, or deleting casts that were never needed:

- **browser**: hoisted typed `attributes` map (autocapture-utils); annotated `AttributeCollector` (logs entrypoint); annotation instead of cast (tracing-headers `target`); dropped redundant casts (`RecordingTriggersStatusV2` literal was fully populated; `CaptureResult.event` is already a string); `this.config` init seed now uses `defaultConfig(config.defaults)` instead of fabricating `{} as PostHogConfig` (fully overwritten by `set_config` immediately after); `_partitionProps` builds a compiler-checked `Record<PersistenceStorageGroup, Properties>` literal (adding a storage group now fails compilation there instead of relying on a loop over a cast); deep-copy helper accumulates into a typed `Record` (utils); `buildCompressedFullSnapshotEvent` now takes the narrowed `fullSnapshotEvent` type and needs no cast at all.
- **core**: `ParsingContext`/`CoercingContext` literals are annotated and checked (the only remaining assertion is a narrowly-scoped `as ExceptionLike` on a call whose `undefined` branch is unreachable at that depth, with a comment); angle-bracket cast → `as`; `resultProps` annotated.
- **mcp**: `isCallbackUpdate` predicate now narrows to `{ callback: ToolCallback }` so the literal needs no cast; `createWrappedTool`'s cast was simply unnecessary.
- **node**: `reduce<Record<string, PostHogFeatureFlag>>` generic instead of casting the seed; capture-properties literal checked via the `.then` callback's return annotation.
- **ai**: dropped three redundant casts (`SpanMetadata`, 2× `FormattedFunctionCall` — the literals fully satisfy the contextual types).
- **rollup-plugin**: plugin object is now a checked `Plugin & { config: ... }` annotation — which surfaced exactly what the old `as Plugin` was hiding: the `config` hook is Vite-specific and not part of rollup's `Plugin` type. It's intentional (Vite sourcemap forcing, see #3519) and now documented in the type.

The remaining **5 sites keep their cast behind a justified inline `eslint-disable`** (each with a comment explaining why the compiler can't verify it): the deliberately-partial `{} as RemoteConfig` fallback itself (supplying real values would change behavior — e.g. `supportedCompression: []` disables compression), the deprecated network-mask shim that intentionally leaves `name` undefined, rrweb incremental-event compression (union reshaping), generic `Partial<TOptions>` merging in next's client cache, and the OpenAI SDK's generic `withResponse` shape swap. New occurrences of the pattern now require the same explicit, reviewed opt-out instead of slipping in silently.

### Verification

- `pnpm lint` (the CI Lint job command) and `pnpm lint:playground`: green.
- `tsc --noEmit` per touched package: clean (pre-existing test-file errors in core/mcp/next are unchanged vs `main`).
- Unit tests: browser (4946 + functional), core (769), node (819), ai (498), next (238), rollup-plugin (3) all pass; mcp failures are identical on `main` (missing generated files in a fresh checkout, unrelated).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [x] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

(`@posthog/core` and `@posthog/mcp` sources were also touched but aren't listed above.)

## Checklist

- [x] Tests for new code (no new runtime code — refactors are covered by the existing suites listed above)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file — intentionally none: every fix is behavior-preserving, so there is nothing to release; the refactors will ride along with each package's next release.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code at Anna's direction, as the follow-up requested in the #4191 review thread. The agent surveyed violations by running the candidate rule repo-wide as a warning, chose the src-only/error + tests-excluded scope from the counts above, fixed the 26 production sites (preferring annotations and cast deletion; 5 justified inline disables where the compiler genuinely can't verify the value), and validated with the CI lint command, per-package `tsc`, and unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
