### PR TITLE
refactor(core): propagate RemoteConfigResult to extension onRemoteConfig handlers

### DIFF
--- a/.changeset/remote-config-result-through-extensions.md
+++ b/.changeset/remote-config-result-through-extensions.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Internal restructuring of remote config failure handling across SDK extensions; no behavior change. A failed config fetch also no longer overwrites the config cached for session recording replay in cookieless mode.

--- a/.changeset/remote-config-result-through-extensions.md
+++ b/.changeset/remote-config-result-through-extensions.md
@@ -2,4 +2,4 @@
 'posthog-js': patch
 ---
 
-Internal restructuring of remote config failure handling across SDK extensions; no behavior change. A failed config fetch also no longer overwrites the config cached for session recording replay in cookieless mode.
+Internal restructuring of remote config failure handling across SDK extensions; no behavior change.

--- a/packages/browser/playwright/mocked/logs.spec.ts
+++ b/packages/browser/playwright/mocked/logs.spec.ts
@@ -51,8 +51,11 @@ test.describe('logs extension', () => {
             if (posthog && posthog.logs && typeof posthog.logs.onRemoteConfig === 'function') {
                 try {
                     posthog.logs.onRemoteConfig({
-                        logs: {
-                            captureConsoleLogs: true,
+                        ok: true,
+                        config: {
+                            logs: {
+                                captureConsoleLogs: true,
+                            },
                         },
                     })
                     configCalled = true
@@ -99,8 +102,11 @@ test.describe('logs extension', () => {
             if (posthog && posthog.logs && typeof posthog.logs.onRemoteConfig === 'function') {
                 try {
                     posthog.logs.onRemoteConfig({
-                        logs: {
-                            captureConsoleLogs: false,
+                        ok: true,
+                        config: {
+                            logs: {
+                                captureConsoleLogs: false,
+                            },
                         },
                     })
                     configCalled = true

--- a/packages/browser/playwright/mocked/z-index-hierarchy.spec.ts
+++ b/packages/browser/playwright/mocked/z-index-hierarchy.spec.ts
@@ -46,10 +46,13 @@ test.describe('z-index hierarchy', () => {
             const posthog = (window as any).posthog
             if (posthog?.conversations) {
                 posthog.conversations.onRemoteConfig({
-                    conversations: {
-                        enabled: true,
-                        token: 'test-token',
-                        widgetEnabled: true,
+                    ok: true,
+                    config: {
+                        conversations: {
+                            enabled: true,
+                            token: 'test-token',
+                            widgetEnabled: true,
+                        },
                     },
                 })
             }

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -378,7 +378,7 @@ describe('Autocapture system', () => {
         beforeEach(() => {
             posthog.config.rageclick = true
             // Trigger proper enabling
-            autocapture.onRemoteConfig({} as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
         })
 
         test.each([
@@ -535,7 +535,7 @@ describe('Autocapture system', () => {
                     }
 
                     const customAutocapture = customPosthog.autocapture
-                    customAutocapture.onRemoteConfig({} as FlagsResponse)
+                    customAutocapture.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
 
                     // Create element and simulate clicks
                     const el = document.createElement(clickEvents[0].target)
@@ -860,7 +860,7 @@ describe('Autocapture system', () => {
 
         it('should not capture events when config returns false, when an element matching any of the event selectors is clicked', () => {
             posthog.config.autocapture = false
-            autocapture.onRemoteConfig({} as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
 
             const eventElement1 = document.createElement('div')
             const eventElement2 = document.createElement('div')
@@ -883,8 +883,11 @@ describe('Autocapture system', () => {
 
         it('should not capture events when config returns true but server setting is disabled', () => {
             autocapture.onRemoteConfig({
-                autocapture_opt_out: true,
-            } as FlagsResponse)
+                ok: true,
+                config: {
+                    autocapture_opt_out: true,
+                } as FlagsResponse,
+            })
 
             const eventElement = document.createElement('a')
             document.body.appendChild(eventElement)
@@ -1291,8 +1294,11 @@ describe('Autocapture system', () => {
             } as unknown as MouseEvent
 
             autocapture.onRemoteConfig({
-                elementsChainAsString: true,
-            } as FlagsResponse)
+                ok: true,
+                config: {
+                    elementsChainAsString: true,
+                } as FlagsResponse,
+            })
 
             autocapture['_captureEvent'](e)
             const props1 = beforeSendMock.mock.calls[0][0].properties
@@ -1361,7 +1367,7 @@ describe('Autocapture system', () => {
         beforeEach(() => {
             document.title = 'test page'
             posthog.config.mask_all_element_attributes = false
-            autocapture.onRemoteConfig({} as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
         })
 
         it('should capture click events', () => {
@@ -1394,7 +1400,7 @@ describe('Autocapture system', () => {
         })
 
         it('should be disabled when remote config has autocapture_opt_out', () => {
-            autocapture.onRemoteConfig({ autocapture_opt_out: true } as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: { autocapture_opt_out: true } as FlagsResponse })
             expect(autocapture.isEnabled).toBe(false)
         })
 
@@ -1410,21 +1416,21 @@ describe('Autocapture system', () => {
             })
 
             it('stays disabled when there has never been a successful config response', () => {
-                autocapture.onRemoteConfigFailed()
+                autocapture.onRemoteConfig({ ok: false })
                 expect(autocapture.isEnabled).toBe(false)
                 expect(posthog.persistence!.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]).toBeUndefined()
             })
 
             it('keeps a persisted server-side opt-out', () => {
                 posthog.persistence!.register({ [AUTOCAPTURE_DISABLED_SERVER_SIDE]: true })
-                autocapture.onRemoteConfigFailed()
+                autocapture.onRemoteConfig({ ok: false })
                 expect(autocapture.isEnabled).toBe(false)
                 expect(posthog.persistence!.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]).toBe(true)
             })
 
             it('keeps a persisted enabled state', () => {
                 posthog.persistence!.register({ [AUTOCAPTURE_DISABLED_SERVER_SIDE]: false })
-                autocapture.onRemoteConfigFailed()
+                autocapture.onRemoteConfig({ ok: false })
                 expect(autocapture.isEnabled).toBe(true)
             })
         })
@@ -1441,8 +1447,11 @@ describe('Autocapture system', () => {
             (clientSideOptIn, serverSideOptOut, expected) => {
                 posthog.config.autocapture = clientSideOptIn
                 autocapture.onRemoteConfig({
-                    autocapture_opt_out: serverSideOptOut,
-                } as FlagsResponse)
+                    ok: true,
+                    config: {
+                        autocapture_opt_out: serverSideOptOut,
+                    } as FlagsResponse,
+                })
                 expect(autocapture.isEnabled).toBe(expected)
             }
         )
@@ -1450,12 +1459,12 @@ describe('Autocapture system', () => {
         it('should call _addDomEventHandlders if autocapture is true in client config', () => {
             posthog.config.autocapture = true
             autocapture['_initialized'] = false
-            autocapture.onRemoteConfig({} as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
             expect(autocapture['_addDomEventHandlers']).toHaveBeenCalled()
         })
 
         it('should not call _addDomEventHandlders if autocapture is opted out in server config', () => {
-            autocapture.onRemoteConfig({ autocapture_opt_out: true } as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: { autocapture_opt_out: true } as FlagsResponse })
             expect(autocapture['_addDomEventHandlers']).not.toHaveBeenCalled()
         })
 
@@ -1463,17 +1472,17 @@ describe('Autocapture system', () => {
             expect(autocapture['_addDomEventHandlers']).not.toHaveBeenCalled()
             posthog.config.autocapture = false
 
-            autocapture.onRemoteConfig({} as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
 
             expect(autocapture['_addDomEventHandlers']).not.toHaveBeenCalled()
         })
 
         it('should NOT call _addDomEventHandlders when the token has already been initialized', () => {
             autocapture['_initialized'] = false
-            autocapture.onRemoteConfig({} as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
             expect(autocapture['_addDomEventHandlers']).toHaveBeenCalledTimes(1)
 
-            autocapture.onRemoteConfig({} as FlagsResponse)
+            autocapture.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
             expect(autocapture['_addDomEventHandlers']).toHaveBeenCalledTimes(1)
         })
     })

--- a/packages/browser/src/__tests__/extension-classes.test.ts
+++ b/packages/browser/src/__tests__/extension-classes.test.ts
@@ -1,5 +1,5 @@
 import { PostHog } from '../posthog-core'
-import { PostHogConfig, RemoteConfig } from '../types'
+import { PostHogConfig, RemoteConfig, RemoteConfigResult } from '../types'
 import { AllExtensions } from '../extensions/extension-bundles'
 import { Autocapture } from '../autocapture'
 import { PostHogFeatureFlags } from '../posthog-featureflags'
@@ -225,8 +225,8 @@ describe('extension lifecycle', () => {
 
             class SpyExtension {
                 constructor() {}
-                onRemoteConfig(config: RemoteConfig) {
-                    onRemoteConfigSpy(config)
+                onRemoteConfig(result: RemoteConfigResult) {
+                    onRemoteConfigSpy(result)
                 }
             }
 
@@ -247,7 +247,7 @@ describe('extension lifecycle', () => {
 
             // Two extensions, each should get onRemoteConfig called once
             expect(onRemoteConfigSpy).toHaveBeenCalledTimes(2)
-            expect(onRemoteConfigSpy).toHaveBeenCalledWith(remoteConfig)
+            expect(onRemoteConfigSpy).toHaveBeenCalledWith({ ok: true, config: remoteConfig })
         })
     })
 

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-api.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-api.test.ts
@@ -186,7 +186,7 @@ describe('Conversations API Methods', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
             await conversations.loadIfEnabled()
         })
 
@@ -567,7 +567,7 @@ describe('Conversations API Methods', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
             await conversations.loadIfEnabled()
         })
 
@@ -617,7 +617,7 @@ describe('Conversations API Methods', () => {
             }
 
             // onRemoteConfig automatically calls loadIfEnabled()
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             // Wait a tick for the loading to complete
             await new Promise((resolve) => setTimeout(resolve, 0))
@@ -655,7 +655,7 @@ describe('Conversations API Methods', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
             await conversations.loadIfEnabled()
 
             expect(conversations.isAvailable()).toBe(true)

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-identity.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-identity.test.ts
@@ -83,7 +83,7 @@ describe('Conversations Identity Verification', () => {
     })
 
     function loadConversations() {
-        conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+        conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
     }
 
     describe('posthog.setIdentity', () => {

--- a/packages/browser/src/__tests__/extensions/conversations/conversations.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations.test.ts
@@ -74,7 +74,7 @@ describe('PostHogConversations', () => {
                 },
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
             conversations.loadIfEnabled()
 
             expect(assignableWindow.__PosthogExtensions__?.loadExternalDependency).not.toHaveBeenCalled()
@@ -85,7 +85,7 @@ describe('PostHogConversations', () => {
                 conversations: null,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             expect(conversations.isAvailable()).toBe(false)
         })
@@ -95,7 +95,7 @@ describe('PostHogConversations', () => {
                 conversations: true,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             // Boolean true without token won't load the manager
             expect(conversations.isAvailable()).toBe(false)
@@ -106,7 +106,7 @@ describe('PostHogConversations', () => {
                 conversations: false,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             expect(conversations.isAvailable()).toBe(false)
         })
@@ -120,7 +120,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             expect(conversations.isAvailable()).toBe(true)
         })
@@ -133,7 +133,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             expect(assignableWindow.__PosthogExtensions__?.loadExternalDependency).toHaveBeenCalledWith(
                 mockPostHog,
@@ -152,7 +152,7 @@ describe('PostHogConversations', () => {
         }
 
         it('should not load if already loaded', () => {
-            conversations.onRemoteConfig(validRemoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: validRemoteConfig as RemoteConfig })
             expect(assignableWindow.__PosthogExtensions__?.loadExternalDependency).toHaveBeenCalledTimes(1)
 
             conversations.loadIfEnabled()
@@ -161,14 +161,14 @@ describe('PostHogConversations', () => {
 
         it('should not load for toolbar internal instance', () => {
             mockPostHog.config.name = 'ph_toolbar_internal'
-            conversations.onRemoteConfig(validRemoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: validRemoteConfig as RemoteConfig })
 
             expect(assignableWindow.__PosthogExtensions__?.loadExternalDependency).not.toHaveBeenCalled()
         })
 
         it('should not load if conversations are disabled', () => {
             mockPostHog.config.disable_conversations = true
-            conversations.onRemoteConfig(validRemoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: validRemoteConfig as RemoteConfig })
 
             expect(assignableWindow.__PosthogExtensions__?.loadExternalDependency).not.toHaveBeenCalled()
         })
@@ -177,7 +177,7 @@ describe('PostHogConversations', () => {
             mockPostHog.config.cookieless_mode = 'always'
             ;(mockPostHog.consent.isOptedOut as jest.Mock).mockReturnValue(true)
 
-            conversations.onRemoteConfig(validRemoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: validRemoteConfig as RemoteConfig })
 
             expect(assignableWindow.__PosthogExtensions__?.loadExternalDependency).not.toHaveBeenCalled()
         })
@@ -185,7 +185,7 @@ describe('PostHogConversations', () => {
         it('should not load if PostHog extensions are not found', () => {
             assignableWindow.__PosthogExtensions__ = undefined
 
-            conversations.onRemoteConfig(validRemoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: validRemoteConfig as RemoteConfig })
 
             expect(conversations.isAvailable()).toBe(false)
         })
@@ -204,7 +204,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(disabledConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: disabledConfig as RemoteConfig })
 
             expect(assignableWindow.__PosthogExtensions__?.loadExternalDependency).not.toHaveBeenCalled()
         })
@@ -217,7 +217,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(noTokenConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: noTokenConfig as RemoteConfig })
 
             expect(assignableWindow.__PosthogExtensions__?.loadExternalDependency).not.toHaveBeenCalled()
         })
@@ -227,7 +227,7 @@ describe('PostHogConversations', () => {
                 initConversations: jest.fn().mockReturnValue(mockManager),
             }
 
-            conversations.onRemoteConfig(validRemoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: validRemoteConfig as RemoteConfig })
 
             expect(assignableWindow.__PosthogExtensions__.initConversations).toHaveBeenCalledWith(
                 expect.objectContaining({ enabled: true, token: 'test-token' }),
@@ -242,7 +242,7 @@ describe('PostHogConversations', () => {
                 }),
             }
 
-            conversations.onRemoteConfig(validRemoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: validRemoteConfig as RemoteConfig })
 
             expect(conversations.isAvailable()).toBe(false)
         })
@@ -257,7 +257,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
             expect(conversations.isAvailable()).toBe(true)
 
             conversations.reset()
@@ -282,7 +282,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
             expect(conversations.isAvailable()).toBe(true)
 
             conversations.reset()
@@ -299,7 +299,7 @@ describe('PostHogConversations', () => {
                     token: 'test-token',
                 } as ConversationsRemoteConfig,
             }
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
         })
 
         describe('show', () => {
@@ -349,7 +349,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
         })
 
         it('should pass the PostHog instance directly to initConversations', () => {
@@ -370,7 +370,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             expect(conversations.isAvailable()).toBe(true)
         })
@@ -380,7 +380,7 @@ describe('PostHogConversations', () => {
                 conversations: false,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             expect(conversations.isAvailable()).toBe(false)
         })
@@ -399,7 +399,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             expect(conversations.isAvailable()).toBe(true)
             ;(mockManager.isVisible as jest.Mock).mockReturnValue(true)
@@ -450,7 +450,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            conversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            conversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             // Bundle should still load - domain check is done in ConversationsManager
             expect(mockInit).toHaveBeenCalled()
@@ -496,7 +496,7 @@ describe('PostHogConversations', () => {
                 } as ConversationsRemoteConfig,
             }
 
-            identifiedConversations.onRemoteConfig(remoteConfig as RemoteConfig)
+            identifiedConversations.onRemoteConfig({ ok: true, config: remoteConfig as RemoteConfig })
 
             // The initConversations is called with the PostHog instance
             // The ConversationsManager will use posthog._isIdentified() to determine

--- a/packages/browser/src/__tests__/extensions/dead-clicks-autocapture.test.ts
+++ b/packages/browser/src/__tests__/extensions/dead-clicks-autocapture.test.ts
@@ -170,7 +170,7 @@ describe('DeadClicksAutocapture', () => {
                 [DEAD_CLICKS_ENABLED_SERVER_SIDE]: true,
             })
 
-            // Call with empty config (simulating config fetch failure)
+            // Call with empty config (server returned no setting for this feature)
             instance.deadClicksAutocapture.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing value

--- a/packages/browser/src/__tests__/extensions/dead-clicks-autocapture.test.ts
+++ b/packages/browser/src/__tests__/extensions/dead-clicks-autocapture.test.ts
@@ -113,7 +113,7 @@ describe('DeadClicksAutocapture', () => {
 
         const mockStop = dca.lazyLoadedDeadClicksAutocapture?.stop as jest.Mock
 
-        dca.onRemoteConfig({ captureDeadClicks: false } as any)
+        dca.onRemoteConfig({ ok: true, config: { captureDeadClicks: false } as any })
 
         expect(mockStop).toHaveBeenCalled()
         expect(dca.lazyLoadedDeadClicksAutocapture).toBeUndefined()
@@ -171,7 +171,7 @@ describe('DeadClicksAutocapture', () => {
             })
 
             // Call with empty config (simulating config fetch failure)
-            instance.deadClicksAutocapture.onRemoteConfig({} as RemoteConfig)
+            instance.deadClicksAutocapture.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing value
             expect(instance.persistence?.props[DEAD_CLICKS_ENABLED_SERVER_SIDE]).toBe(true)
@@ -183,8 +183,11 @@ describe('DeadClicksAutocapture', () => {
             })
 
             instance.deadClicksAutocapture.onRemoteConfig({
-                captureDeadClicks: false,
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    captureDeadClicks: false,
+                } as RemoteConfig,
+            })
 
             expect(instance.persistence?.props[DEAD_CLICKS_ENABLED_SERVER_SIDE]).toBe(false)
         })

--- a/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
@@ -22,7 +22,7 @@ describe('ExceptionObserver', () => {
             })
 
             // Call with empty config (simulating config fetch failure)
-            instance.exceptionObserver.onRemoteConfig({} as RemoteConfig)
+            instance.exceptionObserver.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing value
             expect(instance.persistence?.props[EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE]).toBe(true)
@@ -34,8 +34,11 @@ describe('ExceptionObserver', () => {
             })
 
             instance.exceptionObserver.onRemoteConfig({
-                autocaptureExceptions: false,
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    autocaptureExceptions: false,
+                } as RemoteConfig,
+            })
 
             expect(instance.persistence?.props[EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE]).toBe(false)
         })
@@ -46,8 +49,11 @@ describe('ExceptionObserver', () => {
             })
 
             instance.exceptionObserver.onRemoteConfig({
-                autocaptureExceptions: true,
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    autocaptureExceptions: true,
+                } as RemoteConfig,
+            })
 
             expect(instance.persistence?.props[EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE]).toBe(true)
         })

--- a/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
@@ -21,7 +21,7 @@ describe('ExceptionObserver', () => {
                 [EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE]: true,
             })
 
-            // Call with empty config (simulating config fetch failure)
+            // Call with empty config (server returned no setting for this feature)
             instance.exceptionObserver.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing value

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
@@ -72,7 +72,7 @@ describe('Exception Observer', () => {
 
     describe('when enabled remotely', () => {
         beforeEach(() => {
-            exceptionObserver.onRemoteConfig({ autocaptureExceptions: true } as FlagsResponse)
+            exceptionObserver.onRemoteConfig({ ok: true, config: { autocaptureExceptions: true } as FlagsResponse })
         })
 
         it('should instrument enabled handlers only when started', () => {
@@ -220,7 +220,7 @@ describe('Exception Observer', () => {
             window!.onerror = originalOnError
             window!.onunhandledrejection = originalOnUnhandledRejection
 
-            exceptionObserver.onRemoteConfig({ autocaptureExceptions: true } as FlagsResponse)
+            exceptionObserver.onRemoteConfig({ ok: true, config: { autocaptureExceptions: true } as FlagsResponse })
         })
 
         it('should wrap original onerror handler if one was present when wrapped', () => {
@@ -279,7 +279,7 @@ describe('Exception Observer', () => {
 
     describe('when disabled', () => {
         beforeEach(() => {
-            exceptionObserver.onRemoteConfig({ autocaptureExceptions: false } as FlagsResponse)
+            exceptionObserver.onRemoteConfig({ ok: true, config: { autocaptureExceptions: false } as FlagsResponse })
         })
 
         it('cannot be started', () => {

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -26,6 +26,8 @@ import {
     PerformanceCaptureConfig,
     PostHogConfig,
     Property,
+    RemoteConfig,
+    RemoteConfigResult,
     SessionIdChangedCallback,
     SessionRecordingOptions,
 } from '../../../types'
@@ -173,8 +175,8 @@ const createPluginSnapshot = (event = {}): pluginEvent => ({
     ...event,
 })
 
-function makeFlagsResponse(partialResponse: Partial<FlagsResponse>) {
-    return partialResponse as unknown as FlagsResponse
+function makeFlagsResponse(partialResponse: Partial<FlagsResponse>): RemoteConfigResult {
+    return { ok: true, config: partialResponse as unknown as RemoteConfig }
 }
 
 const originalLocation = window!.location

--- a/packages/browser/src/__tests__/extensions/replay/sessionRecording-onRemoteConfig.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/sessionRecording-onRemoteConfig.test.ts
@@ -7,7 +7,7 @@ import { SESSION_RECORDING_REMOTE_CONFIG } from '../../../constants'
 import { SessionIdManager } from '../../../sessionid'
 import { FULL_SNAPSHOT_EVENT_TYPE, META_EVENT_TYPE } from '../../../extensions/replay/external/sessionrecording-utils'
 import { PostHog } from '../../../posthog-core'
-import { FlagsResponse, PostHogConfig, Property } from '../../../types'
+import { FlagsResponse, PostHogConfig, Property, RemoteConfig, RemoteConfigResult } from '../../../types'
 import { uuidv7 } from '../../../uuidv7'
 import { SessionRecording } from '../../../extensions/replay/session-recording'
 import { assignableWindow, window } from '../../../utils/globals'
@@ -51,8 +51,8 @@ const createFullSnapshot = (event = {}): fullSnapshotEvent =>
         ...event,
     }) as fullSnapshotEvent
 
-function makeFlagsResponse(partialResponse: Partial<FlagsResponse>) {
-    return partialResponse as unknown as FlagsResponse
+function makeFlagsResponse(partialResponse: Partial<FlagsResponse>): RemoteConfigResult {
+    return { ok: true, config: partialResponse as unknown as RemoteConfig }
 }
 
 const originalLocation = window!.location

--- a/packages/browser/src/__tests__/extensions/web-vitals.test.ts
+++ b/packages/browser/src/__tests__/extensions/web-vitals.test.ts
@@ -171,8 +171,11 @@ describe('web vitals', () => {
 
                 // need to force this to get the web vitals script loaded
                 posthog.webVitalsAutocapture!.onRemoteConfig({
-                    capturePerformance: { web_vitals: true },
-                } as unknown as FlagsResponse)
+                    ok: true,
+                    config: {
+                        capturePerformance: { web_vitals: true },
+                    } as unknown as FlagsResponse,
+                })
 
                 expect(posthog.webVitalsAutocapture.allowedMetrics).toEqual(expectedAllowedMetrics)
             })
@@ -299,8 +302,11 @@ describe('web vitals', () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency = loadScriptMock
 
             posthog.webVitalsAutocapture!.onRemoteConfig({
-                capturePerformance: { web_vitals: true },
-            } as unknown as FlagsResponse)
+                ok: true,
+                config: {
+                    capturePerformance: { web_vitals: true },
+                } as unknown as FlagsResponse,
+            })
 
             expect(posthog.webVitalsAutocapture!.allowedMetrics).toEqual(['CLS', 'FCP'])
         })
@@ -387,8 +393,11 @@ describe('web vitals', () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency = loadScriptMock
 
             posthog.webVitalsAutocapture!.onRemoteConfig({
-                capturePerformance: { web_vitals: true },
-            } as unknown as FlagsResponse)
+                ok: true,
+                config: {
+                    capturePerformance: { web_vitals: true },
+                } as unknown as FlagsResponse,
+            })
 
             expect(posthog.webVitalsAutocapture!.allowedMetrics).toEqual(['CLS', 'FCP'])
         })
@@ -454,8 +463,11 @@ describe('web vitals', () => {
             })
 
             posthog.webVitalsAutocapture!.onRemoteConfig({
-                capturePerformance: { web_vitals: true },
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    capturePerformance: { web_vitals: true },
+                } as RemoteConfig,
+            })
 
             expect(loadScriptMock).toHaveBeenCalledWith(expect.anything(), expectedBundle, expect.any(Function))
         })
@@ -477,7 +489,7 @@ describe('web vitals', () => {
             })
 
             // Call with empty config (simulating config fetch failure)
-            posthog.webVitalsAutocapture!.onRemoteConfig({} as RemoteConfig)
+            posthog.webVitalsAutocapture!.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing values
             expect(posthog.persistence!.props[WEB_VITALS_ENABLED_SERVER_SIDE]).toBe(true)
@@ -491,8 +503,11 @@ describe('web vitals', () => {
             })
 
             posthog.webVitalsAutocapture!.onRemoteConfig({
-                capturePerformance: { web_vitals: false, web_vitals_allowed_metrics: ['CLS'] },
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    capturePerformance: { web_vitals: false, web_vitals_allowed_metrics: ['CLS'] },
+                } as RemoteConfig,
+            })
 
             expect(posthog.persistence!.props[WEB_VITALS_ENABLED_SERVER_SIDE]).toBe(false)
             expect(posthog.persistence!.props[WEB_VITALS_ALLOWED_METRICS]).toEqual(['CLS'])
@@ -550,8 +565,11 @@ describe('web vitals', () => {
             (clientSideOptIn, serverSideOptIn, expected) => {
                 posthog.config.capture_performance = { web_vitals: clientSideOptIn }
                 posthog.webVitalsAutocapture!.onRemoteConfig({
-                    capturePerformance: { web_vitals: serverSideOptIn },
-                } as FlagsResponse)
+                    ok: true,
+                    config: {
+                        capturePerformance: { web_vitals: serverSideOptIn },
+                    } as FlagsResponse,
+                })
                 expect(posthog.webVitalsAutocapture!.isEnabled).toBe(expected)
             }
         )
@@ -573,10 +591,13 @@ describe('web vitals', () => {
         })
 
         posthog.webVitalsAutocapture!.onRemoteConfig({
-            capturePerformance: {
-                web_vitals: true,
-            },
-        } as RemoteConfig)
+            ok: true,
+            config: {
+                capturePerformance: {
+                    web_vitals: true,
+                },
+            } as RemoteConfig,
+        })
 
         expect(posthog.webVitalsAutocapture!.isEnabled).toBe(false)
     })
@@ -597,8 +618,11 @@ describe('web vitals', () => {
         })
 
         posthog.webVitalsAutocapture!.onRemoteConfig({
-            capturePerformance: { web_vitals: true },
-        } as RemoteConfig)
+            ok: true,
+            config: {
+                capturePerformance: { web_vitals: true },
+            } as RemoteConfig,
+        })
 
         expect(posthog.webVitalsAutocapture!.isEnabled).toBe(false)
     })
@@ -651,8 +675,11 @@ describe('web vitals', () => {
         })
 
         posthog.webVitalsAutocapture!.onRemoteConfig({
-            capturePerformance: { web_vitals: true },
-        } as RemoteConfig)
+            ok: true,
+            config: {
+                capturePerformance: { web_vitals: true },
+            } as RemoteConfig,
+        })
 
         expect(posthog.webVitalsAutocapture!.isEnabled).toBe(false)
     })
@@ -673,8 +700,11 @@ describe('web vitals', () => {
         })
 
         posthog.webVitalsAutocapture!.onRemoteConfig({
-            capturePerformance: { web_vitals: true },
-        } as FlagsResponse)
+            ok: true,
+            config: {
+                capturePerformance: { web_vitals: true },
+            } as FlagsResponse,
+        })
 
         expect(posthog.webVitalsAutocapture!.isEnabled).toBe(true)
     })
