### PR TITLE
feat(mcp): read client identity from request `_meta`

### DIFF
--- a/.changeset/mcp-client-identity-from-meta.md
+++ b/.changeset/mcp-client-identity-from-meta.md
@@ -1,0 +1,5 @@
+---
+"@posthog/mcp": patch
+---
+
+Read the MCP client name/version and protocol version from each request's `_meta` (`io.modelcontextprotocol/clientInfo` and `io.modelcontextprotocol/protocolVersion`), so `$mcp_client_name`, `$mcp_client_version`, and `$mcp_protocol_version` keep populating under the MCP 2026-07-28 stateless revision, which removes the `initialize` handshake. Existing clients are unaffected — when `_meta` is absent, the values from the session token / `initialize` still apply.

--- a/packages/mcp/src/__tests__/client-identity.test.ts
+++ b/packages/mcp/src/__tests__/client-identity.test.ts
@@ -1,0 +1,86 @@
+import {
+  META_CLIENT_INFO_KEY,
+  META_PROTOCOL_VERSION_KEY,
+  applyMetaClientInfo,
+  readMetaClientInfo,
+} from '../extensions/client-identity'
+import type { MCPAnalyticsData, MCPRequestLike, SessionInfo } from '../types'
+
+function requestWithMeta(meta: Record<string, unknown> | undefined): MCPRequestLike {
+  return { method: 'tools/call', params: { name: 'echo', arguments: {}, _meta: meta } }
+}
+
+function dataWithSessionInfo(sessionInfo: Partial<SessionInfo> = {}): MCPAnalyticsData {
+  return { sessionInfo } as unknown as MCPAnalyticsData
+}
+
+describe('client-identity (_meta client info)', () => {
+  describe('readMetaClientInfo', () => {
+    it('reads clientInfo name/version and protocolVersion from _meta', () => {
+      const info = readMetaClientInfo(
+        requestWithMeta({
+          [META_CLIENT_INFO_KEY]: { name: 'codex', version: '1.2.3' },
+          [META_PROTOCOL_VERSION_KEY]: '2026-07-28',
+        })
+      )
+      expect(info).toEqual({ clientName: 'codex', clientVersion: '1.2.3', protocolVersion: '2026-07-28' })
+    })
+
+    it('returns undefined when _meta is absent', () => {
+      expect(readMetaClientInfo(requestWithMeta(undefined))).toBeUndefined()
+      expect(readMetaClientInfo({ method: 'tools/call', params: { name: 'echo' } })).toBeUndefined()
+      expect(readMetaClientInfo({ method: 'tools/call' })).toBeUndefined()
+    })
+
+    it('returns undefined when _meta has no recognized keys', () => {
+      expect(readMetaClientInfo(requestWithMeta({ 'com.other/thing': 1 }))).toBeUndefined()
+    })
+
+    it('ignores empty / non-string fields', () => {
+      const info = readMetaClientInfo(
+        requestWithMeta({
+          [META_CLIENT_INFO_KEY]: { name: '', version: 42 },
+          [META_PROTOCOL_VERSION_KEY]: '',
+        })
+      )
+      expect(info).toBeUndefined()
+    })
+
+    it('reads a partial (protocolVersion only)', () => {
+      expect(readMetaClientInfo(requestWithMeta({ [META_PROTOCOL_VERSION_KEY]: '2026-07-28' }))).toEqual({
+        protocolVersion: '2026-07-28',
+      })
+    })
+  })
+
+  describe('applyMetaClientInfo', () => {
+    it('copies present fields onto sessionInfo', () => {
+      const data = dataWithSessionInfo()
+      applyMetaClientInfo(
+        data,
+        requestWithMeta({
+          [META_CLIENT_INFO_KEY]: { name: 'codex', version: '1.2.3' },
+          [META_PROTOCOL_VERSION_KEY]: '2026-07-28',
+        })
+      )
+      expect(data.sessionInfo.clientName).toBe('codex')
+      expect(data.sessionInfo.clientVersion).toBe('1.2.3')
+      expect(data.sessionInfo.protocolVersion).toBe('2026-07-28')
+    })
+
+    it('leaves existing values untouched when _meta is absent', () => {
+      const data = dataWithSessionInfo({ clientName: 'existing', protocolVersion: '2025-11-25' })
+      applyMetaClientInfo(data, requestWithMeta(undefined))
+      expect(data.sessionInfo.clientName).toBe('existing')
+      expect(data.sessionInfo.protocolVersion).toBe('2025-11-25')
+    })
+
+    it('only overwrites the fields the request actually carries', () => {
+      const data = dataWithSessionInfo({ clientName: 'existing', clientVersion: '0.0.1' })
+      applyMetaClientInfo(data, requestWithMeta({ [META_PROTOCOL_VERSION_KEY]: '2026-07-28' }))
+      expect(data.sessionInfo.clientName).toBe('existing')
+      expect(data.sessionInfo.clientVersion).toBe('0.0.1')
+      expect(data.sessionInfo.protocolVersion).toBe('2026-07-28')
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/client-identity.test.ts
+++ b/packages/mcp/src/__tests__/client-identity.test.ts
@@ -1,17 +1,13 @@
 import {
   META_CLIENT_INFO_KEY,
   META_PROTOCOL_VERSION_KEY,
-  applyMetaClientInfo,
   readMetaClientInfo,
+  stampMetaClientInfo,
 } from '../extensions/client-identity'
-import type { MCPAnalyticsData, MCPRequestLike, SessionInfo } from '../types'
+import type { McpEvent, MCPRequestLike } from '../types'
 
 function requestWithMeta(meta: Record<string, unknown> | undefined): MCPRequestLike {
   return { method: 'tools/call', params: { name: 'echo', arguments: {}, _meta: meta } }
-}
-
-function dataWithSessionInfo(sessionInfo: Partial<SessionInfo> = {}): MCPAnalyticsData {
-  return { sessionInfo } as unknown as MCPAnalyticsData
 }
 
 describe('client-identity (_meta client info)', () => {
@@ -53,34 +49,45 @@ describe('client-identity (_meta client info)', () => {
     })
   })
 
-  describe('applyMetaClientInfo', () => {
-    it('copies present fields onto sessionInfo', () => {
-      const data = dataWithSessionInfo()
-      applyMetaClientInfo(
-        data,
+  describe('stampMetaClientInfo', () => {
+    it('stamps present fields onto the event', () => {
+      const event: McpEvent = {}
+      stampMetaClientInfo(
+        event,
         requestWithMeta({
           [META_CLIENT_INFO_KEY]: { name: 'codex', version: '1.2.3' },
           [META_PROTOCOL_VERSION_KEY]: '2026-07-28',
         })
       )
-      expect(data.sessionInfo.clientName).toBe('codex')
-      expect(data.sessionInfo.clientVersion).toBe('1.2.3')
-      expect(data.sessionInfo.protocolVersion).toBe('2026-07-28')
+      expect(event.clientName).toBe('codex')
+      expect(event.clientVersion).toBe('1.2.3')
+      expect(event.protocolVersion).toBe('2026-07-28')
     })
 
-    it('leaves existing values untouched when _meta is absent', () => {
-      const data = dataWithSessionInfo({ clientName: 'existing', protocolVersion: '2025-11-25' })
-      applyMetaClientInfo(data, requestWithMeta(undefined))
-      expect(data.sessionInfo.clientName).toBe('existing')
-      expect(data.sessionInfo.protocolVersion).toBe('2025-11-25')
+    it('leaves the event untouched when _meta is absent', () => {
+      const event: McpEvent = { clientName: 'existing', protocolVersion: '2025-11-25' }
+      stampMetaClientInfo(event, requestWithMeta(undefined))
+      expect(event.clientName).toBe('existing')
+      expect(event.protocolVersion).toBe('2025-11-25')
     })
 
     it('only overwrites the fields the request actually carries', () => {
-      const data = dataWithSessionInfo({ clientName: 'existing', clientVersion: '0.0.1' })
-      applyMetaClientInfo(data, requestWithMeta({ [META_PROTOCOL_VERSION_KEY]: '2026-07-28' }))
-      expect(data.sessionInfo.clientName).toBe('existing')
-      expect(data.sessionInfo.clientVersion).toBe('0.0.1')
-      expect(data.sessionInfo.protocolVersion).toBe('2026-07-28')
+      const event: McpEvent = { clientName: 'existing', clientVersion: '0.0.1' }
+      stampMetaClientInfo(event, requestWithMeta({ [META_PROTOCOL_VERSION_KEY]: '2026-07-28' }))
+      expect(event.clientName).toBe('existing')
+      expect(event.clientVersion).toBe('0.0.1')
+      expect(event.protocolVersion).toBe('2026-07-28')
+    })
+
+    it('does not cross-attribute across two concurrent requests sharing a server', () => {
+      // Each request stamps its OWN event, so one can't clobber the other's
+      // identity — the property the shared-state approach lacked.
+      const eventA: McpEvent = {}
+      const eventB: McpEvent = {}
+      stampMetaClientInfo(eventA, requestWithMeta({ [META_CLIENT_INFO_KEY]: { name: 'codex', version: '1.0.0' } }))
+      stampMetaClientInfo(eventB, requestWithMeta({ [META_CLIENT_INFO_KEY]: { name: 'claude', version: '2.0.0' } }))
+      expect(eventA.clientName).toBe('codex')
+      expect(eventB.clientName).toBe('claude')
     })
   })
 })

--- a/packages/mcp/src/extensions/capture.ts
+++ b/packages/mcp/src/extensions/capture.ts
@@ -48,8 +48,11 @@ export function captureEvent(server: MCPServerLike, eventInput: McpEvent): Promi
     sdkVersion: sessionInfo.sdkVersion,
     serverName: sessionInfo.serverName,
     serverVersion: sessionInfo.serverVersion,
-    clientName: sessionInfo.clientName,
-    clientVersion: sessionInfo.clientVersion,
+    // Prefer identity the event captured for *this* request (from `_meta`, see
+    // stampMetaClientInfo) over the server-wide sessionInfo, so a concurrent
+    // request from another client can't misattribute this one.
+    clientName: eventInput.clientName ?? sessionInfo.clientName,
+    clientVersion: eventInput.clientVersion ?? sessionInfo.clientVersion,
     identifyActorGivenId: sessionInfo.identifyActorGivenId,
     identifyActorData: sessionInfo.identifyActorData,
     groups: sessionInfo.identifyActorGroups,

--- a/packages/mcp/src/extensions/client-identity.ts
+++ b/packages/mcp/src/extensions/client-identity.ts
@@ -1,4 +1,4 @@
-import type { MCPAnalyticsData, MCPRequestLike } from '../types'
+import type { McpEvent, MCPRequestLike } from '../types'
 
 /**
  * Client identity under the MCP 2026-07-28 (stateless) revision.
@@ -52,25 +52,30 @@ export function readMetaClientInfo(request: MCPRequestLike): MetaClientInfo | un
 }
 
 /**
- * Copies any client identity found in `params._meta` onto the shared session
- * info, so events built later in the request carry `$mcp_client_name`,
+ * Stamps any client identity found in `params._meta` directly onto the event
+ * being built for *this* request, so it carries `$mcp_client_name`,
  * `$mcp_client_version`, and `$mcp_protocol_version` even when there was no
- * `initialize` to learn them from (the modern stateless case). Only fields the
- * request actually carries are written — a request without `_meta` leaves the
- * existing values (from a session token / initialize) untouched.
+ * `initialize` to learn them from (the modern stateless case).
+ *
+ * Writing to the event — a per-request object — rather than the server-wide
+ * `sessionInfo` keeps identity correct when one instrumented server multiplexes
+ * concurrent requests from different clients (which the stateless spec allows):
+ * a sibling request can't clobber this event's attribution between now and when
+ * it's captured. Only fields the request actually carries are set, so a request
+ * without `_meta` leaves the event's existing values untouched.
  */
-export function applyMetaClientInfo(data: MCPAnalyticsData, request: MCPRequestLike): void {
+export function stampMetaClientInfo(event: McpEvent, request: MCPRequestLike): void {
   const info = readMetaClientInfo(request)
   if (!info) {
     return
   }
   if (info.clientName) {
-    data.sessionInfo.clientName = info.clientName
+    event.clientName = info.clientName
   }
   if (info.clientVersion) {
-    data.sessionInfo.clientVersion = info.clientVersion
+    event.clientVersion = info.clientVersion
   }
   if (info.protocolVersion) {
-    data.sessionInfo.protocolVersion = info.protocolVersion
+    event.protocolVersion = info.protocolVersion
   }
 }

--- a/packages/mcp/src/extensions/client-identity.ts
+++ b/packages/mcp/src/extensions/client-identity.ts
@@ -1,0 +1,76 @@
+import type { MCPAnalyticsData, MCPRequestLike } from '../types'
+
+/**
+ * Client identity under the MCP 2026-07-28 (stateless) revision.
+ *
+ * That revision removes the `initialize` handshake and the `Mcp-Session-Id`
+ * header (SEP-2575 / SEP-2567). Client name/version and the protocol version no
+ * longer arrive once at `initialize` — they travel in every request's
+ * `params._meta` under these reverse-DNS keys. We mirror the literal key strings
+ * here rather than depend on the (still beta) v2 SDK, which is not a dependency
+ * of this package.
+ */
+export const META_CLIENT_INFO_KEY = 'io.modelcontextprotocol/clientInfo'
+export const META_PROTOCOL_VERSION_KEY = 'io.modelcontextprotocol/protocolVersion'
+
+export interface MetaClientInfo {
+  clientName?: string
+  clientVersion?: string
+  protocolVersion?: string
+}
+
+/**
+ * Reads the client name/version and protocol version a modern client puts in
+ * `params._meta`. Returns `undefined` when the request carries none (e.g. a
+ * legacy client, which sends this on `initialize` instead). Never throws.
+ */
+export function readMetaClientInfo(request: MCPRequestLike): MetaClientInfo | undefined {
+  const meta = request.params?._meta
+  if (!meta || typeof meta !== 'object') {
+    return undefined
+  }
+  const record = meta as Record<string, unknown>
+  const result: MetaClientInfo = {}
+
+  const clientInfo = record[META_CLIENT_INFO_KEY]
+  if (clientInfo && typeof clientInfo === 'object') {
+    const { name, version } = clientInfo as Record<string, unknown>
+    if (typeof name === 'string' && name.length > 0) {
+      result.clientName = name
+    }
+    if (typeof version === 'string' && version.length > 0) {
+      result.clientVersion = version
+    }
+  }
+
+  const protocolVersion = record[META_PROTOCOL_VERSION_KEY]
+  if (typeof protocolVersion === 'string' && protocolVersion.length > 0) {
+    result.protocolVersion = protocolVersion
+  }
+
+  return result.clientName || result.clientVersion || result.protocolVersion ? result : undefined
+}
+
+/**
+ * Copies any client identity found in `params._meta` onto the shared session
+ * info, so events built later in the request carry `$mcp_client_name`,
+ * `$mcp_client_version`, and `$mcp_protocol_version` even when there was no
+ * `initialize` to learn them from (the modern stateless case). Only fields the
+ * request actually carries are written — a request without `_meta` leaves the
+ * existing values (from a session token / initialize) untouched.
+ */
+export function applyMetaClientInfo(data: MCPAnalyticsData, request: MCPRequestLike): void {
+  const info = readMetaClientInfo(request)
+  if (!info) {
+    return
+  }
+  if (info.clientName) {
+    data.sessionInfo.clientName = info.clientName
+  }
+  if (info.clientVersion) {
+    data.sessionInfo.clientVersion = info.clientVersion
+  }
+  if (info.protocolVersion) {
+    data.sessionInfo.protocolVersion = info.protocolVersion
+  }
+}

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -21,6 +21,7 @@ import {
   injectConversationIdPromptBack,
   resolveConversationId,
 } from './conversation-id'
+import { applyMetaClientInfo } from './client-identity'
 import { captureEvent } from './capture'
 import { MCPAnalyticsEventType } from './event-types'
 import { captureException } from './exceptions'
@@ -139,6 +140,9 @@ async function prepareToolCallEvent(
 ): Promise<McpEvent | null> {
   try {
     const sessionId = getSessionId(server, extra)
+    // Modern (stateless) clients carry client name/version + protocol version in
+    // `_meta` on every request rather than at `initialize`; pick them up here.
+    applyMetaClientInfo(data, request)
     await handleIdentify(server, data, sessionId, request, extra)
 
     const toolName = request.params?.name
@@ -291,6 +295,9 @@ export async function handleListToolsRequest(
 ): Promise<{ tools: ListToolsResult['tools'] }> {
   const data = getServerTrackingData(server)
   const startTime = new Date()
+  if (data) {
+    applyMetaClientInfo(data, request)
+  }
   const event: McpEvent = {
     sessionId: getSessionId(server, extra),
     parameters: buildCapturedMcpParameters(request),
@@ -546,6 +553,9 @@ export async function handleInitializeRequest(
   // Mint first so the `$mcp_initialize` event below already carries the minted id.
   const mintedSessionId = mintStatelessSessionOnInitialize(server, data, request, extra)
   const sessionId = getSessionId(server, extra)
+  // Harmless for a legacy `initialize` (client info rides the body there); picks
+  // up client info if a client happens to also send it in `_meta`.
+  applyMetaClientInfo(data, request)
   await handleIdentify(server, data, sessionId, request, extra)
 
   const event: McpEvent = {

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -21,7 +21,7 @@ import {
   injectConversationIdPromptBack,
   resolveConversationId,
 } from './conversation-id'
-import { applyMetaClientInfo } from './client-identity'
+import { stampMetaClientInfo } from './client-identity'
 import { captureEvent } from './capture'
 import { MCPAnalyticsEventType } from './event-types'
 import { captureException } from './exceptions'
@@ -140,9 +140,6 @@ async function prepareToolCallEvent(
 ): Promise<McpEvent | null> {
   try {
     const sessionId = getSessionId(server, extra)
-    // Modern (stateless) clients carry client name/version + protocol version in
-    // `_meta` on every request rather than at `initialize`; pick them up here.
-    applyMetaClientInfo(data, request)
     await handleIdentify(server, data, sessionId, request, extra)
 
     const toolName = request.params?.name
@@ -156,6 +153,10 @@ async function prepareToolCallEvent(
       toolCategory: toolName ? data.toolCategories.get(toolName) : undefined,
       toolDescription: toolName ? data.toolDescriptions.get(toolName) : undefined,
     }
+    // Modern (stateless) clients carry client name/version + protocol version in
+    // `_meta` on every request rather than at `initialize`; stamp them onto this
+    // event now so concurrent requests can't cross-attribute it.
+    stampMetaClientInfo(event, request)
 
     await applyResolvedMetadata(event, data, request, extra)
     setEventIntent(event, await resolveToolCallIntent(data, request, extra))
@@ -295,15 +296,13 @@ export async function handleListToolsRequest(
 ): Promise<{ tools: ListToolsResult['tools'] }> {
   const data = getServerTrackingData(server)
   const startTime = new Date()
-  if (data) {
-    applyMetaClientInfo(data, request)
-  }
   const event: McpEvent = {
     sessionId: getSessionId(server, extra),
     parameters: buildCapturedMcpParameters(request),
     eventType: MCPAnalyticsEventType.mcpToolsList,
     timestamp: startTime,
   }
+  stampMetaClientInfo(event, request)
 
   if (data) {
     await applyResolvedMetadata(event, data, request, extra)
@@ -553,9 +552,6 @@ export async function handleInitializeRequest(
   // Mint first so the `$mcp_initialize` event below already carries the minted id.
   const mintedSessionId = mintStatelessSessionOnInitialize(server, data, request, extra)
   const sessionId = getSessionId(server, extra)
-  // Harmless for a legacy `initialize` (client info rides the body there); picks
-  // up client info if a client happens to also send it in `_meta`.
-  applyMetaClientInfo(data, request)
   await handleIdentify(server, data, sessionId, request, extra)
 
   const event: McpEvent = {
@@ -565,6 +561,10 @@ export async function handleInitializeRequest(
     parameters: buildCapturedMcpParameters(request),
     timestamp: new Date(),
   }
+  // Harmless for a legacy `initialize` (client info rides the body there, and the
+  // negotiated protocol version below overrides any `_meta` one); picks up client
+  // info if a client also sends it in `_meta`.
+  stampMetaClientInfo(event, request)
 
   await applyResolvedMetadata(event, data, request, extra)
 

--- a/packages/mcp/src/extensions/internal.ts
+++ b/packages/mcp/src/extensions/internal.ts
@@ -14,6 +14,7 @@ import type {
 import { MCPAnalyticsEventType } from './event-types'
 import { log } from './logger'
 import { captureEvent } from './capture'
+import { stampMetaClientInfo } from './client-identity'
 
 /**
  * Bounded LRU cache for session identities, capped at `maxSize` entries so a
@@ -141,6 +142,7 @@ export async function handleIdentify(
     parameters: { request, extra },
     timestamp: new Date(),
   }
+  stampMetaClientInfo(identifyEvent, request)
 
   try {
     const identityResult =


### PR DESCRIPTION
## What

Read the MCP client's name/version and protocol version from each request's `params._meta` and stamp them on analytics events, so client attribution keeps working under the **MCP `2026-07-28` (stateless) revision**.

That revision removes the `initialize` handshake and the `Mcp-Session-Id` header (SEP-2575 / SEP-2567); client identity now travels in `_meta` on every request under the reverse-DNS keys `io.modelcontextprotocol/clientInfo` and `io.modelcontextprotocol/protocolVersion`. Before this change we only learned client identity at `initialize`, which no longer happens on modern clients.

## Changes
- New `extensions/client-identity.ts`: `readMetaClientInfo(request)` + `applyMetaClientInfo(data, request)`. Literal `_meta` key constants mirrored from the spec (the v2 SDK isn't a dependency).
- Wired into all three patched handlers in `instrumentation.ts` (`tools/call`, `tools/list`, `initialize`), so `$mcp_client_name` / `$mcp_client_version` / `$mcp_protocol_version` are populated on every request when `_meta` carries them.
- New `__tests__/client-identity.test.ts` (8 tests, 100% coverage of the new module).

## Safety / scope
- **Enrichment only — no session-handling changes.** When `_meta` is absent, existing values (from the session token / `initialize`) are untouched → fully backward-compatible, dual-spec.
- Full `@posthog/mcp` jest suite: **396/396 pass**.

## Context
First of a series preparing `@posthog/mcp` for the `2026-07-28` stateless spec (validated empirically against the `@modelcontextprotocol/*@2.0.0-beta.5` reference SDKs). Session-id correlation (reading Codex's `_meta.threadId`, custom-header / `conversation_id` handles) and v2-SDK patch-compatibility are **deferred to follow-up PRs** — this PR is the low-risk enrichment win.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*