### PR TITLE
ci: sign the monorepo posthog-js upgrade commit

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -100,6 +100,9 @@ jobs:
                   HUSKY: '0'
               with:
                   token: ${{ steps.upgrader.outputs.token }}
+                  # Commit through the GitHub API so the bump is GPG-verified by GitHub and
+                  # attributed to the upgrader app, instead of an unsigned github-actions[bot] commit.
+                  sign-commits: true
                   commit-message: ${{ steps.generate-pr-details.outputs.title }}
                   branch: ${{ steps.generate-pr-details.outputs.branch_name }}
                   delete-branch: true


### PR DESCRIPTION
## Problem

The `PostHog Upgrade` workflow uses `peter-evans/create-pull-request`, which commits with local git.
That produces an **unsigned** commit authored by `github-actions[bot]` on every `posthog-js` bump PR into `PostHog/posthog`.
A commit-signing audit of the monorepo flagged these as the largest single-automation source of unverified commits landing on PR branches (~30/month).

## Changes

Set `sign-commits: true` on the create-pull-request step so the bump commit is created through the GitHub API.
GitHub signs API-created commits, so the commit is now **verified** and attributed to the upgrader app (`posthog-js-upgrader[bot]`) instead of an unsigned `github-actions[bot]` commit.

- One-line change; branch reuse, `delete-branch`, automerge, and reviewer assignment are untouched.
- No permission change: the app token already has `contents: write` on `PostHog/posthog` (it pushes the commit today).

## Release info Sub-libraries affected

### Libraries affected

None — CI/workflow-only change, no published package is affected.

## Checklist

- [ ] Tests for new code — N/A (workflow change; verified by dispatching the workflow and checking the resulting commit shows `Verified`)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- No changeset — CI-only change, nothing to release.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom directed this while reviewing a commit-signing audit of `PostHog/posthog`. The audit found the `posthog-js` dependency-bump commits landing unsigned as `github-actions[bot]`; we traced the source to this workflow's `peter-evans/create-pull-request` step (local-git commit) and applied the action's built-in `sign-commits: true` (commit via the GitHub API → GitHub-signed).

Considered swapping to `planetscale/ghcommit-action` (the monorepo standard) but rejected it — that action only commits to a branch, and this workflow's branch-reuse/PR-open/automerge flow would have to be reimplemented. The `sign-commits` flag reaches the same signed-via-API result with a one-line change. Validated with `actionlint`.
