### PR TITLE
refactor(browser-common): use string extension tokens

### DIFF
--- a/.changeset/branded-browser-extension-tokens.md
+++ b/.changeset/branded-browser-extension-tokens.md
@@ -1,0 +1,5 @@
+---
+'@posthog/browser-common': patch
+---
+
+Represent extension capability tokens as branded runtime strings so independently compiled bundles resolve the same providers.

--- a/packages/browser-common/.agents/skills/develop-extension/SKILL.md
+++ b/packages/browser-common/.agents/skills/develop-extension/SKILL.md
@@ -123,7 +123,7 @@ export interface FeatureFlagsExtension extends Extension {
     onChange: Listener<FeatureFlagsChange>
 }
 
-export const FeatureFlags: ExtensionToken<FeatureFlagsExtension> = { name: 'featureFlags' }
+export const FeatureFlags = 'posthog.featureFlags' as ExtensionToken<FeatureFlagsExtension>
 ```
 
 ```ts
@@ -151,7 +151,8 @@ export function featureFlags(): FeatureFlagsExtension {
 ```
 
 The extension must be assignable to each token's type (the registry casts on lookup — the compiler does not check this
-for you).
+for you). A token is a branded runtime string, so use a package-qualified value that is globally unique and stable across
+separately compiled scripts (for example, `posthog.featureFlags`).
 
 ## Depending on another extension
 

--- a/packages/browser-common/README.md
+++ b/packages/browser-common/README.md
@@ -96,10 +96,12 @@ if (flags && (await flags.getFeatureFlag('beta-ui'))) {
 }
 ```
 
-A token is implementation-free, so importing it never pulls the provider's code
-into your bundle — each extension stays independently tree-shakable and lazily
-loadable. An extension that provides a capability declares its token(s) in
-`provides`.
+A token is an implementation-free branded string, so importing it never pulls
+the provider's code into your bundle — each extension stays independently
+tree-shakable and lazily loadable. Use a package-qualified runtime string, such
+as `posthog.featureFlags`, that is globally unique and stable so separately
+compiled scripts resolve the same capability. An extension that provides a
+capability declares its token(s) in `provides`.
 
 ## Utilities
 

--- a/packages/browser-common/src/token.ts
+++ b/packages/browser-common/src/token.ts
@@ -1,21 +1,22 @@
+/** Phantom brand carrying the capability type without emitting runtime code. */
+declare const extensionTokenType: unique symbol
+
 /**
- * A typed, implementation-free key for resolving an extension that provides a
- * capability. Declared as a shared `const` next to the providing extension's
+ * A typed, implementation-free string for resolving an extension that provides
+ * a capability. Declared as a shared `const` next to the providing extension's
  * interface:
  *
  * ```ts
  * export interface FeatureFlagsExtension extends Extension { … }
- * export const FeatureFlags: ExtensionToken<FeatureFlagsExtension> = { name: 'featureFlags' }
+ * export const FeatureFlags = 'posthog.featureFlags' as ExtensionToken<FeatureFlagsExtension>
  * ```
  *
  * A token holds no implementation, so importing one never pulls the provider's
- * code into the consumer's bundle. The registry is keyed by token identity
- * (the shared object reference), so provider and consumer must import the same
- * exported token; `name` is for diagnostics only.
+ * code into the consumer's bundle. Its generic brand lets `getExtension` infer
+ * the provided type, while its runtime string value remains stable across
+ * independently compiled scripts. Token strings must be globally unique and
+ * stable for the lifetime of the capability contract.
  */
-export interface ExtensionToken<T> {
-    /** Human-readable capability name used only for diagnostics. */
-    readonly name: string
-    /** Phantom: carries the provided type for inference; never present at runtime. */
-    readonly __provides?: T
+export type ExtensionToken<T> = string & {
+    readonly [extensionTokenType]: T
 }

--- a/packages/browser-common/tests/token.spec.ts
+++ b/packages/browser-common/tests/token.spec.ts
@@ -1,0 +1,24 @@
+import type { ExtensionToken } from '../src/token'
+import { createTestClient } from './helpers/test-client'
+
+describe('ExtensionToken', () => {
+    it('resolves equivalent string tokens declared independently', () => {
+        interface Capability {
+            value: string
+        }
+
+        const providerToken = 'posthog.test-capability' as ExtensionToken<Capability>
+        const consumerToken = `${'posthog.test-capability'}` as ExtensionToken<Capability>
+        const capability: Capability = { value: 'provided' }
+        const client = createTestClient()
+
+        const registration = client.registerExtension(providerToken, capability)
+        const resolved: Capability | undefined = client.getExtension(consumerToken)
+
+        expect(typeof providerToken).toBe('string')
+        expect(resolved).toBe(capability)
+
+        registration.dispose()
+        expect(client.getExtension(consumerToken)).toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Problem

Extension token objects are keyed by object identity, which cannot be shared reliably between independently compiled browser scripts. Browser common needs a stable, typed token representation before browser adapters and extensions depend on these cross-bundle lookups.

## Changes

- Represent `ExtensionToken<T>` as a branded string that retains generic type inference without emitting runtime code.
- Document package-qualified, globally unique token values.
- Verify that equivalent token strings declared independently resolve the same provider.
- Add a patch changeset for `@posthog/browser-common`.

This is non-behavior changing for the SDK: `ExtensionToken` remains type-only, `token.js` remains empty, and `main` has no production token declarations or extension registry implementation. This prepares the contract for later browser adapter work without changing current runtime behavior or bundle size.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with the Pi coding agent. The implementation uses a phantom-branded string rather than a runtime factory or global token catalog, preserving type inference and tree shaking while making token identity stable across separately compiled scripts. Validation covered the browser-common build, unit tests, lint, formatting, and diff checks.
