### PR TITLE
chore(types): mark capture implementation options internal

### DIFF
--- a/packages/types/src/capture.ts
+++ b/packages/types/src/capture.ts
@@ -71,16 +71,19 @@ export interface CaptureOptions {
 
     /**
      * Used to override the desired endpoint for the captured event
+     * @internal
      */
     _url?: string
 
     /**
      * key of queue, e.g. 'sessionRecording' vs 'event'
+     * @internal
      */
     _batchKey?: string
 
     /**
      * If set, overrides and disables config.properties_string_max_length
+     * @internal
      */
     _noTruncate?: boolean
 
@@ -117,6 +120,7 @@ export interface CaptureOptions {
      * Internal flag set by captureException() / sendExceptionEvent() to indicate this $exception
      * event originated from the proper exception capture path. Used to warn users who call
      * capture('$exception') directly.
+     * @internal
      */
     _originatedFromCaptureException?: boolean
 }


### PR DESCRIPTION
## Problem

Underscore-prefixed `CaptureOptions` fields are SDK implementation details, but their generated declarations do not currently identify them as internal. This can make the supported public capture API unclear.

## Changes

- Add the TSDoc `@internal` tag to `_url`, `_batchKey`, `_noTruncate`, and `_originatedFromCaptureException`.
- Keep the runtime and TypeScript shapes unchanged.
- Do not add a changeset because this only clarifies API intent.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The change is limited to TSDoc annotations on the existing underscore-prefixed capture options; lint and the `@posthog/types` build were used for verification.
