### PR TITLE
fix(nuxt): delete sourcemaps before asset manifest

### DIFF
--- a/.changeset/early-nuxt-maps.md
+++ b/.changeset/early-nuxt-maps.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nuxt': patch
+---
+
+Delete uploaded public sourcemaps before Nitro generates its asset manifest to prevent stale entries from causing runtime 500 errors.

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -140,6 +140,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     let isBuildProcess = false
+    let publicSourcemapsDeleted = false
 
     const posthogCliRunner = () => {
       const cliBinaryPath =
@@ -175,6 +176,11 @@ export default defineNuxtModule<ModuleOptions>({
         // Inject public sourcemaps
         // This cannot be done in the close hook. https://github.com/PostHog/posthog/issues/30957#issuecomment-2824545454
         await cliRunner(getInjectArgs(publicDir, sourcemapsConfig))
+        if (sourcemapsConfig.deleteAfterUpload ?? true) {
+          // Delete public sourcemaps before Nitro generates its asset manifest.
+          await cliRunner(getUploadArgs(publicDir, sourcemapsConfig))
+          publicSourcemapsDeleted = true
+        }
       } catch (error) {
         console.error('Failed to process public sourcemaps:', error)
       }
@@ -190,8 +196,13 @@ export default defineNuxtModule<ModuleOptions>({
         if (nuxt.options.ssr !== false) {
           await cliRunner(getInjectArgs(serverDir, sourcemapsConfig))
         }
-        // Upload all assets (public + any server output that exists)
-        await cliRunner(getUploadArgs(outputDir, sourcemapsConfig))
+        // Upload all assets (public + any server output that exists). If the early public upload failed,
+        // keep its sourcemaps so Nitro's manifest does not point to files deleted after it was generated.
+        const outputSourcemapsConfig =
+          (sourcemapsConfig.deleteAfterUpload ?? true) && !publicSourcemapsDeleted
+            ? { ...sourcemapsConfig, deleteAfterUpload: false }
+            : sourcemapsConfig
+        await cliRunner(getUploadArgs(outputDir, outputSourcemapsConfig))
       } catch (error) {
         console.error('Failed to process or upload sourcemaps:', error)
       }

--- a/packages/nuxt/tests/sourcemaps-ssr.test.mjs
+++ b/packages/nuxt/tests/sourcemaps-ssr.test.mjs
@@ -4,6 +4,8 @@
 // (e.g. `nuxt generate`), causing the CLI to exit 1.
 // Covers both branches: ssr:false must skip the server inject (but still
 // upload outputDir) and ssr:true must still inject the server bundle.
+// Also covers PostHog/posthog-js#4275: public sourcemaps must be uploaded and
+// deleted before Nitro generates its public-asset manifest.
 //
 // Portability: avoids `import('../src/module.ts')` because Node 20 (declared
 // in package.json `engines`) cannot strip TS types. Instead reads module.ts
@@ -41,7 +43,7 @@ const executableSource = source
   // Turn the module's `export default` into a value the wrapper returns.
   .replace('export default defineNuxtModule(', 'return defineNuxtModule(')
 
-function loadModule() {
+function loadModule({ failPublicUpload = false } = {}) {
   const spawnCalls = []
   const stubs = {
     defineNuxtModule: config => config,
@@ -52,18 +54,22 @@ function loadModule() {
     resolveBinaryPath: () => '/fake/posthog-cli',
     spawnLocal: async (bin, args) => {
       spawnCalls.push({ bin, args: [...args] })
+      if (failPublicUpload && args.includes('upload') && args.includes('/build/.output/public')) {
+        throw new Error('public upload failed')
+      }
       return { code: 0 }
     },
     fileURLToPath: u => u,
     dirname: p => p,
+    console: { error: () => {} },
   }
   const factory = new Function(...Object.keys(stubs), executableSource)
   const mod = factory(...Object.values(stubs))
   return { mod, spawnCalls }
 }
 
-async function runLifecycle({ ssr }) {
-  const { mod, spawnCalls } = loadModule()
+async function runLifecycle({ ssr, deleteAfterUpload, failPublicUpload = false }) {
+  const { mod, spawnCalls } = loadModule({ failPublicUpload })
   const hooks = {}
   const nuxt = {
     options: {
@@ -89,6 +95,7 @@ async function runLifecycle({ ssr }) {
         enabled: true,
         personalApiKey: 'phx_test',
         projectId: '123',
+        deleteAfterUpload,
       },
     },
     nuxt,
@@ -138,11 +145,41 @@ for (const { ssr, expectInject } of cases) {
     assert.equal(injectCall, undefined, `ssr:${ssr}: expected no server inject. Got: ${dump}`)
   }
 
-  // Upload of the outputDir must always happen so public sourcemaps reach PostHog.
+  const publicUploadCall = findCall(calls, 'upload', '/build/.output/public')
+  const outputUploadCall = findCall(calls, 'upload', '/build/.output')
+
+  assert.ok(publicUploadCall, `ssr:${ssr}: expected early public sourcemap upload. Got: ${dump}`)
+  assert.ok(publicUploadCall.args.includes('--delete-after'), `ssr:${ssr}: expected public sourcemap deletion`)
+
+  // Upload of the outputDir must still happen so server and preset-specific sourcemaps reach PostHog.
+  assert.ok(outputUploadCall, `ssr:${ssr}: expected sourcemap upload against outputDir. Got: ${dump}`)
   assert.ok(
-    findCall(calls, 'upload', '/build/.output'),
-    `ssr:${ssr}: expected sourcemap upload against outputDir. Got: ${dump}`,
+    calls.indexOf(publicUploadCall) < calls.indexOf(outputUploadCall),
+    `ssr:${ssr}: expected public sourcemaps to be deleted before the final output upload. Got: ${dump}`,
   )
 }
+
+const retainedMapCalls = await runLifecycle({ ssr: true, deleteAfterUpload: false })
+const retainedMapDump = JSON.stringify(retainedMapCalls.map(c => c.args))
+assert.equal(
+  findCall(retainedMapCalls, 'upload', '/build/.output/public'),
+  undefined,
+  `deleteAfterUpload:false: expected no early public upload. Got: ${retainedMapDump}`,
+)
+const retainedMapOutputUpload = findCall(retainedMapCalls, 'upload', '/build/.output')
+assert.ok(retainedMapOutputUpload, `deleteAfterUpload:false: expected final output upload. Got: ${retainedMapDump}`)
+assert.ok(
+  !retainedMapOutputUpload.args.includes('--delete-after'),
+  `deleteAfterUpload:false: expected sourcemaps to be retained. Got: ${retainedMapDump}`,
+)
+
+const failedPublicUploadCalls = await runLifecycle({ ssr: true, failPublicUpload: true })
+const failedPublicUploadDump = JSON.stringify(failedPublicUploadCalls.map(c => c.args))
+const fallbackOutputUpload = findCall(failedPublicUploadCalls, 'upload', '/build/.output')
+assert.ok(fallbackOutputUpload, `failed public upload: expected final output upload. Got: ${failedPublicUploadDump}`)
+assert.ok(
+  !fallbackOutputUpload.args.includes('--delete-after'),
+  `failed public upload: expected final upload to retain manifest-listed maps. Got: ${failedPublicUploadDump}`,
+)
 
 console.log('ok sourcemaps-ssr.test.mjs')


### PR DESCRIPTION
## Problem

Nuxt builds with the default `sourcemaps.deleteAfterUpload` behavior delete public sourcemaps in the final `close` hook, after Nitro has generated its public-asset manifest. The resulting server bundle still lists the deleted `.js.map` files, so requests for discovered sourcemap URLs fail with `ENOENT` and return 500 instead of 404. Fixes #4275.

## Changes

- Upload and delete public sourcemaps in `nitro:build:public-assets`, before Nitro scans the public directory for its manifest.
- Keep the final whole-output upload so server and preset-specific sourcemaps are still handled.
- If the early public upload fails, disable deletion in the final fallback upload so manifest-listed files remain available rather than becoming stale.
- Preserve the existing single final upload when `deleteAfterUpload` is disabled.
- Add regression coverage for SSR and SPA builds, retained sourcemaps, and the failed-early-upload fallback.
- Add an `@posthog/nuxt` patch changeset.

A local node-server integration build confirmed that public maps and manifest entries are both removed and a request for `<chunk>.js.map` returns 404 without an `ENOENT` error.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [x] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using the `karpathy-guidelines` and `pr` skills. The implementation was kept within the existing Nuxt lifecycle: early deletion is limited to the configuration that requests deletion, while the existing whole-output scan remains for preset compatibility. The fallback intentionally retains maps if early cleanup fails so Nitro cannot ship references to files deleted later.
