### PR TITLE
fix(surveys): keep open selector-triggered survey visible when trigger element is removed

### DIFF
--- a/.changeset/keep-open-selector-survey.md
+++ b/.changeset/keep-open-selector-survey.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: keep an open selector-triggered survey visible when its trigger element is removed from the DOM

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -577,6 +577,113 @@ describe('SurveyManager', () => {
         expect(manageWidgetSelectorListenerSpy).toHaveBeenCalledWith(mockSurvey, '.my-selector')
     })
 
+    describe('selector widget survey when the trigger element is removed', () => {
+        // Regression tests for https://github.com/PostHog/posthog-js/issues/2036
+        const selectorSurvey: Survey = {
+            id: 'selectorTriggerSurvey',
+            name: 'Selector Trigger Survey',
+            description: 'Feedback survey opened by a custom CSS selector',
+            type: SurveyType.Widget,
+            questions: [
+                {
+                    question: 'What can we do better?',
+                    type: SurveyQuestionType.Open,
+                    id: 'question-a',
+                },
+            ],
+            appearance: {
+                widgetType: SurveyWidgetType.Selector,
+                widgetSelector: '.survey-trigger',
+            },
+            schedule: SurveySchedule.Always,
+            conditions: null,
+            start_date: '2021-01-01T00:00:00.000Z',
+            end_date: null,
+            current_iteration: null,
+            current_iteration_start_date: null,
+            feature_flag_keys: [],
+            linked_flag_key: null,
+            targeting_flag_key: null,
+            internal_targeting_flag_key: null,
+        }
+
+        const getSurveyContainer = () => document.querySelector(`.PostHogSurvey-${selectorSurvey.id}`)
+        const getOpenPopup = () => getSurveyContainer()?.shadowRoot?.querySelector('.ph-survey') ?? null
+
+        const runEvaluationCycle = () => {
+            act(() => {
+                surveyManager.callSurveysAndEvaluateDisplayLogic()
+            })
+        }
+
+        const clickTrigger = () => {
+            act(() => {
+                fireEvent.click(document.querySelector('.survey-trigger')!)
+            })
+        }
+
+        beforeEach(() => {
+            document.body.innerHTML = '<button class="survey-trigger">Feedback</button>'
+            mockPostHog.surveys.getSurveys = jest.fn((callback) => callback([selectorSurvey]))
+        })
+
+        test('keeps an open survey visible when the trigger element is removed from the DOM', () => {
+            runEvaluationCycle()
+            clickTrigger()
+            expect(getOpenPopup()).toBeTruthy()
+
+            // the trigger unmounts (e.g. it lived inside a dropdown that closed)
+            document.querySelector('.survey-trigger')!.remove()
+            runEvaluationCycle()
+
+            expect(getOpenPopup()).toBeTruthy()
+        })
+
+        test('removes the survey container on the next cycle after the user closes the orphaned popup', () => {
+            jest.useFakeTimers()
+            runEvaluationCycle()
+            clickTrigger()
+            document.querySelector('.survey-trigger')!.remove()
+            runEvaluationCycle()
+            expect(getOpenPopup()).toBeTruthy()
+
+            act(() => {
+                fireEvent.click(getSurveyContainer()!.shadowRoot!.querySelector<HTMLButtonElement>('.form-cancel')!)
+                // resetShowSurvey hides the popup after a 200ms view-transition delay
+                jest.advanceTimersByTime(200)
+            })
+            runEvaluationCycle()
+
+            expect(getSurveyContainer()).toBeNull()
+            jest.useRealTimers()
+        })
+
+        test('removes the widget when the trigger element is removed and the survey is not open', () => {
+            runEvaluationCycle()
+            expect(getSurveyContainer()).toBeTruthy()
+
+            document.querySelector('.survey-trigger')!.remove()
+            runEvaluationCycle()
+
+            expect(getSurveyContainer()).toBeNull()
+        })
+
+        test('keeps an open survey visible when the trigger element is replaced by a new node', () => {
+            runEvaluationCycle()
+            clickTrigger()
+            expect(getOpenPopup()).toBeTruthy()
+
+            // the trigger is re-rendered (e.g. a framework replaced the node), so element identity changes
+            document.querySelector('.survey-trigger')!.remove()
+            const newTrigger = document.createElement('button')
+            newTrigger.className = 'survey-trigger'
+            document.body.appendChild(newTrigger)
+            runEvaluationCycle()
+
+            expect(getOpenPopup()).toBeTruthy()
+        })
+    })
+
     test('callSurveysAndEvaluateDisplayLogic should not call surveys in focus', () => {
         mockPostHog.surveys.getSurveys = jest.fn((callback) => callback(mockSurveys))
 

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -292,8 +292,12 @@ export class SurveyManager {
         )
     }
 
-    private _removeWidgetSelectorListener = (survey: Pick<Survey, 'id' | 'type' | 'appearance'>): void => {
-        this._removeSurveyFromDom(survey)
+    private _isSurveyPopupOpen = (survey: Pick<Survey, 'id'>): boolean => {
+        const shadowContainer = document.querySelector(getSurveyContainerClass(survey, true))
+        return !!shadowContainer?.shadowRoot?.querySelector('.ph-survey')
+    }
+
+    private _detachWidgetSelectorListener = (survey: Pick<Survey, 'id'>): void => {
         const existing = this._widgetSelectorListeners.get(survey.id)
         if (existing) {
             existing.element.removeEventListener('click', existing.listener)
@@ -303,12 +307,24 @@ export class SurveyManager {
         }
     }
 
+    private _removeWidgetSelectorListener = (survey: Pick<Survey, 'id' | 'type' | 'appearance'>): void => {
+        this._removeSurveyFromDom(survey)
+        this._detachWidgetSelectorListener(survey)
+    }
+
     private _manageWidgetSelectorListener = (survey: Survey, selector: string): void => {
         const currentElement = document.querySelector(selector)
         const existingListenerData = this._widgetSelectorListeners.get(survey.id)
 
         if (!currentElement) {
             if (existingListenerData) {
+                if (this._isSurveyPopupOpen(survey)) {
+                    // The trigger element disappeared (e.g. it lived inside a dropdown that closed)
+                    // while the survey is being answered. Keep the survey on screen and keep the
+                    // listener entry so this branch is re-evaluated; cleanup happens on the first
+                    // cycle after the user closes the survey.
+                    return
+                }
                 this._removeWidgetSelectorListener(survey)
             }
             return
@@ -320,7 +336,9 @@ export class SurveyManager {
             // Listener exists, check if element changed
             if (currentElement !== existingListenerData.element) {
                 logger.info(`Selector element changed for survey ${survey.id}. Re-attaching listener.`)
-                this._removeWidgetSelectorListener(survey)
+                // Only detach the listener; removing the whole survey DOM would close a survey
+                // the user currently has open
+                this._detachWidgetSelectorListener(survey)
                 // Continue to attach listener to the new element below
             } else {
                 // Element is the same, listener already attached, do nothing


### PR DESCRIPTION
## Problem

Fixes #2036. Selector-triggered surveys are removed mid-answer when the trigger element leaves the DOM, e.g. a trigger button inside a dropdown that closes. `_removeWidgetSelectorListener` removes the survey container unconditionally, and the popup's open state lives in `FeedbackWidget` where the manager never sees it. Replacing the trigger node (any re-render) kills an open survey the same way.

## Changes

If the popup is open (the shadow root contains `.ph-survey`) when the selector stops matching, removal is skipped. The evaluation loop runs every second, so the container is removed on the first cycle after the survey closes; a closed widget is still removed immediately. When the trigger element changes identity, only the click listener is detached and re-attached instead of tearing down the survey DOM. This is the behavior described in the issue. Added regression tests for the four paths; three fail on master.

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size
- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Assisted with Claude Code. Verified with the survey jest suite (466 passing); not manually tested in a browser.
