### PR TITLE
ci: cache Next.js package smoke builds

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -327,6 +327,20 @@ jobs:
         run: pnpm install --lockfile=false
         working-directory: examples/example-next-app-router
 
+      - name: Restore Next.js build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            examples/example-next-app-router/.next/cache
+            examples/example-nextjs/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml', 'examples/example-next-app-router/package.json', 'examples/example-nextjs/pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml', 'examples/example-next-app-router/package.json', 'examples/example-nextjs/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
+
+      - name: Initialize Next.js build cache directories
+        run: mkdir -p examples/example-next-app-router/.next/cache examples/example-nextjs/.next/cache
+
       - name: Build Next.js App Router example
         run: pnpm build
         working-directory: examples/example-next-app-router

--- a/examples/example-next-app-router/next.config.ts
+++ b/examples/example-next-app-router/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {}
+const nextConfig: NextConfig = {
+    outputFileTracingRoot: process.cwd(),
+}
 
 export default nextConfig

--- a/examples/example-nextjs/next.config.ts
+++ b/examples/example-nextjs/next.config.ts
@@ -4,7 +4,7 @@ import { withPostHogConfig } from '@posthog/nextjs-config'
 import packageJson from './package.json' with { type: 'json' }
 
 const nextConfig = {
-    /* config options here */
+    outputFileTracingRoot: process.cwd(),
 }
 
 export default withPostHogConfig(nextConfig, {


### PR DESCRIPTION
## Problem

The Next.js package smoke builds emit warnings because Next.js detects both the repository and example lockfiles when inferring the workspace root, and CI does not restore the examples' incremental build caches. This adds noise to package validation and prevents rebuilds from benefiting from Next.js caching.

## Changes

- Set `outputFileTracingRoot` explicitly for both Next.js smoke-test examples.
- Restore the examples' `.next/cache` directories with `actions/cache`.
- Initialize cache directories so cold-cache CI runs do not report missing build caching.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent in a dedicated worktree. The change uses explicit Next.js roots rather than removing the standalone example lockfile, and adds CI caching without a package changeset because no published library is affected. Focused CI-mode builds confirmed that the workspace-root and missing-cache warnings are absent; the config example completed successfully, while the App Router example encountered an unrelated stale local-tarball export mismatch after compilation.
