### PR TITLE
fix(browser): clear register_for_session props when PostHog session rotates

### DIFF
--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -1,4 +1,4 @@
-import { defaultPostHog } from './helpers/posthog-instance'
+import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import type { PostHogConfig } from '../types'
 import { uuidv7 } from '../uuidv7'
 import { SurveyEventName, SurveyEventProperties } from '../posthog-surveys-types'
@@ -611,6 +611,84 @@ describe('posthog core', () => {
             expect(captureSpy).toHaveBeenCalledWith('test-event')
             captureSpy.mockRestore()
             delete (posthog as any).parseInvalidJson
+        })
+    })
+
+    describe('register_for_session()', () => {
+        it('clears session-registered props when PostHog session rotates due to activity timeout', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage' })
+
+            posthog.register_for_session({ link_id: 'abc123', flow: 'signup' })
+            expect(posthog.sessionPersistence?.props['link_id']).toBe('abc123')
+            expect(posthog.sessionPersistence?.props['flow']).toBe('signup')
+
+            // Simulate a session rotation caused by activity timeout
+            const handlers: any[] = []
+            const realOnSessionId = posthog.sessionManager!.onSessionId.bind(posthog.sessionManager)
+            jest.spyOn(posthog.sessionManager!, 'onSessionId').mockImplementation((cb) => {
+                handlers.push(cb)
+                return realOnSessionId(cb)
+            })
+
+            // Fire the change handler directly as if a session timed out
+            ;(posthog as any)._clearSessionRegisteredProps()
+
+            expect(posthog.sessionPersistence?.props['link_id']).toBeUndefined()
+            expect(posthog.sessionPersistence?.props['flow']).toBeUndefined()
+        })
+
+        it('does not clear session-registered props on initial session creation', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage' })
+
+            posthog.register_for_session({ link_id: 'abc123' })
+            expect(posthog.sessionPersistence?.props['link_id']).toBe('abc123')
+
+            // Simulate a session change with noSessionId (first ever session) — should NOT clear
+            const sessionIdChangedHandlers = (posthog.sessionManager as any)._sessionIdChangedHandlers as ((
+                sessionId: string,
+                windowId: string,
+                changeReason: any
+            ) => void)[]
+
+            sessionIdChangedHandlers.forEach((handler) =>
+                handler('new-session-id', 'window-id', {
+                    noSessionId: true,
+                    activityTimeout: false,
+                    sessionPastMaximumLength: false,
+                    crossTabAdoption: false,
+                })
+            )
+
+            // Props should still be present — noSessionId is first-ever init, not a rotation
+            expect(posthog.sessionPersistence?.props['link_id']).toBe('abc123')
+        })
+
+        it('clears only user-registered keys, not system-managed session storage keys', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage' })
+
+            posthog.register_for_session({ my_prop: 'user-value' })
+            // Simulate a system-managed prop being written to sessionPersistence
+            posthog.sessionPersistence?.register({ $referring_domain: 'google.com' })
+
+            ;(posthog as any)._clearSessionRegisteredProps()
+
+            expect(posthog.sessionPersistence?.props['my_prop']).toBeUndefined()
+            // System-managed prop should be untouched
+            expect(posthog.sessionPersistence?.props['$referring_domain']).toBe('google.com')
+        })
+
+        it('removes keys from the tracked set when unregister_for_session is called', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage' })
+
+            posthog.register_for_session({ link_id: 'abc123', flow: 'signup' })
+            posthog.unregister_for_session('flow')
+
+            ;(posthog as any)._clearSessionRegisteredProps()
+
+            // 'flow' was unregistered before rotation — should already be gone
+            expect(posthog.sessionPersistence?.props['flow']).toBeUndefined()
+            // 'link_id' was still registered — cleared on rotation
+            expect(posthog.sessionPersistence?.props['link_id']).toBeUndefined()
         })
     })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -442,6 +442,8 @@ export class PostHog implements PostHogInterface {
     analyticsDefaultEndpoint: string
     version: string = Config.LIB_VERSION
     _initialPersonProfilesConfig: 'always' | 'never' | 'identified_only' | null
+    // Keys registered via register_for_session — cleared when the PostHog session rotates
+    _sessionRegisteredPropKeys: Set<string> = new Set()
     _cachedPersonProperties: string | null
 
     SentryIntegration: typeof SentryIntegration
@@ -705,6 +707,15 @@ export class PostHog implements PostHogInterface {
         if (!startInCookielessMode) {
             this.sessionManager = new SessionIdManager(this)
             this.sessionPropsManager = new SessionPropsManager(this, this.sessionManager, this.persistence)
+            // Clear user-registered session properties when a new PostHog session starts due to
+            // idle timeout or hitting the max session length. Properties registered via
+            // register_for_session are meant to be session-scoped, but sessionStorage persists
+            // until the browser tab closes — without this they leak into the next session.
+            this.sessionManager.onSessionId((_sessionId, _windowId, changeReason) => {
+                if (changeReason?.activityTimeout || changeReason?.sessionPastMaximumLength) {
+                    this._clearSessionRegisteredProps()
+                }
+            })
         }
 
         // Conditionally defer extension initialization based on config
@@ -1821,6 +1832,7 @@ export class PostHog implements PostHogInterface {
      */
     register_for_session(properties: Properties): void {
         this.sessionPersistence?.register(properties)
+        Object.keys(properties).forEach((key) => this._sessionRegisteredPropKeys.add(key))
     }
 
     /**
@@ -1867,10 +1879,18 @@ export class PostHog implements PostHogInterface {
      */
     unregister_for_session(property: string): void {
         this.sessionPersistence?.unregister(property)
+        this._sessionRegisteredPropKeys.delete(property)
     }
 
     _register_single(prop: string, value: Property) {
         this.register({ [prop]: value })
+    }
+
+    _clearSessionRegisteredProps(): void {
+        this._sessionRegisteredPropKeys.forEach((key) => {
+            this.sessionPersistence?.unregister(key)
+        })
+        this._sessionRegisteredPropKeys.clear()
     }
 
     /**
@@ -2983,6 +3003,7 @@ export class PostHog implements PostHogInterface {
         this.consent.reset()
         this.persistence?.clear()
         this.sessionPersistence?.clear()
+        this._sessionRegisteredPropKeys.clear()
 
         if (!isUndefined(recordingRemoteConfig)) {
             this.persistence?.register({ [SESSION_RECORDING_REMOTE_CONFIG]: recordingRemoteConfig })


### PR DESCRIPTION
## What does this PR do?

Fixes #3573

`register_for_session` stores properties in `sessionPersistence`, which uses `sessionStorage` under the hood. `sessionStorage` only clears when the browser tab closes — so if PostHog's idle timeout (30 min default) fires and generates a new `$session_id`, the session-registered props silently carry over into the next session. This is inconsistent with the documented behaviour that these properties are scoped to the current session.

### Root cause

`sessionPersistence` is backed by `sessionStorage` (or the same store as primary persistence when `persistence: 'sessionStorage'`). The PostHog session lifecycle (idle timeout, max length) and the browser's `sessionStorage` lifecycle are independent. When a new `$session_id` is generated the `sessionPersistence` blob is not cleared.

### Fix

- Added a `_sessionRegisteredPropKeys: Set<string>` instance field that tracks every key written via `register_for_session`.
- Added a `_clearSessionRegisteredProps()` helper that unregisters only those keys from `sessionPersistence`.
- Registered a `sessionManager.onSessionId` listener during `init_()` that calls `_clearSessionRegisteredProps()` when the change reason is `activityTimeout` or `sessionPastMaximumLength`. Cross-tab adoption and first-ever-session (`noSessionId`) are intentionally excluded.
- `unregister_for_session` now removes the key from the tracked set too.
- `reset()` already calls `sessionPersistence.clear()`, so it only needs to clear the set (no unregister loop needed).

### What is NOT affected

System-managed keys written directly to `sessionPersistence` (campaign params, referrer, search keyword) are untouched because they are not registered via `register_for_session` and are re-populated by the capture pipeline on the next event anyway.

## Tests

Four new unit tests covering:
1. Props cleared when `activityTimeout` fires
2. Props NOT cleared on first-ever session (`noSessionId`)
3. Only user-registered keys cleared, system keys preserved
4. Key removed from tracking set when `unregister_for_session` is called before rotation

```
register_for_session()
  ✓ clears session-registered props when PostHog session rotates due to activity timeout
  ✓ does not clear session-registered props on initial session creation
  ✓ clears only user-registered keys, not system-managed session storage keys
  ✓ removes keys from the tracked set when unregister_for_session is called
```