### PR TITLE
chore(browser): add fast array bundle size comparison

### DIFF
--- a/.agents/skills/compare-array-bundle-size/SKILL.md
+++ b/.agents/skills/compare-array-bundle-size/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: compare-array-bundle-size
+description: Quickly compare the posthog-js array.js bundle size in the current working tree against a git baseline using the repository's esbuild proxy. Use when asked about array.js size, bundle-size percentage changes, whether browser SDK changes increased the bundle, or for a fast size check that should not run the production Rollup build.
+compatibility: Requires a posthog-js checkout with dependencies installed.
+---
+
+# Compare `array.js` bundle size
+
+Use the repository's fast comparison command. Do not run TypeScript compilation, Terser, Rollup, Turbo, or the full build unless the user separately requests production bundle numbers.
+
+## Workflow
+
+1. Use the baseline named by the user. If none is given, let the script default to `origin/main` and then `main`.
+2. From the repository root, run:
+
+    ```bash
+    pnpm bundle-size:array [baseline-ref]
+    ```
+
+3. Report:
+    - the resolved baseline ref and commit
+    - minified percentage and byte change
+    - gzip percentage and byte change
+    - Brotli percentage and byte change
+    - elapsed time
+4. Lead with the percentage most relevant to the user's question. If they did not specify one, lead with minified and include the compressed results below it.
+
+## Interpretation
+
+- The command builds both source trees with the same esbuild version, options, installed dependencies, and workspace-source aliases, so the percentage is an apples-to-apples comparison.
+- The current side includes tracked, uncommitted, and imported untracked source changes from the working tree.
+- The baseline side is a temporary source snapshot from the resolved git commit; the command does not check out or modify the working tree.
+- Treat the result as a fast directional comparison. Absolute bytes differ from the production Rollup/Terser output.
+- A positive percentage is a size increase; a negative percentage is a reduction.
+
+## Validation and troubleshooting
+
+- To verify the comparison machinery itself, run `pnpm bundle-size:array HEAD`. With no relevant uncommitted source changes, every row should report `0.00%`.
+- If the baseline ref cannot be resolved, ask for another local git ref or fetch it only with the user's approval when network access is required.
+- If esbuild or other dependencies are missing, explain that dependencies must be installed. Do not substitute the full production build.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     },
     "scripts": {
         "build-rollup": "pnpm --filter=posthog-js build-rollup",
+        "bundle-size:array": "node packages/browser/scripts/compare-array-bundle-size.mjs",
         "clean": "turbo clean",
         "clean:dep": "rm -rf node_modules && pnpm -r exec rm -rf node_modules",
         "lint": "turbo lint",

--- a/packages/browser/CONTRIBUTING.md
+++ b/packages/browser/CONTRIBUTING.md
@@ -13,6 +13,16 @@ For repository-wide setup, see the root [CONTRIBUTING.md](../../CONTRIBUTING.md)
 - Cypress: run `pnpm start` to have a test server running and separately `pnpm cypress` to launch Cypress test engine.
 - Playwright: run e.g. `pnpm exec playwright test --ui --project webkit --project firefox` to run with UI and in webkit and firefox.
 
+### Comparing `array.js` bundle size
+
+Run `pnpm bundle-size:array` from the repository root for a fast comparison of the current working tree against `origin/main`. Pass another git ref to change the baseline:
+
+```bash
+pnpm bundle-size:array main
+```
+
+The script bundles both versions with the same esbuild settings and reports minified, gzip, and Brotli changes. It is intended for quick percentage comparisons; the production Rollup build will have different absolute sizes.
+
 ### Running TestCafe E2E tests with BrowserStack
 
 Testing on IE11 requires a bit more setup. TestCafe tests use the playground application to test the locally built `array.full.js` bundle. They also verify that the events emitted during the testing of playground are loaded into the PostHog app. By default this uses `https://us.i.posthog.com` and the project with ID `11213`. See the TestCafe tests to override these if needed. PostHog internal users can ask `@benjackwhite` or `@hazzadous` for access. You will need to set `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_API_KEY`.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -15,6 +15,7 @@
         "start": "pnpm build-react && NODE_OPTIONS=\"--max-old-space-size=8192\" pnpm build-rollup -w",
         "dev": "tsc -b && NODE_OPTIONS=\"--max-old-space-size=8192\" rollup -cw",
         "build": "tsc -b && rollup -c",
+        "bundle-size:array": "node scripts/compare-array-bundle-size.mjs",
         "postbuild": "node scripts/strip-lib-package-json.js && node scripts/check-mangled-property-consistency.js && node scripts/copy-rrweb-worker-maps.js",
         "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
         "lint": "eslint src && eslint playwright",

--- a/packages/browser/scripts/compare-array-bundle-size.mjs
+++ b/packages/browser/scripts/compare-array-bundle-size.mjs
@@ -43,6 +43,11 @@ function resolveRef(ref) {
     }
 }
 
