### PR TITLE
feat(flags): add defaultValue option to isFeatureEnabled

### DIFF
--- a/.changeset/is-feature-enabled-default-value.md
+++ b/.changeset/is-feature-enabled-default-value.md
@@ -1,0 +1,11 @@
+---
+'@posthog/core': minor
+'posthog-react-native': minor
+'posthog-js-lite': minor
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+feat: add a default-value option to `isFeatureEnabled`
+
+`isFeatureEnabled` now accepts a fallback value returned when the flag has no value — flags not loaded yet, or no flag with that key — and the return type narrows to `boolean`. In posthog-js the option is `{ default_value: false }`; in posthog-react-native and posthog-js-lite it is `{ defaultValue: false }`. Without it, behavior is unchanged: `boolean | undefined`.

--- a/.changeset/is-feature-enabled-default-value.md
+++ b/.changeset/is-feature-enabled-default-value.md
@@ -8,4 +8,4 @@
 
 feat: add a default-value option to `isFeatureEnabled`
 
-`isFeatureEnabled` now accepts a fallback value returned when the flag has no value — flags not loaded yet, or no flag with that key — and the return type narrows to `boolean`. In posthog-js the option is `{ default_value: false }`; in posthog-react-native and posthog-js-lite it is `{ defaultValue: false }`. Without it, behavior is unchanged: `boolean | undefined`.
+`isFeatureEnabled(key, { defaultValue: false })` now returns the given default when the flag has no value — flags not loaded yet, or no flag with that key — and the return type narrows to `boolean`. The option name is the same in posthog-js, posthog-js-lite, and posthog-react-native. Without `defaultValue`, behavior is unchanged: `boolean | undefined`.

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -1202,7 +1202,7 @@
         {
           "category": "Feature flags",
           "description": "Checks if a feature flag is enabled for the current user.",
-          "details": "Returns true if the flag is enabled, false if disabled, or undefined if not found. This is a convenience method that treats any truthy value as enabled.",
+          "details": "Returns true if the flag is enabled, false if disabled, or undefined if not found (unless `defaultValue` is given, which is returned instead of undefined). This is a convenience method that treats any truthy value as enabled.",
           "id": "isFeatureEnabled",
           "showDocs": true,
           "title": "isFeatureEnabled",
@@ -1227,15 +1227,15 @@
               "name": "key"
             },
             {
-              "description": "Optional lookup settings. If `{ send_event: false }`, we won't send a `$feature_flag_called` event to PostHog. If `{ fresh: true }`, we won't return cached values from localStorage - only values loaded from the server.",
-              "isOptional": true,
-              "type": "FeatureFlagOptions",
+              "description": "Optional lookup settings. If `{ send_event: false }`, we won't send a `$feature_flag_called` event to PostHog. If `{ fresh: true }`, we won't return cached values from localStorage - only values loaded from the server. If `{ defaultValue: false }`, we return that value instead of undefined when the flag has no value.",
+              "isOptional": false,
+              "type": "IsFeatureEnabledOptions & {\n        defaultValue: boolean;\n    }",
               "name": "options"
             }
           ],
           "returnType": {
-            "id": "boolean | undefined",
-            "name": "boolean | undefined"
+            "id": "boolean",
+            "name": "boolean"
           },
           "path": "lib/src/posthog-core.d.ts"
         },
@@ -3744,7 +3744,7 @@
         },
         {
           "description": "Check if a feature flag is enabled.",
-          "type": "(key: string, options?: FeatureFlagOptions) => boolean | undefined",
+          "type": "{ (key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean; }): boolean; (key: string, options?: IsFeatureEnabledOptions): boolean | undefined; }",
           "name": "isFeatureEnabled"
         },
         {

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -224,30 +224,30 @@ describe('featureflags', () => {
         })
     })
 
