### PR TITLE
fix(browser): respect event/action trigger in survey eligibility

### DIFF
--- a/.changeset/fix-survey-event-trigger-eligibility.md
+++ b/.changeset/fix-survey-event-trigger-eligibility.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix `canRenderSurvey` / `canRenderSurveyAsync` reporting a survey as renderable before its event/action activation trigger has fired. Surveys gated on a "User sends events" filter are now only eligible once the trigger event is received.

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -502,6 +502,38 @@ describe('SurveyManager', () => {
         })
     })
 
+    describe('respects the event trigger condition (issue #2501)', () => {
+        const EVENT_GATED_SURVEY_ID = 'event-gated-survey'
+
+        const makeEventGatedSurvey = (): Survey => ({
+            ...mockSurveys[0],
+            id: EVENT_GATED_SURVEY_ID,
+            conditions: { events: { values: [{ name: 'survey_trigger_event' }] } },
+        })
+
+        const setActivatedSurveys = (surveyIds: string[]): void => {
+            ;(mockPostHog.surveys as any)._surveyEventReceiver = { getSurveys: () => surveyIds }
+        }
+
+        it('is not eligible until the trigger event has fired', () => {
+            setActivatedSurveys([])
+            const result = surveyManager.checkSurveyEligibility(makeEventGatedSurvey())
+            expect(result.eligible).toBe(false)
+        })
+
+        it('becomes eligible once the trigger event has fired', () => {
+            setActivatedSurveys([EVENT_GATED_SURVEY_ID])
+            const result = surveyManager.checkSurveyEligibility(makeEventGatedSurvey())
+            expect(result.eligible).toBe(true)
+        })
+
+        it('is unaffected for surveys without an event/action trigger', () => {
+            setActivatedSurveys([])
+            const result = surveyManager.checkSurveyEligibility({ ...mockSurveys[0], conditions: null })
+            expect(result.eligible).toBe(true)
+        })
+    })
+
     test('callSurveysAndEvaluateDisplayLogic should handle popup surveys correctly', () => {
         const handlePopoverSurveyMock = jest
             .spyOn(surveyManager as any, 'handlePopoverSurvey')

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -515,21 +515,29 @@ describe('SurveyManager', () => {
             ;(mockPostHog.surveys as any)._surveyEventReceiver = { getSurveys: () => surveyIds }
         }
 
-        it('is not eligible until the trigger event has fired', () => {
+        it('is not renderable until the trigger event has fired', () => {
             setActivatedSurveys([])
-            const result = surveyManager.checkSurveyEligibility(makeEventGatedSurvey())
+            const result = surveyManager.checkSurveyRenderability(makeEventGatedSurvey())
             expect(result.eligible).toBe(false)
         })
 
-        it('becomes eligible once the trigger event has fired', () => {
+        it('becomes renderable once the trigger event has fired', () => {
             setActivatedSurveys([EVENT_GATED_SURVEY_ID])
-            const result = surveyManager.checkSurveyEligibility(makeEventGatedSurvey())
+            const result = surveyManager.checkSurveyRenderability(makeEventGatedSurvey())
             expect(result.eligible).toBe(true)
         })
 
         it('is unaffected for surveys without an event/action trigger', () => {
             setActivatedSurveys([])
-            const result = surveyManager.checkSurveyEligibility({ ...mockSurveys[0], conditions: null })
+            const result = surveyManager.checkSurveyRenderability({ ...mockSurveys[0], conditions: null })
+            expect(result.eligible).toBe(true)
+        })
+
+        // Regression guard: the trigger gate must live only in checkSurveyRenderability, not in
+        // checkSurveyEligibility, so explicit displaySurvey('id') calls are not silently suppressed.
+        it('checkSurveyEligibility stays eligible for an event-gated survey whose trigger has not fired', () => {
+            setActivatedSurveys([])
+            const result = surveyManager.checkSurveyEligibility(makeEventGatedSurvey())
             expect(result.eligible).toBe(true)
         })
     })

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -656,12 +656,24 @@ export class SurveyManager {
             return eligibility
         }
 
-        if (!this._hasActionOrEventTriggeredSurvey(survey)) {
-            eligibility.eligible = false
-            eligibility.reason = `Survey event/action trigger has not been fired yet`
-            return eligibility
-        }
+        return eligibility
+    }
 
+    /**
+     * Renderability = eligibility (running, type, flags, wait period, already-seen) plus the
+     * survey's event/action activation trigger. Used by the programmatic `canRenderSurvey` /
+     * `canRenderSurveyAsync` checks so they match the display loop.
+     *
+     * The trigger is intentionally kept out of `checkSurveyEligibility`: that method is also
+     * used by the explicit `displaySurvey` path, and the trigger state only lives in memory
+     * (a reload clears it, server-side events never set it). Gating eligibility on it would
+     * make explicit `displaySurvey('id')` calls silently show nothing.
+     */
+    public checkSurveyRenderability(survey: Survey): { eligible: boolean; reason?: string } {
+        const eligibility = this.checkSurveyEligibility(survey)
+        if (eligibility.eligible && !this._hasActionOrEventTriggeredSurvey(survey)) {
+            return { eligible: false, reason: `Survey event/action trigger has not been fired yet` }
+        }
         return eligibility
     }
 

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -656,6 +656,12 @@ export class SurveyManager {
             return eligibility
         }
 
+        if (!this._hasActionOrEventTriggeredSurvey(survey)) {
+            eligibility.eligible = false
+            eligibility.reason = `Survey event/action trigger has not been fired yet`
+            return eligibility
+        }
+
         return eligibility
     }
 

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -399,12 +399,23 @@ export class PostHogSurveys implements Extension {
         return this._surveyManager.checkSurveyEligibility(survey)
     }
 
+    private _checkSurveyRenderability(surveyId: string | Survey): { eligible: boolean; reason?: string } {
+        if (isNullish(this._surveyManager)) {
+            return { eligible: false, reason: SURVEY_NOT_LOADED }
+        }
+        const survey = typeof surveyId === 'string' ? this._getSurveyById(surveyId) : surveyId
+        if (!survey) {
+            return { eligible: false, reason: 'Survey not found' }
+        }
+        return this._surveyManager.checkSurveyRenderability(survey)
+    }
+
     canRenderSurvey(surveyId: string | Survey): SurveyRenderReason {
         if (isNullish(this._surveyManager)) {
             logger.warn('init was not called')
             return { visible: false, disabledReason: SURVEY_NOT_LOADED }
         }
-        const eligibility = this._checkSurveyEligibility(surveyId)
+        const eligibility = this._checkSurveyRenderability(surveyId)
 
         return { visible: eligibility.eligible, disabledReason: eligibility.reason }
     }
@@ -427,7 +438,7 @@ export class PostHogSurveys implements Extension {
                 if (!survey) {
                     resolve({ visible: false, disabledReason: 'Survey not found' })
                 } else {
-                    const eligibility = this._checkSurveyEligibility(survey)
+                    const eligibility = this._checkSurveyRenderability(survey)
                     resolve({ visible: eligibility.eligible, disabledReason: eligibility.reason })
                 }
             }, forceReload)
@@ -493,9 +504,11 @@ export class PostHogSurveys implements Extension {
             logger.warn('initialResponses is only supported for popover surveys. prefill will not be applied.')
         }
         if (options.ignoreConditions === false) {
-            const canRender = this.canRenderSurvey(survey)
-            if (!canRender.visible) {
-                logger.warn('Survey is not eligible to be displayed: ', canRender.disabledReason)
+            // Explicit display goes through eligibility only, not renderability: the event/action
+            // trigger state lives in memory and is irrelevant when the caller asks to show the survey.
+            const eligibility = this._checkSurveyEligibility(survey)
+            if (!eligibility.eligible) {
+                logger.warn('Survey is not eligible to be displayed: ', eligibility.reason)
                 return
             }
         }

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -82,6 +82,7 @@
         "_checkStepText",
         "_checkStepUrl",
         "_checkSurveyEligibility",
+        "_checkSurveyRenderability",
         "_cleanup",
         "_clearBuffer",
         "_clearBufferBeforeMostRecentMeta",


### PR DESCRIPTION
## Problem
Surveys configured with a "User sends events" filter are reported as renderable by `canRenderSurvey` / `canRenderSurveyAsync` even before the trigger event has fired, returning `{ visible: true }` regardless. (Fixes #2501)

## Root cause
`canRenderSurvey` / `canRenderSurveyAsync` only run `SurveyManager.checkSurveyEligibility`, which validates running state, survey type, linked/targeting/internal feature flags, the wait period and the "already seen" check — but **not** the survey's event/action activation trigger. That trigger is evaluated separately, only inside the internal display loop (`_shouldDisplaySurvey` → `_hasActionOrEventTriggeredSurvey`). So the programmatic render check ignores it.

## Change
Include the existing `_hasActionOrEventTriggeredSurvey` check in `checkSurveyEligibility`, so the programmatic render check behaves like the display loop. Surveys without an event/action trigger are unaffected — the helper already returns `true` for them. The (now redundant) call in `_shouldDisplaySurvey` is harmless and left as-is to keep that predicate self-documenting.

Scope is intentionally limited to the event/action trigger, matching the issue. URL/device/selector conditions (`_isSurveyConditionMatched`) are a separate concern and left unchanged.

## Testing
Added unit tests in `surveys.test.ts`:
- not eligible until the trigger event fires,
- eligible once it fires,
- unaffected when there is no event/action trigger.

Local checks (`packages/browser`):
- `pnpm test:unit:surveys` → 461 passing
- `pnpm eslint` on changed files → clean
- `pnpm prettier --check` → clean
- `pnpm typecheck` (src) → clean

Fixes #2501