### PR TITLE
ci: wait for package publishes before upgrade dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,6 @@ jobs:
         if: always() && needs.version-bump.outputs.commit-hash != ''
         permissions:
             contents: write
-            actions: write
             id-token: write
         strategy:
             fail-fast: false
@@ -346,34 +345,12 @@ jobs:
                     --title "$PACKAGE_NAME@$COMMITTED_VERSION" \
                     --notes "$LAST_CHANGELOG_ENTRY"
 
-            ########################################################
-            ############## posthog-js auto-update ##################
-            - name: Dispatch posthog upgrade for posthog-js
-              id: dispatch-posthog-upgrade
-              continue-on-error: true
-              if: matrix.package.name == 'posthog-js' && steps.check-package-version.outputs.is-new-version == 'true'
-              env:
-                  PACKAGE_NAME: ${{ matrix.package.name }}
-                  PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  curl -f -sS -X POST \
-                       -H "Accept: application/vnd.github+json" \
-                       -H "Authorization: Bearer $GITHUB_TOKEN" \
-                       https://api.github.com/repos/posthog/posthog-js/actions/workflows/posthog-upgrade.yml/dispatches \
-                       -d "$(jq -n \
-                         --arg ref "main" \
-                         --arg package_name "$PACKAGE_NAME" \
-                         --arg package_version "$PACKAGE_VERSION" \
-                         '{ref: $ref, inputs: {package_name: $package_name, package_version: $package_version}}' \
-                       )"
-
             ####################################################
             # Notify ourselves in case of a failure here
             # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Resolve release failure metadata
               id: release-failure-metadata
-              if: ${{ failure() || steps.dispatch-posthog-upgrade.outcome == 'failure' }}
+              if: ${{ failure() }}
               env:
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
@@ -398,35 +375,8 @@ jobs:
                       echo "package_ref=$package_ref"
                   } >> "$GITHUB_OUTPUT"
 
-            - name: Send PostHog upgrade dispatch failure event
-              if: ${{ steps.dispatch-posthog-upgrade.outcome == 'failure' }}
-              continue-on-error: true
-              uses: PostHog/posthog-github-action@9a6a19d360820ab4d95ecc4a5a7564062c895f84 # v1.3.0
-              with:
-                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
-                  event: 'posthog-sdk-github-release-workflow-failure'
-                  properties: >-
-                      {
-                        "commitSha": "${{ github.sha }}",
-                        "jobStatus": "failure",
-                        "ref": "${{ github.ref }}",
-                        "repository": "${{ github.repository }}",
-                        "sdk": "posthog-js",
-                        "jobName": "dispatch-posthog-upgrade",
-                        "packageName": "posthog-js",
-                        "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version || 'unknown' }}",
-                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                        "failedStepName": "dispatch-posthog-upgrade",
-                        "alertText": ":warning: Failed to dispatch PostHog/posthog upgrade for ${{ steps.release-failure-metadata.outputs.package_ref }}",
-                        "alertContext": "The SDK release may have succeeded; only the downstream monorepo upgrade workflow dispatch failed."
-                      }
-
-            - name: Fail if posthog upgrade dispatch failed
-              if: ${{ steps.dispatch-posthog-upgrade.outcome == 'failure' }}
-              run: exit 1
-
             - name: Send failure event to PostHog
-              if: ${{ failure() && steps.dispatch-posthog-upgrade.outcome != 'failure' }}
+              if: ${{ failure() }}
               continue-on-error: true
               uses: PostHog/posthog-github-action@9a6a19d360820ab4d95ecc4a5a7564062c895f84 # v1.3.0
               with:
@@ -449,7 +399,7 @@ jobs:
 
             - name: Notify Slack - Failed
               continue-on-error: true # Slack failure shouldn't mark release as failed
-              if: ${{ failure() && steps.dispatch-posthog-upgrade.outcome != 'failure' && needs.notify-approval-needed.outputs.slack_ts != '' }}
+              if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
               uses: PostHog/.github/.github/actions/slack-thread-reply@cb0979b67dcd585828b61ac45927eef4da8f6287 # main
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
@@ -457,6 +407,94 @@ jobs:
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
                   message: '❌ Failed to release `${{ steps.release-failure-metadata.outputs.package_ref }}`! <${{ steps.release-failure-metadata.outputs.action_url }}|View workflow run>'
                   emoji_reaction: 'x'
