### PR TITLE
fix(browser): send capture timestamps in request bodies

### DIFF
--- a/.changeset/fresh-clocks-travel.md
+++ b/.changeset/fresh-clocks-travel.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Send analytics request timestamps in capture bodies while retaining query timestamps for session recordings.

--- a/packages/browser/functional_tests/mock-server.ts
+++ b/packages/browser/functional_tests/mock-server.ts
@@ -5,6 +5,7 @@ import { setupServer } from 'msw/node'
 import { RestContext } from 'msw'
 import { RestRequest } from 'msw'
 import { decompressSync, strFromU8 } from 'fflate'
+import { isArray } from '@posthog/core'
 
 // the request bodies in a store that we can inspect within tests.
 const capturedRequests: { '/e/': any[]; '/engage/': any[]; '/flags/': any[] } = {
@@ -36,7 +37,8 @@ const handleRequest = (group: string) => (req: RestRequest, res: ResponseComposi
         }
     }
 
-    capturedRequests[group] = [...(capturedRequests[group] || []), body]
+    const requests = group === '/e/' ? (isArray(body) ? body : isArray(body.batch) ? body.batch : [body]) : [body]
+    capturedRequests[group] = [...(capturedRequests[group] || []), ...requests]
 
     return res(ctx.json({}))
 }

--- a/packages/browser/playwright/mocked/capture.spec.ts
+++ b/packages/browser/playwright/mocked/capture.spec.ts
@@ -65,8 +65,11 @@ test.describe('event capture', () => {
         // see e.g. https://github.com/microsoft/playwright/issues/6479
         if (browserName !== 'webkit') {
             const payload = getGzipEncodedPayloady(captureRequest)
-            expect(payload.event).toEqual('$pageview')
-            expect(Object.keys(payload.properties).length).toBeGreaterThan(0)
+            expect(payload.api_key).toEqual('test token')
+            expect(payload.sent_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+            expect(payload.batch).toHaveLength(1)
+            expect(payload.batch[0].event).toEqual('$pageview')
+            expect(Object.keys(payload.batch[0].properties).length).toBeGreaterThan(0)
         }
     })
 

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -4698,7 +4698,7 @@
           "name": "timeout"
         },
         {
-          "description": "Include the request dispatch time in a body field, capture envelope, or query string.",
+          "description": "Controls where the request dispatch time is sent. `body` adds ISO `sent_at` to the existing request object, `capture-body` wraps events in `{ api_key, batch, sent_at }`, and `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.",
           "type": "'body' | 'capture-body' | 'query'",
           "name": "timestampMode"
         },

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -4698,7 +4698,7 @@
           "name": "timeout"
         },
         {
-          "description": "Controls where the request dispatch time is sent. `body` adds ISO `sent_at` to the existing request object, `capture-body` wraps events in `{ api_key, batch, sent_at }`, and `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.",
+          "description": "Controls where the request dispatch time is sent. - `body` adds ISO `sent_at` to the existing request object (for example, flags). - `capture-body` wraps events in `{ api_key, batch, sent_at }` with an ISO timestamp. - `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.",
           "type": "'body' | 'capture-body' | 'query'",
           "name": "timestampMode"
         },

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -4698,8 +4698,8 @@
           "name": "timeout"
         },
         {
-          "description": "Include the request dispatch time in a body field or query string.",
-          "type": "'body' | 'query'",
+          "description": "Include the request dispatch time in a body field, capture envelope, or query string.",
+          "type": "'body' | 'capture-body' | 'query'",
           "name": "timestampMode"
         },
         {

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -396,13 +396,13 @@ describe('cookieless', () => {
 
             posthog.opt_in_capturing()
             expect(mockedFetch).toBeCalledTimes(3) // flags + opt in + pageview
-            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).event).toEqual('$opt_in')
-            expect(JSON.parse(mockedFetch.mock.calls[2][1].body).event).toEqual('$pageview')
+            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).batch[0].event).toEqual('$opt_in')
+            expect(JSON.parse(mockedFetch.mock.calls[2][1].body).batch[0].event).toEqual('$pageview')
 
             posthog.capture('custom event')
             jest.advanceTimersByTime(5000) // flush the batch queue (3s interval) without triggering 5-min remote config refresh
             expect(mockedFetch).toBeCalledTimes(4) // flags + opt in + pageview + custom event