-    describe('default_value option', () => {
-        it('should return default_value for a missing flag', () => {
-            expect(featureFlags.isFeatureEnabled('random', { default_value: true })).toEqual(true)
-            expect(featureFlags.isFeatureEnabled('random', { default_value: false })).toEqual(false)
+    describe('defaultValue option', () => {
+        it('should return defaultValue for a missing flag', () => {
+            expect(featureFlags.isFeatureEnabled('random', { defaultValue: true })).toEqual(true)
+            expect(featureFlags.isFeatureEnabled('random', { defaultValue: false })).toEqual(false)
         })
 
         it('should be ignored when the flag has a value', () => {
-            expect(featureFlags.isFeatureEnabled('disabled-flag', { default_value: true })).toEqual(false)
-            expect(featureFlags.isFeatureEnabled('multivariate-flag', { default_value: false })).toEqual(true)
+            expect(featureFlags.isFeatureEnabled('disabled-flag', { defaultValue: true })).toEqual(false)
+            expect(featureFlags.isFeatureEnabled('multivariate-flag', { defaultValue: false })).toEqual(true)
         })
 
-        it('should return default_value when flags have not loaded', () => {
+        it('should return defaultValue when flags have not loaded', () => {
             featureFlags._hasLoadedFlags = false
             instance.persistence.unregister('$enabled_feature_flags')
             instance.persistence.unregister('$active_feature_flags')
 
-            expect(featureFlags.isFeatureEnabled('beta-feature', { default_value: true })).toEqual(true)
+            expect(featureFlags.isFeatureEnabled('beta-feature', { defaultValue: true })).toEqual(true)
         })
 
-        it('should return default_value when fresh: true and flags have not been loaded from remote', () => {
+        it('should return defaultValue when fresh: true and flags have not been loaded from remote', () => {
             featureFlags._hasLoadedFlags = true
             featureFlags._flagsLoadedFromRemote = false
 
-            expect(featureFlags.isFeatureEnabled('beta-feature', { fresh: true, default_value: false })).toEqual(false)
+            expect(featureFlags.isFeatureEnabled('beta-feature', { fresh: true, defaultValue: false })).toEqual(false)
         })
     })
 

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -224,6 +224,33 @@ describe('featureflags', () => {
         })
     })
 
+    describe('default_value option', () => {
+        it('should return default_value for a missing flag', () => {
+            expect(featureFlags.isFeatureEnabled('random', { default_value: true })).toEqual(true)
+            expect(featureFlags.isFeatureEnabled('random', { default_value: false })).toEqual(false)
+        })
+
+        it('should be ignored when the flag has a value', () => {
+            expect(featureFlags.isFeatureEnabled('disabled-flag', { default_value: true })).toEqual(false)
+            expect(featureFlags.isFeatureEnabled('multivariate-flag', { default_value: false })).toEqual(true)
+        })
+
+        it('should return default_value when flags have not loaded', () => {
+            featureFlags._hasLoadedFlags = false
+            instance.persistence.unregister('$enabled_feature_flags')
+            instance.persistence.unregister('$active_feature_flags')
+
+            expect(featureFlags.isFeatureEnabled('beta-feature', { default_value: true })).toEqual(true)
+        })
+
+        it('should return default_value when fresh: true and flags have not been loaded from remote', () => {
+            featureFlags._hasLoadedFlags = true
+            featureFlags._flagsLoadedFromRemote = false
+
+            expect(featureFlags.isFeatureEnabled('beta-feature', { fresh: true, default_value: false })).toEqual(false)
+        })
+    })
+
     it('should return the right feature flag and call capture', () => {
         featureFlags._hasLoadedFlags = false
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -62,6 +62,7 @@ import {
     FeatureFlagsCallback,
     FeatureFlagOptions,
     FeatureFlagResult,
+    IsFeatureEnabledOptions,
     JsonType,
     OverrideConfig,
     PostHogConfig,
@@ -2008,7 +2009,8 @@ export class PostHog implements PostHogInterface {
      * Checks if a feature flag is enabled for the current user.
      *
      * @remarks
-     * Returns true if the flag is enabled, false if disabled, or undefined if not found.
+     * Returns true if the flag is enabled, false if disabled, or undefined if not found
+     * (unless `default_value` is given, which is returned instead of undefined).
      * This is a convenience method that treats any truthy value as enabled.
      *
      * {@label Feature flags}
@@ -2032,11 +2034,13 @@ export class PostHog implements PostHogInterface {
      * @public
      *
      * @param {string} key Key of the feature flag.
-     * @param {FeatureFlagOptions} [options] Optional lookup settings. If `{ send_event: false }`, we won't send a `$feature_flag_called` event to PostHog. If `{ fresh: true }`, we won't return cached values from localStorage - only values loaded from the server.
-     * @returns {boolean | undefined} Whether the feature flag is enabled, or undefined if the flag is unavailable.
+     * @param {IsFeatureEnabledOptions} [options] Optional lookup settings. If `{ send_event: false }`, we won't send a `$feature_flag_called` event to PostHog. If `{ fresh: true }`, we won't return cached values from localStorage - only values loaded from the server. If `{ default_value: false }`, we return that value instead of undefined when the flag has no value.
+     * @returns {boolean | undefined} Whether the feature flag is enabled; when the flag has no value, default_value if given, otherwise undefined.
      */
-    isFeatureEnabled(key: string, options?: FeatureFlagOptions): boolean | undefined {
-        return this.featureFlags?.isFeatureEnabled(key, options)
+    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { default_value: boolean }): boolean
+    isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
+    isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined {
+        return this.featureFlags?.isFeatureEnabled(key, options) ?? options?.default_value
     }
 
     /**

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1804,11 +1804,11 @@ export class PostHog implements PostHogInterface {
      * @public
      *
      * @param {Object} properties An associative array of properties to store about the user
-     * @param {*} [default_value] Value to override if already set in super properties (ex: 'False') Default: 'None'
+     * @param {*} [defaultValue] Value to override if already set in super properties (ex: 'False') Default: 'None'
      * @param {Number} [days] How many days since the users last visit to store the super properties
      */
-    register_once(properties: Properties, default_value?: Property, days?: number): void {
-        this.persistence?.register_once(properties, default_value, days)
+    register_once(properties: Properties, defaultValue?: Property, days?: number): void {
+        this.persistence?.register_once(properties, defaultValue, days)
     }
 
     /**
@@ -2010,7 +2010,7 @@ export class PostHog implements PostHogInterface {
      *
      * @remarks
      * Returns true if the flag is enabled, false if disabled, or undefined if not found
-     * (unless `default_value` is given, which is returned instead of undefined).
+     * (unless `defaultValue` is given, which is returned instead of undefined).
      * This is a convenience method that treats any truthy value as enabled.
      *
      * {@label Feature flags}
@@ -2034,13 +2034,13 @@ export class PostHog implements PostHogInterface {
      * @public
      *
      * @param {string} key Key of the feature flag.
-     * @param {IsFeatureEnabledOptions} [options] Optional lookup settings. If `{ send_event: false }`, we won't send a `$feature_flag_called` event to PostHog. If `{ fresh: true }`, we won't return cached values from localStorage - only values loaded from the server. If `{ default_value: false }`, we return that value instead of undefined when the flag has no value.
-     * @returns {boolean | undefined} Whether the feature flag is enabled; when the flag has no value, default_value if given, otherwise undefined.
+     * @param {IsFeatureEnabledOptions} [options] Optional lookup settings. If `{ send_event: false }`, we won't send a `$feature_flag_called` event to PostHog. If `{ fresh: true }`, we won't return cached values from localStorage - only values loaded from the server. If `{ defaultValue: false }`, we return that value instead of undefined when the flag has no value.
+     * @returns {boolean | undefined} Whether the feature flag is enabled; when the flag has no value, defaultValue if given, otherwise undefined.
      */
-    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { default_value: boolean }): boolean
+    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean }): boolean
     isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
     isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined {
-        return this.featureFlags?.isFeatureEnabled(key, options) ?? options?.default_value
+        return this.featureFlags?.isFeatureEnabled(key, options) ?? options?.defaultValue
     }
 
     /**

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1804,11 +1804,11 @@ export class PostHog implements PostHogInterface {
      * @public
      *
      * @param {Object} properties An associative array of properties to store about the user
-     * @param {*} [defaultValue] Value to override if already set in super properties (ex: 'False') Default: 'None'
+     * @param {*} [default_value] Value to override if already set in super properties (ex: 'False') Default: 'None'
      * @param {Number} [days] How many days since the users last visit to store the super properties
      */
-    register_once(properties: Properties, defaultValue?: Property, days?: number): void {
-        this.persistence?.register_once(properties, defaultValue, days)
+    register_once(properties: Properties, default_value?: Property, days?: number): void {
+        this.persistence?.register_once(properties, default_value, days)
     }
 
     /**

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -14,6 +14,7 @@ import {
     FeatureFlagDetail,
     FeatureFlagResult,
     FeatureFlagOptions,
+    IsFeatureEnabledOptions,
     OverrideFeatureFlagsOptions,
 } from './types'
 import { PostHogPersistence } from './posthog-persistence'
@@ -1021,18 +1022,21 @@ export class PostHogFeatureFlags implements Extension {
      * @param {boolean} [options.fresh=false] If true, only returns values loaded from the server, not cached localStorage values.
      *                  Use this when you need to ensure the flag value reflects the current server state.
      *                  Returns undefined until the /flags endpoint responds.
-     * @returns {boolean | undefined} Whether the flag is enabled, or undefined if not found or not yet loaded.
+     * @param {boolean} [options.default_value] Value to return when the flag has no value, e.g. flags have not loaded yet or no flag with that key exists.
+     * @returns {boolean | undefined} Whether the flag is enabled; when the flag has no value, default_value if given, otherwise undefined.
      */
-    isFeatureEnabled(key: string, options: FeatureFlagOptions = {}): boolean | undefined {
+    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { default_value: boolean }): boolean
+    isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
+    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions = {}): boolean | undefined {
         if (options.fresh && !this._flagsLoadedFromRemote) {
-            return undefined
+            return options.default_value
         }
         if (!this._hasLoadedFlags && !(this.getFlags() && this.getFlags().length > 0)) {
             logger.warn('isFeatureEnabled for key "' + key + FLAG_TIMEOUT_MSG)
-            return undefined
+            return options.default_value
         }
         const flagValue = this.getFeatureFlag(key, options)
-        return isUndefined(flagValue) ? undefined : !!flagValue
+        return isUndefined(flagValue) ? options.default_value : !!flagValue
     }
 
     addFeatureFlagsHandler(handler: FeatureFlagsCallback): void {

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -1022,21 +1022,21 @@ export class PostHogFeatureFlags implements Extension {
      * @param {boolean} [options.fresh=false] If true, only returns values loaded from the server, not cached localStorage values.
      *                  Use this when you need to ensure the flag value reflects the current server state.
      *                  Returns undefined until the /flags endpoint responds.
-     * @param {boolean} [options.default_value] Value to return when the flag has no value, e.g. flags have not loaded yet or no flag with that key exists.
-     * @returns {boolean | undefined} Whether the flag is enabled; when the flag has no value, default_value if given, otherwise undefined.
+     * @param {boolean} [options.defaultValue] Value to return when the flag has no value, e.g. flags have not loaded yet or no flag with that key exists.
+     * @returns {boolean | undefined} Whether the flag is enabled; when the flag has no value, defaultValue if given, otherwise undefined.
      */
-    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { default_value: boolean }): boolean
+    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean }): boolean
     isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
     isFeatureEnabled(key: string, options: IsFeatureEnabledOptions = {}): boolean | undefined {
         if (options.fresh && !this._flagsLoadedFromRemote) {
-            return options.default_value
+            return options.defaultValue
         }
         if (!this._hasLoadedFlags && !(this.getFlags() && this.getFlags().length > 0)) {
             logger.warn('isFeatureEnabled for key "' + key + FLAG_TIMEOUT_MSG)
-            return options.default_value
+            return options.defaultValue
         }
         const flagValue = this.getFeatureFlag(key, options)
-        return isUndefined(flagValue) ? options.default_value : !!flagValue
+        return isUndefined(flagValue) ? options.defaultValue : !!flagValue
     }
 
     addFeatureFlagsHandler(handler: FeatureFlagsCallback): void {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -49,6 +49,7 @@ export type {
     EvaluationReason,
     FeatureFlagResult,
     FeatureFlagOptions,
+    IsFeatureEnabledOptions,
     RemoteConfigFeatureFlagCallback,
     EarlyAccessFeature,
     EarlyAccessFeatureStage,

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -149,6 +149,11 @@ describe('PostHog Feature Flags v4', () => {
       expect(posthog.isFeatureEnabled('feature-1')).toEqual(undefined)
     })
 
+    it('isFeatureEnabled should return defaultValue if not loaded', () => {
+      expect(posthog.isFeatureEnabled('my-flag', { defaultValue: true })).toEqual(true)
+      expect(posthog.isFeatureEnabled('my-flag', { defaultValue: false })).toEqual(false)
+    })
+
     it('should load persisted feature flags', () => {
       const flagsResponse = { flags: createMockFeatureFlags() } as PostHogV2FlagsResponse
       const normalizedFeatureFlags = normalizeFlagsResponse(flagsResponse)
@@ -477,6 +482,11 @@ describe('PostHog Feature Flags v4', () => {
           expect(posthog.isFeatureEnabled('feature-variant')).toEqual(true)
           expect(posthog.isFeatureEnabled('feature-missing')).toEqual(false)
           expect(posthog.isFeatureEnabled('x-flag')).toEqual(true)
+
+          expect(posthog.isFeatureEnabled('feature-1', { defaultValue: true })).toEqual(false)
+          expect(posthog.isFeatureEnabled('feature-variant', { defaultValue: false })).toEqual(true)
+          expect(posthog.isFeatureEnabled('feature-missing', { defaultValue: true })).toEqual(true)
+          expect(posthog.isFeatureEnabled('feature-missing', { defaultValue: false })).toEqual(false)
         })
       })
 

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -10,6 +10,7 @@ import type {
   FeatureFlagValue,
   FeatureFlagResult,
   FeatureFlagResultOptions,
+  IsFeatureEnabledOptions,
   PostHogV2FlagsResponse,
   PostHogV1FlagsResponse,
   PostHogFeatureFlagDetails,
@@ -1152,12 +1153,15 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     }
   }
 
-  isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean | undefined {
-    const response = this.getFeatureFlag(key, options)
-    if (response === undefined) {
-      return undefined
-    }
-    return !!response
+  isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean }): boolean
+  isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
+  isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined {
+    const result = this._getFeatureFlagResult(key, {
+      sendEvent: options?.sendEvent,
+      missingFlagBehavior: options?.defaultValue === undefined ? 'getFeatureFlag' : undefined,
+    })
+    const value = result?.variant ?? result?.enabled
+    return value === undefined ? options?.defaultValue : !!value
   }
 
   // Used when we want to trigger the reload but we don't care about the result

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -1156,12 +1156,13 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean }): boolean
   isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
   isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined {
-    const result = this._getFeatureFlagResult(key, {
-      sendEvent: options?.sendEvent,
-      missingFlagBehavior: options?.defaultValue === undefined ? 'getFeatureFlag' : undefined,
-    })
+    if (options?.defaultValue === undefined) {
+      const response = this.getFeatureFlag(key, options)
+      return response === undefined ? undefined : !!response
+    }
+    const result = this._getFeatureFlagResult(key, { sendEvent: options.sendEvent })
     const value = result?.variant ?? result?.enabled
-    return value === undefined ? options?.defaultValue : !!value
+    return value === undefined ? options.defaultValue : !!value
   }
 
   // Used when we want to trigger the reload but we don't care about the result

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -430,6 +430,11 @@ export type FeatureFlagResultOptions = {
   sendEvent?: boolean
 }
 
+export type IsFeatureEnabledOptions = FeatureFlagResultOptions & {
+  /** Value to return when the flag has no value, e.g. flags have not loaded yet or no flag with that key exists. */
+  defaultValue?: boolean
+}
+
 export type PostHogFlagsResponse = Omit<PostHogRemoteConfig, 'hasFeatureFlags'> & {
   featureFlags: {
     [key: string]: FeatureFlagValue

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -732,7 +732,7 @@
         },
         {
           "category": "Feature flags",
-          "description": "Checks if a feature flag is enabled for the current user.\nDefaults to undefined if not loaded yet or if there was a problem loading.",
+          "description": "Checks if a feature flag is enabled for the current user.\nDefaults to undefined if not loaded yet or if there was a problem loading, unless `defaultValue` is provided.",
           "details": null,
           "id": "isFeatureEnabled",
           "showDocs": true,
@@ -741,7 +741,12 @@
             {
               "id": "check_if_feature_flag_is_enabled",
               "name": "check if feature flag is enabled",
-              "code": "\n\n// check if feature flag is enabled\nconst isEnabled = posthog.isFeatureEnabled('key-for-your-boolean-flag')\n\n\n\n"
+              "code": "\n\n// check if feature flag is enabled\nconst isEnabled = posthog.isFeatureEnabled('key-for-your-boolean-flag')\n\n\n"
+            },
+            {
+              "id": "fall_back_to_false_while_flags_are_not_loaded",
+              "name": "fall back to false while flags are not loaded",
+              "code": "\n\n// fall back to false while flags are not loaded\nconst isEnabled = posthog.isFeatureEnabled('key-for-your-boolean-flag', { defaultValue: false })\n\n\n\n"
             }
           ],
           "releaseTag": "public",
@@ -754,14 +759,14 @@
             },
             {
               "description": "Optional per-call settings",
-              "isOptional": true,
-              "type": "FeatureFlagResultOptions",
+              "isOptional": false,
+              "type": "IsFeatureEnabledOptions & {\n        defaultValue: boolean;\n    }",
               "name": "options"
             }
           ],
           "returnType": {
-            "id": "boolean | undefined",
-            "name": "boolean | undefined"
+            "id": "boolean",
+            "name": "boolean"
           },
           "path": "dist/posthog-rn.d.ts"
         },
@@ -2625,6 +2630,13 @@
       "properties": [],
       "path": "../core/src/error-tracking/types.ts",
       "example": "(filename: string | undefined) => string | undefined"
+    },
+    {
+      "id": "IsFeatureEnabledOptions",
+      "name": "IsFeatureEnabledOptions",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "FeatureFlagResultOptions & {\n    defaultValue?: boolean;\n}"
     },
     {
       "id": "JsonType",

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -23,6 +23,7 @@ import {
   safeSetTimeout,
   FeatureFlagValue,
   FeatureFlagResultOptions,
+  IsFeatureEnabledOptions,
   ErrorTracking as CoreErrorTracking,
 } from '@posthog/core'
 import { Properties } from '@posthog/types'
@@ -945,7 +946,8 @@ export class PostHog extends PostHogCore {
   /**
    * Checks if a feature flag is enabled for the current user.
    *
-   * Defaults to undefined if not loaded yet or if there was a problem loading.
+   * Defaults to undefined if not loaded yet or if there was a problem loading,
+   * unless `defaultValue` is provided.
    *
    * {@label Feature flags}
    *
@@ -955,13 +957,21 @@ export class PostHog extends PostHogCore {
    * const isEnabled = posthog.isFeatureEnabled('key-for-your-boolean-flag')
    * ```
    *
+   * @example
+   * ```js
+   * // fall back to false while flags are not loaded
+   * const isEnabled = posthog.isFeatureEnabled('key-for-your-boolean-flag', { defaultValue: false })
+   * ```
+   *
    * @public
    *
    * @param key The feature flag key
    * @param options Optional per-call settings
-   * @returns True if enabled, false if disabled, undefined if not loaded
+   * @returns True if enabled, false if disabled; when the flag has no value, defaultValue if given, otherwise undefined
    */
-  isFeatureEnabled(key: string, options?: FeatureFlagResultOptions): boolean | undefined {
+  isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean }): boolean
+  isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
+  isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined {
     return super.isFeatureEnabled(key, options)
   }
 

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -113,7 +113,7 @@ export type IsFeatureEnabledOptions = FeatureFlagOptions & {
     /**
      * Value to return when the flag has no value, e.g. flags have not loaded yet or no flag with that key exists.
      */
-    default_value?: boolean
+    defaultValue?: boolean
 }
 
 /**

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -107,6 +107,16 @@ export type FeatureFlagOptions = {
 }
 
 /**
+ * Options for isFeatureEnabled.
+ */
+export type IsFeatureEnabledOptions = FeatureFlagOptions & {
+    /**
+     * Value to return when the flag has no value, e.g. flags have not loaded yet or no flag with that key exists.
+     */
+    default_value?: boolean
+}
+
+/**
  * Options for overriding feature flags on the client-side.
  *
  * Can be:

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,6 +29,7 @@ export type {
     EvaluationReason,
     FeatureFlagResult,
     FeatureFlagOptions,
+    IsFeatureEnabledOptions,
     RemoteConfigFeatureFlagCallback,
     EarlyAccessFeature,
     EarlyAccessFeatureStage,

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -15,6 +15,7 @@ import type {
     EarlyAccessFeatureStage,
     FeatureFlagResult,
     FeatureFlagOptions,
+    IsFeatureEnabledOptions,
     OverrideFeatureFlagsOptions,
 } from './feature-flags'
 import type { SessionIdChangedCallback } from './session-recording'
@@ -331,9 +332,11 @@ export interface PostHog {
      * @param options - Options for the feature flag lookup
      * @param options.send_event - Whether to send a $feature_flag_called event (default: true)
      * @param options.fresh - If true, only return values loaded from the server, not cached localStorage values (default: false)
+     * @param options.default_value - Value to return when the flag has no value (default: undefined)
      * @returns Whether the feature flag is enabled
      */
-    isFeatureEnabled(key: string, options?: FeatureFlagOptions): boolean | undefined
+    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { default_value: boolean }): boolean
+    isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
 
     /**
      * Reload feature flags from the server.

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -332,10 +332,10 @@ export interface PostHog {
      * @param options - Options for the feature flag lookup
      * @param options.send_event - Whether to send a $feature_flag_called event (default: true)
      * @param options.fresh - If true, only return values loaded from the server, not cached localStorage values (default: false)
-     * @param options.default_value - Value to return when the flag has no value (default: undefined)
+     * @param options.defaultValue - Value to return when the flag has no value (default: undefined)
      * @returns Whether the feature flag is enabled
      */
-    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { default_value: boolean }): boolean
+    isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean }): boolean
     isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
 
     /**
@@ -436,10 +436,10 @@ export interface PostHog {
      * Register properties to be sent with every event, but only if they haven't been set before.
      *
      * @param properties - The properties to register
-     * @param default_value - Default value for the property
+     * @param defaultValue - Default value for the property
      * @param days - Number of days to persist the properties
      */
