### PR TITLE
ci: pin changeset hygiene script ref

### DIFF
--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -15,3 +15,5 @@ concurrency:
 jobs:
   check:
     uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
+    with:
+      script-ref: 5fc4680761e8ac29a61b212756230eba0e276d8c


### PR DESCRIPTION
## Problem

The changeset hygiene reusable workflow is pinned to an immutable commit, but its script checkout defaults to `PostHog/.github@main`. Because the job has pull request write permission, this leaves executed code mutable after review.

## Changes

Pass the reusable workflow's pinned commit as `script-ref`, ensuring both the workflow definition and `check-changeset-coverage.mjs` are loaded from the same reviewed, immutable revision.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The workflow and nested script checkout use the same full commit SHA so no executable code is loaded from mutable `main`. Validation included `git diff --check`, YAML parsing, and confirming the pinned reusable workflow exposes the `script-ref` input.
