### PR TITLE
ci: reduce duplicate browser work

### DIFF
--- a/.github/actions/is-affected/action.yaml
+++ b/.github/actions/is-affected/action.yaml
@@ -1,14 +1,26 @@
 name: "Check affected packages"
-description: "Checks which packages are affected by a change"
+description: "Checks whether a package is affected by a change"
 
 inputs:
   branch:
-    description: "The branch to compare against"
+    description: "The branch to compare against when base-ref is not provided"
     required: false
     default: "main"
   package-name:
     description: "The name of the package to check"
     required: true
+  base-ref:
+    description: "The base Git ref or SHA to compare"
+    required: false
+    default: ""
+  head-ref:
+    description: "The head Git ref or SHA to compare"
+    required: false
+    default: "HEAD"
+  additional-paths:
+    description: "Newline-separated paths that should always mark the package as affected"
+    required: false
+    default: ""
 
 outputs:
   is-affected:
@@ -23,13 +35,48 @@ runs:
       shell: bash
       env:
         PACKAGE_NAME: ${{ inputs.package-name }}
-        BRANCH_NAME: ${{inputs.branch}}
+        BRANCH_NAME: ${{ inputs.branch }}
+        BASE_REF: ${{ inputs.base-ref }}
+        HEAD_REF: ${{ inputs.head-ref }}
+        ADDITIONAL_PATHS: ${{ inputs.additional-paths }}
       run: |