-            expect(JSON.parse(mockedFetch.mock.calls[3][1].body)[0].event).toEqual('custom event')
+            expect(JSON.parse(mockedFetch.mock.calls[3][1].body).batch[0].event).toEqual('custom event')
         })
 
         it('should start the request queue when opting out (cookieless transport regression #3680)', async () => {
@@ -420,14 +420,16 @@ describe('cookieless', () => {
             posthog.opt_out_capturing()
             // opt_out triggers an initial $pageview in cookieless mode — it should be sent immediately (non-batched)
             expect(mockedFetch).toBeCalledTimes(2) // flags + pageview
-            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).event).toEqual('$pageview')
-            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).properties.distinct_id).toEqual('$posthog_cookieless')
+            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).batch[0].event).toEqual('$pageview')
+            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).batch[0].properties.distinct_id).toEqual(
+                '$posthog_cookieless'
+            )
 
             posthog.capture('custom event')
             jest.advanceTimersByTime(5000) // flush the batch queue
             expect(mockedFetch).toBeCalledTimes(3) // flags + pageview + custom event
-            expect(JSON.parse(mockedFetch.mock.calls[2][1].body)[0].event).toEqual('custom event')
-            expect(JSON.parse(mockedFetch.mock.calls[2][1].body)[0].properties.distinct_id).toEqual(
+            expect(JSON.parse(mockedFetch.mock.calls[2][1].body).batch[0].event).toEqual('custom event')
+            expect(JSON.parse(mockedFetch.mock.calls[2][1].body).batch[0].properties.distinct_id).toEqual(
                 '$posthog_cookieless'
             )
         })

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -338,7 +338,7 @@ describe('posthog core', () => {
             expect(posthog._send_request).toHaveBeenCalledWith(
                 expect.objectContaining({
                     url: 'https://us.i.posthog.com/e/',
-                    timestampMode: 'query',
+                    timestampMode: 'capture-body',
                 })
             )
         })
@@ -356,14 +356,22 @@ describe('posthog core', () => {
             )
         })
 
-        it('sends payloads to overriden endpoint if given', () => {
+        it('sends session recordings with sent_at in the query', () => {
             const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
 
-            posthog.capture('event-name', { foo: 'bar', length: 0 }, { _url: 'https://app.posthog.com/s/' })
+            posthog.capture(
+                'event-name',
+                { foo: 'bar', length: 0 },
+                {
+                    _url: 'https://app.posthog.com/s/',
+                    _batchKey: 'recordings',
+                }
+            )
 
             expect(posthog._send_request).toHaveBeenCalledWith(
                 expect.objectContaining({
                     url: 'https://app.posthog.com/s/',
+                    timestampMode: 'query',
                 })
             )
         })

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -385,6 +385,7 @@ describe('posthog core', () => {
             expect(posthog._send_request).toHaveBeenCalledWith(
                 expect.objectContaining({
                     url: 'https://app.posthog.com/s/',
+                    timestampMode: 'query',
                 })
             )
         })

--- a/packages/browser/src/__tests__/posthog-core.beforeSend.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.beforeSend.test.ts
@@ -80,7 +80,7 @@ describe('posthog core - before send', () => {
             compression: 'best-available',
             data: capturedData,
             method: 'POST',
-            timestampMode: 'query',
+            timestampMode: 'capture-body',
             url: 'https://us.i.posthog.com/e/',
         })
     })
@@ -149,7 +149,7 @@ describe('posthog core - before send', () => {
             compression: 'best-available',
             data: capturedData[0],
             method: 'POST',
-            timestampMode: 'query',
+            timestampMode: 'capture-body',
             url: 'https://us.i.posthog.com/e/',
         })
     })
@@ -172,7 +172,7 @@ describe('posthog core - before send', () => {
             compression: 'best-available',
             data: capturedData,
             method: 'POST',
-            timestampMode: 'query',
+            timestampMode: 'capture-body',
             url: 'https://us.i.posthog.com/e/',
         })
     })
