### PR TITLE
chore(tests): fail on unexpected console output

### DIFF
--- a/packages/browser/src/__tests__/ai.test.ts
+++ b/packages/browser/src/__tests__/ai.test.ts
@@ -10,7 +10,6 @@ describe('ai', () => {
     const setup = (config: Partial<PostHogConfig> = {}, token: string = uuidv7()) => {
         const beforeSendMock = jest.fn().mockImplementation((e) => e)
         const posthog = defaultPostHog().init(token, { ...config, before_send: beforeSendMock }, token)!
-        posthog.debug()
         return { posthog, beforeSendMock }
     }
 

--- a/packages/browser/src/__tests__/bot-detection.test.ts
+++ b/packages/browser/src/__tests__/bot-detection.test.ts
@@ -26,7 +26,6 @@ describe('bot detection and pageview collection', () => {
                     uuidv7()
                 )!
         )
-        posthog.debug()
         return posthog
     }
 

--- a/packages/browser/src/__tests__/consent.test.ts
+++ b/packages/browser/src/__tests__/consent.test.ts
@@ -32,7 +32,6 @@ describe('consentManager', () => {
             (resolve) =>
                 defaultPostHog().init('testtoken', { ...config, loaded: (posthog) => resolve(posthog) }, uuidv7())!
         )
-        posthog.debug()
         return posthog
     }
 

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -71,7 +71,6 @@ describe('cookieless', () => {
             ...config,
             before_send: beforeSendMock,
         })!
-        posthog.debug()
         return { posthog, beforeSendMock }
     }
 
