### PR TITLE
chore(browser): gate Husky installation explicitly

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -40,7 +40,7 @@
         "playwright:surveys": "pnpm exec playwright test packages/browser/playwright/mocked/surveys/* --project webkit --project firefox --project chromium",
         "playwright:surveys:ui": "pnpm exec playwright test packages/browser/playwright/mocked/surveys/* --ui --project webkit --project firefox --project chromium",
         "playwright:tours:ui": "pnpm exec playwright test packages/browser/playwright/mocked/product-tours/* --ui --project webkit --project firefox --project chromium",
-        "prepare": "[ -z \"$VERCEL\" ] && husky install || echo \"Skipping husky install on vercel build\"",
+        "prepare": "if [ -z \"$CI\" ] && [ \"$HUSKY\" != \"0\" ]; then husky install; fi",
         "deprecate-old-versions": "node scripts/deprecate-old-versions.mjs",
         "check-testcafe-results": "ts-node testcafe/check-testcafe-results.js",
         "run-testcafe-localhost": "node scripts/run-testcafe-localhost.mjs",


### PR DESCRIPTION
## Problem

The browser package's Husky `prepare` script uses an `&& ... || echo` chain that turns `husky install` failures into successful installs. This can hide broken local Git hook setup.

## Changes

- Skip Husky installation explicitly when `CI` is set or `HUSKY=0`.
- Run `husky install` normally otherwise, allowing failures to propagate.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's coding agent made the targeted package-script change and verified formatting plus shell behavior for CI, `HUSKY=0`, and propagated installation failures. No changeset was added because this only affects repository development setup.