@@ -195,7 +195,7 @@ describe('posthog core - before send', () => {
             compression: 'best-available',
             data: capturedData,
             method: 'POST',
-            timestampMode: 'query',
+            timestampMode: 'capture-body',
             url: 'https://us.i.posthog.com/e/',
         })
         expect(mockLogger.warn).toHaveBeenCalledWith(

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -205,29 +205,35 @@ describe('request', () => {
         })
 
         it.each([
-            ['/e/', 'https://any.posthog-instance.com/e/?sent_at=1700000000000'],
-            ['/i/v0/e/', 'https://any.posthog-instance.com/i/v0/e/?sent_at=1700000000000'],
-            ['/batch/', 'https://any.posthog-instance.com/batch/?sent_at=1700000000000&ver=1.23.45'],
-            ['/capture/', 'https://any.posthog-instance.com/capture/?sent_at=1700000000000&ver=1.23.45'],
-            ['/track/', 'https://any.posthog-instance.com/track/?sent_at=1700000000000&ver=1.23.45'],
-            ['/engage/', 'https://any.posthog-instance.com/engage/?sent_at=1700000000000&ver=1.23.45'],
-        ])('adds sent_at to the query without changing the capture body for %s', (path, expectedUrl) => {
+            ['/e/', 'https://any.posthog-instance.com/e/'],
+            ['/i/v0/e/', 'https://any.posthog-instance.com/i/v0/e/'],
+            ['/batch/', 'https://any.posthog-instance.com/batch/?ver=1.23.45'],
+            ['/capture/', 'https://any.posthog-instance.com/capture/?ver=1.23.45'],
+            ['/track/', 'https://any.posthog-instance.com/track/?ver=1.23.45'],
+            ['/engage/', 'https://any.posthog-instance.com/engage/?ver=1.23.45'],
+        ])('adds sent_at to the capture body for analytics endpoint %s', (path, expectedUrl) => {
             const event = { event: 'test event', properties: { token: 'testtoken' } }
             request(
                 createRequest({
                     url: `https://any.posthog-instance.com${path}`,
                     method: 'POST',
                     data: event,
-                    timestampMode: 'query',
+                    timestampMode: 'capture-body',
                 })
             )
 
             const [requestedUrl, requestOptions] = mockedFetch.mock.calls[0]
             expect(requestedUrl).toBe(expectedUrl)
-            expect(JSON.parse(requestOptions.body)).toEqual(event)
+            expect(requestedUrl).not.toContain('sent_at=')
+            expect(requestedUrl).not.toContain('_=')
+            expect(JSON.parse(requestOptions.body)).toEqual({
+                api_key: 'testtoken',
+                batch: [event],
+                sent_at: '2023-11-14T22:13:20.000Z',
+            })
         })
 
-        it('keeps batched analytics bodies unchanged and adds sent_at to the query', () => {
+        it('puts batched analytics events in one sent_at body envelope', () => {
             const events = [
                 { event: 'first event', properties: { token: 'testtoken' } },
                 { event: 'second event', properties: { token: 'testtoken' } },
@@ -237,26 +243,49 @@ describe('request', () => {
                     url: 'https://any.posthog-instance.com/e/',
                     method: 'POST',
                     data: events,
-                    timestampMode: 'query',
+                    timestampMode: 'capture-body',
                 })
             )
 
-            expect(mockedFetch.mock.calls[0][0]).toBe('https://any.posthog-instance.com/e/?sent_at=1700000000000')
-            expect(JSON.parse(mockedFetch.mock.calls[0][1].body)).toEqual(events)
+            expect(JSON.parse(mockedFetch.mock.calls[0][1].body)).toEqual({
+                api_key: 'testtoken',
+                batch: events,
+                sent_at: '2023-11-14T22:13:20.000Z',
+            })
         })
 
-        it('adds sent_at to the query for session recording requests', () => {
+        it('uses a top-level event token in the capture body envelope', () => {
+            const event = { event: 'test event', token: 'testtoken' }
+            request(
+                createRequest({
+                    url: 'https://any.posthog-instance.com/e/',
+                    method: 'POST',
+                    data: event,
+                    timestampMode: 'capture-body',
+                })
+            )
+
+            expect(JSON.parse(mockedFetch.mock.calls[0][1].body)).toEqual({
+                api_key: 'testtoken',
+                batch: [event],
+                sent_at: '2023-11-14T22:13:20.000Z',
+            })
+        })
+
+        it('keeps session recording bodies unchanged and adds sent_at to the query', () => {
+            const recording = { event: '$snapshot' }
             request(
                 createRequest({
                     url: 'https://any.posthog-instance.com/ingest/s/',
                     method: 'POST',
-                    data: { event: '$snapshot' },
+                    data: recording,
                     timestampMode: 'query',
                 })
             )
 
-            const requestedUrl = mockedFetch.mock.calls[0][0]
+            const [requestedUrl, requestOptions] = mockedFetch.mock.calls[0]
             expect(requestedUrl).toBe('https://any.posthog-instance.com/ingest/s/?sent_at=1700000000000')
+            expect(JSON.parse(requestOptions.body)).toEqual(recording)
         })
 
         it('does not rely on String.prototype.endsWith for capture endpoint matching', () => {
@@ -270,12 +299,12 @@ describe('request', () => {
                         url: 'https://any.posthog-instance.com/e/',
                         method: 'POST',
                         data: { event: 'test event', properties: { token: 'testtoken' } },
-                        timestampMode: 'query',
+                        timestampMode: 'capture-body',
                     })
                 )
 
                 const requestedUrl = mockedFetch.mock.calls[0][0]
-                expect(requestedUrl).toBe('https://any.posthog-instance.com/e/?sent_at=1700000000000')
+                expect(requestedUrl).toBe('https://any.posthog-instance.com/e/')
             } finally {
                 String.prototype.endsWith = originalEndsWith
             }
@@ -287,12 +316,12 @@ describe('request', () => {
                     url: 'https://any.posthog-instance.com/e/?ver=1.23.45&foo=bar',
                     method: 'POST',
                     data: { event: 'test event', properties: { token: 'testtoken' } },
-                    timestampMode: 'query',
+                    timestampMode: 'capture-body',
                 })
             )
 
             const requestedUrl = mockedFetch.mock.calls[0][0]
-            expect(requestedUrl).toBe('https://any.posthog-instance.com/e/?foo=bar&sent_at=1700000000000')
+            expect(requestedUrl).toBe('https://any.posthog-instance.com/e/?foo=bar')
         })
 
         it('adds sent_at to the body and keeps ver on POST feature flag requests', () => {
@@ -1034,7 +1063,12 @@ describe('request', () => {
             })
 
             describe('quota rejection (sendBeacon returns false)', () => {
-                const bigEvent = (i: number) => ({ event: 'big', i, payload: 'x'.repeat(8 * 1024) })
+                const bigEvent = (i: number) => ({
+                    event: 'big',
+                    i,
+                    payload: 'x'.repeat(8 * 1024),
+                    properties: { token: 'testtoken' },
+                })
                 let warnSpy: jest.SpyInstance
 
                 beforeEach(() => {
@@ -1048,15 +1082,14 @@ describe('request', () => {
                     warnSpy.mockRestore()
                 })
 
-                it('splits a rejected over-quota batch without dropping sent_at', () => {
+                it('splits a rejected sent_at body envelope in half and re-sends each piece', async () => {
                     mockedNavigator!.sendBeacon.mockReturnValueOnce(false).mockReturnValue(true)
 
                     request(
                         createRequest({
-                            url: 'https://any.posthog-instance.com/e/',
                             method: 'POST',
                             data: [bigEvent(1), bigEvent(2), bigEvent(3), bigEvent(4)],
-                            timestampMode: 'query',
+                            timestampMode: 'capture-body',
                         })
                     )
 
@@ -1066,10 +1099,30 @@ describe('request', () => {
                     )
                     expect(firstHalf).toBeLessThan(full)
                     expect(secondHalf).toBeLessThan(full)
-                    expect(mockedNavigator?.sendBeacon.mock.calls.map((call) => call[0])).toEqual([
-                        'https://any.posthog-instance.com/e/?sent_at=1700000000000&compression=base64',
-                        'https://any.posthog-instance.com/e/?sent_at=1700000000000&compression=base64',
-                        'https://any.posthog-instance.com/e/?sent_at=1700000000000&compression=base64',
+
+                    const splitBodies = await Promise.all(
+                        mockedNavigator!.sendBeacon.mock.calls.slice(1).map(async (call) => {
+                            const text = await new Promise<string>((resolve) => {
+                                const reader = new FileReader()
+                                reader.onload = () => resolve(reader.result as string)
+                                reader.readAsText(call[1] as Blob)
+                            })
+                            return JSON.parse(
+                                Buffer.from(decodeURIComponent(text.slice('data='.length)), 'base64').toString()
+                            )
+                        })
+                    )
+                    expect(splitBodies).toEqual([
+                        {
+                            api_key: 'testtoken',
+                            batch: [bigEvent(1), bigEvent(2)],
+                            sent_at: '2023-11-14T22:13:20.000Z',
+                        },
+                        {
+                            api_key: 'testtoken',
+                            batch: [bigEvent(3), bigEvent(4)],
+                            sent_at: '2023-11-14T22:13:20.000Z',
+                        },
                     ])
                     expect(mockedFetch).not.toHaveBeenCalled()
                 })
@@ -1214,28 +1267,31 @@ describe('request', () => {
             isolatedCompression = (await import('../types')).Compression
         })
 
-        it('retries uncompressed without dropping sent_at after NotReadableError', async () => {
+        it('retries uncompressed without dropping the capture envelope after NotReadableError', async () => {
             mockedIsolatedGzipCompress.mockRejectedValueOnce({ name: 'NotReadableError' })
+            const event = { event: 'test event', properties: { token: 'testtoken' } }
 
             isolatedRequestModule.request({
-                url: 'https://any.posthog-instance.com?ver=1.23.45',
-                data: { foo: 'bar' },
+                url: 'https://any.posthog-instance.com/e/',
+                data: event,
                 headers: {},
                 callback: jest.fn(),
                 transport: 'fetch',
                 method: 'POST',
                 compression: isolatedCompression.GZipJS,
-                timestampMode: 'query',
+                timestampMode: 'capture-body',
             })
 
             await flushPromises()
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toMatch(
-                /^https:\/\/any\.posthog-instance\.com\?ver=1\.23\.45&sent_at=\d+$/
-            )
-            expect(mockedIsolatedFetch.mock.calls[0][1].body).toBe('{"foo":"bar"}')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).toBe('https://any.posthog-instance.com/e/')
+            expect(JSON.parse(mockedIsolatedFetch.mock.calls[0][1].body)).toEqual({
+                api_key: 'testtoken',
+                batch: [event],
+                sent_at: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+            })
 
             mockedIsolatedFetch.mockClear()
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1511,7 +1511,7 @@ export class PostHog implements PostHogInterface {
             url: options?._url ?? this.requestRouter.endpointFor('api', this.analyticsDefaultEndpoint),
             data,
             compression: 'best-available',
-            timestampMode: 'query',
+            timestampMode: options?._batchKey === 'recordings' ? 'query' : 'capture-body',
             batchKey: options?._batchKey,
             transport: options?.transport,
         }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1506,12 +1506,14 @@ export class PostHog implements PostHogInterface {
 
         this._internalEventEmitter.emit('eventCaptured', data)
 
+        const url = options?._url ?? this.requestRouter.endpointFor('api', this.analyticsDefaultEndpoint)
+        const isSessionRecording = options?._batchKey === 'recordings' || /\/s\/(?:\?|$)/.test(url)
         const requestOptions: QueuedRequestWithOptions = {
             method: 'POST',
-            url: options?._url ?? this.requestRouter.endpointFor('api', this.analyticsDefaultEndpoint),
+            url,
             data,
             compression: 'best-available',
-            timestampMode: options?._batchKey === 'recordings' ? 'query' : 'capture-body',
+            timestampMode: isSessionRecording ? 'query' : 'capture-body',
             batchKey: options?._batchKey,
             transport: options?.transport,
         }

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -439,10 +439,13 @@ const _sendBeacon = (options: RequestWithOptions) => {
 
         // rejected: over the page's shared ~64KiB in-flight keepalive quota
         // (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch) — halve so what fits still delivers
-        if (isArray(options.data) && options.data.length > 1 && (estimatedSize ?? 0) > BEACON_SPLIT_FLOOR_BYTES) {
-            const mid = Math.ceil(options.data.length / 2)
-            _sendBeacon({ ...options, data: options.data.slice(0, mid) })
-            _sendBeacon({ ...options, data: options.data.slice(mid) })
+        const batch = isArray(options.data) ? options.data : options.data?.batch
+        if (isArray(batch) && batch.length > 1 && (estimatedSize ?? 0) > BEACON_SPLIT_FLOOR_BYTES) {
+            const mid = Math.ceil(batch.length / 2)
+            const splitData = (events: Record<string, any>[]): RequestWithOptions['data'] =>
+                isArray(options.data) ? events : { ...options.data, batch: events }
+            _sendBeacon({ ...options, data: splitData(batch.slice(0, mid)) })
+            _sendBeacon({ ...options, data: splitData(batch.slice(mid)) })
             return
         }
 
@@ -494,6 +497,17 @@ const buildRequestURL = (
     )
 }
 
+const addSentAtToCaptureBody = (data: NonNullable<RequestWithOptions['data']>): Record<string, any> => {
+    const batch = isArray(data) ? data : [data]
+    const firstEvent = batch[0]
+
+    return {
+        api_key: firstEvent?.properties?.token ?? firstEvent?.token,
+        batch,
+        sent_at: new Date().toISOString(),
+    }
+}
+
 const AVAILABLE_TRANSPORTS: {
     transport: RequestWithOptions['transport']
     method: (options: RequestWithOptions) => void
@@ -535,8 +549,12 @@ export const request = (_options: RequestWithOptions) => {
         options.compression = Compression.Base64
     }
 
-    if (options.timestampMode === 'body' && options.method === 'POST' && options.data && !isArray(options.data)) {
-        options.data = { ...options.data, sent_at: new Date().toISOString() }
+    if (options.method === 'POST' && options.data) {
+        if (options.timestampMode === 'capture-body') {
+            options.data = addSentAtToCaptureBody(options.data)
+        } else if (options.timestampMode === 'body' && !isArray(options.data)) {
+            options.data = { ...options.data, sent_at: new Date().toISOString() }
+        }
     }
 
     options.url = buildRequestURL(options.url, options.method, options.compression, options.timestampMode)

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -231,8 +231,8 @@ export interface RequestWithOptions {
     noRetries?: boolean
     disableTransport?: ('XHR' | 'fetch' | 'sendBeacon')[]
     compression?: Compression | 'best-available'
-    /** Include the request dispatch time in a body field or query string. */
-    timestampMode?: 'body' | 'query'
+    /** Include the request dispatch time in a body field, capture envelope, or query string. */
+    timestampMode?: 'body' | 'capture-body' | 'query'
     fetchOptions?: {
         cache?: RequestInit['cache']
         next?: NextOptions

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -231,7 +231,12 @@ export interface RequestWithOptions {
     noRetries?: boolean
     disableTransport?: ('XHR' | 'fetch' | 'sendBeacon')[]
     compression?: Compression | 'best-available'
-    /** Include the request dispatch time in a body field, capture envelope, or query string. */
+    /**
+     * Controls where the request dispatch time is sent.
+     * - `body` adds ISO `sent_at` to the existing request object (for example, flags).
+     * - `capture-body` wraps events in `{ api_key, batch, sent_at }` with an ISO timestamp.
+     * - `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.
+     */
     timestampMode?: 'body' | 'capture-body' | 'query'
     fetchOptions?: {
         cache?: RequestInit['cache']


### PR DESCRIPTION
## Problem

Browser analytics requests currently send their dispatch timestamp as a numeric `sent_at` query parameter. The analytics capture backend supports the batch-style request envelope and reads an ISO `sent_at` value from its body, which avoids putting this metadata in analytics request URLs.

Session recording ingestion uses a separate payload parser that does not yet support the batch envelope, so `/s/` must continue using the query parameter.

## Changes

- Wrap analytics payloads for `/e/`, `/i/v0/e/`, `/batch/`, `/capture/`, `/track/`, and `/engage/` in `{ api_key, batch, sent_at }`, with an ISO dispatch timestamp.
- Keep session recording payloads unchanged and retain their numeric query `sent_at`.
- Preserve the analytics envelope when oversized beacons are split or native gzip falls back to an uncompressed request.
- Document the distinct `body`, `capture-body`, and `query` timestamp modes.
- Update functional request handling, API references, and focused coverage for every supported analytics route and the `/s/` exception.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. A scout subagent verified the current backend request parsers and routing, and a reviewer subagent audited the browser diff. Based on that verification, all analytics aliases use the supported batch envelope while session recording remains on its existing query timestamp until `/s/` supports a body envelope.
