### PR TITLE
fix(browser): send recording timestamps in request bodies

### DIFF
--- a/.changeset/tidy-recording-clocks.md
+++ b/.changeset/tidy-recording-clocks.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Send session recording request timestamps in request bodies instead of query strings.

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -4229,7 +4229,7 @@
           "name": "timeout"
         },
         {
-          "description": "Controls where the request dispatch time is sent. - `body` adds ISO `sent_at` to the request object, or the first object in an array (for example, flags and recordings). - `capture-body` wraps events in `{ api_key, batch, sent_at }` with an ISO timestamp. - `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.",
+          "description": "Controls where the request dispatch time is sent. - `body` adds ISO `sent_at` to the request object, or every object in an array (for example, flags and recordings). - `capture-body` wraps events in `{ api_key, batch, sent_at }` with an ISO timestamp. - `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.",
           "type": "'body' | 'capture-body' | 'query'",
           "name": "timestampMode"
         },

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -4229,7 +4229,7 @@
           "name": "timeout"
         },
         {
-          "description": "Controls where the request dispatch time is sent. - `body` adds ISO `sent_at` to the existing request object (for example, flags). - `capture-body` wraps events in `{ api_key, batch, sent_at }` with an ISO timestamp. - `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.",
+          "description": "Controls where the request dispatch time is sent. - `body` adds ISO `sent_at` to the request object, or the first object in an array (for example, flags and recordings). - `capture-body` wraps events in `{ api_key, batch, sent_at }` with an ISO timestamp. - `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.",
           "type": "'body' | 'capture-body' | 'query'",
           "name": "timestampMode"
         },

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -356,7 +356,7 @@ describe('posthog core', () => {
             )
         })
 