@@ -101,8 +100,9 @@ describe('cookieless', () => {
             expect(document.cookie).toBe('')
             expect(posthog.sessionRecording).toBeFalsy()
 
-            // should ignore cookie consent, and throw in test code due to logging an error
-            expect(() => posthog.opt_in_capturing()).toThrow()
+            // should ignore cookie consent
+            posthog.opt_in_capturing()
+            expect(posthog.has_opted_in_capturing()).toBe(false)
         })
 
         it.each([[true], ['history_change']])(
@@ -127,8 +127,9 @@ describe('cookieless', () => {
                 expect(document.cookie).toBe('')
                 expect(posthog.sessionRecording).toBeFalsy()
 
-                // should ignore cookie consent, and throw in test code due to logging an error
-                expect(() => posthog.opt_in_capturing()).toThrow()
+                // should ignore cookie consent
+                posthog.opt_in_capturing()
+                expect(posthog.has_opted_in_capturing()).toBe(false)
             }
         )
     })

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-api.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-api.test.ts
@@ -19,6 +19,7 @@ describe('Conversations API Methods', () => {
     let conversations: PostHogConversations
     let mockPostHog: PostHog
     let mockManager: ConversationsManager
+    let consoleLogSpy: jest.SpyInstance
     let consoleWarnSpy: jest.SpyInstance
 
     beforeEach(() => {
@@ -29,7 +30,8 @@ describe('Conversations API Methods', () => {
         // Enable debug mode so logger actually logs
         Config.DEBUG = true
 
-        // Spy on console.warn
+        // Debug mode is required to exercise warnings, so silence the expected informational logs.
+        consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
         consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
 
         // Setup mock manager with API methods
@@ -85,6 +87,7 @@ describe('Conversations API Methods', () => {
     })
 
     afterEach(() => {
+        consoleLogSpy.mockRestore()
         consoleWarnSpy.mockRestore()
         Config.DEBUG = false
     })

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -3740,15 +3740,18 @@ describe('Lazy SessionRecording', () => {
         })
 
         describe('warns when client-side masking shadows the project setting', () => {
+            let logSpy: jest.SpyInstance
             let warnSpy: jest.SpyInstance
 
             beforeEach(() => {
                 // the logger only emits to the console when debug mode is enabled
                 assignableWindow.POSTHOG_DEBUG = true
+                logSpy = jest.spyOn(window!.console, 'log').mockImplementation(() => {})
                 warnSpy = jest.spyOn(window!.console, 'warn').mockImplementation(() => {})
             })
 
             afterEach(() => {
+                logSpy.mockRestore()
                 warnSpy.mockRestore()
                 assignableWindow.POSTHOG_DEBUG = undefined
             })

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -2052,18 +2052,12 @@ describe('preview renders', () => {
             } as Survey
 
             useEffect(() => {
-                console.log('Render effect triggered with page index:', currentPageIndex)
                 if (surveyPreviewRef.current) {
                     renderSurveysPreview({
                         survey,
                         parentElement: surveyPreviewRef.current,
                         previewPageIndex: currentPageIndex,
-                        onPreviewSubmit: () => {
-                            setCurrentPageIndex((prev) => {
-                                console.log('Setting page index from', prev, 'to', prev + 1)
-                                return prev + 1
-                            })
-                        },
+                        onPreviewSubmit: () => setCurrentPageIndex((prev) => prev + 1),
                     })
                 }
             }, [currentPageIndex])
@@ -2080,7 +2074,6 @@ describe('preview renders', () => {
 
         // Find and fill the textarea
         const textarea = container.querySelector('textarea')
-        console.log('Found textarea:', !!textarea)
 
         await act(async () => {
             // Use fireEvent.input to trigger onInput handler (change event fires on blur)
@@ -2089,9 +2082,6 @@ describe('preview renders', () => {
 
         // Find and click the submit button (using button type="button" instead of form-submit class)
         const submitButton = container.querySelectorAll('button[type="button"]')[1]
-
-        console.log('Found submit button:', !!submitButton)
-        console.log('Submit button text:', submitButton?.textContent)
 
         await act(async () => {
             fireEvent.click(submitButton!)

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -17,6 +17,11 @@ import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
 jest.useFakeTimers()
 jest.spyOn(global, 'setTimeout')
 
+beforeEach(() => {
+    window.POSTHOG_DEBUG = true
+    console.log = jest.fn()
+})
+
 describe('featureflags', () => {
     let instance
     let featureFlags

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -17,10 +17,22 @@ import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
 jest.useFakeTimers()
 jest.spyOn(global, 'setTimeout')
 
-beforeEach(() => {
-    window.POSTHOG_DEBUG = true
-    console.log = jest.fn()
-})
+const expectedFeatureFlagDebugMessages = new Set([
+    'All overrides cleared',
+    'Flag overrides cleared',
+    'Flag overrides set',
+    'Payload overrides cleared',
+    'Payload overrides set',
+])
+
+const mockExpectedFeatureFlagDebugLogs = (): void => {
+    const failOnUnexpectedLog = console.log
+    jest.spyOn(console, 'log').mockImplementation((...args) => {
+        if (args[0] !== '[PostHog.js] [FeatureFlags]' || !expectedFeatureFlagDebugMessages.has(args[1])) {
+            failOnUnexpectedLog(...args)
+        }
+    })
+}
 
 describe('featureflags', () => {
     let instance
@@ -35,6 +47,9 @@ describe('featureflags', () => {
     let mockWarn
 
     beforeEach(() => {
+        window.POSTHOG_DEBUG = true
+        mockExpectedFeatureFlagDebugLogs()
+
         const internalEventEmitter = new SimpleEventEmitter()
         instance = {
             config: { ...config },
@@ -3003,6 +3018,7 @@ describe('parseFlagsResponse', () => {
     let persistence
 
     beforeEach(() => {
+        window.POSTHOG_DEBUG = true
         persistence = { register: jest.fn(), unregister: jest.fn() }
     })
 
@@ -3476,6 +3492,7 @@ describe('getRemoteConfigPayload', () => {
     let featureFlags: PostHogFeatureFlags
 
     beforeEach(() => {
+        window.POSTHOG_DEBUG = true
         instance = createMockPostHog({
             config: {
                 token: 'test-token',
@@ -3686,6 +3703,7 @@ describe('updateFlags', () => {
     it('merge does not bake an active override into the stored flags', async () => {
         const posthog = await createPosthogInstance()
         posthog.updateFlags({ 'base-flag': 'control' })
+        mockExpectedFeatureFlagDebugLogs()
         posthog.featureFlags.overrideFeatureFlags({ flags: { 'base-flag': 'test' } })
         expect(posthog.getFeatureFlag('base-flag')).toBe('test')
 
@@ -4249,6 +4267,8 @@ describe('$feature_flag_error tracking', () => {
 
     describe('feature flag cache TTL', () => {
         beforeEach(() => {
+            window.POSTHOG_DEBUG = true
+
             // Set up flags in persistence for TTL tests
             instance.persistence.register({
                 $enabled_feature_flags: {

--- a/packages/browser/src/__tests__/group-before-identify-bug.test.ts
+++ b/packages/browser/src/__tests__/group-before-identify-bug.test.ts
@@ -59,14 +59,7 @@ describe('group before identify bug', () => {
 
         // Find the events
         const calls = beforeSendMock.mock.calls
-        const groupIdentifyCall = calls.find((c: any) => c[0].event === '$groupidentify')
         const identifyCall = calls.find((c: any) => c[0].event === '$identify')
-
-        console.log(
-            '$groupidentify $set_once.$initial_utm_source:',
-            groupIdentifyCall?.[0]?.$set_once?.$initial_utm_source
-        )
-        console.log('$identify $set_once.$initial_utm_source:', identifyCall?.[0]?.$set_once?.$initial_utm_source)
 
         // THE BUG: $identify should have $set_once with initial UTM params
         // but because group() was called first, _personProcessingSetOncePropertiesSent is already true
@@ -90,8 +83,6 @@ describe('group before identify bug', () => {
 
         const calls = beforeSendMock.mock.calls
         const identifyCall = calls.find((c: any) => c[0].event === '$identify')
-
-        console.log('$identify $set_once (no group):', JSON.stringify(identifyCall?.[0]?.$set_once, null, 2))
 
         // This should work
         expect(identifyCall).toBeDefined()

--- a/packages/browser/src/__tests__/posthog-core.identify.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.identify.test.ts
@@ -231,6 +231,7 @@ describe('identify()', () => {
     describe('invalid id passed', () => {
         it('does not update user', () => {
             console.error = jest.fn()
+            console.log = jest.fn()
 
             instance.debug()
 
@@ -246,6 +247,7 @@ describe('identify()', () => {
 
         it('does not update user when distinct ID is $posthog_cookieless', () => {
             console.error = jest.fn()
+            console.log = jest.fn()
 
             instance.debug()
 

--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -92,7 +92,6 @@ describe('posthog core', () => {
         const setup = (config: Partial<PostHogConfig> = {}, token: string = uuidv7()) => {
             const beforeSendMock = jest.fn().mockImplementation((e) => e)
             const posthog = defaultPostHog().init(token, { ...config, before_send: beforeSendMock }, token)!
-            posthog.debug()
             return { posthog, beforeSendMock }
         }
 

--- a/packages/browser/src/__tests__/remote-config.test.ts
+++ b/packages/browser/src/__tests__/remote-config.test.ts
@@ -45,7 +45,6 @@ describe('RemoteConfigLoader', () => {
 
         beforeEach(() => {
             assignableWindow._POSTHOG_REMOTE_CONFIG = undefined
-            assignableWindow.POSTHOG_DEBUG = true
 
             assignableWindow.__PosthogExtensions__.loadExternalDependency = jest.fn(
                 (_ph: PostHog, _name: string, cb: (err?: any) => void) => {

--- a/packages/browser/src/__tests__/segment.test.ts
+++ b/packages/browser/src/__tests__/segment.test.ts
@@ -23,7 +23,6 @@ const initPostHogInAPromise = (
         return new PostHog().init(
             `test-token`,
             {
-                debug: true,
                 persistence: `localStorage`,
                 api_host: `https://test.com`,
                 segment: segment,

--- a/packages/browser/src/__tests__/setup.js
+++ b/packages/browser/src/__tests__/setup.js
@@ -1,11 +1,41 @@
-beforeEach(() => {
+import Config from '../config'
+
+const failOnUnexpectedConsoleOutput = () => {
+    console.debug = (...args) => {
+        throw new Error(`Unexpected console.debug: ${args}`)
+    }
+
     console.error = (...args) => {
         throw new Error(`Unexpected console.error: ${args}`)
+    }
+
+    console.info = (...args) => {
+        throw new Error(`Unexpected console.info: ${args}`)
+    }
+
+    console.log = (...args) => {
+        throw new Error(`Unexpected console.log: ${args}`)
     }
 
     console.warn = (...args) => {
         throw new Error(`Unexpected console.warn: ${args}`)
     }
+}
+
+failOnUnexpectedConsoleOutput()
+
+beforeEach(() => {
+    Config.DEBUG = false
+    if (typeof window !== 'undefined') {
+        delete window.POSTHOG_DEBUG
+        try {
+            window.localStorage?.removeItem('ph_debug')
+        } catch {
+            // Some storage tests intentionally replace localStorage with a throwing mock.
+        }
+    }
+
+    failOnUnexpectedConsoleOutput()
 
     // Prevent jsdom XHR requests from creating open handles (TLSWRAP/Timeout)
     // that keep Jest from exiting. No unit tests need real HTTP responses.

--- a/packages/react-native/jest.config.js
+++ b/packages/react-native/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
   collectCoverage: true,
   clearMocks: true,
   coverageDirectory: 'coverage',
+  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
   testPathIgnorePatterns: ['<rootDir>/lib/', 'node_modules', 'examples'],
   fakeTimers: { enableGlobally: true },
   transformIgnorePatterns: [],

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -403,13 +403,16 @@ describe('addPostHogAndroidGradlePluginClasspath', () => {
   })
 
   it('leaves contents unchanged and reports not present when there is no buildscript dependencies block', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
     const contents = 'plugins {\n  id "com.android.application"\n}'
     const result = addPostHogAndroidGradlePluginClasspath(contents)
     expect(result.contents).toBe(contents)
     expect(result.classpathPresent).toBe(false)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Could not find a buildscript dependencies block'))
   })
 
   it('does not place the classpath in a later block when buildscript has no dependencies block', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
     const contents = [
       'buildscript {',
       '    repositories { google() }',
@@ -423,6 +426,7 @@ describe('addPostHogAndroidGradlePluginClasspath', () => {
     // The only dependencies block is in allprojects, outside buildscript — must not be used.
     expect(result.classpathPresent).toBe(false)
     expect(result.contents).toBe(contents)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Could not find a buildscript dependencies block'))
   })
 })
 

--- a/packages/react-native/test/setup.ts
+++ b/packages/react-native/test/setup.ts
@@ -1,0 +1,25 @@
+const failOnUnexpectedConsoleOutput = (): void => {
+  console.debug = (...args) => {
+    throw new Error(`Unexpected console.debug: ${args}`)
+  }
+
+  console.error = (...args) => {
+    throw new Error(`Unexpected console.error: ${args}`)
+  }
+
+  console.info = (...args) => {
+    throw new Error(`Unexpected console.info: ${args}`)
+  }
+
+  console.log = (...args) => {
+    throw new Error(`Unexpected console.log: ${args}`)
+  }
+
+  console.warn = (...args) => {
+    throw new Error(`Unexpected console.warn: ${args}`)
+  }
+}
+
+failOnUnexpectedConsoleOutput()
+
+beforeEach(failOnUnexpectedConsoleOutput)


### PR DESCRIPTION
## Problem

The Unit tests job emits roughly 52,900 lines (3.8 MB), including 920 `console.log` blocks. Most of that output comes from browser tests enabling or leaking debug mode, while expected React Native warnings are left unmocked. The noise makes CI failures harder to inspect and allows new accidental console output to go unnoticed.

## Changes

- Fail browser and React Native tests on unexpected `console.debug`, `console.error`, `console.info`, `console.log`, and `console.warn` calls, including calls during module initialization and `beforeAll` hooks.
- Reset browser debug state between tests so `Config.DEBUG`, `POSTHOG_DEBUG`, and persisted debug settings do not leak.
- Explicitly mock expected debug logs and React Native Gradle warnings.
- Remove unnecessary debug mode and diagnostic logging from browser tests.
- Reduce the local full Unit output from roughly 52,900 lines / 3.8 MB to 2,622 lines / 285 KB, with no Jest console blocks.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

This only changes test infrastructure and does not require a package release.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and reviewed with a read-only delegate subagent. The implementation targets the two test packages responsible for the visible console output, removes unnecessary debug activation, and mocks logging only where tests intentionally exercise it. Validation included the focused browser and React Native suites, package lint checks, and the complete monorepo Unit task.
