### PR TITLE
chore(browser): improve ingestion polling output

### DIFF
--- a/packages/browser/playwright/fixtures/ingestion.ts
+++ b/packages/browser/playwright/fixtures/ingestion.ts
@@ -2,6 +2,7 @@ import { CaptureResult } from '@/types'
 import { PosthogPage, testPostHog } from './posthog'
 
 const INGESTION_TIMEOUT = 30 * 60 * 1000 // 30 min
+const INITIAL_INGESTION_DELAY = 5 * 1000 // 5 seconds
 const currentEnv = process.env
 const {
     POSTHOG_PERSONAL_API_KEY = 'private_key',
@@ -121,6 +122,8 @@ export async function retryUntilResults(
     let last_validation_error: unknown = null
     let elapsedSeconds = 0
 
+    await delay(INITIAL_INGESTION_DELAY)
+
     do {
         attempts++
         let results
@@ -154,10 +157,9 @@ export async function retryUntilResults(
                     return dedupedResults
                 } catch (err) {
                     last_validation_error = err
-                    const message = err instanceof Error ? err.message : String(err)
                     // eslint-disable-next-line no-console
                     console.log(
-                        `Validation failed with ${dedupedResults.length} results (attempt: ${attempts}, testSessionId: ${testSessionId}, testTitle: ${testTitle}): ${message}`
+                        `Validation pending with ${dedupedResults.length} results (attempt: ${attempts}, testSessionId: ${testSessionId}, testTitle: ${testTitle})`
                     )
                 }
             } else if (dedupedResults.length >= target_results) {

--- a/packages/browser/testcafe/helpers.js
+++ b/packages/browser/testcafe/helpers.js
@@ -18,6 +18,7 @@ export const {
 } = currentEnv
 
 const HEADERS = { Authorization: `Bearer ${POSTHOG_PERSONAL_API_KEY}` }
+const INITIAL_INGESTION_DELAY = 5 * 1000 // 5 seconds
 
 export const captureLogger = RequestLogger(/\/(e|batch|s)\//, {
     logRequestHeaders: true,
@@ -127,6 +128,8 @@ export async function retryUntilResults(
     let last_validation_error = null
     let elapsedSeconds = 0
 
+    await delay(INITIAL_INGESTION_DELAY)
+
     do {
         attempts++
         let results
@@ -149,8 +152,7 @@ export async function retryUntilResults(
                     return results
                 } catch (err) {
                     last_validation_error = err
-                    const message = err instanceof Error ? err.message : String(err)
-                    log(`Validation failed with ${results.length} results (attempt ${attempts}): ${message}`)
+                    log(`Validation pending with ${results.length} results (attempt ${attempts})`)
                 }
             } else if (results.length >= target_results) {
                 log(


### PR DESCRIPTION
## Problem

Production ingestion checks commonly run before events are queryable. These expected transient misses are currently reported as validation failures, adding noisy assertion output to CI logs.

## Changes

- Wait five seconds before the first production ingestion query while retaining the existing 30-second retry interval.
- Report intermediate semantic validation misses as pending without printing assertion details.
- Keep the final assertion error available when polling reaches its timeout.
- Apply the same behavior to the Playwright and TestCafe ingestion helpers.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent after reviewing recent production ingestion polling behavior. A 30-second initial delay was considered but rejected because it would apply to every session check; a five-second grace period keeps the checks responsive while avoiding immediate queries. ESLint, Prettier, and diff validation were run on the changed helpers.
