### PR TITLE
chore(browser): suppress expected rrweb Babel notices

### DIFF
--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -77,6 +77,14 @@ const plugins = (es5, noExternal) => [
     babel({
         extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx'],
         babelHelpers: 'bundled',
+        overrides: [
+            {
+                // This prebuilt rrweb module intentionally exceeds Babel's 500 KB compacting threshold.
+                // Make the existing behavior explicit without hiding warnings for other unexpectedly large modules.
+                test: /[\\/]packages[\\/]rrweb[\\/]rrweb[\\/]dist[\\/]rrweb\.js$/,
+                compact: true,
+            },
+        ],
         plugins: [
             '@babel/plugin-transform-nullish-coalescing-operator',
             // Explicitly included so we transform 1 ** 2 to Math.pow(1, 2) for ES6 compatibility


### PR DESCRIPTION
## Problem

The browser Rollup build emits 31 Babel de-optimization notices because the same prebuilt rrweb module exceeds Babel's 500 KB automatic compacting threshold. The repetition makes build output noisy and can obscure unexpected oversized modules.

## Changes

- Explicitly enable Babel's existing compact behavior for `packages/rrweb/rrweb/dist/rrweb.js`.
- Scope the override to that exact known rrweb file so Babel still warns about any other module that unexpectedly crosses the threshold.
- Keep shipped output behavior unchanged: Babel was already automatically compacting this module.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using repository read, edit, and shell tools. The override is intentionally scoped to the exact prebuilt rrweb module rather than setting `compact: true` globally, preserving Babel's warning for newly oversized modules. Verified with the focused rrweb build and the full browser Rollup build; both completed successfully with zero Babel de-optimization notices.
