### PR TITLE
fix(replay): prevent server timings from causing an endless capture loop

### DIFF
--- a/.changeset/quiet-proxies-stop.md
+++ b/.changeset/quiet-proxies-stop.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): prevent server timings from dropped ingestion requests causing an endless capture loop

--- a/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/network-plugin.test.ts
@@ -2,7 +2,9 @@
 
 import { expect } from '@jest/globals'
 import { TextDecoder as NodeTextDecoder, TextEncoder as NodeTextEncoder } from 'util'
+import { buildNetworkRequestOptions } from '../../../../extensions/replay/external/config'
 import { NetworkRecordOptions } from '../../../../types'
+import { defaultConfig } from '../../../../posthog-core'
 import {
     _contentLengthExceedsLimit,
     _readBody,
@@ -84,6 +86,26 @@ function createMockWindow() {
     mockWindow.PerformanceObserver.supportedEntryTypes = ['navigation', 'resource']
 
     return { mockWindow, performanceEntries, observerCallbacks }
+}
+
+function createResourceTimingEntry(name: string, serverTimingName: string, serverTimingDuration: number) {
+    return {
+        name,
+        entryType: 'resource',
+        initiatorType: 'fetch',
+        startTime: 10,
+        responseEnd: 20,
+        serverTiming: [{ name: serverTimingName, duration: serverTimingDuration }],
+        toJSON() {
+            return {
+                name: this.name,
+                entryType: this.entryType,
+                initiatorType: this.initiatorType,
+                startTime: this.startTime,
+                duration: 10,
+            }
+        },
+    }
 }
 
 const blobUrlTestCases = [
@@ -296,6 +318,58 @@ describe('network plugin', () => {
     })
 
     describe('network observer lifecycle', () => {
+        it('drops server timings derived from a masked PostHog ingestion request', () => {
+            jest.isolateModules(() => {
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
+                const { getRecordNetworkPlugin } = require('../../../../extensions/replay/external/network-plugin')
+                const { mockWindow, observerCallbacks } = createMockWindow()
+                global.PerformanceObserver = mockWindow.PerformanceObserver
+
+                const callback = jest.fn()
+                const networkOptions = buildNetworkRequestOptions(
+                    { ...defaultConfig(), api_host: 'https://example.com/ingest' },
+                    { recordPerformance: true }
+                )
+                const plugin = getRecordNetworkPlugin(networkOptions)
+                const cleanup = plugin.observer(callback, mockWindow, networkOptions)
+                const entry = createResourceTimingEntry('https://example.com/ingest/s/?ver=1.406.2', 'proxy', 5)
+
+                observerCallbacks[0]({ getEntries: () => [entry] } as PerformanceObserverEntryList)
+
+                expect(callback).not.toHaveBeenCalled()
+                cleanup()
+            })
+        })
+
+        it('does not let a dropped parent suppress the next request in a performance observer batch', () => {
+            jest.isolateModules(() => {
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
+                const { getRecordNetworkPlugin } = require('../../../../extensions/replay/external/network-plugin')
+                const { mockWindow, observerCallbacks } = createMockWindow()
+                global.PerformanceObserver = mockWindow.PerformanceObserver
+
+                const callback = jest.fn()
+                const networkOptions = buildNetworkRequestOptions(
+                    { ...defaultConfig(), api_host: 'https://example.com/ingest' },
+                    { recordPerformance: true }
+                )
+                const plugin = getRecordNetworkPlugin(networkOptions)
+                const cleanup = plugin.observer(callback, mockWindow, networkOptions)
+                const droppedEntry = createResourceTimingEntry('https://example.com/ingest/s/', 'proxy', 5)
+                const allowedEntry = createResourceTimingEntry('https://example.com/api/data', 'allowed-proxy', 3)
+
+                observerCallbacks[0]({ getEntries: () => [droppedEntry, allowedEntry] } as PerformanceObserverEntryList)
+
+                expect(callback).toHaveBeenCalledWith({
+                    requests: [
+                        expect.objectContaining({ name: allowedEntry.name, entryType: 'resource' }),
+                        expect.objectContaining({ name: 'allowed-proxy', entryType: 'serverTiming' }),
+                    ],
+                })
+                cleanup()
+            })
+        })
+
         describe('singleton initialization and cleanup', () => {
             it('should initialize successfully on first call', () => {
                 jest.isolateModules(() => {

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -888,8 +888,20 @@ function initNetworkObserver(
 
     const cb: networkCallback = (data) => {
         const requests: CapturedNetworkRequest[] = []
+        let parentRequestDropped = false
         data.requests.forEach((request) => {
+            const isServerTiming = request.entryType === 'serverTiming'
+
+            // Server timings are emitted immediately after their resource or navigation entry.
+            // If a parent is dropped (i.e. a PostHog ingestion request), derived timings must too or an endless capture loop ensues.
+            if (isServerTiming && parentRequestDropped) {
+                return
+            }
+
             const maskedRequest = networkOptions.maskRequestFn(request)
+            if (!isServerTiming) {
+                parentRequestDropped = !maskedRequest
+            }
             if (maskedRequest) {
                 requests.push(maskedRequest)
             }


### PR DESCRIPTION
## Problem

When session replay performance capture is enabled and ingestion is routed through a proxy that adds `Server-Timing` headers (i.e. Cloudflare, CloudFront, etc) derived `serverTiming` entries are not filtered (ingestion request are fine) .

Entries are then added to replay queue and sent to the same ingestion endpoint, often causing an endless capture loop.

## Changes

- Drop derived `serverTiming` entries when their parent resource or navigation request is filtered out.
- Unrelated requests in the same performance observer batch are preserved.
- Add separate regression tests for both the ingestion loop and multi-request batch behavior.
- Add a patch changeset for `posthog-js`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Human identified bug using pattern matching. Codex traced the behavior through session replay performance capture, checked repository history and existing GitHub issues and PRs, and assisted with the implementation, regression tests, and changeset.

The human reviewed the implementation and ran the focused network plugin tests, browser TypeScript check, production browser build, and pertinent CI workflows successfully. The PR still requires independent human review.