+
+    # Wait for the full publish matrix so newly bumped workspace dependencies are available on npm.
+    # The posthog-js tag points at this release commit only when this run published a new browser SDK version.
+    dispatch-posthog-upgrade:
+        name: Dispatch PostHog upgrade
+        needs: [version-bump, publish]
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            actions: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  ref: ${{ needs.version-bump.outputs.commit-hash }}
+                  fetch-depth: 1
+
+            - name: Check whether posthog-js was published by this release
+              id: release-metadata
+              env:
+                  RELEASE_SHA: ${{ needs.version-bump.outputs.commit-hash }}
+              run: |
+                  set -euo pipefail
+
+                  package_version=$(jq -r '.version' packages/browser/package.json)
+                  package_ref="posthog-js@v$package_version"
+                  tag_sha=$(git ls-remote --tags origin "refs/tags/posthog-js@$package_version" | awk 'NR == 1 { print $1 }')
+
+                  was_published=false
+                  if [ "$tag_sha" = "$RELEASE_SHA" ]; then
+                      was_published=true
+                      echo "$package_ref was published by this release."
+                  else
+                      echo "$package_ref was not published by this release; skipping the downstream upgrade."
+                  fi
+
+                  {
+                      echo "package_version=$package_version"
+                      echo "package_ref=$package_ref"
+                      echo "was_published=$was_published"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Dispatch posthog upgrade
+              id: dispatch-posthog-upgrade
+              continue-on-error: true
+              if: steps.release-metadata.outputs.was_published == 'true'
+              env:
+                  PACKAGE_VERSION: ${{ steps.release-metadata.outputs.package_version }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  curl -f -sS -X POST \
+                       -H "Accept: application/vnd.github+json" \
+                       -H "Authorization: Bearer $GITHUB_TOKEN" \
+                       https://api.github.com/repos/posthog/posthog-js/actions/workflows/posthog-upgrade.yml/dispatches \
+                       -d "$(jq -n \
+                         --arg ref "main" \
+                         --arg package_name "posthog-js" \
+                         --arg package_version "$PACKAGE_VERSION" \
+                         '{ref: $ref, inputs: {package_name: $package_name, package_version: $package_version}}' \
+                       )"
+
+            # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
+            - name: Send PostHog upgrade dispatch failure event
+              if: ${{ steps.dispatch-posthog-upgrade.outcome == 'failure' }}
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@9a6a19d360820ab4d95ecc4a5a7564062c895f84 # v1.3.0
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  event: 'posthog-sdk-github-release-workflow-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "failure",
+                        "ref": "${{ github.ref }}",
+                        "repository": "${{ github.repository }}",
+                        "sdk": "posthog-js",
+                        "jobName": "dispatch-posthog-upgrade",
+                        "packageName": "posthog-js",
+                        "packageVersion": "${{ steps.release-metadata.outputs.package_version || 'unknown' }}",
+                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                        "failedStepName": "dispatch-posthog-upgrade",
+                        "alertText": ":warning: Failed to dispatch PostHog/posthog upgrade for ${{ steps.release-metadata.outputs.package_ref }}",
+                        "alertContext": "The SDK release may have succeeded; only the downstream monorepo upgrade workflow dispatch failed."
+                      }
+
+            - name: Fail if posthog upgrade dispatch failed
+              if: ${{ steps.dispatch-posthog-upgrade.outcome == 'failure' }}
+              run: exit 1
 
     build-s3-artifacts:
         name: Build posthog-js dist for S3
@@ -894,11 +932,12 @@ jobs:
 
     notify-released:
         name: Notify Slack - Released
-        needs: [notify-approval-needed, publish, upload-s3]
+        needs: [notify-approval-needed, publish, dispatch-posthog-upgrade, upload-s3]
         runs-on: ubuntu-latest
         if: >-
             always() &&
             needs.publish.result == 'success' &&
+            needs.dispatch-posthog-upgrade.result == 'success' &&
             (needs.upload-s3.result == 'success' || needs.upload-s3.result == 'skipped') &&
             needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
@@ -923,11 +962,12 @@ jobs:
     # failed step is retried.
     notify-partial-release:
         name: Notify Slack - Partial Release (npm only)
-        needs: [notify-approval-needed, build-s3-artifacts, publish, upload-s3]
+        needs: [notify-approval-needed, build-s3-artifacts, publish, dispatch-posthog-upgrade, upload-s3]
         runs-on: ubuntu-latest
         if: >-
             always() &&
             needs.publish.result == 'success' &&
+            needs.dispatch-posthog-upgrade.result == 'success' &&
             needs.build-s3-artifacts.outputs.is-new-version == 'true' &&
             needs.upload-s3.result == 'failure' &&
             needs.notify-approval-needed.outputs.slack_ts != ''


### PR DESCRIPTION
## Problem

The downstream PostHog dependency upgrade was dispatched as soon as the `posthog-js` publish matrix entry completed. When a release also bumped a workspace dependency, the downstream install could start before that dependency reached npm, as happened with `@posthog/browser-common@0.2.2`.

## Changes

- Move the downstream upgrade dispatch into a dedicated job that waits for the complete package publish matrix.
- Confirm the current release actually published `posthog-js` by checking that its version tag points to the release commit.
- Preserve dispatch failure telemetry and release notification gating.
- Limit `actions: write` permission to the dispatch job.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and GitHub CLI. The dispatch now uses the release tag-to-commit relationship to distinguish browser SDK releases from releases of other workspace packages, without depending on timing-sensitive npm version checks.
