### PR TITLE
ci: use rm force for generated TypeScript file

### DIFF
--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test TypeScript Import
         run: |
-          rm ci-ts-file.js || true
+          rm -f ci-ts-file.js
           pnpm exec tsc --version
           pnpm exec tsc ci-ts-file.ts --strict --target es2017 --skipLibCheck ${{ matrix.typescript-version.extra-flags }}
           node ci-ts-file.js


### PR DESCRIPTION
## Problem

The minimum TypeScript version workflow ignores a missing generated JavaScript file by appending `|| true` to `rm`, which is more verbose and can hide errors other than a missing file.

## Changes

Use `rm -f` for the generated `ci-ts-file.js` cleanup so a missing file is handled directly by `rm`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent applied the requested workflow cleanup. The change uses `rm`'s standard force option instead of suppressing every removal error with `|| true`; no package changeset is needed for this CI-only update.