-    register_once(properties: Properties, default_value?: any, days?: number): void
+    register_once(properties: Properties, defaultValue?: any, days?: number): void
 
     /**
      * Register properties for the current session only.

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -436,10 +436,10 @@ export interface PostHog {
      * Register properties to be sent with every event, but only if they haven't been set before.
      *
      * @param properties - The properties to register
-     * @param defaultValue - Default value for the property
+     * @param default_value - Default value for the property
      * @param days - Number of days to persist the properties
      */
-    register_once(properties: Properties, defaultValue?: any, days?: number): void
+    register_once(properties: Properties, default_value?: any, days?: number): void
 
     /**
      * Register properties for the current session only.


### PR DESCRIPTION
## Problem

`isFeatureEnabled` returns `undefined` when a flag has no value (flags not loaded yet, or no flag with that key), and callers have no way to supply a fallback. Android and Unity already expose a `defaultValue` parameter for this, and the sdk-specs server-side canonical signature includes `defaultValue` in its options — the JS SDKs did not.

## Changes

Adds an optional default value to `isFeatureEnabled`, returned whenever the flag has no value — flags not loaded, failed to load, or no flag with that key. When a flag *has* a value, it always wins over the default. Passing a default narrows the return type to `boolean` via TS overloads; without it, behavior and the `boolean | undefined` type are byte-for-byte unchanged.

- **`@posthog/core`** (inherited by `posthog-react-native` and `posthog-js-lite`): new `IsFeatureEnabledOptions` with `defaultValue?: boolean`. The implementation now calls `_getFeatureFlagResult` directly, using the legacy `missingFlagBehavior` only when no default is passed, so bare-call semantics and `$feature_flag_called` events are unchanged.
- **`posthog-js` (browser)**: same feature in its own implementation, as `defaultValue`, matching core/RN/js-lite (one option name across all JS SDKs). Applies to the `fresh`-miss, not-loaded, and missing-key paths.
- **`@posthog/types`**: `IsFeatureEnabledOptions` + interface overloads.
- **`posthog-react-native`**: override mirrors the overloads; JSDoc/docs updated.

Semantics match Android (`getFeatureFlagResult(key)?.value ?: defaultValue`) and Unity (`if (!flag.Value.HasValue) return defaultValue`): the default applies to *any* missing value, including a key absent from loaded flags. iOS and Flutter hard-code the equivalent of `defaultValue: false`.

Note for spec follow-up: the sdk-specs client-side canonical signature doesn't include `defaultValue` yet; it should be added once this ships.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [x] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Fable 5); Anna Garcia directed scope and decisions throughout.
- Key decisions: `defaultValue` lives in the existing options object (the positional slot is taken by `options` already shipped in stable; matches the sdk-specs server-side canonical shape); the default applies to any missing value, not just the not-loaded state (chosen for Android/Unity parity after comparing their implementations); bare calls keep returning `undefined` per the maintainer discussion on #3930.
- Verified against `sdk-specs/openspec/specs/is-feature-enabled/spec.md` and the Android, Unity, iOS, and Flutter implementations. Node/Python/PHP/Ruby are unaffected (separate implementations; Node's method is deprecated in favor of `evaluateFlags`).

