### PR TITLE
fix(build): define CommonJS export mode

### DIFF
--- a/.changeset/calm-exports-build.md
+++ b/.changeset/calm-exports-build.md
@@ -1,6 +1,0 @@
----
-'posthog-js': patch
-'@posthog/rrweb-utils': patch
----
-
-Explicitly define named CommonJS exports in browser and rrweb builds.

--- a/.changeset/calm-exports-build.md
+++ b/.changeset/calm-exports-build.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/rrweb-utils': patch
+---
+
+Explicitly define named CommonJS exports in browser and rrweb builds.

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -379,7 +379,7 @@ const entrypointTargets = entrypoints.map((file) => {
                           },
                       }
                     : {}),
-                ...(format === 'cjs' ? { exports: 'auto' } : {}),
+                ...(format === 'cjs' ? { exports: 'named' } : {}),
             },
         ],
         plugins: [...pluginsForThisFile, visualizer({ filename: `bundle-stats-${fileName}.html`, gzipSize: true })],

--- a/packages/rrweb/vite.config.default.ts
+++ b/packages/rrweb/vite.config.default.ts
@@ -130,6 +130,12 @@ export default function (
 
       emptyOutDir,
 
+      rollupOptions: {
+        output: {
+          exports: 'named',
+        },
+      },
+
       // Leaving this unminified so you can see what exactly gets included in
       // the bundles
       minify: false,


### PR DESCRIPTION
## Problem

Browser and rrweb builds repeatedly report that their entry modules mix named and default exports because the CommonJS export mode is inferred. The repeated diagnostics obscure actionable build output even though these packages intentionally expose a CommonJS namespace containing both export styles.

## Changes

- Configure browser CommonJS entrypoints with `output.exports: 'named'` instead of `auto`.
- Configure the shared rrweb Vite build with `rollupOptions.output.exports: 'named'`.
- Verify the focused browser and rrweb builds no longer emit export-mode diagnostics and retain their existing `require()` shape.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using repository file-editing and terminal tools. The named CommonJS namespace was chosen because both affected entrypoints intentionally combine default and named exports; this suppresses inference warnings while preserving the existing public `require()` shape. Focused Vite and Rollup builds plus runtime export assertions were used for verification.