-        AFFECTED=$(pnpm exec turbo run build "--filter=$PACKAGE_NAME...[origin/$BRANCH_NAME...HEAD]" --dry=json)
+        set -euo pipefail
+
+        BASE_REF="${BASE_REF:-origin/$BRANCH_NAME}"
+        HEAD_REF="${HEAD_REF:-HEAD}"
+
+        # A missing push base (for example, a newly created branch) must fail
+        # open so that CI runs rather than incorrectly skipping validation.
+        if [[ "$BASE_REF" =~ ^0+$ ]] || ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+          echo "Base ref $BASE_REF is unavailable; treating $PACKAGE_NAME as affected"
+          echo "is-affected=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        EXTRA_PATHS=()
+        while IFS= read -r path; do
+          if [[ -n "$path" ]]; then
+            EXTRA_PATHS+=("$path")
+          fi
+        done <<< "$ADDITIONAL_PATHS"
+        if (( ${#EXTRA_PATHS[@]} > 0 )) && ! git diff --quiet "$BASE_REF" "$HEAD_REF" -- "${EXTRA_PATHS[@]}"; then
+          echo "Additional CI paths affecting $PACKAGE_NAME changed"
+          echo "is-affected=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ -x node_modules/.bin/turbo ]]; then
+          TURBO=(pnpm exec turbo)
+        else
+          TURBO_VERSION=$(node -e "const spec = require('./package.json').devDependencies.turbo; const version = spec.match(/[0-9]+\\.[0-9]+\\.[0-9]+/); if (!version) process.exit(1); process.stdout.write(version[0])")
+          TURBO=(pnpm dlx "turbo@$TURBO_VERSION")
+        fi
+
+        AFFECTED=$("${TURBO[@]}" run build "--filter=$PACKAGE_NAME...[$BASE_REF...$HEAD_REF]" --dry=json)
         IS_AFFECTED=$(echo "$AFFECTED" | jq '.tasks | length > 0')
-        if [ "$IS_AFFECTED" = "true" ]; then
+        if [[ "$IS_AFFECTED" == "true" ]]; then
           echo "The package $PACKAGE_NAME is affected by changes"
         else
           echo "The package $PACKAGE_NAME is not affected by changes"
         fi
-        echo "is-affected=$IS_AFFECTED" >> $GITHUB_OUTPUT
+        echo "is-affected=$IS_AFFECTED" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -36,6 +36,10 @@ runs:
     - name: Install package.json dependencies with pnpm
       if: ${{ inputs.install == 'true' }}
       shell: bash
+      env:
+        # Puppeteer is only used by rrweb tests, which install Chrome explicitly
+        # after confirming that rrweb is affected.
+        PUPPETEER_SKIP_DOWNLOAD: "true"
       run: pnpm install --frozen-lockfile
 
     - name: Build project with pnpm

--- a/.github/workflows/check-affected.yml
+++ b/.github/workflows/check-affected.yml
@@ -1,0 +1,59 @@
+name: Check affected package
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: Package name to check with Turbo
+        required: true
+        type: string
+      additional-paths:
+        description: Newline-separated paths that should mark the package as affected
+        required: false
+        default: ''
+        type: string
+    outputs:
+      is-affected:
+        description: Whether the package or an additional path is affected
+        value: ${{ jobs.check.outputs.is-affected }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    outputs:
+      is-affected: ${{ steps.is-affected.outputs.is-affected }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Fetch comparison history
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          REFS=("+refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH")
+          if [[ -n "$PR_NUMBER" ]]; then
+            REFS+=("+refs/pull/$PR_NUMBER/merge:refs/remotes/pull/$PR_NUMBER/merge")
+          fi
+
+          git fetch --no-tags --unshallow origin "${REFS[@]}"
+
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
+        with:
+          runtime: node@24
+          cache: false
+          install: false
+
+      - name: Check affected package
+        id: is-affected
+        uses: ./.github/actions/is-affected
+        with:
+          package-name: ${{ inputs.package-name }}
+          base-ref: ${{ github.event.pull_request.base.sha || github.event.before }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          additional-paths: ${{ inputs.additional-paths }}

--- a/.github/workflows/check-affected.yml
+++ b/.github/workflows/check-affected.yml
@@ -43,7 +43,7 @@ jobs:
           git fetch --no-tags --unshallow origin "${REFS[@]}"
 
       - name: Setup pnpm and Node.js
-        uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
+        uses: pnpm/setup@5d160c5bc68a09337ad0d5654e237e03253b5879 # v1
         with:
           runtime: node@24
           cache: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  affected:
+    uses: ./.github/workflows/check-affected.yml
+    with:
+      package-name: posthog-js
+      additional-paths: |
+        packages/browser/
+        .github/workflows/integration.yml
+        .github/workflows/check-affected.yml
+        .github/actions/is-affected/action.yaml
+        .github/actions/setup/action.yaml
+
   browsers:
     name: Test on ${{ matrix.tests.name }}
+    needs: affected
     runs-on: ubuntu-22.04
     env:
       CAN_RUN_INTEGRATION_TESTS: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
@@ -25,20 +37,19 @@ jobs:
       matrix:
         tests:
           - name: Chromium
-            project: "chromium"
+            projects: "--project chromium --project chromium-es5"
             install: "chromium"
+            browser: "chromium"
 
           - name: Firefox
-            project: "firefox"
+            projects: "--project firefox"
             install: "firefox"
+            browser: "firefox"
 
           - name: Safari
-            project: "webkit"
+            projects: "--project webkit"
             install: "webkit"
-
-          - name: Edge
-            project: "msedge"
-            install: "chromium"
+            browser: "webkit"
 
     steps:
       - name: Skip fork PR
@@ -46,36 +57,28 @@ jobs:
         run: echo "Skipping ${{ matrix.tests.name }} integration tests for fork PRs because required secrets are unavailable."
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' }}
-        with:
-          fetch-depth: 0
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
 
       - uses: ./.github/actions/setup
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
         with:
           build: false
 
-      - uses: ./.github/actions/is-affected
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' }}
-        id: is-affected
-        with:
-          package-name: posthog-js
-
       - name: Build packages
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
       - name: Install Playwright Browsers
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
         run: pnpm exec playwright install ${{ matrix.tests.install }} --with-deps --only-shell
         working-directory: packages/browser
 
       - name: Run ${{ matrix.tests.name }} test
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
           RUN_ID: ${{ github.run_id }}
-          BROWSER: ${{ matrix.tests.project }}
-        run: pnpm exec playwright test --config playwright.config.integration.ts --project ${{ matrix.tests.project }}
+          BROWSER: ${{ matrix.tests.browser }}
+        run: pnpm exec playwright test --config playwright.config.integration.ts ${{ matrix.tests.projects }}
         working-directory: packages/browser

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -14,6 +14,17 @@ permissions:
   contents: read
 
 jobs:
+  affected:
+    uses: ./.github/workflows/check-affected.yml
+    with:
+      package-name: posthog-js
+      additional-paths: |
+        packages/browser/
+        .github/workflows/library-ci.yml
+        .github/workflows/check-affected.yml
+        .github/actions/is-affected/action.yaml
+        .github/actions/setup/action.yaml
+
   unit:
     name: Unit tests
     runs-on: ubuntu-22.04
@@ -41,38 +52,34 @@ jobs:
 
   integration:
     name: Playwright E2E tests
+    needs: affected
     runs-on: depot-ubuntu-latest-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
+        if: needs.affected.outputs.is-affected == 'true'
 
       - name: Setup environment
+        if: needs.affected.outputs.is-affected == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
-      - uses: ./.github/actions/is-affected
-        id: is-affected
-        with:
-          package-name: posthog-js
-
       - name: Build package
         run: pnpm build
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: needs.affected.outputs.is-affected == 'true'
 
       - name: Install Playwright Browsers
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: needs.affected.outputs.is-affected == 'true'
         run: pnpm exec playwright install --with-deps
         working-directory: packages/browser
 
       - name: Run Playwright tests
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: needs.affected.outputs.is-affected == 'true'
         run: pnpm exec playwright test --workers=5
         working-directory: packages/browser
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ !cancelled() && needs.affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-report
           path: packages/browser/playwright-report/
@@ -80,6 +87,7 @@ jobs:
 
   compat:
     name: Backward compatibility tests
+    needs: affected
     runs-on: depot-ubuntu-latest-8
     if: github.event_name == 'pull_request'
     permissions:
@@ -87,31 +95,26 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
+        if: needs.affected.outputs.is-affected == 'true'
 
       - name: Setup environment
+        if: needs.affected.outputs.is-affected == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
-      - uses: ./.github/actions/is-affected
-        id: is-affected
-        with:
-          package-name: posthog-js
-
       - name: Build package
         run: pnpm build
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: needs.affected.outputs.is-affected == 'true'
 
       - name: Install Playwright Browsers
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: needs.affected.outputs.is-affected == 'true'
         run: pnpm exec playwright install --with-deps chromium
         working-directory: packages/browser
 
       - name: Run backward compatibility tests
         id: compat-tests
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: needs.affected.outputs.is-affected == 'true'
         continue-on-error: true
         run: |
           pnpm exec playwright test --config playwright.config.compat.ts --project chromium-compat --workers=5 --reporter=json > compat-results.json 2>&1 || true
@@ -119,7 +122,7 @@ jobs:
         working-directory: packages/browser
 
       - name: Process compat test results
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: needs.affected.outputs.is-affected == 'true'
         id: process-results
         working-directory: packages/browser
         run: |
@@ -203,7 +206,7 @@ jobs:
             </details>
 
       - name: Delete compat comment if tests pass
-        if: ${{ steps.process-results.outputs.has_failures == 'false' && steps.is-affected.outputs.is-affected == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.process-results.outputs.has_failures == 'false' && needs.affected.outputs.is-affected == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-passing-comment
         with:
@@ -225,7 +228,7 @@ jobs:
             })
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ !cancelled() && needs.affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-compat-report
           path: packages/browser/playwright-report/
@@ -247,19 +250,50 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
-      - name: Setup environment
-        uses: ./.github/actions/setup
-        with:
-          build: false
+      - name: Fetch comparison history
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          REFS=("+refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH")
+          if [[ -n "$PR_NUMBER" ]]; then
+            REFS+=("+refs/pull/$PR_NUMBER/merge:refs/remotes/pull/$PR_NUMBER/merge")
+          fi
+
+          git fetch --no-tags --unshallow origin "${REFS[@]}"
 
       - name: Check if rrweb packages changed
         id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          CHANGED=$(git diff --name-only origin/main...HEAD | grep -c '^packages/rrweb/' || true)
-          echo "rrweb-changed=$([[ $CHANGED -gt 0 ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]] || ! git rev-parse --verify "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+            echo "Unable to determine the base commit; running rrweb tests"
+            echo "rrweb-changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            packages/rrweb/ \
+            package.json \
+            pnpm-lock.yaml \
+            pnpm-workspace.yaml \
+            turbo.json \
+            .github/actions/setup/ \
+            .github/workflows/library-ci.yml; then
+            echo "rrweb-changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "rrweb-changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup environment
+        if: steps.changed.outputs.rrweb-changed == 'true'
+        uses: ./.github/actions/setup
+        with:
+          build: false
 
       - name: Build rrweb packages
         if: steps.changed.outputs.rrweb-changed == 'true'

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -8,6 +8,9 @@ env:
   BROWSERSTACK_USE_AUTOMATE: "true"
   BROWSERSTACK_PROJECT_NAME: "PostHog JS SDK"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -13,8 +13,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  affected:
+    uses: ./.github/workflows/check-affected.yml
+    with:
+      package-name: posthog-js
+      additional-paths: |
+        packages/browser/
+        .github/workflows/testcafe.yml
+        .github/workflows/check-affected.yml
+        .github/actions/is-affected/action.yaml
+        .github/actions/setup/action.yaml
+
   browsers:
     name: Test on ${{ matrix.name }}
+    needs: affected
     runs-on: ubuntu-22.04
     env:
       BROWSERSTACK_ACCESS_KEY: "${{ secrets.BROWSERSTACK_ACCESS_KEY }}"
@@ -36,31 +48,23 @@ jobs:
         run: echo "Skipping ${{ matrix.name }} TestCafe tests for fork PRs because required BrowserStack/PostHog secrets are unavailable."
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        with:
-          fetch-depth: 0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
 
       - uses: ./.github/actions/setup
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
         with:
           build: false
 
-      - uses: ./.github/actions/is-affected
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        id: is-affected
-        with:
-          package-name: posthog-js
-
       - name: Build packages
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
       - name: Serve static files
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
         run: python -m http.server 8080 &
 
       - name: Run ${{ matrix.name }} test
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
         timeout-minutes: 10
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -98,7 +102,7 @@ jobs:
         working-directory: packages/browser
 
       - name: Check ${{ matrix.name }} events
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         run: pnpm check-testcafe-results
         working-directory: packages/browser

--- a/packages/browser/playwright.config.integration.ts
+++ b/packages/browser/playwright.config.integration.ts
@@ -20,9 +20,12 @@ export default {
     projects: [
         ...(baseConfig.projects || []),
         {
-            name: 'msedge',
+            name: 'chromium-es5',
+            metadata: {
+                testBrowser: 'chromium-es5',
+            },
             use: {
-                ...devices['Desktop Edge'],
+                ...devices['Desktop Chrome'],
                 staticOverrides: {
                     'array.full.js': 'array.full.es5.js',
                 },

--- a/packages/browser/playwright/fixtures/posthog.ts
+++ b/packages/browser/playwright/fixtures/posthog.ts
@@ -80,7 +80,7 @@ export class PosthogPage {
             testName: this.testInfos.title,
             testBranchName: BRANCH_NAME,
             testRunId: RUN_ID,
-            testBrowser: BROWSER,
+            testBrowser: this.testInfos.project.metadata.testBrowser || BROWSER,
         }
         const storeHandle = await this.page.createFunctionHandle((evt: CaptureResult) => {
             this.events.addEvent(evt)


### PR DESCRIPTION
## Problem

Browser CI repeatedly performs the same affected-package calculation, full repository builds, browser downloads, and full-depth Git fetches across Playwright and TestCafe jobs. The rrweb job also installs the workspace before determining whether rrweb changed.

## Changes

- Add a reusable affected-package job and share its result with browser test jobs.
- Fetch only the PR merge and base branch histories needed for merge-base comparisons, without fetching tags or every branch.
- Gate browser setup, builds, downloads, and tests on the shared affected result.
- Run Chromium and the ES5 Chromium project together, removing the duplicate Edge lane.
- Check rrweb paths before installing dependencies and skip Puppeteer's automatic download during the workspace install.
- Make the affected-package action support explicit base/head refs, additional CI paths, and fail-open behavior when a comparison base is unavailable.
- Restrict the TestCafe workflow's `GITHUB_TOKEN` to read-only repository contents.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The changes keep affected-package checks fail-open, preserve Chromium ES5 coverage while removing a duplicate browser build, and retain complete merge-base traversal through targeted Git refs rather than full branch/tag fetches. Validation included browser lint, workflow YAML parsing, `git diff --check`, and a local targeted-fetch simulation.