+function pathsAtCommit(commit, filePaths) {
+    const existingPaths = new Set(git(['ls-tree', '--name-only', commit, '--', ...filePaths]).split('\n'))
+    return filePaths.filter((filePath) => existingPaths.has(filePath))
+}
+
 function defaultBaseline() {
     for (const ref of ['origin/main', 'main']) {
         if (resolveRef(ref)) {
@@ -171,11 +176,12 @@ async function main() {
     const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'posthog-array-size-'))
     const snapshotRoot = path.join(temporaryRoot, 'baseline')
     const archivePath = path.join(temporaryRoot, 'baseline.tar')
+    const baselineSnapshotPaths = pathsAtCommit(baselineCommit, snapshotPaths)
 
     try {
         execFileSync(
             'git',
-            ['archive', '--format=tar', `--output=${archivePath}`, baselineCommit, '--', ...snapshotPaths],
+            ['archive', '--format=tar', `--output=${archivePath}`, baselineCommit, '--', ...baselineSnapshotPaths],
             { cwd: repositoryRoot, stdio: ['ignore', 'ignore', 'pipe'] }
         )
         await mkdir(snapshotRoot)

--- a/packages/browser/scripts/compare-array-bundle-size.mjs
+++ b/packages/browser/scripts/compare-array-bundle-size.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, realpath, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { brotliCompressSync, constants as zlibConstants, gzipSync } from 'node:zlib'
+import { build, version as esbuildVersion } from 'esbuild'
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = path.resolve(scriptDirectory, '../../..')
+const entrypoint = 'packages/browser/src/entrypoints/array.ts'
+const snapshotPaths = [
+    'packages/browser/src',
+    'packages/browser/package.json',
+    'packages/browser/tsconfig.json',
+    'packages/browser-common/src',
+    'packages/browser-common/package.json',
+    'packages/browser-common/tsconfig.json',
+    'packages/core/src',
+    'packages/core/package.json',
+    'packages/core/tsconfig.json',
+    'packages/types/src',
+    'packages/types/package.json',
+    'packages/types/tsconfig.json',
+]
+
+function git(args, options = {}) {
+    return execFileSync('git', args, {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        ...options,
+    }).trim()
+}
+
+function resolveRef(ref) {
+    try {
+        return git(['rev-parse', '--verify', `${ref}^{commit}`])
+    } catch {
+        return undefined
+    }
+}
+
+function defaultBaseline() {
+    for (const ref of ['origin/main', 'main']) {
+        if (resolveRef(ref)) {
+            return ref
+        }
+    }
+
+    throw new Error('Could not find origin/main or main. Pass the baseline git ref explicitly.')
+}
+
+function workspaceAliases(sourceRoot) {
+    return {
+        '@posthog/browser-common': path.join(sourceRoot, 'packages/browser-common/src'),
+        '@posthog/core': path.join(sourceRoot, 'packages/core/src'),
+        '@posthog/types': path.join(sourceRoot, 'packages/types/src'),
+    }
+}
+
+async function bundle(sourceRoot) {
+    const browserPackagePath = await realpath(path.join(sourceRoot, 'packages/browser/package.json'))
+    const result = await build({
+        entryPoints: [path.join(sourceRoot, entrypoint)],
+        alias: workspaceAliases(sourceRoot),
+        bundle: true,
+        format: 'iife',
+        legalComments: 'none',
+        logLevel: 'silent',
+        minify: true,
+        nodePaths: [
+            path.join(repositoryRoot, 'packages/browser/node_modules'),
+            path.join(repositoryRoot, 'node_modules'),
+        ],
+        platform: 'browser',
+        plugins: [
+            {
+                name: 'browser-package-version-only',
+                setup(esbuild) {
+                    esbuild.onLoad({ filter: /package\.json$/ }, async ({ path: loadedPath }) => {
+                        if (path.resolve(loadedPath) !== browserPackagePath) {
+                            return undefined
+                        }
+
+                        const { version } = JSON.parse(await readFile(loadedPath, 'utf8'))
+                        return { contents: JSON.stringify({ version }), loader: 'json' }
+                    })
+                },
+            },
+        ],
+        target: 'es2015',
+        write: false,
+    })
+
+    if (result.outputFiles.length !== 1) {
+        throw new Error(`Expected one JavaScript bundle, received ${result.outputFiles.length} outputs.`)
+    }
+
+    return result.outputFiles[0].contents
+}
+
+function sizes(contents) {
+    return {
+        minified: contents.byteLength,
+        gzip: gzipSync(contents, { level: 9 }).byteLength,
+        brotli: brotliCompressSync(contents, {
+            params: {
+                [zlibConstants.BROTLI_PARAM_QUALITY]: 11,
+            },
+        }).byteLength,
+    }
+}
+
+function formatSize(bytes) {
+    return `${(bytes / 1024).toFixed(2)} KiB`
+}
+
+function formatChange(baseline, current) {
+    const bytes = current - baseline
+    const percentage = baseline === 0 ? 0 : (bytes / baseline) * 100
+    const sign = bytes >= 0 ? '+' : '-'
+
+    return `${sign}${formatSize(Math.abs(bytes))} (${sign}${Math.abs(percentage).toFixed(2)}%)`
+}
+
+function printTable(baseline, current) {
+    const rows = [
+        ['Minified', baseline.minified, current.minified],
+        ['Gzip', baseline.gzip, current.gzip],
+        ['Brotli', baseline.brotli, current.brotli],
+    ].map(([label, baselineBytes, currentBytes]) => [
+        label,
+        formatSize(baselineBytes),
+        formatSize(currentBytes),
+        formatChange(baselineBytes, currentBytes),
+    ])
+    const headings = ['Size', 'Baseline', 'Current', 'Change']
+    const widths = headings.map((heading, index) =>
+        Math.max(heading.length, ...rows.map((row) => String(row[index]).length))
+    )
+    const printRow = (row) => row.map((value, index) => String(value).padEnd(widths[index])).join('  ')
+
+    console.log(printRow(headings))
+    console.log(widths.map((width) => '-'.repeat(width)).join('  '))
+    for (const row of rows) {
+        console.log(printRow(row))
+    }
+}
+
+async function main() {
+    const args = process.argv.slice(2)
+    if (args.includes('--help') || args.includes('-h')) {
+        console.log('Usage: pnpm bundle-size:array [baseline-ref]')
+        console.log('Defaults to origin/main, then main.')
+        return
+    }
+    if (args.length > 1) {
+        throw new Error('Expected at most one baseline git ref. See --help for usage.')
+    }
+
+    const startedAt = performance.now()
+    const baselineRef = args[0] ?? defaultBaseline()
+    const baselineCommit = resolveRef(baselineRef)
+    if (!baselineCommit) {
+        throw new Error(`Could not resolve baseline ref: ${baselineRef}`)
+    }
+
+    const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'posthog-array-size-'))
+    const snapshotRoot = path.join(temporaryRoot, 'baseline')
+    const archivePath = path.join(temporaryRoot, 'baseline.tar')
+
+    try {
+        execFileSync(
+            'git',
+            ['archive', '--format=tar', `--output=${archivePath}`, baselineCommit, '--', ...snapshotPaths],
+            { cwd: repositoryRoot, stdio: ['ignore', 'ignore', 'pipe'] }
+        )
+        await mkdir(snapshotRoot)
+        execFileSync('tar', ['-xf', archivePath, '-C', snapshotRoot])
+
+        const [baselineBundle, currentBundle] = await Promise.all([bundle(snapshotRoot), bundle(repositoryRoot)])
+        const baselineSizes = sizes(baselineBundle)
+        const currentSizes = sizes(currentBundle)
+        const branch = git(['branch', '--show-current']) || 'detached HEAD'
+
+        console.log(`Fast array.js comparison against ${baselineRef} (${baselineCommit.slice(0, 8)})`)
+        console.log(`Current working tree: ${branch}`)
+        console.log(`Bundler: esbuild ${esbuildVersion}\n`)
+        printTable(baselineSizes, currentSizes)
+        console.log(`\nCompleted in ${((performance.now() - startedAt) / 1000).toFixed(2)}s.`)
+        console.log('This is an apples-to-apples esbuild comparison; absolute production Rollup sizes will differ.')
+    } finally {
+        await rm(temporaryRoot, { recursive: true, force: true })
+    }
+}
+
+main().catch((error) => {
+    const detail = error?.stderr?.toString().trim()
+    console.error(`array.js size comparison failed: ${detail || error.message}`)
+    process.exitCode = 1
+})


### PR DESCRIPTION
## Problem

Checking whether browser SDK work changes `array.js` size currently requires the full Rollup build, which takes too long for quick iteration. Contributors need a fast, directional, apples-to-apples percentage comparison against `main` or another git baseline.

Sometimes I need to do this a lot. Maybe you might need to too. Now we can do it faster.

## Changes

- Add `pnpm bundle-size:array [baseline-ref]`, backed by esbuild rather than the production Rollup pipeline.
- Bundle the current working tree and a temporary git snapshot with identical options and installed dependencies.
- Report minified, gzip, and Brotli byte and percentage changes in about one second.
- Add contributor documentation and a project skill for invoking and interpreting the comparison.
- Keep browser package metadata out of the proxy bundle so unrelated `package.json` changes do not affect results.

Validated with `pnpm bundle-size:array HEAD`; all three comparisons reported `0.00%` (tested against a real branch too, but the robot didn't think you'd want to know that).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with the Pi coding agent. The implementation intentionally uses esbuild as a fast comparison proxy rather than reproducing the production Rollup/Terser pipeline; the command labels absolute production sizes as different. The branch is based directly on the latest `origin/main` and the original feature worktree was left clean.
