### PR TITLE
fix(ai): sanitize base64 content in $ai_trace/$ai_span input/output state

### DIFF
--- a/.changeset/gentle-traces-rest.md
+++ b/.changeset/gentle-traces-rest.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Redact base64 content from LangChain trace and span input and output state.

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -409,7 +409,7 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
       $ai_lib: 'posthog-ai',
       $ai_lib_version: version,
       $ai_trace_id: traceId,
-      $ai_input_state: withPrivacyMode(this.client, this.privacyMode, run.input),
+      $ai_input_state: withPrivacyMode(this.client, this.privacyMode, sanitizeLangChain(run.input)),
       $ai_latency: latency,
       $ai_span_name: run.name,
       $ai_span_id: runId,
@@ -427,7 +427,7 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
       eventProperties['$ai_error'] = stringifyError(outputs)
       eventProperties['$ai_is_error'] = true
     } else if (outputs !== undefined) {
-      eventProperties['$ai_output_state'] = withPrivacyMode(this.client, this.privacyMode, outputs)
+      eventProperties['$ai_output_state'] = withPrivacyMode(this.client, this.privacyMode, sanitizeLangChain(outputs))
     }
     this.client.capture({
       distinctId: this.distinctId ? this.distinctId.toString() : runId,

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -686,3 +686,49 @@ describe('LangChainCallbackHandler', () => {
     expect(captureCall[0].properties['$ai_cache_creation_input_tokens']).toBe(800)
   })
 })
+
+describe('LangChainCallbackHandler trace/span state sanitization', () => {
+  it('redacts base64 data URLs from $ai_input_state and $ai_output_state', () => {
+    const handler = new LangChainCallbackHandler({ client: mockPostHogClient })
+    jest.clearAllMocks()
+
+    const dataUrl = 'data:image/jpeg;base64,' + 'A'.repeat(2000)
+    const serialized = {
+      lc: 1,
+      type: 'constructor' as const,
+      id: ['langchain', 'schema', 'runnable', 'RunnableSequence'],
+      kwargs: {},
+    }
+    const runId = 'run_chain_redact'
+
+    handler.handleChainStart(
+      serialized,
+      {
+        messages: [
+          {
+            content: [
+              { type: 'text', text: 'describe this image' },
+              { type: 'image_url', image_url: { url: dataUrl } },
+            ],
+          },
+        ],
+      } as any,
+      runId
+    )
+    handler.handleChainEnd({ echoed: dataUrl, parsed: { title: 'ok' } }, runId)
+
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    expect(captureCall[0].event).toBe('$ai_trace')
+
+    const inputState = JSON.stringify(captureCall[0].properties['$ai_input_state'])
+    expect(inputState).toContain('describe this image')
+    expect(inputState).toContain('[base64 image/jpeg redacted]')
+    expect(inputState).not.toContain('AAAAAAAA')
+
+    const outputState = JSON.stringify(captureCall[0].properties['$ai_output_state'])
+    expect(outputState).toContain('ok')
+    expect(outputState).toContain('[base64 image/jpeg redacted]')
+    expect(outputState).not.toContain('AAAAAAAA')
+  })
+})


### PR DESCRIPTION
## Problem

`_setLLMMetadata` runs generation input through `sanitizeLangChain` (BinaryContentRedactor), but `_popRunAndCaptureTraceOrSpan` captures `run.input` and `outputs` **raw** into `$ai_input_state` / `$ai_output_state`.

Since every `withStructuredOutput().invoke()` (and any chain) emits a `$ai_trace`/`$ai_span`, an image call embeds its full base64 data URLs in the trace event. In production we observed 1–4.5 MB events that ingest rejects with:

```
HTTP 413 — maximum event size exceeded: Event rejected by kafka during send
```

The whole batch POST is dropped after retries — **including unrelated `$exception` events queued alongside**, which silently degrades error tracking. In short-lived runtimes (Supabase edge functions) the timer-driven flush rejection also surfaced as an uncaught `event loop error`, terminating the worker.

Observed on `@posthog/ai` 8.2.1; the gap is still present on `main`.

## Fix

Apply `sanitizeLangChain` to `$ai_input_state` and `$ai_output_state` at capture time in `_popRunAndCaptureTraceOrSpan`, mirroring the generation path. Sanitizing at the capture site covers all sources that feed `_setTraceOrSpanMetadata` (chains, tools, retrievers, agent actions).

## Testing

- New regression test: a chain start/end carrying a base64 image data URL asserts both state properties contain `[base64 image/jpeg redacted]` (and not the payload) while normal text survives.
- `tests/callbacks.test.ts` (14 passed), `tests/sanitization.test.ts` + `tests/binary_content_redactor.test.ts` (90 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)