### PR TITLE
ci: gate irrelevant watcher events

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -24,7 +24,16 @@ concurrency:
 
 jobs:
     enqueue:
-        if: ${{ github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: >-
+            ${{
+              github.event_name == 'issues' ||
+              (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@posthog-watcher')) ||
+              (
+                github.event.pull_request.head.repo.full_name == github.repository &&
+                startsWith(github.event.pull_request.head.ref, 'posthog-watcher/') &&
+                (github.event_name != 'pull_request_review' || github.event.review.state == 'commented' || github.event.review.state == 'changes_requested')
+              )
+            }}
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Problem

The watcher enqueue workflow starts jobs for ordinary PR activity and review-generated events even though the watcher only handles its own repair PRs or explicit commands. A single review can therefore trigger multiple write-permission jobs that check out the repository and then no-op.

## Changes

- Only run issue comment jobs when the comment mentions `@posthog-watcher`.
- Only run PR and review jobs for same-repository branches under `posthog-watcher/`.
- Only handle submitted reviews whose state is `commented` or `changes_requested`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent in a dedicated worktree. The event gates mirror the watcher's existing command and watcher-branch checks so irrelevant events stop before checkout; checkout credential behavior was intentionally left unchanged. YAML parsing, Prettier, and diff validation were run locally.
