### PR TITLE
fix(node): normalize V8 promise index frames

### DIFF
--- a/.changeset/tidy-promises-frame.md
+++ b/.changeset/tidy-promises-frame.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-node': patch
+---
+
+Normalize V8 Promise combinator stack frames so input indexes are not treated as source filenames.

--- a/packages/core/src/error-tracking/parsers/node.spec.ts
+++ b/packages/core/src/error-tracking/parsers/node.spec.ts
@@ -1,0 +1,19 @@
+import { nodeStackLineParser } from './node'
+
+describe('nodeStackLineParser', () => {
+  it.each([
+    ['at async Promise.all (index 3)', 'Promise.all'],
+    ['at async Promise.all (index 472)', 'Promise.all'],
+    ['at async Promise.any (index 11)', 'Promise.any'],
+  ])('canonicalizes the V8 Promise index in %s', (line, functionName) => {
+    expect(nodeStackLineParser(line, 'node:javascript')).toEqual({
+      filename: 'node:internal/promise',
+      module: undefined,
+      function: functionName,
+      lineno: undefined,
+      colno: undefined,
+      in_app: false,
+      platform: 'node:javascript',
+    })
+  })
+})

--- a/packages/core/src/error-tracking/parsers/node.ts
+++ b/packages/core/src/error-tracking/parsers/node.ts
@@ -8,6 +8,9 @@ import { UNKNOWN_FUNCTION } from './base'
 /** Node Stack line parser */
 const FILENAME_MATCH = /^\s*[-]{4,}$/
 const FULL_MATCH = /at (?:async )?(?:(.+?)\s+\()?(?:(.+):(\d+):(\d+)?|([^)]+))\)?/
+const PROMISE_COMBINATOR = /^Promise\.(?:all|any)$/
+const PROMISE_INDEX = /^index \d+$/
+const PROMISE_FRAME_FILENAME = 'node:internal/promise'
 
 export const nodeStackLineParser: StackLineParser = (line: string, platform: Platform) => {
   const lineMatch = line.match(FULL_MATCH)
@@ -64,6 +67,11 @@ export const nodeStackLineParser: StackLineParser = (line: string, platform: Pla
 
     if (!filename && lineMatch[5] && !isNative) {
       filename = lineMatch[5]
+    }
+
+    // V8's Promise index identifies the input promise rather than a source file.
+    if (PROMISE_COMBINATOR.test(functionName) && PROMISE_INDEX.test(filename || '')) {
+      filename = PROMISE_FRAME_FILENAME
     }
 
     return {


### PR DESCRIPTION
## Problem

V8 renders asynchronous Promise combinator frames as `Promise.all (index N)` or `Promise.any (index N)`. The Node stack parser treated the input position as a source filename, producing different frame identifiers for otherwise equivalent frames.

https://us.posthog.com/project/2/error_tracking/019f8c1b-0cf6-7281-833b-f65414a9094a/fingerprints

## Changes

- Canonicalize V8 Promise combinator pseudo-locations to `node:internal/promise` while preserving the function name.
- Cover both `Promise.all` and `Promise.any`, including varying input indexes.
- Add patch changesets for `@posthog/core` and `posthog-node`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent after investigating how V8 Promise combinator frames flow through the Node parser. The change is intentionally parser-only: indexed pseudo-locations are canonicalized at capture time rather than adding server-side normalization. Targeted Jest tests, package lint, and the dependency-aware core build passed.