### PR TITLE
feat(react-native): add autoPresentSurveys prop to defer popover survey presentation

### DIFF
--- a/.changeset/tidy-ships-nod.md
+++ b/.changeset/tidy-ships-nod.md
@@ -1,0 +1,5 @@
+---
+"posthog-react-native": minor
+---
+
+Add an `autoPresentSurveys` prop to `PostHogSurveyProvider`. Set it to `false` to defer automatic presentation of popover surveys, for example while a native-stack `formSheet` or `modal` is on top. Deferral is display-only: the survey stays armed and presents once the prop becomes `true` again, and a survey already on screen is never interrupted.

--- a/examples/example-expo-53/app/_layout.tsx
+++ b/examples/example-expo-53/app/_layout.tsx
@@ -1,6 +1,6 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native'
 import { useFonts } from 'expo-font'
-import { Stack } from 'expo-router'
+import { Stack, usePathname } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import 'react-native-reanimated'
 
@@ -11,6 +11,15 @@ import { posthog } from './posthog'
 
 export default function RootLayout() {
     const colorScheme = useColorScheme()
+
+    // Demo of deferring popover surveys via `autoPresentSurveys`. Here we defer while the
+    // Surveys screen is open so an auto-popover doesn't fight that screen's demo UI, and
+    // let it present anywhere else. Real apps wire this to whatever should hold a popover
+    // back — e.g. a native formSheet/modal being on top — and are responsible for flipping
+    // it true again (here, on route change), or the survey stays deferred and never shows.
+    const pathname = usePathname()
+    const autoPresentSurveys = pathname !== '/surveys'
+
     const [loaded] = useFonts({
          
         SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
@@ -31,7 +40,7 @@ export default function RootLayout() {
             }}
             debug={true}
         >
-            <PostHogSurveyProvider client={posthog}>
+            <PostHogSurveyProvider client={posthog} autoPresentSurveys={autoPresentSurveys}>
                 <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
                     <Stack>
                         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -4042,6 +4042,11 @@
       "name": "PostHogSurveyProviderProps",
       "properties": [
         {
+          "description": "Whether eligible popover surveys are automatically presented. (Default: true)\nSet to false to defer presentation — e.g. while a native-stack formSheet/modal is on top.\nDeferral is display-only: the survey stays armed and presents once this is true again.\nA survey already on screen is not interrupted when this becomes false.",
+          "type": "boolean",
+          "name": "autoPresentSurveys"
+        },
+        {
           "description": "The default appearance for surveys when not specified in PostHog.",
           "type": "SurveyAppearance",
           "name": "defaultSurveyAppearance"

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -4042,7 +4042,7 @@
       "name": "PostHogSurveyProviderProps",
       "properties": [
         {
-          "description": "Whether eligible popover surveys are automatically presented. (Default: true)\nSet to false to defer presentation — e.g. while a native-stack formSheet/modal is on top.\nDeferral is display-only: the survey stays armed and presents once this is true again.\nA survey already on screen is not interrupted when this becomes false.",
+          "description": "Whether eligible popover surveys are automatically presented. (Default: true)\nSet to false to defer presentation — e.g. while a native-stack formSheet/modal is on top.\nDeferral is display-only: the survey stays armed and presents once this is true again.\nA survey already on screen is not interrupted when this becomes false.\n\nYou own flipping this back to true (e.g. wire it to route/screen focus). While it stays\nfalse the survey remains deferred and never shows — if the un-defer never happens\n(sheet dismissed without re-focusing the provider, an unmount, an error boundary), the\nsurvey stays armed indefinitely and no \"survey shown\" event fires.",
           "type": "boolean",
           "name": "autoPresentSurveys"
         },

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -63,6 +63,11 @@ export type PostHogSurveyProviderProps = {
    * Set to false to defer presentation — e.g. while a native-stack formSheet/modal is on top.
    * Deferral is display-only: the survey stays armed and presents once this is true again.
    * A survey already on screen is not interrupted when this becomes false.
+   *
+   * You own flipping this back to true (e.g. wire it to route/screen focus). While it stays
+   * false the survey remains deferred and never shows — if the un-defer never happens
+   * (sheet dismissed without re-focusing the provider, an unmount, an error boundary), the
+   * survey stays armed indefinitely and no "survey shown" event fires.
    */
   autoPresentSurveys?: boolean
 

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 
 import { dismissedSurveyEvent, sendSurveyShownEvent } from './components/Surveys'
 
@@ -58,11 +58,13 @@ const FeedbackSurveyContext = React.createContext<
 // }
 
 export type PostHogSurveyProviderProps = {
-  // /**
-  //  * Whether to show the default survey modal when there is an active survey. (Default true)
-  //  * If false, you can call useActiveSurvey and render survey content yourself.
-  //  **/
-  // automaticSurveyModal?: boolean
+  /**
+   * Whether eligible popover surveys are automatically presented. (Default: true)
+   * Set to false to defer presentation — e.g. while a native-stack formSheet/modal is on top.
+   * Deferral is display-only: the survey stays armed and presents once this is true again.
+   * A survey already on screen is not interrupted when this becomes false.
+   */
+  autoPresentSurveys?: boolean
 
   /**
    * The default appearance for surveys when not specified in PostHog.
@@ -93,6 +95,9 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
   const { seenSurveys, setSeenSurvey, setLastSeenSurveyDate } = useSurveyStorage()
   const [surveys, setSurveys] = useState<Survey[]>([])
   const [activeSurvey, setActiveSurvey] = useState<Survey | undefined>(undefined)
+  // Latches the id of the survey once its modal has actually painted, so deferring presentation
+  // (autoPresentSurveys=false) never tears down a survey the user is already interacting with.
+  const shownSurveyIdRef = useRef<string | undefined>(undefined)
   const activatedSurveys = useActivatedSurveys(posthog, surveys)
 
   const flags = useFeatureFlags(posthog)
@@ -165,10 +170,12 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
       survey: translatedActiveSurvey.survey,
       surveyLanguage: translatedActiveSurvey.language,
       onShow: () => {
+        shownSurveyIdRef.current = activeSurvey.id
         sendSurveyShownEvent(translatedActiveSurvey.survey, posthog, translatedActiveSurvey.language)
         setLastSeenSurveyDate(new Date())
       },
       onClose: (submitted: boolean, responses: SurveyResponses) => {
+        shownSurveyIdRef.current = undefined
         setSeenSurvey(activeSurvey)
         setActiveSurvey(undefined)
         if (!submitted) {
@@ -178,9 +185,13 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
     }
   }, [activeSurvey, posthog, setLastSeenSurveyDate, setSeenSurvey, translatedActiveSurvey])
 
-  // Modal is shown for PopOver surveys or if automaticSurveyModal is true, and for all widget surveys
-  // because these would have been invoked by the useFeedbackSurvey hook's showSurveyModal() method
-  const shouldShowModal = activeContext && activeContext.survey.type === SurveyType.Popover
+  // Present a popover survey when autoPresentSurveys is on. Once it has painted (shownSurveyIdRef),
+  // keep it mounted regardless of the gate so a mid-interaction survey is never yanked — the gate
+  // defers not-yet-shown surveys, it does not interrupt a live one.
+  const autoPresent = props.autoPresentSurveys !== false
+  const isAlreadyShown = !!activeSurvey && shownSurveyIdRef.current === activeSurvey.id
+  const shouldShowModal =
+    activeContext && activeContext.survey.type === SurveyType.Popover && (autoPresent || isAlreadyShown)
 
   return (
     <ActiveSurveyContext.Provider value={activeContext}>

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -112,9 +112,12 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
       .catch(() => {})
   }, [posthog])
 
-  // Whenever state changes and there's no active survey, check if there is a new survey to show
+  // Whenever state changes, re-select the popover survey to show. A survey that has already
+  // painted is left alone; an armed-but-deferred one is re-validated so it can't be presented
+  // after it stops matching (e.g. its targeting flag flips off during a long deferral).
   useEffect(() => {
-    if (activeSurvey) {
+    const isShown = !!activeSurvey && shownSurveyIdRef.current === activeSurvey.id
+    if (isShown) {
       return
     }
 
@@ -130,9 +133,11 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
     // TODO: sort by appearance delay, implement delay
     // const popoverSurveyQueue = sortSurveysByAppearanceDelay(popoverSurveys)
 
-    if (popoverSurveys.length > 0) {
-      setActiveSurvey(popoverSurveys[0])
+    if (activeSurvey && popoverSurveys.some((survey) => survey.id === activeSurvey.id)) {
+      return
     }
+
+    setActiveSurvey(popoverSurveys.length > 0 ? popoverSurveys[0] : undefined)
   }, [activeSurvey, flags, surveys, seenSurveys, activatedSurveys])
 
   const translatedActiveSurvey = useMemo(() => {

--- a/packages/react-native/test/PostHogSurveyProvider.spec.tsx
+++ b/packages/react-native/test/PostHogSurveyProvider.spec.tsx
@@ -178,6 +178,42 @@ describe('PostHogSurveyProvider — autoPresentSurveys gating', () => {
     expect(sendSurveyShownEvent).toHaveBeenCalledTimes(1)
   })
 
+  it('re-validates a deferred survey: does not present one that became ineligible mid-deferral', async () => {
+    let flags: Record<string, any> = { f1: true }
+    let flagCb: ((f: any) => void) | undefined
+    const flaggedSurvey = { ...popoverSurvey, id: 's-flag', linked_flag_key: 'f1' } as unknown as Survey
+    mockClient = {
+      ...makeClient([flaggedSurvey]),
+      getFeatureFlags: jest.fn(() => flags),
+      onFeatureFlags: jest.fn((cb: any) => {
+        flagCb = cb
+        return () => {}
+      }),
+    }
+
+    // Armed while eligible, but deferred (gate off) so it never paints.
+    const { queryByTestId, rerender } = renderProvider(false)
+    await flush()
+    expect(queryByTestId('survey-modal')).toBeNull()
+
+    // Its linked flag flips off during the deferral window.
+    await act(async () => {
+      flags = {}
+      flagCb?.({})
+    })
+
+    // Un-defer: the survey no longer matches, so nothing is presented.
+    rerender(
+      <PostHogSurveyProvider client={mockClient} autoPresentSurveys={true}>
+        <div data-testid="child" />
+      </PostHogSurveyProvider>
+    )
+    await flush()
+
+    expect(queryByTestId('survey-modal')).toBeNull()
+    expect(sendSurveyShownEvent).not.toHaveBeenCalled()
+  })
+
   it('clears the latch on close so a new gated survey stays deferred', async () => {
     const { queryByTestId, rerender } = renderProvider(true)
     await flush()

--- a/packages/react-native/test/PostHogSurveyProvider.spec.tsx
+++ b/packages/react-native/test/PostHogSurveyProvider.spec.tsx
@@ -1,0 +1,203 @@
+/** @jest-environment jsdom */
+import React from 'react'
+import { act, fireEvent, render, cleanup, waitFor } from '@testing-library/react'
+import { Survey, SurveyType } from '@posthog/core'
+
+// Minimal react-native shim — the full preset pulls in TurboModule code that
+// explodes under jsdom. The provider itself renders no RN primitives, but its
+// import chain (surveys-utils etc.) touches a few.
+jest.mock('react-native', () => {
+  const RealReact = jest.requireActual('react')
+  const Box = RealReact.forwardRef(({ children, testID, ...rest }: any, ref: any) =>
+    RealReact.createElement('div', { ref, 'data-testid': testID, ...rest }, children)
+  )
+  return {
+    View: Box,
+    Modal: Box,
+    Text: Box,
+    Platform: { OS: 'android', select: (o: any) => o.android ?? o.default },
+    StyleSheet: { create: (s: any) => s, flatten: (s: any) => s, absoluteFill: {} },
+    Appearance: { getColorScheme: () => 'light', addChangeListener: () => ({ remove: jest.fn() }) },
+    useColorScheme: () => 'light',
+    useWindowDimensions: () => ({ width: 375, height: 800 }),
+  }
+})
+
+jest.mock('../src/native-deps', () => ({ currentDeviceType: 'Mobile' }))
+
+// Stub the modal: mirror the real behavior (fires onShow once on mount, exposes
+// a close hook) without dragging in the SurveyModal render tree.
+jest.mock('../src/surveys/components/SurveyModal', () => {
+  const R = jest.requireActual('react')
+  return {
+    SurveyModal: (props: any) => {
+      R.useEffect(() => {
+        props.onShow()
+      }, [])
+      return R.createElement('div', {
+        'data-testid': 'survey-modal',
+        onClick: () => props.onClose(false, {}), // simulate a dismiss (not submitted)
+      })
+    },
+  }
+})
+
+// Spy on the shown/dismissed events without executing the real capture path.
+jest.mock('../src/surveys/components/Surveys', () => ({
+  sendSurveyShownEvent: jest.fn(),
+  dismissedSurveyEvent: jest.fn(),
+}))
+
+// Skip translation resolution — irrelevant to presentation gating.
+jest.mock('../src/surveys/survey-translations', () => ({
+  applySurveyTranslationForUser: (survey: Survey) => ({ survey, language: null }),
+}))
+
+let mockClient: any
+jest.mock('../src/hooks/usePostHog', () => ({ usePostHog: () => mockClient }))
+
+import { PostHogSurveyProvider } from '../src/surveys/PostHogSurveyProvider'
+import { sendSurveyShownEvent, dismissedSurveyEvent } from '../src/surveys/components/Surveys'
+
+const popoverSurvey: Survey = {
+  id: 's1',
+  name: 'S1',
+  type: SurveyType.Popover,
+  questions: [],
+  start_date: '2023-01-01T00:00:00Z',
+  end_date: undefined,
+  linked_flag_key: undefined,
+  targeting_flag_key: undefined,
+  internal_targeting_flag_key: undefined,
+  feature_flag_keys: [],
+  conditions: undefined,
+} as unknown as Survey
+
+const makeClient = (surveys: Survey[] = [popoverSurvey]) => ({
+  ready: jest.fn(() => Promise.resolve()),
+  _onSurveysReady: jest.fn(() => Promise.resolve()),
+  getSurveys: jest.fn(() => Promise.resolve(surveys)),
+  getFeatureFlags: jest.fn(() => ({})),
+  onFeatureFlags: jest.fn(() => () => {}),
+  getPersistedProperty: jest.fn(() => undefined),
+  setPersistedProperty: jest.fn(),
+  capture: jest.fn(),
+  on: jest.fn(() => () => {}),
+})
+
+const renderProvider = (autoPresentSurveys?: boolean) =>
+  render(
+    <PostHogSurveyProvider client={mockClient} autoPresentSurveys={autoPresentSurveys}>
+      <div data-testid="child" />
+    </PostHogSurveyProvider>
+  )
+
+// The provider loads surveys via a real-promise chain; the shared jest config
+// enables fake timers globally, which deadlocks async act()/waitFor(). This file
+// drives no timer-based logic (the modal is stubbed), so real timers are safe.
+const flush = async () => {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0))
+  })
+}
+
+describe('PostHogSurveyProvider — autoPresentSurveys gating', () => {
+  beforeEach(() => {
+    jest.useRealTimers()
+    mockClient = makeClient()
+  })
+  afterEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+  })
+
+  it('defers presentation while gated: no modal, no "survey shown"', async () => {
+    const { queryByTestId } = renderProvider(false)
+    await flush()
+
+    expect(queryByTestId('survey-modal')).toBeNull()
+    expect(sendSurveyShownEvent).not.toHaveBeenCalled()
+  })
+
+  it('presents once the gate flips true, firing "survey shown" exactly once', async () => {
+    const { queryByTestId, rerender } = renderProvider(false)
+    await flush()
+    expect(queryByTestId('survey-modal')).toBeNull()
+
+    rerender(
+      <PostHogSurveyProvider client={mockClient} autoPresentSurveys={true}>
+        <div data-testid="child" />
+      </PostHogSurveyProvider>
+    )
+    await flush()
+
+    await waitFor(() => expect(queryByTestId('survey-modal')).not.toBeNull())
+    expect(sendSurveyShownEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not interrupt an on-screen survey when the gate flips false', async () => {
+    const { queryByTestId, rerender } = renderProvider(true)
+    await flush()
+    expect(queryByTestId('survey-modal')).not.toBeNull()
+    expect(sendSurveyShownEvent).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <PostHogSurveyProvider client={mockClient} autoPresentSurveys={false}>
+        <div data-testid="child" />
+      </PostHogSurveyProvider>
+    )
+    await flush()
+
+    // Still mounted, and no re-show (no duplicate event).
+    expect(queryByTestId('survey-modal')).not.toBeNull()
+    expect(sendSurveyShownEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('never presents while it stays gated, even across re-renders', async () => {
+    const { queryByTestId, rerender } = renderProvider(false)
+    await flush()
+
+    for (const on of [false, false, false]) {
+      rerender(
+        <PostHogSurveyProvider client={mockClient} autoPresentSurveys={on}>
+          <div data-testid="child" />
+        </PostHogSurveyProvider>
+      )
+      await flush()
+    }
+
+    expect(queryByTestId('survey-modal')).toBeNull()
+    expect(sendSurveyShownEvent).not.toHaveBeenCalled()
+  })
+
+  it('auto-presents by default (prop omitted) — regression guard', async () => {
+    const { queryByTestId } = renderProvider(undefined)
+    await flush()
+
+    await waitFor(() => expect(queryByTestId('survey-modal')).not.toBeNull())
+    expect(sendSurveyShownEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the latch on close so a new gated survey stays deferred', async () => {
+    const { queryByTestId, rerender } = renderProvider(true)
+    await flush()
+    const modal = queryByTestId('survey-modal')
+    expect(modal).not.toBeNull()
+
+    // Close the survey, then gate off before the next one could present.
+    await act(async () => {
+      fireEvent.click(modal!)
+      await Promise.resolve()
+    })
+    expect(dismissedSurveyEvent).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <PostHogSurveyProvider client={mockClient} autoPresentSurveys={false}>
+        <div data-testid="child" />
+      </PostHogSurveyProvider>
+    )
+    await flush()
+
+    expect(queryByTestId('survey-modal')).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #4242

## Problem

React Native apps have no supported way to defer an auto-presented popover survey. `PostHogSurveyProvider` picks the first matching popover survey and renders its full-screen transparent `Modal` the moment the survey activates. When a route presented by a native stack as `formSheet` or `modal` (react-native-screens, so Expo Router / React Navigation) is on top, that Modal mounts over it and its absolute-fill backdrop can swallow touches meant for the native sheet, so the UI goes unresponsive on iOS.

## Changes

Adds an optional `autoPresentSurveys` prop to `PostHogSurveyProvider`, defaulting to `true` so nothing changes for existing apps. Set it to `false` to defer presentation, e.g. while a native-stack `formSheet` or `modal` is on top.

Deferral is display-only and non-destructive:

- An eligible popover survey stays armed while the prop is `false` and presents once it flips back to `true`. The prop is reactive, so the recheck is automatic.
- A survey already on screen isn't interrupted when the prop goes `false`. A latch keeps it mounted until the user closes it.
- `survey shown` still fires only when the modal actually displays, exactly once. Survey selection, fetch, and seen-tracking are untouched.

Tested with six new provider tests (deferred, presents once when enabled, no interruption when disabled mid-display, stays gated across re-renders, default auto-presents, latch clears on close). Also validated end to end in the `example-expo-53` app against a mock server: with `autoPresentSurveys={false}` the survey is armed but not shown, flipping to `true` presents it and fires exactly one `survey shown`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
