### PR TITLE
fix(replay): rebuild full snapshot at paused seek boundary

### DIFF
--- a/.changeset/calm-snapshots-rebuild.md
+++ b/.changeset/calm-snapshots-rebuild.md
@@ -1,0 +1,6 @@
+---
+'@posthog/rrweb': patch
+'posthog-js': patch
+---
+
+Fix paused replay seeks at an exact full snapshot timestamp so the snapshot frame is rebuilt before playback pauses.

--- a/.changeset/calm-snapshots-rebuild.md
+++ b/.changeset/calm-snapshots-rebuild.md
@@ -1,5 +1,4 @@
 ---
-'@posthog/rrweb': patch
 'posthog-js': patch
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,8 @@ This repository uses [Changesets](https://github.com/changesets/changesets) for 
 
 ### Creating a Changeset
 
+Never add changesets for modules under `packages/rrweb/`; they are built with `posthog-js`. For rrweb changes that require a release, add only a `posthog-js` changeset.
+
 Before submitting a PR with changes that should be released:
 
 ```bash

--- a/packages/rrweb/rrweb/src/replay/machine.ts
+++ b/packages/rrweb/rrweb/src/replay/machine.ts
@@ -209,7 +209,14 @@ export function createPlayerService(
             ) {
               continue;
             }
-            if (event.timestamp < baselineTime) {
+            // A paused seek clears future timer actions before this event can run.
+            const isFullSnapshotAtSeekBoundary =
+              event.type === EventType.FullSnapshot &&
+              event.timestamp === baselineTime;
+            if (
+              event.timestamp < baselineTime ||
+              isFullSnapshotAtSeekBoundary
+            ) {
               syncEvents.push(event);
             } else {
               const castFn = getCastFn(event, false);

--- a/packages/rrweb/rrweb/src/replay/machine.ts
+++ b/packages/rrweb/rrweb/src/replay/machine.ts
@@ -185,6 +185,11 @@ export function createPlayerService(
             addDelay(event, baselineTime);
           }
           const neededEvents = discardPriorSnapshots(events, baselineTime);
+          const hasFullSnapshotAtSeekBoundary = neededEvents.some(
+            (event) =>
+              event.type === EventType.FullSnapshot &&
+              event.timestamp === baselineTime,
+          );
 
           let lastPlayedTimestamp = lastPlayedEvent?.timestamp;
           if (
@@ -209,14 +214,13 @@ export function createPlayerService(
             ) {
               continue;
             }
-            // A paused seek clears future timer actions before this event can run.
-            const isFullSnapshotAtSeekBoundary =
-              event.type === EventType.FullSnapshot &&
-              event.timestamp === baselineTime;
-            if (
-              event.timestamp < baselineTime ||
-              isFullSnapshotAtSeekBoundary
-            ) {
+            // A paused seek clears timer actions; apply the snapshot and its metadata now.
+            const isSnapshotBoundaryEvent =
+              hasFullSnapshotAtSeekBoundary &&
+              event.timestamp === baselineTime &&
+              (event.type === EventType.Meta ||
+                event.type === EventType.FullSnapshot);
+            if (event.timestamp < baselineTime || isSnapshotBoundaryEvent) {
               syncEvents.push(event);
             } else {
               const castFn = getCastFn(event, false);

--- a/packages/rrweb/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/rrweb/test/replayer.test.ts
@@ -164,6 +164,31 @@ describe('replayer', function () {
     expect(currentState).toEqual('paused');
   });
 
+  it('applies the full snapshot when pausing exactly at its timestamp', async () => {
+    await page.evaluate(`events = ${JSON.stringify(styleSheetRuleEvents)}`);
+    const result = await page.evaluate(`
+      (() => {
+        const { Replayer } = rrweb;
+        const replayer = new Replayer(events);
+        const fullSnapshot = events.find((event) => event.type === 2);
+        const fullSnapshotOffset = fullSnapshot.timestamp - events[0].timestamp;
+
+        replayer.pause(1500);
+        const laterFrameHasJss = replayer.iframe.contentDocument.head.innerHTML.includes('data-jss');
+
+        replayer.pause(fullSnapshotOffset);
+        const snapshotFrameHasJss = replayer.iframe.contentDocument.head.innerHTML.includes('data-jss');
+
+        return { laterFrameHasJss, snapshotFrameHasJss };
+      })()
+    `);
+
+    expect(result).toEqual({
+      laterFrameHasJss: true,
+      snapshotFrameHasJss: false,
+    });
+  });
+
   it('can fast forward past StyleSheetRule changes on virtual elements', async () => {
     await page.evaluate(`events = ${JSON.stringify(styleSheetRuleEvents)}`);
     const actionLength = await page.evaluate(`

--- a/packages/rrweb/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/rrweb/test/replayer.test.ts
@@ -32,7 +32,11 @@ import adoptedStyleSheetModification from './events/adopted-style-sheet-modifica
 import documentReplacementEvents from './events/document-replacement';
 import hoverInIframeShadowDom from './events/iframe-shadowdom-hover';
 import customElementDefineClass from './events/custom-element-define-class';
-import { ReplayerEvents } from '@posthog/rrweb-types';
+import {
+  EventType,
+  IncrementalSource,
+  ReplayerEvents,
+} from '@posthog/rrweb-types';
 
 interface ISuite {
   code: string;
@@ -165,27 +169,47 @@ describe('replayer', function () {
   });
 
   it('applies the full snapshot when pausing exactly at its timestamp', async () => {
-    await page.evaluate(`events = ${JSON.stringify(styleSheetRuleEvents)}`);
+    const eventsWithLaterResize = [
+      ...styleSheetRuleEvents,
+      {
+        type: EventType.IncrementalSnapshot,
+        data: {
+          source: IncrementalSource.ViewportResize,
+          width: 1200,
+          height: 900,
+        },
+        timestamp: styleSheetRuleEvents[0].timestamp + 1400,
+      },
+    ].sort((a, b) => a.timestamp - b.timestamp);
+    await page.evaluate(`events = ${JSON.stringify(eventsWithLaterResize)}`);
     const result = await page.evaluate(`
       (() => {
         const { Replayer } = rrweb;
         const replayer = new Replayer(events);
         const fullSnapshot = events.find((event) => event.type === 2);
         const fullSnapshotOffset = fullSnapshot.timestamp - events[0].timestamp;
+        const frameSize = () => ({
+          width: replayer.iframe.getAttribute('width'),
+          height: replayer.iframe.getAttribute('height'),
+        });
 
         replayer.pause(1500);
         const laterFrameHasJss = replayer.iframe.contentDocument.head.innerHTML.includes('data-jss');
+        const laterFrameSize = frameSize();
 
         replayer.pause(fullSnapshotOffset);
         const snapshotFrameHasJss = replayer.iframe.contentDocument.head.innerHTML.includes('data-jss');
+        const snapshotFrameSize = frameSize();
 
-        return { laterFrameHasJss, snapshotFrameHasJss };
+        return { laterFrameHasJss, laterFrameSize, snapshotFrameHasJss, snapshotFrameSize };
       })()
     `);
 
     expect(result).toEqual({
       laterFrameHasJss: true,
+      laterFrameSize: { width: '1200', height: '900' },
       snapshotFrameHasJss: false,
+      snapshotFrameSize: { width: '1000', height: '800' },
     });
   });
 


### PR DESCRIPTION
## Problem

When a paused replay seek lands exactly on a FullSnapshot timestamp, the replay machine classifies the snapshot as a future event. `pause(timeOffset)` then immediately clears the timer, so the snapshot is never rebuilt and the previously rendered frame remains visible. A paired Meta event at the same timestamp is also discarded, which can preserve stale viewport dimensions.

Fixes #4239.

## Changes

- Apply a FullSnapshot and its same-timestamp Meta event synchronously when the snapshot exactly matches the seek baseline.
- Keep the existing strict boundary behavior for all unrelated events to avoid changing `lastPlayedEvent` bookkeeping.
- Add a regression test that seeks forward and then pauses exactly at the FullSnapshot boundary, verifying both the rebuilt DOM and viewport dimensions.
- Add a patch changeset for `posthog-js`.
- Document that modules under `packages/rrweb/` are built with `posthog-js` and do not receive separate changesets.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent after reviewing #4239 and its relationship to #4226. The broader `<` to `<=` change was rejected because it changes boundary handling for every event and had already caused replay bookkeeping regressions; this PR uses the narrower snapshot-boundary behavior and verifies it with the reported seek sequence.
