### PR TITLE
ci: refresh TypeScript compatibility matrix

### DIFF
--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -24,7 +24,7 @@ jobs:
             extra-flags: "--module commonjs --moduleResolution node"
           - version: "6.0.3"
             extra-flags: "--module commonjs --ignoreConfig"
-          - version: "7.0.2"
+          - version: "latest"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
           - version: "7.1.0-dev.20260723.1"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -24,7 +24,7 @@ jobs:
             extra-flags: "--module commonjs --moduleResolution node"
           - version: "6.0.3"
             extra-flags: "--module commonjs --ignoreConfig"
-          - version: "latest"
+          - version: "7.0.2"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
           - version: "7.1.0-dev.20260723.1"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -5,14 +5,17 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '17 8 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   unit:
     name: Check minimum TS version
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -22,10 +25,10 @@ jobs:
             extra-flags: "--module commonjs --moduleResolution node"
           - version: "5.9.2"
             extra-flags: "--module commonjs --moduleResolution node"
-          - version: "latest"
+          - version: "7.0.2"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
-          - version: "6.0.0-dev.20251204"
-            extra-flags: "--module commonjs --ignoreConfig"
+          - version: "7.1.0-dev.20260723.1"
+            extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,12 +42,39 @@ jobs:
       - name: Override TypeScript version
         env:
           TS_VERSION: ${{ matrix.typescript-version.version }}
-        run: yq -i '.catalog.typescript = strenv(TS_VERSION)' pnpm-workspace.yaml && pnpm install --no-frozen-lockfile
+        run: yq -i '.catalog.typescript = strenv(TS_VERSION) | .minimumReleaseAgeExclude += ["typescript"]' pnpm-workspace.yaml && pnpm install --no-frozen-lockfile
 
       - name: Test TypeScript Import
         run: |
           rm ci-ts-file.js || true
           pnpm exec tsc --version
           pnpm exec tsc ci-ts-file.ts --strict --target es2017 --skipLibCheck ${{ matrix.typescript-version.extra-flags }}
+          node ci-ts-file.js
+        working-directory: packages/browser
+
+  latest-smoke-test:
+    name: Check latest TS version
+    if: github.event_name == 'schedule'
+    continue-on-error: true
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup
+        with:
+          node_version: 24
+          build: true
+
+      - name: Override TypeScript version
+        env:
+          TS_VERSION: latest
+        run: yq -i '.catalog.typescript = strenv(TS_VERSION) | .minimumReleaseAgeExclude += ["typescript"]' pnpm-workspace.yaml && pnpm install --no-frozen-lockfile
+
+      - name: Test TypeScript Import
+        run: |
+          rm ci-ts-file.js || true
+          pnpm exec tsc --version
+          pnpm exec tsc ci-ts-file.ts --strict --target es2017 --skipLibCheck --module nodenext --moduleResolution nodenext --ignoreConfig
           node ci-ts-file.js
         working-directory: packages/browser

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -26,7 +26,7 @@ jobs:
             extra-flags: "--module commonjs --ignoreConfig"
           - version: "7.0.2"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
-          - version: "7.1.0-dev.20260723.1"
+          - version: "7.1.0-dev.20260715.1"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
     steps:
       - name: Checkout repository

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -24,7 +24,7 @@ jobs:
             extra-flags: "--module commonjs --moduleResolution node"
           - version: "6.0.3"
             extra-flags: "--module commonjs --ignoreConfig"
-          - version: "7.0.2"
+          - version: "latest"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
           - version: "7.1.0-dev.20260715.1"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
@@ -38,10 +38,11 @@ jobs:
           build: true
 
       # once its built we can see if we can use it on the forced version
+      # Intentionally don't set minimumReleaseAgeExclude so TypeScript versions respect the supply-chain policy.
       - name: Override TypeScript version
         env:
           TS_VERSION: ${{ matrix.typescript-version.version }}
-        run: yq -i '.catalog.typescript = strenv(TS_VERSION) | .minimumReleaseAgeExclude += ["typescript"]' pnpm-workspace.yaml && pnpm install --no-frozen-lockfile
+        run: yq -i '.catalog.typescript = strenv(TS_VERSION)' pnpm-workspace.yaml && pnpm install --no-frozen-lockfile
 
       - name: Test TypeScript Import
         run: |

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -5,17 +5,14 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '17 8 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   unit:
     name: Check minimum TS version
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -54,7 +51,7 @@ jobs:
 
   latest-smoke-test:
     name: Check latest TS version
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'pull_request'
     continue-on-error: true
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -22,6 +22,8 @@ jobs:
             extra-flags: "--module commonjs --moduleResolution node"
           - version: "5.9.2"
             extra-flags: "--module commonjs --moduleResolution node"
+          - version: "6.0.3"
+            extra-flags: "--module commonjs --ignoreConfig"
           - version: "7.0.2"
             extra-flags: "--module nodenext --moduleResolution nodenext --ignoreConfig"
           - version: "7.1.0-dev.20260723.1"
@@ -46,32 +48,5 @@ jobs:
           rm ci-ts-file.js || true
           pnpm exec tsc --version
           pnpm exec tsc ci-ts-file.ts --strict --target es2017 --skipLibCheck ${{ matrix.typescript-version.extra-flags }}
-          node ci-ts-file.js
-        working-directory: packages/browser
-
-  latest-smoke-test:
-    name: Check latest TS version
-    if: github.event_name == 'pull_request'
-    continue-on-error: true
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: ./.github/actions/setup
-        with:
-          node_version: 24
-          build: true
-
-      - name: Override TypeScript version
-        env:
-          TS_VERSION: latest
-        run: yq -i '.catalog.typescript = strenv(TS_VERSION) | .minimumReleaseAgeExclude += ["typescript"]' pnpm-workspace.yaml && pnpm install --no-frozen-lockfile
-
-      - name: Test TypeScript Import
-        run: |
-          rm ci-ts-file.js || true
-          pnpm exec tsc --version
-          pnpm exec tsc ci-ts-file.ts --strict --target es2017 --skipLibCheck --module nodenext --moduleResolution nodenext --ignoreConfig
           node ci-ts-file.js
         working-directory: packages/browser


### PR DESCRIPTION
## Problem

The TypeScript compatibility matrix still tests an old TypeScript 6 development build, and its prerelease coverage no longer represents the current `next` compiler.

## Changes

- Replace the stale TypeScript 6 prerelease with TypeScript 6.0.3.
- Keep `latest` for current stable coverage and add pinned 7.1.0-dev.20260723.1 next coverage.
- Exempt only the temporarily overridden TypeScript package from the release-age policy so `latest` and the pinned `next` release can be tested immediately.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The matrix keeps floating stable coverage while replacing the stale TypeScript 6 development build with its stable release and adding a pinned current next build. The compilers were compile-tested locally, and the TypeScript-only release-age exemption was verified with pnpm.