@@ -735,8 +765,11 @@ describe('web vitals', () => {
 
                 // need to force this to get the web vitals script loaded
                 posthog.webVitalsAutocapture!.onRemoteConfig({
-                    capturePerformance: { web_vitals: true },
-                } as unknown as FlagsResponse)
+                    ok: true,
+                    config: {
+                        capturePerformance: { web_vitals: true },
+                    } as unknown as FlagsResponse,
+                })
             })
 
             it('masks properties accordingly', async () => {

--- a/packages/browser/src/__tests__/extensions/web-vitals.test.ts
+++ b/packages/browser/src/__tests__/extensions/web-vitals.test.ts
@@ -488,7 +488,7 @@ describe('web vitals', () => {
                 [WEB_VITALS_ALLOWED_METRICS]: ['LCP', 'FCP'],
             })
 
-            // Call with empty config (simulating config fetch failure)
+            // Call with empty config (server returned no setting for this feature)
             posthog.webVitalsAutocapture!.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing values

--- a/packages/browser/src/__tests__/heatmaps.test.ts
+++ b/packages/browser/src/__tests__/heatmaps.test.ts
@@ -264,7 +264,7 @@ describe('heatmaps', () => {
             posthog.persistence!.register({ [HEATMAPS_ENABLED_SERVER_SIDE]: true })
             const heatmaps = new Heatmaps(posthog)
 
-            // Call with empty config (simulating config fetch failure)
+            // Call with empty config (server returned no setting for this feature)
             heatmaps.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
 
             // Should NOT have overwritten the existing value

--- a/packages/browser/src/__tests__/heatmaps.test.ts
+++ b/packages/browser/src/__tests__/heatmaps.test.ts
@@ -265,7 +265,7 @@ describe('heatmaps', () => {
             const heatmaps = new Heatmaps(posthog)
 
             // Call with empty config (simulating config fetch failure)
-            heatmaps.onRemoteConfig({} as FlagsResponse)
+            heatmaps.onRemoteConfig({ ok: true, config: {} as FlagsResponse })
 
             // Should NOT have overwritten the existing value
             expect(posthog.persistence!.props[HEATMAPS_ENABLED_SERVER_SIDE]).toBe(true)
@@ -275,7 +275,7 @@ describe('heatmaps', () => {
             posthog.persistence!.register({ [HEATMAPS_ENABLED_SERVER_SIDE]: true })
             const heatmaps = new Heatmaps(posthog)
 
-            heatmaps.onRemoteConfig({ heatmaps: false } as FlagsResponse)
+            heatmaps.onRemoteConfig({ ok: true, config: { heatmaps: false } as FlagsResponse })
 
             expect(posthog.persistence!.props[HEATMAPS_ENABLED_SERVER_SIDE]).toBe(false)
         })
@@ -354,8 +354,11 @@ describe('heatmaps', () => {
                 posthog.config.enable_heatmaps = deprecatedclientSideOptIn
                 posthog.config.capture_heatmaps = clientSideOptIn
                 posthog.heatmaps!.onRemoteConfig({
-                    heatmaps: serverSideOptIn,
-                } as FlagsResponse)
+                    ok: true,
+                    config: {
+                        heatmaps: serverSideOptIn,
+                    } as FlagsResponse,
+                })
                 expect(posthog.heatmaps!.isEnabled).toBe(expected)
             }
         )

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -427,6 +427,30 @@ describe('posthog core', () => {
             expect(posthog.persistence!.props[HEATMAPS_ENABLED_SERVER_SIDE]).toBeUndefined()
             expect(posthog.heatmaps!.isEnabled).toBe(false)
         })
+
+        it('reaches every registered extension and no failure branch throws', async () => {
+            const posthog = await createPosthogInstance()
+            const handlers = (posthog as any)._extensions.filter((ext: any) => ext.onRemoteConfig)
+            expect(handlers.length).toBeGreaterThanOrEqual(10)
+            const spies = handlers.map((ext: any) => jest.spyOn(ext, 'onRemoteConfig'))
+
+            expect(() => posthog._onRemoteConfig({ ok: false })).not.toThrow()
+
+            for (const spy of spies) {
+                expect(spy).toHaveBeenCalledWith({ ok: false })
+            }
+        })
+
+        it('session recording treats a failure like a config without recording settings', async () => {
+            const posthog = await createPosthogInstance()
+            posthog.sessionRecording!.onRemoteConfig({ ok: false })
+
+            const other = await createPosthogInstance()
+            other.sessionRecording!.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
+
+            expect(posthog.sessionRecording!.status).toBe(other.sessionRecording!.status)
+            expect(posthog.sessionRecording!.started).toBe(false)
+        })
     })
 
     describe('_afterFlagsResponse', () => {

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -4,7 +4,13 @@ import * as globals from '../utils/globals'
 import { document, window } from '../utils/globals'
 import { uuidv7 } from '../uuidv7'
 import { isUndefined } from '@posthog/core'
-import { ENABLE_PERSON_PROCESSING, SESSION_RECORDING_REMOTE_CONFIG, USER_STATE } from '../constants'
+import {
+    AUTOCAPTURE_DISABLED_SERVER_SIDE,
+    ENABLE_PERSON_PROCESSING,
+    HEATMAPS_ENABLED_SERVER_SIDE,
+    SESSION_RECORDING_REMOTE_CONFIG,
+    USER_STATE,
+} from '../constants'
 import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import { PostHogConfig, RemoteConfig } from '../types'
 import { configRenames, PostHog } from '../posthog-core'
@@ -397,17 +403,29 @@ describe('posthog core', () => {
     })
 
     describe('_onRemoteConfig failure dispatch', () => {
-        it('routes failure to onRemoteConfigFailed and gives other extensions an empty config', async () => {
+        it('passes the failure result to every extension', async () => {
             const posthog = await createPosthogInstance()
-            const autocaptureFailed = jest.spyOn(posthog.autocapture!, 'onRemoteConfigFailed')
-            const autocaptureConfig = jest.spyOn(posthog.autocapture!, 'onRemoteConfig')
-            const heatmapsConfig = jest.spyOn(posthog.heatmaps!, 'onRemoteConfig')
+            const autocaptureResult = jest.spyOn(posthog.autocapture!, 'onRemoteConfig')
+            const heatmapsResult = jest.spyOn(posthog.heatmaps!, 'onRemoteConfig')
+
+            // the test helper delivers a successful config during init; clear that
+            // state so this test observes what a failure does on a fresh page
+            posthog.autocapture!['_isDisabledServerSide'] = null
+            posthog.persistence!.unregister(AUTOCAPTURE_DISABLED_SERVER_SIDE)
 
             posthog._onRemoteConfig({ ok: false })
 
-            expect(autocaptureFailed).toHaveBeenCalledTimes(1)
-            expect(autocaptureConfig).not.toHaveBeenCalled()
-            expect(heatmapsConfig).toHaveBeenCalledWith(expect.objectContaining({ supportedCompression: [] }))
+            // autocapture keeps waiting for a server verdict: stays disabled,
+            // with no server opt-out value persisted
+            expect(autocaptureResult).toHaveBeenCalledWith({ ok: false })
+            expect(posthog.autocapture!.isEnabled).toBe(false)
+            expect(posthog.persistence!.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]).toBeUndefined()
+
+            // heatmaps behaves as it would for a config without a heatmaps key:
+            // nothing persisted, not started
+            expect(heatmapsResult).toHaveBeenCalledWith({ ok: false })
+            expect(posthog.persistence!.props[HEATMAPS_ENABLED_SERVER_SIDE]).toBeUndefined()
+            expect(posthog.heatmaps!.isEnabled).toBe(false)
         })
     })
 

--- a/packages/browser/src/__tests__/posthog-exceptions.test.ts
+++ b/packages/browser/src/__tests__/posthog-exceptions.test.ts
@@ -68,7 +68,7 @@ describe('PostHogExceptions', () => {
         it('persists the suppression rules', () => {
             const suppressionRule = createSuppressionRule()
             const remoteResponse: Partial<RemoteConfig> = { errorTracking: { suppressionRules: [suppressionRule] } }
-            exceptions.onRemoteConfig(remoteResponse as RemoteConfig)
+            exceptions.onRemoteConfig({ ok: true, config: remoteResponse as RemoteConfig })
             expect(exceptions['_suppressionRules']).toEqual([suppressionRule])
         })
 
@@ -84,7 +84,7 @@ describe('PostHogExceptions', () => {
             const newExceptions = new PostHogExceptions(posthog)
 
             // Call with empty config (simulating config fetch failure)
-            newExceptions.onRemoteConfig({} as RemoteConfig)
+            newExceptions.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing values
             expect(posthog.persistence!.props[ERROR_TRACKING_SUPPRESSION_RULES]).toEqual([suppressionRule])
@@ -100,8 +100,11 @@ describe('PostHogExceptions', () => {
 
             const newExceptions = new PostHogExceptions(posthog)
             newExceptions.onRemoteConfig({
-                errorTracking: { suppressionRules: [], captureExtensionExceptions: false },
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    errorTracking: { suppressionRules: [], captureExtensionExceptions: false },
+                } as RemoteConfig,
+            })
 
             expect(posthog.persistence!.props[ERROR_TRACKING_SUPPRESSION_RULES]).toEqual([])
             expect(posthog.persistence!.props[ERROR_TRACKING_CAPTURE_EXTENSION_EXCEPTIONS]).toBe(false)
@@ -127,21 +130,30 @@ describe('PostHogExceptions', () => {
             ['GenericError', 'This is a message that contains a ReactMinified error'],
         ])('drops the event if a suppression rule matches', (type, value) => {
             const suppressionRule = createSuppressionRule('OR')
-            exceptions.onRemoteConfig({ errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig)
+            exceptions.onRemoteConfig({
+                ok: true,
+                config: { errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig,
+            })
             exceptions.sendExceptionEvent({ $exception_list: [{ type, value }] })
             expect(captureMock).not.toBeCalled()
         })
 
         it('captures an exception if no $exception_list property exists', () => {
             const suppressionRule = createSuppressionRule('AND')
-            exceptions.onRemoteConfig({ errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig)
+            exceptions.onRemoteConfig({
+                ok: true,
+                config: { errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig,
+            })
             exceptions.sendExceptionEvent({ custom_property: true })
             expect(captureMock).toBeCalled()
         })
 
         it('captures an exception if all rule conditions do not match', () => {
             const suppressionRule = createSuppressionRule('AND')
-            exceptions.onRemoteConfig({ errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig)
+            exceptions.onRemoteConfig({
+                ok: true,
+                config: { errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig,
+            })
             exceptions.sendExceptionEvent({ $exception_list: [{ type: 'TypeError', value: 'This is a type error' }] })
             expect(captureMock).toBeCalled()
         })
@@ -155,7 +167,10 @@ describe('PostHogExceptions', () => {
                     type: 'error_tracking_issue_property',
                 },
             ])
-            exceptions.onRemoteConfig({ errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig)
+            exceptions.onRemoteConfig({
+                ok: true,
+                config: { errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig,
+            })
             exceptions.sendExceptionEvent({ $exception_list: [{ type: 'TypeError', value: 'This is a type error' }] })
             expect(captureMock).toBeCalled()
         })
@@ -173,7 +188,10 @@ describe('PostHogExceptions', () => {
             })
 
             it('captures extension exceptions when enabled', () => {
-                exceptions.onRemoteConfig({ errorTracking: { captureExtensionExceptions: true } } as RemoteConfig)
+                exceptions.onRemoteConfig({
+                    ok: true,
+                    config: { errorTracking: { captureExtensionExceptions: true } } as RemoteConfig,
+                })
                 const frame = { filename: 'chrome-extension://', platform: 'javascript:web' }
                 const exception = { stacktrace: { frames: [frame], type: 'raw' } }
                 exceptions.sendExceptionEvent({ $exception_list: [exception] })
@@ -275,14 +293,17 @@ describe('PostHogExceptions', () => {
             exceptions.addExceptionStep('kept step')
 
             const suppressionRule = createSuppressionRule('OR')
-            exceptions.onRemoteConfig({ errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig)
+            exceptions.onRemoteConfig({
+                ok: true,
+                config: { errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig,
+            })
 
             exceptions.sendExceptionEvent({
                 $exception_list: [{ type: 'TypeError', value: 'This is a type error' }],
             })
             expect(captureMock).not.toHaveBeenCalled()
 
-            exceptions.onRemoteConfig({ errorTracking: { suppressionRules: [] } } as RemoteConfig)
+            exceptions.onRemoteConfig({ ok: true, config: { errorTracking: { suppressionRules: [] } } as RemoteConfig })
             exceptions.sendExceptionEvent({ custom_property: true })
 
             expect(captureMock).toHaveBeenCalledWith(

--- a/packages/browser/src/__tests__/posthog-exceptions.test.ts
+++ b/packages/browser/src/__tests__/posthog-exceptions.test.ts
@@ -83,7 +83,7 @@ describe('PostHogExceptions', () => {
             // Create new instance to pick up persisted values
             const newExceptions = new PostHogExceptions(posthog)
 
-            // Call with empty config (simulating config fetch failure)
+            // Call with empty config (server returned no setting for this feature)
             newExceptions.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing values

--- a/packages/browser/src/__tests__/posthog-logs.test.ts
+++ b/packages/browser/src/__tests__/posthog-logs.test.ts
@@ -122,7 +122,7 @@ describe('posthog-logs', () => {
                     logs: { captureConsoleLogs: false },
                 }
 
-                logs.onRemoteConfig(response)
+                logs.onRemoteConfig({ ok: true, config: response })
 
                 expect((logs as any)._isLogsEnabled).toBeFalsy()
             })
@@ -137,7 +137,7 @@ describe('posthog-logs', () => {
                     logs: null,
                 } as any
 
-                logs.onRemoteConfig(response)
+                logs.onRemoteConfig({ ok: true, config: response })
 
                 expect((logs as any)._isLogsEnabled).toBeFalsy()
             })
@@ -151,7 +151,7 @@ describe('posthog-logs', () => {
                     siteApps: [],
                 }
 
-                logs.onRemoteConfig(response)
+                logs.onRemoteConfig({ ok: true, config: response })
 
                 expect((logs as any)._isLogsEnabled).toBeFalsy()
             })
@@ -166,7 +166,7 @@ describe('posthog-logs', () => {
                     logs: { captureConsoleLogs: true },
                 }
 
-                logs.onRemoteConfig(response)
+                logs.onRemoteConfig({ ok: true, config: response })
 
                 expect((logs as any)._isLogsEnabled).toBe(true)
             })
@@ -182,7 +182,7 @@ describe('posthog-logs', () => {
                     logs: { captureConsoleLogs: true },
                 }
 
-                logs.onRemoteConfig(response)
+                logs.onRemoteConfig({ ok: true, config: response })
 
                 expect(loadIfEnabledSpy).toHaveBeenCalled()
             })
@@ -288,7 +288,7 @@ describe('posthog-logs', () => {
                     logs: { captureConsoleLogs: true },
                 }
 
-                logs.onRemoteConfig(response)
+                logs.onRemoteConfig({ ok: true, config: response })
 
                 expect((logs as any)._isLogsEnabled).toBe(true)
                 expect(mockLoadExternalDependency).toHaveBeenCalledWith(mockPostHog, 'logs', expect.any(Function))
@@ -305,7 +305,7 @@ describe('posthog-logs', () => {
                     logs: { captureConsoleLogs: false },
                 }
 
-                logs.onRemoteConfig(response)
+                logs.onRemoteConfig({ ok: true, config: response })
                 logs.loadIfEnabled()
 
                 expect(mockLoadExternalDependency).not.toHaveBeenCalled()
@@ -331,15 +331,15 @@ describe('posthog-logs', () => {
                 }
 
                 // First enable
-                logs.onRemoteConfig(enabledResponse)
+                logs.onRemoteConfig({ ok: true, config: enabledResponse })
                 expect((logs as any)._isLogsEnabled).toBe(true)
 
                 // Then disable (should not change the enabled state)
-                logs.onRemoteConfig(disabledResponse)
+                logs.onRemoteConfig({ ok: true, config: disabledResponse })
                 expect((logs as any)._isLogsEnabled).toBe(true) // Still enabled from first call
 
                 // Enable again
-                logs.onRemoteConfig(enabledResponse)
+                logs.onRemoteConfig({ ok: true, config: enabledResponse })
                 expect((logs as any)._isLogsEnabled).toBe(true)
             })
 
@@ -359,7 +359,7 @@ describe('posthog-logs', () => {
 
                 configs.forEach((config) => {
                     const testLogs = new PostHogLogs(mockPostHog)
-                    testLogs.onRemoteConfig(config)
+                    testLogs.onRemoteConfig({ ok: true, config: config })
                     expect((testLogs as any)._isLogsEnabled).toBe(true)
                 })
             })
@@ -377,7 +377,7 @@ describe('posthog-logs', () => {
                     logs: { captureConsoleLogs: true },
                 }
 
-                expect(() => logsWithNullPostHog.onRemoteConfig(response)).not.toThrow()
+                expect(() => logsWithNullPostHog.onRemoteConfig({ ok: true, config: response })).not.toThrow()
                 expect(() => logsWithNullPostHog.loadIfEnabled()).not.toThrow()
                 expect(() => logsWithNullPostHog.reset()).not.toThrow()
             })
@@ -423,7 +423,7 @@ describe('posthog-logs', () => {
 
                 malformedResponses.forEach((response) => {
                     const testLogs = new PostHogLogs(mockPostHog)
-                    expect(() => testLogs.onRemoteConfig(response as any)).not.toThrow()
+                    expect(() => testLogs.onRemoteConfig({ ok: true, config: response as any })).not.toThrow()
                     expect((testLogs as any)._isLogsEnabled).toBeFalsy()
                 })
 
@@ -431,7 +431,7 @@ describe('posthog-logs', () => {
                 const nullUndefinedResponses = [null, undefined]
                 nullUndefinedResponses.forEach((response) => {
                     const testLogs = new PostHogLogs(mockPostHog)
-                    expect(() => testLogs.onRemoteConfig(response as any)).toThrow()
+                    expect(() => testLogs.onRemoteConfig({ ok: true, config: response as any })).toThrow()
                 })
             })
 
@@ -1497,7 +1497,7 @@ describe('posthog-logs', () => {
                     isAuthenticated: false,
                     siteApps: [],
                 }
-                logs.onRemoteConfig({ ...baseConfig, logs: { captureConsoleLogs: true } })
+                logs.onRemoteConfig({ ok: true, config: { ...baseConfig, logs: { captureConsoleLogs: true } } })
                 expect((logs as any)._isLogsEnabled).toBe(true)
                 expect((logs as any)._isLoaded).toBe(true)
 
@@ -1519,16 +1519,16 @@ describe('posthog-logs', () => {
                     siteApps: [],
                 }
 
-                logs.onRemoteConfig({ ...baseConfig, logs: { captureConsoleLogs: false } })
+                logs.onRemoteConfig({ ok: true, config: { ...baseConfig, logs: { captureConsoleLogs: false } } })
                 expect(mockLoadExternalDependency).toHaveBeenCalledTimes(0)
 
-                logs.onRemoteConfig({ ...baseConfig, logs: { captureConsoleLogs: true } })
+                logs.onRemoteConfig({ ok: true, config: { ...baseConfig, logs: { captureConsoleLogs: true } } })
                 expect(mockLoadExternalDependency).toHaveBeenCalledTimes(1)
 
-                logs.onRemoteConfig({ ...baseConfig, logs: { captureConsoleLogs: true } })
+                logs.onRemoteConfig({ ok: true, config: { ...baseConfig, logs: { captureConsoleLogs: true } } })
                 expect(mockLoadExternalDependency).toHaveBeenCalledTimes(1)
 
-                logs.onRemoteConfig({ ...baseConfig, logs: { captureConsoleLogs: false } })
+                logs.onRemoteConfig({ ok: true, config: { ...baseConfig, logs: { captureConsoleLogs: false } } })
                 expect(mockLoadExternalDependency).toHaveBeenCalledTimes(1)
             })
         })

--- a/packages/browser/src/__tests__/posthog-product-tours.test.ts
+++ b/packages/browser/src/__tests__/posthog-product-tours.test.ts
@@ -21,7 +21,7 @@ describe('PostHogProductTours', () => {
                 [PRODUCT_TOURS_ENABLED_SERVER_SIDE]: true,
             })
 
-            // Call with empty config (simulating config fetch failure)
+            // Call with empty config (server returned no setting for this feature)
             instance.productTours.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing value

--- a/packages/browser/src/__tests__/posthog-product-tours.test.ts
+++ b/packages/browser/src/__tests__/posthog-product-tours.test.ts
@@ -22,7 +22,7 @@ describe('PostHogProductTours', () => {
             })
 
             // Call with empty config (simulating config fetch failure)
-            instance.productTours.onRemoteConfig({} as RemoteConfig)
+            instance.productTours.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             // Should NOT have overwritten the existing value
             expect(instance.persistence?.props[PRODUCT_TOURS_ENABLED_SERVER_SIDE]).toBe(true)
@@ -34,8 +34,11 @@ describe('PostHogProductTours', () => {
             })
 
             instance.productTours.onRemoteConfig({
-                productTours: false,
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    productTours: false,
+                } as RemoteConfig,
+            })
 
             expect(instance.persistence?.props[PRODUCT_TOURS_ENABLED_SERVER_SIDE]).toBe(false)
         })
@@ -46,8 +49,11 @@ describe('PostHogProductTours', () => {
             })
 
             instance.productTours.onRemoteConfig({
-                productTours: true,
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    productTours: true,
+                } as RemoteConfig,
+            })
 
             expect(instance.persistence?.props[PRODUCT_TOURS_ENABLED_SERVER_SIDE]).toBe(true)
         })
@@ -74,7 +80,7 @@ describe('PostHogProductTours', () => {
                 [PRODUCT_TOURS]: [{ id: 'tour-1', name: 'stale cached tour' }],
             })
 
-            instance.productTours.onRemoteConfig(response as RemoteConfig)
+            instance.productTours.onRemoteConfig({ ok: true, config: response as RemoteConfig })
 
             expect(instance.persistence?.props[PRODUCT_TOURS]).toBeUndefined()
         })
@@ -86,7 +92,7 @@ describe('PostHogProductTours', () => {
                 [PRODUCT_TOURS]: tours,
             })
 
-            instance.productTours.onRemoteConfig({ productTours: true } as RemoteConfig)
+            instance.productTours.onRemoteConfig({ ok: true, config: { productTours: true } as RemoteConfig })
 
             expect(instance.persistence?.props[PRODUCT_TOURS]).toEqual(tours)
         })
@@ -100,7 +106,7 @@ describe('PostHogProductTours', () => {
             instance.productTours.getProductTours(consumer, true)
             expect(requests).toHaveLength(1)
 
-            instance.productTours.onRemoteConfig({ productTours: false } as RemoteConfig)
+            instance.productTours.onRemoteConfig({ ok: true, config: { productTours: false } as RemoteConfig })
 
             requests[0].callback({ statusCode: 200, json: { product_tours: [{ id: 'tour-1' }] } })
 
@@ -113,7 +119,7 @@ describe('PostHogProductTours', () => {
             ;(instance.productTours as any)._productTourManager = { stop }
             instance.persistence?.register({ [PRODUCT_TOURS_ENABLED_SERVER_SIDE]: true })
 
-            instance.productTours.onRemoteConfig({ productTours: false } as RemoteConfig)
+            instance.productTours.onRemoteConfig({ ok: true, config: { productTours: false } as RemoteConfig })
 
             expect(stop).toHaveBeenCalled()
             expect((instance.productTours as any)._productTourManager).toBeNull()
@@ -126,7 +132,7 @@ describe('PostHogProductTours', () => {
                 [PRODUCT_TOURS]: tours,
             })
 
-            instance.productTours.onRemoteConfig({} as RemoteConfig)
+            instance.productTours.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             expect(instance.persistence?.props[PRODUCT_TOURS]).toEqual(tours)
         })

--- a/packages/browser/src/__tests__/site-apps.test.ts
+++ b/packages/browser/src/__tests__/site-apps.test.ts
@@ -230,7 +230,7 @@ describe('SiteApps', () => {
 
         it('loads stops buffering if no site apps', () => {
             posthog.config.opt_in_site_apps = true
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             expect(removeCaptureHook).toHaveBeenCalled()
             expect(siteAppsInstance['_stopBuffering']).toBeUndefined()
@@ -240,11 +240,14 @@ describe('SiteApps', () => {
         it('does not loads site apps if disabled', () => {
             posthog.config.opt_in_site_apps = false
             siteAppsInstance.onRemoteConfig({
-                siteApps: [
-                    { id: '1', url: '/site_app/1' },
-                    { id: '2', url: '/site_app/2' },
-                ],
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    siteApps: [
+                        { id: '1', url: '/site_app/1' },
+                        { id: '2', url: '/site_app/2' },
+                    ],
+                } as RemoteConfig,
+            })
 
             expect(removeCaptureHook).toHaveBeenCalled()
             expect(siteAppsInstance['_stopBuffering']).toBeUndefined()
@@ -268,19 +271,25 @@ describe('SiteApps', () => {
                 },
             } as any
             siteAppsInstance.onRemoteConfig({
-                siteApps: [{ id: '1', url: '/site_app/1' }],
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    siteApps: [{ id: '1', url: '/site_app/1' }],
+                } as RemoteConfig,
+            })
 
             expect(assignableWindow.__PosthogExtensions__?.loadSiteApp).not.toHaveBeenCalled()
         })
 
         it('loads site apps if new global loader is not available', () => {
             siteAppsInstance.onRemoteConfig({
-                siteApps: [
-                    { id: '1', url: '/site_app/1' },
-                    { id: '2', url: '/site_app/2' },
-                ],
-            } as RemoteConfig)
+                ok: true,
+                config: {
+                    siteApps: [
+                        { id: '1', url: '/site_app/1' },
+                        { id: '2', url: '/site_app/2' },
+                    ],
+                } as RemoteConfig,
+            })
 
             expect(removeCaptureHook).toHaveBeenCalled()
             expect(siteAppsInstance['_stopBuffering']).toBeUndefined()
@@ -344,7 +353,7 @@ describe('SiteApps', () => {
 
         it('sets up the eventCaptured listener if site apps', () => {
             init()
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             expect(posthog.on).toHaveBeenCalledWith('eventCaptured', expect.any(Function))
         })
 
@@ -356,13 +365,13 @@ describe('SiteApps', () => {
                     siteApps: [],
                 },
             } as any
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             expect(posthog.on).not.toHaveBeenCalled()
         })
 
         it('loads site apps via the window object if defined', () => {
             init()
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             expect(appConfigs[0]).toBeDefined()
             expect(siteAppsInstance.apps['1']).toEqual({
                 errored: false,
@@ -399,7 +408,7 @@ describe('SiteApps', () => {
                 callback(true)
             })
 
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             const styleElement = document.body.querySelector('div')?.shadowRoot?.querySelector('style')
             expect(posthog.config.prepare_external_dependency_stylesheet).toHaveBeenCalledWith(styleElement)
@@ -443,7 +452,7 @@ describe('SiteApps', () => {
                 callback(true)
             })
 
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             const expectedStyleCount = stylesInsertedPerAppInit * appConfigs.length
             const expectedAttachedStyleCount = 4 * appConfigs.length
@@ -469,7 +478,7 @@ describe('SiteApps', () => {
                 })
             })
 
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             const secondAppStyle = finishInit[1]()
             const stillPendingStyle = document.createElement('style')
@@ -520,7 +529,7 @@ describe('SiteApps', () => {
                 callback(true)
             })
 
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             expectMethodsUnchanged()
         })
 
@@ -530,7 +539,7 @@ describe('SiteApps', () => {
                 return script
             })
             init()
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             appConfigs[0].processEvent.mockImplementation(() => {
                 const script = document.createElement('script')
                 document.head.append(script)
@@ -546,7 +555,7 @@ describe('SiteApps', () => {
 
         it('marks site app as errored if callback fails', () => {
             init()
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             expect(appConfigs[0]).toBeDefined()
             expect(siteAppsInstance.apps['1']).toMatchObject({
                 errored: false,
@@ -566,7 +575,7 @@ describe('SiteApps', () => {
         it('calls the processEvent method if it exists and events are buffered', () => {
             init()
             emitCaptureEvent?.('test_event1', { event: 'test_event1' } as any)
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             emitCaptureEvent?.('test_event2', { event: 'test_event2' } as any)
             expect(siteAppsInstance['_bufferedInvocations'].length).toBe(2)
             appConfigs[0].callback(true)
@@ -586,7 +595,7 @@ describe('SiteApps', () => {
             emitCaptureEvent?.('test_event2', { event: 'test_event2' } as any)
             expect(siteAppsInstance['_bufferedInvocations'].length).toBe(2)
 
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             appConfigs[0].callback(true)
             expect(siteAppsInstance['_bufferedInvocations'].length).toBe(2)
             appConfigs[1].callback(true)
@@ -604,7 +613,7 @@ describe('SiteApps', () => {
             emitCaptureEvent?.('test_event2', { event: 'test_event2' } as any)
             expect(siteAppsInstance['_bufferedInvocations'].length).toBe(2)
 
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
             expect(siteAppsInstance['_bufferedInvocations'].length).toBe(0)
 
             expect(siteAppsInstance.apps['1'].processEvent).toHaveBeenCalledTimes(2)
@@ -616,7 +625,7 @@ describe('SiteApps', () => {
             posthog.config.opt_in_site_apps = false
             assignableWindow.POSTHOG_DEBUG = true
 
-            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            siteAppsInstance.onRemoteConfig({ ok: true, config: {} as RemoteConfig })
 
             expect(mockLogger.error).toHaveBeenCalledWith(
                 'PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.'

--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -1539,24 +1539,33 @@ describe('surveys', () => {
 
         it('is disabled by having no results in onRemoteConfig', () => {
             surveys.onRemoteConfig({
-                surveys: [],
-            } as Partial<RemoteConfig> as RemoteConfig)
+                ok: true,
+                config: {
+                    surveys: [],
+                } as Partial<RemoteConfig> as RemoteConfig,
+            })
             expect(surveys['_isSurveysEnabled']).toBe(false)
         })
 
         it('is enabled by having results in onRemoteConfig', () => {
             expect(surveys['_isSurveysEnabled']).toBe(undefined)
             surveys.onRemoteConfig({
-                surveys: ['example' as unknown as Survey],
-            } as Partial<RemoteConfig> as RemoteConfig)
+                ok: true,
+                config: {
+                    surveys: ['example' as unknown as Survey],
+                } as Partial<RemoteConfig> as RemoteConfig,
+            })
             expect(surveys['_isSurveysEnabled']).toBe(true)
         })
 
         it('can be disabled by config despite results of onRemoteConfig', () => {
             surveys['_instance'].config.disable_surveys = true
             surveys.onRemoteConfig({
-                surveys: ['example' as unknown as Survey],
-            } as Partial<RemoteConfig> as RemoteConfig)
+                ok: true,
+                config: {
+                    surveys: ['example' as unknown as Survey],
+                } as Partial<RemoteConfig> as RemoteConfig,
+            })
             expect(surveys['_isSurveysEnabled']).toBe(undefined)
         })
     })

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -18,7 +18,7 @@ import {
 } from './autocapture-utils'
 
 import RageClick from './extensions/rageclick'
-import { AutocaptureConfig, EventName, Properties, RemoteConfig } from './types'
+import { AutocaptureConfig, EventName, Properties, RemoteConfigResult } from './types'
 import { PostHog } from './posthog-core'
 import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from './constants'
 
@@ -342,14 +342,16 @@ export class Autocapture implements Extension {
         }
     }
 
-    // Failed fetch = opt-out unknown: keep the last known server value instead
-    // of defaulting to enabled, so a network error cannot turn autocapture on
-    // for an opted-out project.
-    public onRemoteConfigFailed(): void {
-        this.startIfEnabled()
-    }
+    public onRemoteConfig(result: RemoteConfigResult) {
+        if (!result.ok) {
+            // Failed fetch = opt-out unknown: keep the last known persisted server
+            // value instead of defaulting to enabled, so a network error cannot turn
+            // autocapture on for an opted-out project. No persistence write.
+            this.startIfEnabled()
+            return
+        }
 
-    public onRemoteConfig(response: RemoteConfig) {
+        const response = result.config
         if (response.elementsChainAsString) {
             this._elementsChainAsString = response.elementsChainAsString
         }

--- a/packages/browser/src/extensions/conversations/posthog-conversations.ts
+++ b/packages/browser/src/extensions/conversations/posthog-conversations.ts
@@ -11,7 +11,7 @@ import {
     SendMessageResponse,
     UserProvidedTraits,
 } from '../../posthog-conversations-types'
-import { RemoteConfig } from '../../types'
+import { RemoteConfigResult } from '../../types'
 import { assignableWindow, LazyLoadedConversationsInterface } from '../../utils/globals'
 import { createLogger } from '../../utils/logger'
 import { isNullish, isUndefined, isBoolean, isNull } from '@posthog/core'
@@ -38,13 +38,19 @@ export class PostHogConversations implements Extension {
         this.loadIfEnabled()
     }
 
-    onRemoteConfig(response: RemoteConfig) {
+    onRemoteConfig(result: RemoteConfigResult) {
         // Don't load conversations if disabled via config
         if (this._instance.config.disable_conversations) {
             return
         }
 
-        const conversations = response['conversations']
+        if (!result.ok) {
+            // Conversations are opt-in: a failed fetch, like a response without a
+            // conversations key, leaves them unloaded.
+            return
+        }
+
+        const conversations = result.config['conversations']
         if (isNullish(conversations)) {
             return
         }

--- a/packages/browser/src/extensions/conversations/posthog-conversations.ts
+++ b/packages/browser/src/extensions/conversations/posthog-conversations.ts
@@ -45,8 +45,7 @@ export class PostHogConversations implements Extension {
         }
 
         if (!result.ok) {
-            // Conversations are opt-in: a failed fetch, like a response without a
-            // conversations key, leaves them unloaded.
+            // Failure behaves like a response without a conversations key.
             return
         }
 

--- a/packages/browser/src/extensions/dead-clicks-autocapture.ts
+++ b/packages/browser/src/extensions/dead-clicks-autocapture.ts
@@ -3,7 +3,7 @@ import { DEAD_CLICKS_ENABLED_SERVER_SIDE } from '../constants'
 import { isBoolean, isObject } from '@posthog/core'
 import { assignableWindow, document, LazyLoadedDeadClicksAutocaptureInterface } from '../utils/globals'
 import { createLogger } from '../utils/logger'
-import { DeadClicksAutoCaptureConfig, RemoteConfig } from '../types'
+import { DeadClicksAutoCaptureConfig, RemoteConfigResult } from '../types'
 import type { Extension } from './types'
 
 const logger = createLogger('[Dead Clicks]')
@@ -38,7 +38,14 @@ export class DeadClicksAutocapture implements Extension {
         this.startIfEnabledOrStop()
     }
 
-    public onRemoteConfig(response: RemoteConfig) {
+    public onRemoteConfig(result: RemoteConfigResult) {
+        if (!result.ok) {
+            // Dead clicks capture is opt-in: a failed fetch, like a response without a
+            // captureDeadClicks key, leaves the last known server-side setting untouched.
+            return
+        }
+
+        const response = result.config
         if (!('captureDeadClicks' in response)) {
             return
         }

--- a/packages/browser/src/extensions/dead-clicks-autocapture.ts
+++ b/packages/browser/src/extensions/dead-clicks-autocapture.ts
@@ -40,8 +40,7 @@ export class DeadClicksAutocapture implements Extension {
 
     public onRemoteConfig(result: RemoteConfigResult) {
         if (!result.ok) {
-            // Dead clicks capture is opt-in: a failed fetch, like a response without a
-            // captureDeadClicks key, leaves the last known server-side setting untouched.
+            // Failure behaves like a response without a captureDeadClicks key.
             return
         }
 

--- a/packages/browser/src/extensions/exception-autocapture/index.ts
+++ b/packages/browser/src/extensions/exception-autocapture/index.ts
@@ -131,8 +131,7 @@ export class ExceptionObserver {
 
     onRemoteConfig(result: RemoteConfigResult) {
         if (!result.ok) {
-            // Exception autocapture is opt-in: a failed fetch, like a response without
-            // an autocaptureExceptions key, leaves the last known setting untouched.
+            // Failure behaves like a response without an autocaptureExceptions key.
             return
         }
 

--- a/packages/browser/src/extensions/exception-autocapture/index.ts
+++ b/packages/browser/src/extensions/exception-autocapture/index.ts
@@ -1,6 +1,6 @@
 import { assignableWindow, window } from '../../utils/globals'
 import { PostHog } from '../../posthog-core'
-import { RemoteConfig } from '../../types'
+import { RemoteConfigResult } from '../../types'
 
 import { createLogger } from '../../utils/logger'
 import { EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE } from '../../constants'
@@ -129,7 +129,14 @@ export class ExceptionObserver {
         this._unwrapConsoleError = undefined
     }
 
-    onRemoteConfig(response: RemoteConfig) {
+    onRemoteConfig(result: RemoteConfigResult) {
+        if (!result.ok) {
+            // Exception autocapture is opt-in: a failed fetch, like a response without
+            // an autocaptureExceptions key, leaves the last known setting untouched.
+            return
+        }
+
+        const response = result.config
         if (!('autocaptureExceptions' in response)) {
             return
         }

--- a/packages/browser/src/extensions/replay/session-recording.ts
+++ b/packages/browser/src/extensions/replay/session-recording.ts
@@ -11,7 +11,13 @@ import {
 } from '../../constants'
 import { PostHog } from '../../posthog-core'
 import { RemoteConfigLoader } from '../../remote-config'
-import { Properties, RemoteConfig, SessionRecordingPersistedConfig, SessionStartReason } from '../../types'
+import {
+    Properties,
+    RemoteConfig,
+    RemoteConfigResult,
+    SessionRecordingPersistedConfig,
+    SessionStartReason,
+} from '../../types'
 import { type eventWithTime } from './types/rrweb-types'
 
 import { isNullish, isNumber, isUndefined, isValidSampleRate } from '@posthog/core'
@@ -236,8 +242,11 @@ export class SessionRecording implements Extension {
         }
     }
 
-    onRemoteConfig(response: RemoteConfig) {
-        if (!('sessionRecording' in response)) {
+    onRemoteConfig(result: RemoteConfigResult) {
+        // A failed fetch and a response without a sessionRecording key behave the same:
+        // no fresh server config arrived, so fall back to whatever is already persisted.
+        const response = result.ok ? result.config : undefined
+        if (!response || !('sessionRecording' in response)) {
             if (this._recordingStatus === AWAITING_CONFIG) {
                 this._recordingStatus = MISSING_CONFIG
                 logger.warn('config refresh failed, recording will not start until page reload')

--- a/packages/browser/src/extensions/types.ts
+++ b/packages/browser/src/extensions/types.ts
@@ -1,15 +1,14 @@
 import type { PostHog } from '../posthog-core'
-import type { RemoteConfig } from '../types'
+import type { RemoteConfigResult } from '../types'
 
 export type ExtensionConstructor<T extends Extension> = new (instance: PostHog, ...args: any[]) => T
 
 export interface Extension {
     initialize?(): boolean | void
-    onRemoteConfig?(config: RemoteConfig): void
     /**
-     * Called instead of onRemoteConfig when the remote config could not be fetched.
-     * Implement when a server-controlled setting must not fall back to its default
-     * on failure; extensions without it receive onRemoteConfig with an empty config.
+     * Receives the full remote config fetch result. Handlers must narrow on
+     * `result.ok` before reading config fields, and encode their failure
+     * behavior explicitly in the `!result.ok` branch.
      */
-    onRemoteConfigFailed?(): void
+    onRemoteConfig?(result: RemoteConfigResult): void
 }

--- a/packages/browser/src/extensions/web-vitals/index.ts
+++ b/packages/browser/src/extensions/web-vitals/index.ts
@@ -93,8 +93,7 @@ export class WebVitalsAutocapture {
 
     public onRemoteConfig(result: RemoteConfigResult) {
         if (!result.ok) {
-            // Web vitals capture is opt-in: a failed fetch, like a response without a
-            // capturePerformance key, leaves the last known server-side setting untouched.
+            // Failure behaves like a response without a capturePerformance key.
             return
         }
 

--- a/packages/browser/src/extensions/web-vitals/index.ts
+++ b/packages/browser/src/extensions/web-vitals/index.ts
@@ -1,5 +1,5 @@
 import { PostHog } from '../../posthog-core'
-import { PostHogConfig, RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
+import { PostHogConfig, RemoteConfigResult, SupportedWebVitalsMetrics } from '../../types'
 import { createLogger } from '../../utils/logger'
 import { isBoolean, isNullish, isNumber, isUndefined, isObject, stripUrlHash } from '@posthog/core'
 import { WEB_VITALS_ALLOWED_METRICS, WEB_VITALS_ENABLED_SERVER_SIDE } from '../../constants'
@@ -91,7 +91,14 @@ export class WebVitalsAutocapture {
         }
     }
 
-    public onRemoteConfig(response: RemoteConfig) {
+    public onRemoteConfig(result: RemoteConfigResult) {
+        if (!result.ok) {
+            // Web vitals capture is opt-in: a failed fetch, like a response without a
+            // capturePerformance key, leaves the last known server-side setting untouched.
+            return
+        }
+
+        const response = result.config
         if (!('capturePerformance' in response)) {
             return
         }

--- a/packages/browser/src/heatmaps.ts
+++ b/packages/browser/src/heatmaps.ts
@@ -126,8 +126,7 @@ export class Heatmaps implements Extension {
 
     public onRemoteConfig(result: RemoteConfigResult) {
         if (!result.ok) {
-            // Heatmaps is opt-in: a failed fetch, like a response without a heatmaps
-            // key, leaves the last known server-side setting untouched.
+            // Failure behaves like a response without a heatmaps key.
             return
         }
 

--- a/packages/browser/src/heatmaps.ts
+++ b/packages/browser/src/heatmaps.ts
@@ -1,5 +1,5 @@
 import RageClick from './extensions/rageclick'
-import { DeadClickCandidate, Properties, RemoteConfig } from './types'
+import { DeadClickCandidate, Properties, RemoteConfigResult } from './types'
 import { PostHog } from './posthog-core'
 
 import { document, window } from './utils/globals'
@@ -124,7 +124,14 @@ export class Heatmaps implements Extension {
         }
     }
 
-    public onRemoteConfig(response: RemoteConfig) {
+    public onRemoteConfig(result: RemoteConfigResult) {
+        if (!result.ok) {
+            // Heatmaps is opt-in: a failed fetch, like a response without a heatmaps
+            // key, leaves the last known server-side setting untouched.
+            return
+        }
+
+        const response = result.config
         if (!('heatmaps' in response)) {
             return
         }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1012,8 +1012,8 @@ export class PostHog implements PostHogInterface {
         // Cache the latest remote config result so extensions that are created later
         // (e.g. sessionRecording after opt_in_capturing from cookieless mode) can
         // replay it and pick up server-side settings like recording enable flags.
-        // Storing the result (not just a config) keeps a later failed refresh from
-        // overwriting a previously cached successful config with an empty one.
+        // Storing the result (not just a config) means a replayed failure is
+        // distinguishable from a successful empty config.
         this._lastRemoteConfig = result
 
         this.compression = undefined

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -67,7 +67,6 @@ import {
     Properties,
     Property,
     QueuedRequestWithOptions,
-    RemoteConfig,
     RemoteConfigResult,
     RequestCallback,
     SessionIdChangedCallback,
@@ -437,7 +436,7 @@ export class PostHog implements PostHogInterface {
     compression?: Compression
     __request_queue: QueuedRequestWithOptions[]
     _pendingRemoteConfig?: RemoteConfigResult
-    _lastRemoteConfig?: RemoteConfig
+    _lastRemoteConfig?: RemoteConfigResult
     _remoteConfigLoader?: RemoteConfigLoader
     analyticsDefaultEndpoint: string
     version: string = Config.LIB_VERSION
@@ -1010,49 +1009,39 @@ export class PostHog implements PostHogInterface {
             this._pendingRemoteConfig = result
         }
 
-        // On failure, extensions without onRemoteConfigFailed still initialize with
-        // their defaults from an empty config, as they would for absent keys.
-        const config: RemoteConfig = result.ok
-            ? result.config
-            : {
-                  supportedCompression: [],
-                  toolbarParams: {},
-                  toolbarVersion: 'toolbar',
-                  isAuthenticated: false,
-                  siteApps: [],
-              }
-
-        // Cache the latest remote config so extensions that are created later
+        // Cache the latest remote config result so extensions that are created later
         // (e.g. sessionRecording after opt_in_capturing from cookieless mode) can
         // replay it and pick up server-side settings like recording enable flags.
-        this._lastRemoteConfig = config
+        // Storing the result (not just a config) keeps a later failed refresh from
+        // overwriting a previously cached successful config with an empty one.
+        this._lastRemoteConfig = result
 
         this.compression = undefined
-        if (config.supportedCompression && !this.config.disable_compression) {
-            this.compression = includes(config['supportedCompression'], Compression.GZipJS)
-                ? Compression.GZipJS
-                : includes(config['supportedCompression'], Compression.Base64)
-                  ? Compression.Base64
-                  : undefined
+        if (result.ok) {
+            const config = result.config
+            if (config.supportedCompression && !this.config.disable_compression) {
+                this.compression = includes(config['supportedCompression'], Compression.GZipJS)
+                    ? Compression.GZipJS
+                    : includes(config['supportedCompression'], Compression.Base64)
+                      ? Compression.Base64
+                      : undefined
+            }
+
+            if (config.analytics?.endpoint) {
+                this.analyticsDefaultEndpoint = config.analytics.endpoint
+            }
         }
 
-        if (config.analytics?.endpoint) {
-            this.analyticsDefaultEndpoint = config.analytics.endpoint
-        }
-
+        // Runs on failure too: the person_profiles default must be applied even when
+        // the remote config could not be fetched.
         this.set_config({
             person_profiles: this._initialPersonProfilesConfig
                 ? this._initialPersonProfilesConfig
                 : PERSON_PROFILES_IDENTIFIED_ONLY,
         })
 
-        this._extensions.forEach((ext) => {
-            if (!result.ok && ext.onRemoteConfigFailed) {
-                ext.onRemoteConfigFailed()
-            } else {
-                ext.onRemoteConfig?.(config)
-            }
-        })
+        // Every extension receives the full result and handles the failure case itself.
+        this._extensions.forEach((ext) => ext.onRemoteConfig?.(result))
     }
 
     _loaded(): void {
@@ -3893,9 +3882,9 @@ export class PostHog implements PostHogInterface {
                     this.sessionRecording,
                     new SessionRecordingClass(this) as SessionRecording
                 )
-                // Replay the cached remote config so the new recorder picks up server-side
-                // settings (enable flag, endpoint, sampling) that arrived while we were
-                // still in cookieless mode and sessionRecording didn't yet exist.
+                // Replay the cached remote config result so the new recorder picks up
+                // server-side settings (enable flag, endpoint, sampling) that arrived while
+                // we were still in cookieless mode and sessionRecording didn't yet exist.
                 if (this._lastRemoteConfig) {
                     this.sessionRecording?.onRemoteConfig?.(this._lastRemoteConfig)
                 }

--- a/packages/browser/src/posthog-exceptions.ts
+++ b/packages/browser/src/posthog-exceptions.ts
@@ -44,8 +44,7 @@ export class PostHogExceptions implements Extension {
 
     onRemoteConfig(result: RemoteConfigResult) {
         if (!result.ok) {
-            // A failed fetch, like a response without an errorTracking key, keeps the
-            // last known suppression rules (in-memory and persisted) untouched.
+            // Failure behaves like a response without an errorTracking key.
             return
         }
 

--- a/packages/browser/src/posthog-exceptions.ts
+++ b/packages/browser/src/posthog-exceptions.ts
@@ -1,7 +1,7 @@
 import { ERROR_TRACKING_CAPTURE_EXTENSION_EXCEPTIONS, ERROR_TRACKING_SUPPRESSION_RULES } from './constants'
 import { Extension } from './extensions/types'
 import { PostHog } from './posthog-core'
-import { CaptureResult, ErrorTrackingSuppressionRule, Properties, RemoteConfig } from './types'
+import { CaptureResult, ErrorTrackingSuppressionRule, Properties, RemoteConfigResult } from './types'
 import { createLogger } from './utils/logger'
 import { propertyComparisons } from './utils/property-utils'
 import { isString, isArray, isObject, ErrorTracking, isNullish } from '@posthog/core'
@@ -42,7 +42,14 @@ export class PostHogExceptions implements Extension {
         this._exceptionStepsBuffer.setConfig(this._exceptionStepsConfig)
     }
 
-    onRemoteConfig(response: RemoteConfig) {
+    onRemoteConfig(result: RemoteConfigResult) {
+        if (!result.ok) {
+            // A failed fetch, like a response without an errorTracking key, keeps the
+            // last known suppression rules (in-memory and persisted) untouched.
+            return
+        }
+
+        const response = result.config
         if (!('errorTracking' in response)) {
             return
         }

--- a/packages/browser/src/posthog-logs.ts
+++ b/packages/browser/src/posthog-logs.ts
@@ -1,7 +1,7 @@
 import { LOAD_EXT_NOT_FOUND } from './constants'
 import Config from './config'
 import { PostHog } from './posthog-core'
-import type { CaptureLogOptions, RemoteConfig, Logger, LogSdkContext, OtlpLogsPayload } from './types'
+import type { CaptureLogOptions, RemoteConfigResult, Logger, LogSdkContext, OtlpLogsPayload } from './types'
 import {
     PostHogLogs as CorePostHogLogs,
     buildOtlpLogsPayload,
@@ -136,8 +136,14 @@ export class PostHogLogs implements Extension {
         this.loadIfEnabled()
     }
 
-    onRemoteConfig(response: RemoteConfig) {
-        const logCapture = response.logs?.captureConsoleLogs
+    onRemoteConfig(result: RemoteConfigResult) {
+        if (!result.ok) {
+            // Console log capture is opt-in: a failed fetch, like a response without a
+            // logs key, leaves it disabled.
+            return
+        }
+
+        const logCapture = result.config.logs?.captureConsoleLogs
         if (isNullish(logCapture) || !logCapture) {
             return
         }

--- a/packages/browser/src/posthog-logs.ts
+++ b/packages/browser/src/posthog-logs.ts
@@ -138,8 +138,7 @@ export class PostHogLogs implements Extension {
 
     onRemoteConfig(result: RemoteConfigResult) {
         if (!result.ok) {
-            // Console log capture is opt-in: a failed fetch, like a response without a
-            // logs key, leaves it disabled.
+            // Failure behaves like a response without a logs key.
             return
         }
 

--- a/packages/browser/src/posthog-product-tours.ts
+++ b/packages/browser/src/posthog-product-tours.ts
@@ -1,7 +1,7 @@
 import { PostHog } from './posthog-core'
 import { ProductTour, ProductTourCallback } from './posthog-product-tours-types'
 import { PRODUCT_TOURS, PRODUCT_TOURS_ENABLED_SERVER_SIDE } from './constants'
-import { RemoteConfig } from './types'
+import { RemoteConfigResult } from './types'
 import { createLogger } from './utils/logger'
 import { isArray, isNullish } from '@posthog/core'
 import { assignableWindow } from './utils/globals'
@@ -47,7 +47,14 @@ export class PostHogProductTours implements Extension {
         this.loadIfEnabled()
     }
 
-    onRemoteConfig(response: RemoteConfig): void {
+    onRemoteConfig(result: RemoteConfigResult): void {
+        if (!result.ok) {
+            // Product tours are opt-in: a failed fetch, like a response without a
+            // productTours key, leaves the last known server-side setting untouched.
+            return
+        }
+
+        const response = result.config
         if (!('productTours' in response)) {
             return
         }

--- a/packages/browser/src/posthog-product-tours.ts
+++ b/packages/browser/src/posthog-product-tours.ts
@@ -49,8 +49,7 @@ export class PostHogProductTours implements Extension {
 
     onRemoteConfig(result: RemoteConfigResult): void {
         if (!result.ok) {
-            // Product tours are opt-in: a failed fetch, like a response without a
-            // productTours key, leaves the last known server-side setting untouched.
+            // Failure behaves like a response without a productTours key.
             return
         }
 

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -18,7 +18,7 @@ import {
     SurveyCallback,
     SurveyRenderReason,
 } from './posthog-surveys-types'
-import { Properties, RemoteConfig } from './types'
+import { Properties, RemoteConfigResult } from './types'
 import { assignableWindow, document } from './utils/globals'
 import { SurveyEventReceiver } from './utils/survey-event-receiver'
 import {
@@ -66,13 +66,19 @@ export class PostHogSurveys implements Extension {
         this.loadIfEnabled()
     }
 
-    onRemoteConfig(response: RemoteConfig) {
+    onRemoteConfig(result: RemoteConfigResult) {
         // only load surveys if they are enabled and there are surveys to load
         if (this._config.disable_surveys) {
             return
         }
 
-        const surveys = response['surveys']
+        if (!result.ok) {
+            // Surveys are opt-in: without a fetched config we don't know whether any
+            // surveys exist, so don't load them.
+            return logger.warn('Remote config unavailable. Not loading surveys.')
+        }
+
+        const surveys = result.config['surveys']
         if (isNullish(surveys)) {
             return logger.warn('Flags not loaded yet. Not loading surveys.')
         }

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -73,8 +73,7 @@ export class PostHogSurveys implements Extension {
         }
 
         if (!result.ok) {
-            // Surveys are opt-in: without a fetched config we don't know whether any
-            // surveys exist, so don't load them.
+            // Failure behaves like a response without a surveys key: not loaded.
             return logger.warn('Remote config unavailable. Not loading surveys.')
         }
 

--- a/packages/browser/src/site-apps.ts
+++ b/packages/browser/src/site-apps.ts
@@ -1,7 +1,7 @@
 import type { Extension } from './extensions/types'
 import { PostHog } from './posthog-core'
 import { isNull } from '@posthog/core'
-import { CaptureResult, Properties, RemoteConfig, SiteApp, SiteAppGlobals, SiteAppLoader } from './types'
+import { CaptureResult, Properties, RemoteConfigResult, SiteApp, SiteAppGlobals, SiteAppLoader } from './types'
 import { assignableWindow, document } from './utils/globals'
 import { createLogger } from './utils/logger'
 
@@ -375,7 +375,7 @@ export class SiteApps implements Extension {
         }
     }
 
-    onRemoteConfig(response: RemoteConfig): void {
+    onRemoteConfig(result: RemoteConfigResult): void {
         if (this.siteAppLoaders?.length) {
             if (!this.isEnabled) {
                 logger.error(`PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.`)
@@ -394,6 +394,13 @@ export class SiteApps implements Extension {
 
         this._stopBuffering?.()
 
+        // On a failed fetch there are no legacy site apps to load; buffering has
+        // already been stopped above, same as for a response without site apps.
+        if (!result.ok) {
+            return
+        }
+
+        const response = result.config
         if (!response['siteApps']?.length) {
             return
         }


### PR DESCRIPTION
## Problem

Follow-up to #4191, promised in [dustinbyrne's review thread](https://github.com/PostHog/posthog-js/pull/4191#discussion_r3605160436): the `onRemoteConfigFailed` hook made failure handling opt-in, so any extension that didn't implement it silently received a synthesized empty config and could not tell "server says nothing is enabled" apart from "we never heard from the server". As Dustin put it, propagating the full result forces handlers to rectify the failure case — the discriminant leaking into extensions is the feature, not the bug.

## Changes

- `Extension.onRemoteConfig?(result: RemoteConfigResult)` now receives the full fetch result (`{ ok: true; config } | { ok: false }`). Every handler must narrow on `result.ok` before touching config fields, and every handler now has an explicit, deliberate failure branch. `onRemoteConfigFailed` is deleted.
- `PostHog._onRemoteConfig` no longer synthesizes an empty `RemoteConfig` on failure. Its own inline uses handle failure explicitly and keep today's behavior: compression stays `undefined`, the analytics endpoint is untouched, and the `person_profiles` `set_config` call still runs on failure.
- `_lastRemoteConfig` now stores the result instead of a config. Note this does **not** change the cache-overwrite behavior: a failed load still replaces the cached value (now with an honest `{ ok: false }` rather than a synthetic empty config, so a replayed failure is distinguishable from a successful empty response). The replay consumer behaves identically in both cases.
- Internal replay plumbing (`triggerMatching`, `recording-strategies`, `lazy-loaded-session-recorder`) still operates on plain `RemoteConfig`/persisted config — unwrapping happens once at the extension boundary in `SessionRecording.onRemoteConfig`.
- No `as RemoteConfig` object-literal casts were added to production src (per the upcoming lint rule in #4192).

### No extension's failure behavior changes

For every extension except autocapture, the failure branch encodes exactly what that handler did when handed the old synthetic empty config (derived by reading each handler's guard against the empty config's keys — they are opt-in features, so absent key = off/keep current state):

| Extension | Explicit behavior on `{ ok: false }` | Same as empty config before? |
| --- | --- | --- |
| autocapture | `startIfEnabled()`; keeps last known persisted server opt-out, **no persistence write** (fail-closed model from #4191) | n/a — was `onRemoteConfigFailed` (identical body) |
| heatmaps | return; last known server-side setting untouched | Yes (`!('heatmaps' in response)` returned) |
| dead-clicks autocapture | return; last known server-side setting untouched | Yes (`captureDeadClicks` key guard) |
| web-vitals | return; last known server-side setting untouched | Yes (`capturePerformance` key guard) |
| exception autocapture | return; last known setting untouched | Yes (`autocaptureExceptions` key guard) |
| exceptions (suppression rules) | return; keeps last known rules | Yes (`errorTracking` key guard) |
| logs | return; console log capture stays off | Yes (`logs?.captureConsoleLogs` nullish guard) |
| product tours | return; last known server-side setting untouched | Yes (`productTours` key guard) |
| surveys | warn + return; surveys not loaded | Yes (nullish `surveys` warned + returned) |
| conversations | return (after `disable_conversations` check); not loaded | Yes (nullish `conversations` guard) |
| site apps | loader path unchanged (doesn't read the response); legacy path stops buffering then returns | Yes (empty `siteApps` array returned after `_stopBuffering`) |
| session recording | same branch as a response without a `sessionRecording` key: `AWAITING_CONFIG → MISSING_CONFIG` warn, then `startIfEnabledOrStop()` (falls back to persisted config) | Yes (missing-key branch) |

The integration test in `posthog-core-also.test.ts` now dispatches `{ ok: false }` and asserts observable state: autocapture stays disabled with nothing persisted, heatmaps persists nothing and stays off. The three #4191 regression tests keep their exact semantics via `onRemoteConfig({ ok: false })`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## Verification

- `npx jest src/__tests__`: 120 suites, 4953 passed / 8 skipped (4961 total), all green
- `npx jest functional_tests`: 7 passed
- `npx tsc --noEmit -p tsconfig.json`: clean; test-tsconfig typecheck error set identical to main (line shifts only)
- `npx eslint src playwright` (as CI's `pnpm lint`): clean, prettier included
- `pnpm build` green; `pnpm write-mangled-property-names` produced no `terser-mangled-names.json` diff (unprefixed member names are not mangled)
- End-to-end against the built `dist/array.js` (Playwright harness stubbing `/array/<token>/config`):

```
D (normal project, fetch fails): autocapture events = 1  persisted=false  -> availability preserved

=== VERDICT ===
A (config fails):        autocapture events = 0  persisted=undefined  -> not reproduced
C (race after A):        autocapture events = 0  persisted=true  -> 0 captured
B (control, opt_out ok): autocapture events = 0  persisted=true  -> setting honoured when fetch succeeds
```

(A = failure with nothing persisted stays off and persists nothing; C = persisted opt-out kept through a failure; B = opt-out honoured on success; D = a previously allowed project keeps autocapture working when a later fetch fails.)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. Migrated the `Extension` interface and all 12 handlers, then mechanically rewrote ~110 direct test invocations to the result shape and replaced `onRemoteConfigFailed()` test calls with `onRemoteConfig({ ok: false })`.
- Per-handler failure semantics were derived from each handler's existing empty-config behavior (key-presence guards) rather than invented, to guarantee behavior parity; the two playwright specs that invoke `posthog.logs.onRemoteConfig` / `posthog.conversations.onRemoteConfig` at runtime were updated to the result shape so they keep exercising the enable path.
- Considered keeping the empty-config synthesis for the core's own compression/endpoint reads; rejected in favor of an explicit `result.ok` branch so no `RemoteConfig` is ever fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