-        it('sends session recordings with sent_at in the query', () => {
+        it('sends session recordings with sent_at in the body', () => {
             const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
 
             posthog.capture(
@@ -371,7 +371,7 @@ describe('posthog core', () => {
             expect(posthog._send_request).toHaveBeenCalledWith(
                 expect.objectContaining({
                     url: 'https://app.posthog.com/s/',
-                    timestampMode: 'query',
+                    timestampMode: 'body',
                 })
             )
         })
@@ -385,7 +385,7 @@ describe('posthog core', () => {
             expect(posthog._send_request).toHaveBeenCalledWith(
                 expect.objectContaining({
                     url: 'https://app.posthog.com/s/',
-                    timestampMode: 'query',
+                    timestampMode: 'body',
                 })
             )
         })

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -288,22 +288,32 @@ describe('request', () => {
             })
         })
 
-        it('adds sent_at only to the first recording in a batched session recording body', () => {
-            request(
-                createRequest({
-                    url: 'https://any.posthog-instance.com/ingest/s/',
-                    method: 'POST',
-                    data: [{ event: '$snapshot' }, { event: '$snapshot' }],
-                    timestampMode: 'body',
-                })
-            )
+        it('adds the same sent_at to every recording in a batched session recording body', () => {
+            const toISOString = jest
+                .spyOn(Date.prototype, 'toISOString')
+                .mockReturnValueOnce('2023-11-14T22:13:20.000Z')
+                .mockReturnValue('2023-11-14T22:13:21.000Z')
 
-            const [requestedUrl, requestOptions] = mockedFetch.mock.calls[0]
-            expect(requestedUrl).toBe('https://any.posthog-instance.com/ingest/s/')
-            expect(JSON.parse(requestOptions.body)).toEqual([
-                { event: '$snapshot', sent_at: '2023-11-14T22:13:20.000Z' },
-                { event: '$snapshot' },
-            ])
+            try {
+                request(
+                    createRequest({
+                        url: 'https://any.posthog-instance.com/ingest/s/',
+                        method: 'POST',
+                        data: [{ event: '$snapshot' }, { event: '$snapshot' }],
+                        timestampMode: 'body',
+                    })
+                )
+
+                const [requestedUrl, requestOptions] = mockedFetch.mock.calls[0]
+                expect(requestedUrl).toBe('https://any.posthog-instance.com/ingest/s/')
+                expect(JSON.parse(requestOptions.body)).toEqual([
+                    { event: '$snapshot', sent_at: '2023-11-14T22:13:20.000Z' },
+                    { event: '$snapshot', sent_at: '2023-11-14T22:13:20.000Z' },
+                ])
+                expect(toISOString).toHaveBeenCalledTimes(1)
+            } finally {
+                toISOString.mockRestore()
+            }
         })
 
         it('preserves caller-provided query parameters', () => {
@@ -1147,8 +1157,14 @@ describe('request', () => {
                         })
                     )
                     expect(splitBodies).toEqual([
-                        [{ ...bigEvent(1), sent_at: '2023-11-14T22:13:20.000Z' }, bigEvent(2)],
-                        [{ ...bigEvent(3), sent_at: '2023-11-14T22:13:20.000Z' }, bigEvent(4)],
+                        [
+                            { ...bigEvent(1), sent_at: '2023-11-14T22:13:20.000Z' },
+                            { ...bigEvent(2), sent_at: '2023-11-14T22:13:20.000Z' },
+                        ],
+                        [
+                            { ...bigEvent(3), sent_at: '2023-11-14T22:13:20.000Z' },
+                            { ...bigEvent(4), sent_at: '2023-11-14T22:13:20.000Z' },
+                        ],
                     ])
                     expect(mockedFetch).not.toHaveBeenCalled()
                 })

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -270,20 +270,40 @@ describe('request', () => {
             })
         })
 
-        it('keeps session recording bodies unchanged and adds sent_at to the query', () => {
-            const recording = { event: '$snapshot' }
+        it('adds sent_at to an unbatched session recording body', () => {
             request(
                 createRequest({
                     url: 'https://any.posthog-instance.com/ingest/s/',
                     method: 'POST',
-                    data: recording,
-                    timestampMode: 'query',
+                    data: { event: '$snapshot' },
+                    timestampMode: 'body',
                 })
             )
 
             const [requestedUrl, requestOptions] = mockedFetch.mock.calls[0]
-            expect(requestedUrl).toBe('https://any.posthog-instance.com/ingest/s/?sent_at=1700000000000')
-            expect(JSON.parse(requestOptions.body)).toEqual(recording)
+            expect(requestedUrl).toBe('https://any.posthog-instance.com/ingest/s/')
+            expect(JSON.parse(requestOptions.body)).toEqual({
+                event: '$snapshot',
+                sent_at: '2023-11-14T22:13:20.000Z',
+            })
+        })
+
+        it('adds sent_at only to the first recording in a batched session recording body', () => {
+            request(
+                createRequest({
+                    url: 'https://any.posthog-instance.com/ingest/s/',
+                    method: 'POST',
+                    data: [{ event: '$snapshot' }, { event: '$snapshot' }],
+                    timestampMode: 'body',
+                })
+            )
+
+            const [requestedUrl, requestOptions] = mockedFetch.mock.calls[0]
+            expect(requestedUrl).toBe('https://any.posthog-instance.com/ingest/s/')
+            expect(JSON.parse(requestOptions.body)).toEqual([
+                { event: '$snapshot', sent_at: '2023-11-14T22:13:20.000Z' },
+                { event: '$snapshot' },
+            ])
         })
 
         it('preserves caller-provided query parameters', () => {
@@ -1099,6 +1119,36 @@ describe('request', () => {
                             batch: [bigEvent(3), bigEvent(4)],
                             sent_at: '2023-11-14T22:13:20.000Z',
                         },
+                    ])
+                    expect(mockedFetch).not.toHaveBeenCalled()
+                })
+
+                it('adds sent_at to each split recording request body', async () => {
+                    mockedNavigator!.sendBeacon.mockReturnValueOnce(false).mockReturnValue(true)
+
+                    request(
+                        createRequest({
+                            method: 'POST',
+                            data: [bigEvent(1), bigEvent(2), bigEvent(3), bigEvent(4)],
+                            timestampMode: 'body',
+                        })
+                    )
+
+                    const splitBodies = await Promise.all(
+                        mockedNavigator!.sendBeacon.mock.calls.slice(1).map(async (call) => {
+                            const text = await new Promise<string>((resolve) => {
+                                const reader = new FileReader()
+                                reader.onload = () => resolve(reader.result as string)
+                                reader.readAsText(call[1] as Blob)
+                            })
+                            return JSON.parse(
+                                Buffer.from(decodeURIComponent(text.slice('data='.length)), 'base64').toString()
+                            )
+                        })
+                    )
+                    expect(splitBodies).toEqual([
+                        [{ ...bigEvent(1), sent_at: '2023-11-14T22:13:20.000Z' }, bigEvent(2)],
+                        [{ ...bigEvent(3), sent_at: '2023-11-14T22:13:20.000Z' }, bigEvent(4)],
                     ])
                     expect(mockedFetch).not.toHaveBeenCalled()
                 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1513,7 +1513,7 @@ export class PostHog implements PostHogInterface {
             url,
             data,
             compression: 'best-available',
-            timestampMode: isSessionRecording ? 'query' : 'capture-body',
+            timestampMode: isSessionRecording ? 'body' : 'capture-body',
             batchKey: options?._batchKey,
             transport: options?.transport,
         }

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -414,6 +414,17 @@ const _fetch = (options: RequestWithOptions & { _keepaliveDisabled?: boolean }) 
 // below this size a rejection means the shared quota is exhausted, not that the payload is too big
 const BEACON_SPLIT_FLOOR_BYTES = 16 * 1024
 
+const addSentAtToBody = (
+    data: NonNullable<RequestWithOptions['data']>,
+    sentAt = new Date().toISOString()
+): NonNullable<RequestWithOptions['data']> => {
+    if (!isArray(data)) {
+        return { ...data, sent_at: sentAt }
+    }
+
+    return data.length > 0 ? [{ ...data[0], sent_at: sentAt }, ...data.slice(1)] : data
+}
+
 const _sendBeacon = (options: RequestWithOptions) => {
     // beacon documentation https://w3c.github.io/beacon/
     // beacons format the message and use the type property
@@ -438,7 +449,11 @@ const _sendBeacon = (options: RequestWithOptions) => {
         if (isArray(batch) && batch.length > 1 && (estimatedSize ?? 0) > BEACON_SPLIT_FLOOR_BYTES) {
             const mid = Math.ceil(batch.length / 2)
             const splitData = (events: Record<string, any>[]): RequestWithOptions['data'] =>
-                isArray(options.data) ? events : { ...options.data, batch: events }
+                isArray(options.data)
+                    ? options.timestampMode === 'body'
+                        ? addSentAtToBody(events, options.data[0]?.sent_at)
+                        : events
+                    : { ...options.data, batch: events }
             _sendBeacon({ ...options, data: splitData(batch.slice(0, mid)) })
             _sendBeacon({ ...options, data: splitData(batch.slice(mid)) })
             return
@@ -522,8 +537,8 @@ export const request = (_options: RequestWithOptions) => {
     if (options.method === 'POST' && options.data) {
         if (options.timestampMode === 'capture-body') {
             options.data = addSentAtToCaptureBody(options.data)
-        } else if (options.timestampMode === 'body' && !isArray(options.data)) {
-            options.data = { ...options.data, sent_at: new Date().toISOString() }
+        } else if (options.timestampMode === 'body') {
+            options.data = addSentAtToBody(options.data)
         }
     }
 

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -422,7 +422,7 @@ const addSentAtToBody = (
         return { ...data, sent_at: sentAt }
     }
 
-    return data.length > 0 ? [{ ...data[0], sent_at: sentAt }, ...data.slice(1)] : data
+    return data.map((item) => ({ ...item, sent_at: sentAt }))
 }
 
 const _sendBeacon = (options: RequestWithOptions) => {
@@ -449,11 +449,7 @@ const _sendBeacon = (options: RequestWithOptions) => {
         if (isArray(batch) && batch.length > 1 && (estimatedSize ?? 0) > BEACON_SPLIT_FLOOR_BYTES) {
             const mid = Math.ceil(batch.length / 2)
             const splitData = (events: Record<string, any>[]): RequestWithOptions['data'] =>
-                isArray(options.data)
-                    ? options.timestampMode === 'body'
-                        ? addSentAtToBody(events, options.data[0]?.sent_at)
-                        : events
-                    : { ...options.data, batch: events }
+                isArray(options.data) ? events : { ...options.data, batch: events }
             _sendBeacon({ ...options, data: splitData(batch.slice(0, mid)) })
             _sendBeacon({ ...options, data: splitData(batch.slice(mid)) })
             return

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -239,7 +239,7 @@ export interface RequestWithOptions {
     compression?: Compression | 'best-available'
     /**
      * Controls where the request dispatch time is sent.
-     * - `body` adds ISO `sent_at` to the existing request object (for example, flags).
+     * - `body` adds ISO `sent_at` to the request object, or the first object in an array (for example, flags and recordings).
      * - `capture-body` wraps events in `{ api_key, batch, sent_at }` with an ISO timestamp.
      * - `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.
      */

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -239,7 +239,7 @@ export interface RequestWithOptions {
     compression?: Compression | 'best-available'
     /**
      * Controls where the request dispatch time is sent.
-     * - `body` adds ISO `sent_at` to the request object, or the first object in an array (for example, flags and recordings).
+     * - `body` adds ISO `sent_at` to the request object, or every object in an array (for example, flags and recordings).
      * - `capture-body` wraps events in `{ api_key, batch, sent_at }` with an ISO timestamp.
      * - `query` adds numeric `sent_at` to POST requests or cache-busting `_` to GET requests.
      */


### PR DESCRIPTION
## Problem

The capture service now accepts an ISO 8601 `sent_at` value on session recording items ([PostHog/posthog#73077](https://github.com/PostHog/posthog/pull/73077)). The browser SDK still sends a numeric recording dispatch timestamp in the query string, unlike other POST endpoints that carry request metadata in the body.

## Changes

- Send session recording timestamps with the existing `body` timestamp mode instead of the query string.
- Generate one request timestamp and add the same `sent_at` value to every recording in a batch, making each item self-contained if ordering changes downstream.
- Preserve those timestamps when an oversized recording beacon is split into multiple requests.
- Add regression coverage for unbatched, batched, and split-beacon recording requests, including verification that the timestamp is generated only once per request.
- Update the generated API reference and add a patch changeset.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The request body keeps the established recording object/array shape and duplicates one shared request timestamp across all recording items for resilience to downstream reordering. Validation included typecheck, lint, API reference generation, focused request tests, and the complete browser unit test suite.
