### PR TITLE
fix(docs): restore browser-common types missing from the public API reference

### DIFF
--- a/packages/browser/api-extractor.json
+++ b/packages/browser/api-extractor.json
@@ -67,7 +67,7 @@
    *
    *   "bundledPackages": [ "@my-company/*" ],
    */
-  "bundledPackages": [],
+  "bundledPackages": ["@posthog/browser-common"],
 
   /**
    * Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -2334,6 +2334,156 @@
   ],
   "types": [
     {
+      "id": "ActionStepStringMatching",
+      "name": "ActionStepStringMatching",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "\"contains\" | \"exact\" | \"regex\""
+    },
+    {
+      "id": "ActionStepType",
+      "name": "ActionStepType",
+      "properties": [
+        {
+          "type": "string | null",
+          "name": "event"
+        },
+        {
+          "description": "StringMatching.Exact",
+          "type": "ActionStepStringMatching | null",
+          "name": "href_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "href"
+        },
+        {
+          "description": "Property filters for action step matching.",
+          "type": "{\n        key: string;\n        value?: string | number | boolean | (string | number | boolean)[] | null;\n        operator?: PropertyMatchType;\n        type?: string;\n    }[]",
+          "name": "properties"
+        },
+        {
+          "description": "Pre-compiled regex pattern for matching selector against `$elements_chain`.",
+          "type": "string | null",
+          "name": "selector_regex"
+        },
+        {
+          "type": "string | null",
+          "name": "selector"
+        },
+        {
+          "description": "Deprecated: Only `selector` should be used now.",
+          "type": "string",
+          "name": "tag_name",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "StringMatching.Exact",
+          "type": "ActionStepStringMatching | null",
+          "name": "text_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "text"
+        },
+        {
+          "description": "StringMatching.Contains",
+          "type": "ActionStepStringMatching | null",
+          "name": "url_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "url"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
+      "id": "BasicSurveyQuestion",
+      "name": "BasicSurveyQuestion",
+      "properties": [
+        {
+          "type": "typeof SurveyQuestionType.Open",
+          "name": "type"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
+      "id": "Compression",
+      "name": "Compression",
+      "properties": [],
+      "path": "../browser-common/dist/types/compression.d.ts",
+      "example": "(typeof Compression)[keyof typeof Compression]"
+    },
+    {
+      "id": "ConversationsRemoteConfig",
+      "name": "ConversationsRemoteConfig",
+      "properties": [
+        {
+          "description": "Whether to show the name field in the identification form.",
+          "type": "boolean",
+          "name": "collectName"
+        },
+        {
+          "description": "Primary color for the widget UI.",
+          "type": "string",
+          "name": "color"
+        },
+        {
+          "description": "Domains where the widget may be shown.",
+          "type": "string[]",
+          "name": "domains"
+        },
+        {
+          "description": "Whether conversations are enabled for this team.",
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "description": "Greeting text to show when the widget is first opened.",
+          "type": "string",
+          "name": "greetingText"
+        },
+        {
+          "description": "Description for the identification form.",
+          "type": "string",
+          "name": "identificationFormDescription"
+        },
+        {
+          "description": "Title for the identification form.",
+          "type": "string",
+          "name": "identificationFormTitle"
+        },
+        {
+          "description": "Placeholder text for the message input.",
+          "type": "string",
+          "name": "placeholderText"
+        },
+        {
+          "description": "Whether to require an email address before starting a conversation.",
+          "type": "boolean",
+          "name": "requireEmail"
+        },
+        {
+          "description": "Public token for authenticating conversations API requests.",
+          "type": "string",
+          "name": "token"
+        },
+        {
+          "description": "Whether the widget UI should be shown.",
+          "type": "boolean",
+          "name": "widgetEnabled"
+        },
+        {
+          "description": "Position of the widget on the screen.",
+          "type": "WidgetPosition",
+          "name": "widgetPosition"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
+    },
+    {
       "id": "ConversationsTraits",
       "name": "ConversationsTraits",
       "properties": [
@@ -2389,11 +2539,56 @@
       "path": "lib/src/posthog-surveys-types.d.ts"
     },
     {
+      "id": "DisplaySurveyType",
+      "name": "DisplaySurveyType",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof DisplaySurveyType)[keyof typeof DisplaySurveyType]"
+    },
+    {
       "id": "ErrorEventArgs",
       "name": "ErrorEventArgs",
       "properties": [],
       "path": "lib/src/types.d.ts",
       "example": "[\n    event: string | Event,\n    source?: string | undefined,\n    lineno?: number | undefined,\n    colno?: number | undefined,\n    error?: Error | undefined\n]"
+    },
+    {
+      "id": "ErrorTrackingSuppressionRule",
+      "name": "ErrorTrackingSuppressionRule",
+      "properties": [
+        {
+          "type": "'AND' | 'OR'",
+          "name": "type"
+        },
+        {
+          "type": "ErrorTrackingSuppressionRuleValue[]",
+          "name": "values"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
+    },
+    {
+      "id": "ErrorTrackingSuppressionRuleValue",
+      "name": "ErrorTrackingSuppressionRuleValue",
+      "properties": [
+        {
+          "type": "'$exception_types' | '$exception_values'",
+          "name": "key"
+        },
+        {
+          "type": "PropertyMatchType",
+          "name": "operator"
+        },
+        {
+          "type": "string",
+          "name": "type"
+        },
+        {
+          "type": "string | string[]",
+          "name": "value"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
     },
     {
       "id": "EventHandler",
@@ -2437,6 +2632,21 @@
         }
       ],
       "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "FlagVariant",
+      "name": "FlagVariant",
+      "properties": [
+        {
+          "type": "string",
+          "name": "flag"
+        },
+        {
+          "type": "string",
+          "name": "variant"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
     },
     {
       "id": "GetMessagesResponse",
@@ -2537,6 +2747,21 @@
       "path": "lib/src/posthog-product-tours-types.d.ts"
     },
     {
+      "id": "LinkSurveyQuestion",
+      "name": "LinkSurveyQuestion",
+      "properties": [
+        {
+          "type": "string | null",
+          "name": "link"
+        },
+        {
+          "type": "typeof SurveyQuestionType.Link",
+          "name": "type"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
       "id": "MarkAsReadResponse",
       "name": "MarkAsReadResponse",
       "properties": [
@@ -2603,6 +2828,85 @@
       "example": "\"customer\" | \"AI\" | \"human\""
     },
     {
+      "id": "MultipleSurveyQuestion",
+      "name": "MultipleSurveyQuestion",
+      "properties": [
+        {
+          "type": "string[]",
+          "name": "choices"
+        },
+        {
+          "type": "boolean",
+          "name": "hasOpenChoice"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleOptions"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        },
+        {
+          "type": "typeof SurveyQuestionType.SingleChoice | typeof SurveyQuestionType.MultipleChoice",
+          "name": "type"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
+      "id": "NetworkRecordOptions",
+      "name": "NetworkRecordOptions",
+      "properties": [
+        {
+          "type": "InitiatorType[]",
+          "name": "initiatorTypes"
+        },
+        {
+          "type": "(data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined",
+          "name": "maskRequestFn"
+        },
+        {
+          "type": "boolean | { request: boolean; response: boolean; }",
+          "name": "recordHeaders"
+        },
+        {
+          "type": "boolean | string[] | { request: boolean | string[]; response: boolean | string[]; }",
+          "name": "recordBody"
+        },
+        {
+          "type": "boolean",
+          "name": "recordInitialRequests"
+        },
+        {
+          "description": "whether to record PerformanceEntry events for network requests",
+          "type": "boolean",
+          "name": "recordPerformance"
+        },
+        {
+          "description": "the PerformanceObserver will only observe these entry types",
+          "type": "string[]",
+          "name": "performanceEntryTypeToObserve"
+        },
+        {
+          "description": "the maximum size of the request/response body to record\nNB this will be at most 1MB even if set larger",
+          "type": "number",
+          "name": "payloadSizeLimitBytes"
+        },
+        {
+          "description": "when true, read bodies through a streaming reader that stops at payloadSizeLimitBytes\ninstead of buffering the whole body and then enforcing the limit. Reads only a clone of\nthe body, so it never consumes the stream the page itself reads.",
+          "type": "boolean",
+          "name": "streamNetworkBody"
+        },
+        {
+          "description": "some domains we should never record the payload\nfor example other companies session replay ingestion payloads aren't super useful but are gigantic\nif this isn't provided we use a default list\nif this is provided - we add the provided list to the default list\ni.e. we never record the payloads on the default deny list",
+          "type": "string[]",
+          "name": "payloadHostDenyList"
+        }
+      ],
+      "path": "../browser-common/dist/types/network-recording.d.ts"
+    },
+    {
       "id": "OverrideConfig",
       "name": "OverrideConfig",
       "properties": [
@@ -2636,6 +2940,11 @@
       "name": "PostHogConfig",
       "properties": [
         {
+          "description": "The name this instance will be identified by.\nYou don't need to set this most of the time,\nbut can be useful if you have several Posthog instances running at the same time.",
+          "type": "string",
+          "name": "name"
+        },
+        {
           "description": "URL of your PostHog instance.",
           "type": "string",
           "name": "api_host"
@@ -2652,18 +2961,13 @@
         },
         {
           "description": "The transport method to use for API requests.",
-          "type": "\"XHR\" | \"fetch\"",
+          "type": "\"fetch\" | \"XHR\"",
           "name": "api_transport"
         },
         {
           "description": "The token for your PostHog project.\nIt should NOT be provided manually in the config, but rather passed as the first parameter to `posthog.init()`.",
           "type": "string",
           "name": "token"
-        },
-        {
-          "description": "The name this instance will be identified by.\nYou don't need to set this most of the time,\nbut can be useful if you have several Posthog instances running at the same time.",
-          "type": "string",
-          "name": "name"
         },
         {
           "description": "Determines whether PostHog should autocapture events.\nThis setting does not affect capturing pageview events (see `capture_pageview`).\n\nby default autocapture is ignored on elements that match a `ph-no-capture` css class on the element or a parent",
@@ -4146,6 +4450,27 @@
       "path": "lib/src/posthog-product-tours-types.d.ts"
     },
     {
+      "id": "PropertyFilters",
+      "name": "PropertyFilters",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "{\n    [propertyName: string]: {\n        values: string[];\n        operator: PropertyOperator;\n    };\n}"
+    },
+    {
+      "id": "PropertyMatchType",
+      "name": "PropertyMatchType",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "\"regex\" | \"not_regex\" | \"exact\" | \"is_not\" | \"icontains\" | \"not_icontains\""
+    },
+    {
+      "id": "PropertyOperator",
+      "name": "PropertyOperator",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "\"gt\" | \"lt\""
+    },
+    {
       "id": "QueuedRequestWithOptions",
       "name": "QueuedRequestWithOptions",
       "properties": [
@@ -4156,6 +4481,151 @@
         }
       ],
       "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RatingSurveyQuestion",
+      "name": "RatingSurveyQuestion",
+      "properties": [
+        {
+          "type": "'number' | 'emoji'",
+          "name": "display"
+        },
+        {
+          "type": "string",
+          "name": "lowerBoundLabel"
+        },
+        {
+          "type": "2 | 3 | 5 | 7 | 10",
+          "name": "scale"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        },
+        {
+          "type": "typeof SurveyQuestionType.Rating",
+          "name": "type"
+        },
+        {
+          "type": "string",
+          "name": "upperBoundLabel"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
+      "id": "RemoteConfig",
+      "name": "RemoteConfig",
+      "properties": [
+        {
+          "description": "Custom endpoint configuration for analytics events.",
+          "type": "{\n        endpoint?: string;\n    }",
+          "name": "analytics"
+        },
+        {
+          "description": "If true, disables autocapture. When absent or not a boolean, the SDK keeps the last known server value; a visitor with no stored value keeps autocapture off until a response containing the field arrives.",
+          "type": "boolean",
+          "name": "autocapture_opt_out"
+        },
+        {
+          "description": "Exception autocapture configuration.",
+          "type": "boolean | {\n        endpoint?: string;\n    }",
+          "name": "autocaptureExceptions"
+        },
+        {
+          "description": "Whether to capture dead clicks.",
+          "type": "boolean",
+          "name": "captureDeadClicks"
+        },
+        {
+          "description": "Performance capture configuration shared by replay and web vitals.",
+          "type": "boolean | PerformanceCaptureConfig",
+          "name": "capturePerformance"
+        },
+        {
+          "description": "Conversations widget configuration.",
+          "type": "boolean | ConversationsRemoteConfig",
+          "name": "conversations"
+        },
+        {
+          "description": "Whether to capture only identified users by default.",
+          "type": "boolean",
+          "name": "defaultIdentifiedOnly"
+        },
+        {
+          "description": "Deprecated: Renamed to `toolbarParams`; still present on older API responses.",
+          "type": "ToolbarParams",
+          "name": "editorParams",
+          "releaseTag": "deprecated"
+        },
+        {
+          "description": "Whether `$elements_chain` is sent as a string rather than an array.",
+          "type": "boolean",
+          "name": "elementsChainAsString"
+        },
+        {
+          "description": "Error tracking configuration.",
+          "type": "{\n        autocaptureExceptions?: boolean;\n        captureExtensionExceptions?: boolean;\n        suppressionRules?: ErrorTrackingSuppressionRule[];\n    }",
+          "name": "errorTracking"
+        },
+        {
+          "description": "Whether the team has any feature flags enabled.",
+          "type": "boolean",
+          "name": "hasFeatureFlags"
+        },
+        {
+          "description": "Whether heatmaps are enabled.",
+          "type": "boolean",
+          "name": "heatmaps"
+        },
+        {
+          "description": "Whether the current user is authenticated.",
+          "type": "boolean",
+          "name": "isAuthenticated"
+        },
+        {
+          "description": "Log capture configuration.",
+          "type": "{\n        captureConsoleLogs?: boolean;\n    }",
+          "name": "logs"
+        },
+        {
+          "description": "Whether product tours are enabled.",
+          "type": "boolean",
+          "name": "productTours"
+        },
+        {
+          "description": "Session recording configuration.",
+          "type": "SessionRecordingRemoteConfig | false",
+          "name": "sessionRecording"
+        },
+        {
+          "description": "Site apps available to the client.",
+          "type": "{\n        id: string;\n        url: string;\n    }[]",
+          "name": "siteApps"
+        },
+        {
+          "description": "Supported compression algorithms.",
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "description": "Whether surveys are enabled, optionally including their definitions.",
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "description": "Parameters for the toolbar.",
+          "type": "ToolbarParams",
+          "name": "toolbarParams"
+        },
+        {
+          "description": "Deprecated: Moved to `toolbarParams`.",
+          "type": "'toolbar'",
+          "name": "toolbarVersion",
+          "releaseTag": "deprecated"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
     },
     {
       "id": "RequestRestoreLinkPayload",
@@ -4422,6 +4892,21 @@
       "path": "lib/src/posthog-conversations-types.d.ts"
     },
     {
+      "id": "SessionRecordingEventTrigger",
+      "name": "SessionRecordingEventTrigger",
+      "properties": [
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "SessionRecordingTriggerPropertyFilter[]",
+          "name": "properties"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
+    },
+    {
       "id": "SessionRecordingPersistedConfig",
       "name": "SessionRecordingPersistedConfig",
       "properties": [
@@ -4499,6 +4984,152 @@
         }
       ],
       "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "SessionRecordingRemoteConfig",
+      "name": "SessionRecordingRemoteConfig",
+      "properties": [
+        {
+          "description": "If set, records the canvas",
+          "type": "boolean",
+          "name": "recordCanvas"
+        },
+        {
+          "description": "If set, records the canvas at the given FPS\nCan be set in the remote configuration\nLimited between 0 and 12\nWhen canvas recording is enabled, if this is not set locally, then remote config sets this as 4",
+          "type": "number",
+          "name": "canvasFps"
+        },
+        {
+          "description": "If set, records the canvas at the given quality\nCan be set in the remote configuration\nMust be a string that is a valid decimal between 0 and 1\nWhen canvas recording is enabled, if this is not set locally, then remote config sets this as \"0.4\"",
+          "type": "string",
+          "name": "canvasQuality"
+        },
+        {
+          "type": "string",
+          "name": "endpoint"
+        },
+        {
+          "type": "boolean",
+          "name": "consoleLogRecordingEnabled"
+        },
+        {
+          "type": "string",
+          "name": "sampleRate"
+        },
+        {
+          "type": "number",
+          "name": "minimumDurationMilliseconds"
+        },
+        {
+          "type": "string | FlagVariant",
+          "name": "linkedFlag"
+        },
+        {
+          "type": "Pick<NetworkRecordOptions, \"recordBody\" | \"recordHeaders\">",
+          "name": "networkPayloadCapture"
+        },
+        {
+          "type": "Pick<SessionRecordingOptions, \"maskAllInputs\" | \"maskTextSelector\" | \"blockSelector\">",
+          "name": "masking"
+        },
+        {
+          "type": "SessionRecordingUrlTrigger[]",
+          "name": "urlTriggers"
+        },
+        {
+          "type": "{ script?: string | undefined; }",
+          "name": "scriptConfig"
+        },
+        {
+          "type": "SessionRecordingUrlTrigger[]",
+          "name": "urlBlocklist"
+        },
+        {
+          "type": "string[]",
+          "name": "eventTriggers"
+        },
+        {
+          "description": "Controls how event, URL, sampling, and linked flag triggers are combined.\n\n`any` means that if any of the triggers match, the session will be recorded.\n`all` means that all the triggers must match for the session to be recorded.",
+          "type": "\"any\" | \"all\"",
+          "name": "triggerMatchType"
+        },
+        {
+          "description": "Config version - defaults to 1 (legacy).\nWhen version is 2, triggerGroups is used instead of individual trigger fields.",
+          "type": "1 | 2",
+          "name": "version"
+        },
+        {
+          "description": "V2 Trigger Groups - multiple named trigger groups with their own conditions and sample rates.\nOnly used when version === 2.",
+          "type": "SessionRecordingTriggerGroup[]",
+          "name": "triggerGroups"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
+    },
+    {
+      "id": "SessionRecordingTriggerGroup",
+      "name": "SessionRecordingTriggerGroup",
+      "properties": [
+        {
+          "type": "{\n        matchType: 'any' | 'all';\n        events?: SessionRecordingEventTrigger[];\n        urls?: SessionRecordingUrlTrigger[];\n        flag?: string | FlagVariant;\n        properties?: SessionRecordingTriggerPropertyFilter[];\n    }",
+          "name": "conditions"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "number",
+          "name": "minDurationMs"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "number",
+          "name": "sampleRate"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
+    },
+    {
+      "id": "SessionRecordingTriggerPropertyFilter",
+      "name": "SessionRecordingTriggerPropertyFilter",
+      "properties": [
+        {
+          "type": "string",
+          "name": "key"
+        },
+        {
+          "type": "'exact' | 'is_not' | 'icontains' | 'not_icontains' | 'regex' | 'not_regex' | 'gt' | 'lt'",
+          "name": "operator"
+        },
+        {
+          "type": "'event' | 'person'",
+          "name": "type"
+        },
+        {
+          "type": "string | number | boolean | string[]",
+          "name": "value"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
+    },
+    {
+      "id": "SessionRecordingUrlTrigger",
+      "name": "SessionRecordingUrlTrigger",
+      "properties": [
+        {
+          "type": "'regex'",
+          "name": "matching"
+        },
+        {
+          "type": "string",
+          "name": "url"
+        }
+      ],
+      "path": "../browser-common/dist/types/remote-config.d.ts"
     },
     {
       "id": "SessionStartReason",
@@ -4591,6 +5222,171 @@
       "example": "[method: string, ...args: any[]]"
     },
     {
+      "id": "Survey",
+      "name": "Survey",
+      "properties": [
+        {
+          "type": "SurveyAppearance | null",
+          "name": "appearance"
+        },
+        {
+          "type": "{\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: PropertyMatchType;\n        events: {\n            repeatedActivation?: boolean;\n            values: SurveyEventWithFilters[];\n        } | null;\n        cancelEvents: {\n            values: SurveyEventWithFilters[];\n        } | null;\n        actions: {\n            values: SurveyActionType[];\n        } | null;\n        deviceTypes?: string[];\n        deviceTypesMatchType?: PropertyMatchType;\n        linkedFlagVariant?: string;\n    } | null",
+          "name": "conditions"
+        },
+        {
+          "type": "string | null",
+          "name": "current_iteration_start_date"
+        },
+        {
+          "type": "number | null",
+          "name": "current_iteration"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "boolean | null",
+          "name": "enable_partial_responses"
+        },
+        {
+          "type": "string | null",
+          "name": "end_date"
+        },
+        {
+          "type": "{\n        key: string;\n        value?: string;\n    }[] | null",
+          "name": "feature_flag_keys"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string | null",
+          "name": "internal_targeting_flag_key"
+        },
+        {
+          "type": "string | null",
+          "name": "linked_flag_key"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "SurveyQuestion[]",
+          "name": "questions"
+        },
+        {
+          "type": "SurveySchedule | null",
+          "name": "schedule"
+        },
+        {
+          "type": "string | null",
+          "name": "start_date"
+        },
+        {
+          "type": "string | null",
+          "name": "targeting_flag_key"
+        },
+        {
+          "type": "Record<string, SurveyTranslation>",
+          "name": "translations"
+        },
+        {
+          "type": "SurveyType",
+          "name": "type"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
+      "id": "SurveyActionType",
+      "name": "SurveyActionType",
+      "properties": [
+        {
+          "type": "number",
+          "name": "id"
+        },
+        {
+          "type": "string | null",
+          "name": "name"
+        },
+        {
+          "type": "ActionStepType[]",
+          "name": "steps"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
+      "id": "SurveyAppearance",
+      "name": "SurveyAppearance",
+      "properties": [
+        {
+          "type": "string",
+          "name": "boxPadding"
+        },
+        {
+          "description": "Deprecated: Not currently used.",
+          "type": "string",
+          "name": "descriptionTextColor",
+          "releaseTag": "deprecated"
+        },
+        {
+          "type": "boolean",
+          "name": "disableAutofocus"
+        },
+        {
+          "type": "string",
+          "name": "disabledButtonOpacity"
+        },
+        {
+          "type": "string",
+          "name": "fontFamily"
+        },
+        {
+          "type": "boolean",
+          "name": "hideCancelButton"
+        },
+        {
+          "description": "Deprecated: Use `inputBackground` instead.",
+          "type": "string",
+          "name": "inputBackgroundColor",
+          "releaseTag": "deprecated"
+        },
+        {
+          "type": "string",
+          "name": "maxWidth"
+        },
+        {
+          "type": "SurveyPosition",
+          "name": "position"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonHoverColor"
+        },
+        {
+          "type": "SurveyTabPosition",
+          "name": "tabPosition"
+        },
+        {
+          "type": "boolean",
+          "name": "whiteLabel"
+        },
+        {
+          "type": "SurveyWidgetType",
+          "name": "widgetType"
+        },
+        {
+          "type": "string",
+          "name": "zIndex"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
       "id": "SurveyCallback",
       "name": "SurveyCallback",
       "properties": [],
@@ -4677,10 +5473,128 @@
       "path": "lib/src/posthog-surveys-types.d.ts"
     },
     {
+      "id": "SurveyEventName",
+      "name": "SurveyEventName",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyEventName)[keyof typeof SurveyEventName]"
+    },
+    {
+      "id": "SurveyEventProperties",
+      "name": "SurveyEventProperties",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyEventProperties)[keyof typeof SurveyEventProperties]"
+    },
+    {
+      "id": "SurveyEventType",
+      "name": "SurveyEventType",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyEventType)[keyof typeof SurveyEventType]"
+    },
+    {
+      "id": "SurveyEventWithFilters",
+      "name": "SurveyEventWithFilters",
+      "properties": [
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "PropertyFilters",
+          "name": "propertyFilters"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
+    },
+    {
+      "id": "SurveyPosition",
+      "name": "SurveyPosition",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyPosition)[keyof typeof SurveyPosition]"
+    },
+    {
+      "id": "SurveyQuestion",
+      "name": "SurveyQuestion",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion"
+    },
+    {
+      "id": "SurveyQuestionBranchingType",
+      "name": "SurveyQuestionBranchingType",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyQuestionBranchingType)[keyof typeof SurveyQuestionBranchingType]"
+    },
+    {
+      "id": "SurveyQuestionDescriptionContentType",
+      "name": "SurveyQuestionDescriptionContentType",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "\"html\" | \"text\""
+    },
+    {
+      "id": "SurveyQuestionType",
+      "name": "SurveyQuestionType",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyQuestionType)[keyof typeof SurveyQuestionType]"
+    },
+    {
       "id": "SurveyResponseValue",
       "name": "SurveyResponseValue",
       "properties": [],
       "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveySchedule",
+      "name": "SurveySchedule",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveySchedule)[keyof typeof SurveySchedule]"
+    },
+    {
+      "id": "SurveyTabPosition",
+      "name": "SurveyTabPosition",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyTabPosition)[keyof typeof SurveyTabPosition]"
+    },
+    {
+      "id": "SurveyType",
+      "name": "SurveyType",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyType)[keyof typeof SurveyType]"
+    },
+    {
+      "id": "SurveyWidgetType",
+      "name": "SurveyWidgetType",
+      "properties": [],
+      "path": "../browser-common/dist/types/surveys.d.ts",
+      "example": "(typeof SurveyWidgetType)[keyof typeof SurveyWidgetType]"
+    },
+    {
+      "id": "SurveyWithTypeAndAppearance",
+      "name": "SurveyWithTypeAndAppearance",
+      "properties": [
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "SurveyType",
+          "name": "type"
+        },
+        {
+          "type": "SurveyAppearance",
+          "name": "appearance"
+        }
+      ],
+      "path": "../browser-common/dist/types/surveys.d.ts"
     },
     {
       "id": "Ticket",
@@ -4807,6 +5721,13 @@
         }
       ],
       "path": "lib/src/posthog-conversations-types.d.ts"
+    },
+    {
+      "id": "WidgetPosition",
+      "name": "WidgetPosition",
+      "properties": [],
+      "path": "../browser-common/dist/types/remote-config.d.ts",
+      "example": "\"bottom_left\" | \"bottom_right\" | \"top_left\" | \"top_right\""
     }
   ],
   "categories": [


### PR DESCRIPTION
## Problem

#4269 moved the browser config and survey types into `@posthog/browser-common` and re-exported them, so the
public API didn't change but the generated reference went from 107 types down to 67 at [`1abdbfd`](https://github.com/PostHog/posthog-js/commit/1abdbfd).

```bash
git show 1abdbfd^:packages/browser/references/posthog-js-references-latest.json | jq '.types | length'   # 107
git show origin/main:packages/browser/references/posthog-js-references-latest.json | jq '.types | length' #  67
```

All 40 are still public exports, and 13 are still referenced by types that stayed, so `Survey` shows up 9 times in the published reference with nothing defining it.

Nothing's wrong with the PR itself: api-extractor builds its doc model from one package's rollup, so a type re-exported from a sibling package leaves the model while staying in the public API. CI didn't catch it because `check-public-api.js` regenerates and diffs against what's committed, which compares the output to itself.

## Changes

One line in `packages/browser/api-extractor.json` plus the regenerated reference, which puts it back to 107.
This is what the other two packages already do: `packages/node/api-extractor.jsonc:70` and `packages/react-native/api-extractor.json:70` both bundle `@posthog/core`. Browser was the only one left on `[]`, which is why it was the one that broke.

```json
"bundledPackages": ["@posthog/browser-common"],
```

Checked on a clean checkout of main:

- restored set matches `1abdbfd^` exactly. 40 back, nothing extra
- the 67 that survived are unchanged apart from `PostHogConfig` property order
- classes and methods sections byte-identical
- `pnpm test:docs-scripts` 35 pass, `pnpm check:public-api` green, and a second regenerate is byte-identical
- nothing shipped changes. api-extractor only runs in `generate-references`, published types come from the rollup, and `references/` isn't in `files`

Two small things I noticed but didn't touch:

- the restored entries have `path` values like `../browser-common/dist/types/surveys.d.ts` where existing ones
  use `lib/src/types.d.ts`. If the docs site builds source links off `path`, that wants a mapping first. Say the word and I'll add it.
- `packages/browser-common/src/types/surveys.ts:270` reads `@default StringMatching.Exact`, but the type is `ActionStepStringMatching`. Pre-existing, just visible again now that `ActionStepType` is back in the reference. Left it alone since fixing it means bumping browser-common.

## Not in this PR

Same mechanism, older. 79 more public types re-exported from `@posthog/core` and `@posthog/types` are missing, and they aren't hypothetical: 43 of them were documented up through 1.314.0 and vanished in 1.315.0 (116 types → 72, nothing gained). `CaptureResult`, `AutocaptureConfig`, `BootstrapConfig`, `EarlyAccessFeature` and the rest have been undocumented ever since. So #4269 is the second time this has happened, not the first.

I did test it, for what it's worth: bundling all three gets 186 types, keeps all 107, and nothing degrades. But that's a much larger docs diff and a call about what the reference is meant to cover, so I'd rather leave it with you than tack it onto a regression fix. Happy to open another PR or write up what I found.

## Release info Sub-libraries affected

### Libraries affected

<!-- No version bump. Docs generation only, no published files change. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code — no new code, the existing 35 docs-script tests pass unchanged
- [x] Accounted for the impact of any changes across different platforms — node and react-native configs untouched, their references regenerate identically
- [x] Accounted for backwards compatibility of any changes — additive to the reference, no published output changes
- [x] Took care not to unnecessarily increase the bundle size — no bundle impact, api-extractor doesn't run in the build

### If releasing new changes

- [ ] Ran `pnpm changeset` — skipped, nothing published changes. Can add an empty one if hygiene wants it.