### PR TITLE
docs(browser): use public customizations entrypoint in playgrounds

### DIFF
--- a/packages/browser/playground/redux-todo-list/src/kea-store.ts
+++ b/packages/browser/playground/redux-todo-list/src/kea-store.ts
@@ -1,5 +1,5 @@
 import { resetContext, getContext } from 'kea'
-import { posthogKeaLogger } from 'posthog-js/lib/src/customizations'
+import { posthogKeaLogger } from 'posthog-js/customizations'
 
 // Initialize Kea with PostHog logging plugin
 resetContext({

--- a/packages/browser/playground/redux-todo-list/src/store.ts
+++ b/packages/browser/playground/redux-todo-list/src/store.ts
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { posthogReduxLogger } from 'posthog-js/lib/src/customizations'
+import { posthogReduxLogger } from 'posthog-js/customizations'
 
 // Types
 export interface Todo {

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -1,7 +1,7 @@
 import { PostHogFeature, useActiveFeatureFlags, usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { cookieConsentGiven, PERSON_PROCESSING_MODE } from '@/src/posthog'
-import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/lib/src/customizations'
+import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/customizations'
 import { STORED_PERSON_PROPERTIES_KEY } from 'posthog-js/lib/src/constants'
 import { DisplaySurveyType, Survey } from 'posthog-js'
 import { SessionInteractions } from '@/src/SessionInteractions'


### PR DESCRIPTION
## Problem

Playground examples still import optional browser SDK helpers through the internal `posthog-js/lib/src/customizations` build path. That path is CJS-only and is not intended as a public package API.

## Changes

- Update the Next.js playground to import the feature flag property helper from `posthog-js/customizations`.
- Update the Redux and Kea playgrounds to import their loggers from `posthog-js/customizations`.
- Leave historical changelog text and internal implementation comments unchanged.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prepared with Pi in a dedicated worktree. The migration is limited to user-facing playground imports; the public subpath and all imported symbols were verified with an esbuild consumer smoke test, and the changed TypeScript files pass Prettier checks. No package code or release metadata changed.
