### PR TITLE
fix(react-native): compose iOS source map upload wrappers

### DIFF
--- a/.changeset/quick-badgers-compose.md
+++ b/.changeset/quick-badgers-compose.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix iOS Expo source map uploads when another config plugin wraps the React Native bundle phase.

--- a/.changeset/quick-badgers-compose.md
+++ b/.changeset/quick-badgers-compose.md
@@ -2,4 +2,4 @@
 'posthog-react-native': patch
 ---
 
-Fix iOS Expo source map uploads when another config plugin wraps the React Native bundle phase.
+Fix iOS Expo source map uploads when another config plugin wraps the React Native bundle phase. After upgrading, projects with a checked-in `ios/` directory should run `npx expo prebuild --platform ios` to migrate the existing bundle phase.

--- a/examples/example-expo-53/ios/exampleexpo53.xcodeproj/project.pbxproj
+++ b/examples/example-expo-53/ios/exampleexpo53.xcodeproj/project.pbxproj
@@ -147,7 +147,6 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
 				15D5BF81B29F1ADC40A535B9 /* [CP] Embed Pods Frameworks */,
-				A1570BF79F4847D980409CD6 /* Upload PostHog Debug Symbols */,
 			);
 			buildRules = (
 			);
@@ -324,32 +323,6 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-exampleexpo53/Pods-exampleexpo53-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A1570BF79F4847D980409CD6 /* Upload PostHog Debug Symbols */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			name = "Upload PostHog Debug Symbols";
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			shellPath = /bin/sh;
-			shellScript = "# Upload iOS dSYMs to PostHog so native crashes can be symbolicated.
-# upload-symbols.sh ships inside the posthog-ios dependency.
-# Also upload native source files for source-code context around crashes.
-export POSTHOG_INCLUDE_SOURCE=1
-PODS_SCRIPT=\"${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh\"
-SPM_SCRIPT=\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/posthog-ios/build-tools/upload-symbols.sh\"
-if [ -f \"$PODS_SCRIPT\" ]; then
-  /bin/sh \"$PODS_SCRIPT\"
-elif [ -f \"$SPM_SCRIPT\" ]; then
-  /bin/sh \"$SPM_SCRIPT\"
-else
-  echo \"warning: PostHog upload-symbols.sh not found in Pods or SwiftPM checkouts; skipping dSYM upload.\"
-fi";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -392,13 +365,12 @@ fi";
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.marandaneto.exampleexpo53;
-				PRODUCT_NAME = "exampleexpo53";
+				PRODUCT_NAME = exampleexpo53;
 				SWIFT_OBJC_BRIDGING_HEADER = "exampleexpo53/exampleexpo53-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				ENABLE_USER_SCRIPT_SANDBOXING = "NO";
 			};
 			name = Debug;
 		};
@@ -424,12 +396,11 @@ fi";
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.marandaneto.exampleexpo53;
-				PRODUCT_NAME = "exampleexpo53";
+				PRODUCT_NAME = exampleexpo53;
 				SWIFT_OBJC_BRIDGING_HEADER = "exampleexpo53/exampleexpo53-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				ENABLE_USER_SCRIPT_SANDBOXING = "NO";
 			};
 			name = Release;
 		};
@@ -496,7 +467,6 @@ fi";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				USE_HERMES = true;
-				ENABLE_USER_SCRIPT_SANDBOXING = "NO";
 			};
 			name = Debug;
 		};
@@ -555,7 +525,6 @@ fi";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = "NO";
 			};
 			name = Release;
 		};

--- a/examples/example-expo-53/ios/exampleexpo53.xcodeproj/project.pbxproj
+++ b/examples/example-expo-53/ios/exampleexpo53.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
 				15D5BF81B29F1ADC40A535B9 /* [CP] Embed Pods Frameworks */,
+				A1570BF79F4847D980409CD6 /* Upload PostHog Debug Symbols */,
 			);
 			buildRules = (
 			);
@@ -216,7 +217,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n/bin/sh `\"$NODE_BINARY\" --print \"require('path').join(require('path').dirname(require.resolve('posthog-react-native')), '..', 'tooling', 'posthog-xcode.sh')\"` `\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').join(require('path').dirname(require.resolve('posthog-react-native')), '..', 'tooling', 'posthog-xcode.sh')\"` `\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
 		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -323,6 +324,32 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-exampleexpo53/Pods-exampleexpo53-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		A1570BF79F4847D980409CD6 /* Upload PostHog Debug Symbols */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Upload PostHog Debug Symbols";
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			shellPath = /bin/sh;
+			shellScript = "# Upload iOS dSYMs to PostHog so native crashes can be symbolicated.
+# upload-symbols.sh ships inside the posthog-ios dependency.
+# Also upload native source files for source-code context around crashes.
+export POSTHOG_INCLUDE_SOURCE=1
+PODS_SCRIPT=\"${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh\"
+SPM_SCRIPT=\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/posthog-ios/build-tools/upload-symbols.sh\"
+if [ -f \"$PODS_SCRIPT\" ]; then
+  /bin/sh \"$PODS_SCRIPT\"
+elif [ -f \"$SPM_SCRIPT\" ]; then
+  /bin/sh \"$SPM_SCRIPT\"
+else
+  echo \"warning: PostHog upload-symbols.sh not found in Pods or SwiftPM checkouts; skipping dSYM upload.\"
+fi";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -365,12 +392,13 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.marandaneto.exampleexpo53;
-				PRODUCT_NAME = exampleexpo53;
+				PRODUCT_NAME = "exampleexpo53";
 				SWIFT_OBJC_BRIDGING_HEADER = "exampleexpo53/exampleexpo53-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
+				ENABLE_USER_SCRIPT_SANDBOXING = "NO";
 			};
 			name = Debug;
 		};
@@ -396,11 +424,12 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.marandaneto.exampleexpo53;
-				PRODUCT_NAME = exampleexpo53;
+				PRODUCT_NAME = "exampleexpo53";
 				SWIFT_OBJC_BRIDGING_HEADER = "exampleexpo53/exampleexpo53-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
+				ENABLE_USER_SCRIPT_SANDBOXING = "NO";
 			};
 			name = Release;
 		};
@@ -467,6 +496,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				USE_HERMES = true;
+				ENABLE_USER_SCRIPT_SANDBOXING = "NO";
 			};
 			name = Debug;
 		};
@@ -525,6 +555,7 @@
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = "NO";
 			};
 			name = Release;
 		};

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -5,6 +5,9 @@
     "url": "https://github.com/PostHog/posthog-js/issues"
   },
   "license": "MIT",
+  "bin": {
+    "posthog-react-native-xcode": "tooling/posthog-xcode.sh"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -182,8 +182,8 @@ export function modifyExistingXcodeBuildScript(script: BuildPhase | undefined, s
   }
 
   if (script.shellScript.includes('posthog-xcode.sh')) {
-    const code = JSON.parse(script.shellScript)
-    script.shellScript = JSON.stringify(updatePostHogSkipOnConflictArg(code, skipOnConflict))
+    const code = migrateLegacyPostHogWrapperInvocation(JSON.parse(script.shellScript))
+    script.shellScript = JSON.stringify(updatePostHogSkipOnConflict(code, skipOnConflict))
     return
   }
 
@@ -205,10 +205,13 @@ const POSTHOG_SKIP_ON_CONFLICT_EXPORT = 'export POSTHOG_SKIP_ON_CONFLICT=1'
 const REACT_NATIVE_XCODE_LINE =
   /^([ \t]*)(?![A-Za-z_][A-Za-z0-9_]*=)([^\n]*(?:packager|scripts)\/react-native-xcode\.sh\b[^\n]*)$/m
 
-function updatePostHogSkipOnConflictArg(script: string, skipOnConflict: boolean): string {
+function migrateLegacyPostHogWrapperInvocation(script: string): string {
+  return script.replace(`/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH}`, POSTHOG_REACT_NATIVE_XCODE_PATH)
+}
+
+function updatePostHogSkipOnConflict(script: string, skipOnConflict: boolean): string {
   const skipArg = '--posthog-skip-on-conflict --'
   const lines = script
-    .replace(`/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH}`, POSTHOG_REACT_NATIVE_XCODE_PATH)
     .replace(new RegExp(`\\s*${skipArg}\\s*`, 'g'), ' ')
     .split('\n')
     .filter((line) => line.trim() !== POSTHOG_SKIP_ON_CONFLICT_EXPORT)

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -195,32 +195,43 @@ export function modifyExistingXcodeBuildScript(script: BuildPhase | undefined, s
   script.shellScript = JSON.stringify(addPostHogWithBundledScriptsToBundleShellScript(code, skipOnConflict))
 }
 
+// Invoked directly so another wrapper receives this script—not /bin/sh—as $1.
+// package.json declares it as a bin target so package managers preserve its executable bit.
 const POSTHOG_REACT_NATIVE_XCODE_PATH =
   "`\"$NODE_BINARY\" --print \"require('path').join(require('path').dirname(require.resolve('posthog-react-native')), '..', 'tooling', 'posthog-xcode.sh')\"`"
 
+const POSTHOG_SKIP_ON_CONFLICT_EXPORT = 'export POSTHOG_SKIP_ON_CONFLICT=1'
+
 const REACT_NATIVE_XCODE_LINE =
-  /^([ \t]*)(?![A-Za-z_][A-Za-z0-9_]*=)(?:\/bin\/sh\s+)?([^\n]*(?:packager|scripts)\/react-native-xcode\.sh\b[^\n]*)$/m
+  /^([ \t]*)(?![A-Za-z_][A-Za-z0-9_]*=)([^\n]*(?:packager|scripts)\/react-native-xcode\.sh\b[^\n]*)$/m
 
 function updatePostHogSkipOnConflictArg(script: string, skipOnConflict: boolean): string {
   const skipArg = '--posthog-skip-on-conflict --'
-  const withoutSkipArg = script.replace(new RegExp(`\\s*${skipArg}\\s*`, 'g'), ' ')
-  if (!skipOnConflict) {
-    return withoutSkipArg
+  const lines = script
+    .replace(`/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH}`, POSTHOG_REACT_NATIVE_XCODE_PATH)
+    .replace(new RegExp(`\\s*${skipArg}\\s*`, 'g'), ' ')
+    .split('\n')
+    .filter((line) => line.trim() !== POSTHOG_SKIP_ON_CONFLICT_EXPORT)
+
+  if (skipOnConflict) {
+    const commandIndex = lines.findIndex((line) => line.includes(POSTHOG_REACT_NATIVE_XCODE_PATH))
+    if (commandIndex !== -1) {
+      const indent = lines[commandIndex].match(/^[ \t]*/)?.[0] ?? ''
+      lines.splice(commandIndex, 0, `${indent}${POSTHOG_SKIP_ON_CONFLICT_EXPORT}`)
+    }
   }
-  return withoutSkipArg.replace(`${POSTHOG_REACT_NATIVE_XCODE_PATH} `, `${POSTHOG_REACT_NATIVE_XCODE_PATH} ${skipArg} `)
+
+  return lines.join('\n')
 }
 
 export function addPostHogWithBundledScriptsToBundleShellScript(script: string, skipOnConflict = false): string {
-  const postHogArgs = skipOnConflict ? '--posthog-skip-on-conflict -- ' : ''
-
   // Capture the full RN script invocation. Expo uses a backtick-wrapped
   // node --print command, so matching only up to react-native-xcode.sh cuts the
   // command substitution in half and leaves the generated shell invalid.
-  return script.replace(
-    REACT_NATIVE_XCODE_LINE,
-    (_match: string, indent: string, rnCommand: string) =>
-      `${indent}/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH} ${postHogArgs}${rnCommand}`
-  )
+  return script.replace(REACT_NATIVE_XCODE_LINE, (_match: string, indent: string, rnCommand: string) => {
+    const skipOnConflictExport = skipOnConflict ? `${indent}${POSTHOG_SKIP_ON_CONFLICT_EXPORT}\n` : ''
+    return `${skipOnConflictExport}${indent}${POSTHOG_REACT_NATIVE_XCODE_PATH} ${rnCommand}`
+  })
 }
 
 const POSTHOG_DSYM_BUILD_PHASE_NAME = 'Upload PostHog Debug Symbols'

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -65,17 +65,16 @@ describe('disableUserScriptSandboxing', () => {
   })
 })
 
-// Extracts the argument that would become $1 inside posthog-xcode.sh when
-// the wrapped line is executed by the shell. The shell runs:
-//   /bin/sh <posthog-xcode.sh-path> <...rest>
-// so $1 is the token immediately after the posthog-xcode.sh path.
-const extractArg1 = (wrappedLine: string): string => {
-  // The line looks like: /bin/sh `<node eval>` <arg1> ...
-  // Split on the backtick-delimited posthog-xcode.sh path expression, then
-  // take the first whitespace-separated token from whatever follows it.
-  const afterPosthog = wrappedLine.split(/`[^`]+`/)[1] ?? ''
-  return afterPosthog.trim().split(/\s+/)[0]
-}
+const SENTRY_REACT_NATIVE_XCODE_PATH =
+  "`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'\"`"
+
+// Mirrors @sentry/react-native's Expo config-plugin transformation so these
+// tests cover both plugin execution orders without adding Sentry as a dependency.
+const addSentryWithBundledScriptsToBundleShellScript = (script: string): string =>
+  script.replace(
+    /^.*?(packager|scripts)\/react-native-xcode\.sh\s*(\\'\\\\")?/m,
+    (match) => `/bin/sh ${SENTRY_REACT_NATIVE_XCODE_PATH} ${match}`
+  )
 
 const expectValidShellSyntax = (script: string): void => {
   const result = spawnSync('/bin/sh', ['-n'], { input: script, encoding: 'utf8' })
@@ -89,7 +88,7 @@ describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
     const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
     expect(wrapped).toContain('posthog-xcode.sh')
     expect(wrapped).toContain('react-native-xcode.sh')
-    expect(wrapped.startsWith('/bin/sh ')).toBe(true)
+    expect(wrapped.startsWith('/bin/sh ')).toBe(false)
     expect(wrapped.indexOf('posthog-xcode.sh')).toBeLessThan(wrapped.indexOf('react-native-xcode.sh'))
   })
 
@@ -100,22 +99,32 @@ describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
     expect(wrapped).toContain('packager/react-native-xcode.sh')
   })
 
-  // Regression tests for issue #3682:
-  // When the Expo bundle phase already contains a /bin/sh prefix (common in
-  // Expo SDK 53+ and plain RN projects), posthog-xcode.sh receives /bin/sh as
-  // $1, which makes the REACT_NATIVE_XCODE variable resolve to /bin/sh instead
-  // of react-native-xcode.sh, silently breaking the PACKAGER_SOURCEMAP_FILE patch.
-  it.each([
-    ['simple path (no shell prefix)', '../node_modules/react-native/scripts/react-native-xcode.sh'],
-    [
-      'shell-prefixed command (Expo SDK 53+ / plain RN)',
-      '/bin/sh "$PODS_ROOT/../.."/node_modules/react-native/scripts/react-native-xcode.sh',
-    ],
-  ])('arg1 passed to posthog-xcode.sh is react-native-xcode.sh path, not /bin/sh — %s', (_desc, original) => {
+  it('preserves a shell-prefixed React Native command for argument forwarding', () => {
+    const original = '/bin/sh "$PODS_ROOT/../.."/node_modules/react-native/scripts/react-native-xcode.sh'
     const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
-    const arg1 = extractArg1(wrapped)
-    expect(arg1).toContain('react-native-xcode.sh')
-    expect(arg1).not.toBe('/bin/sh')
+
+    expect(wrapped).toContain('/bin/sh "$PODS_ROOT/../.."/node_modules/react-native/scripts/react-native-xcode.sh')
+    expectValidShellSyntax(wrapped)
+  })
+
+  it('composes outside an existing Sentry wrapper', () => {
+    const reactNativeCommand = '../node_modules/react-native/scripts/react-native-xcode.sh'
+    const sentryWrapped = `/bin/sh ${SENTRY_REACT_NATIVE_XCODE_PATH} ${reactNativeCommand}`
+    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(sentryWrapped)
+
+    expect(wrapped.indexOf('posthog-xcode.sh')).toBeLessThan(wrapped.indexOf('sentry-xcode.sh'))
+    expect(wrapped).toContain(`/bin/sh ${SENTRY_REACT_NATIVE_XCODE_PATH} ${reactNativeCommand}`)
+    expectValidShellSyntax(wrapped)
+  })
+
+  it('remains composable when Sentry wraps it afterwards', () => {
+    const reactNativeCommand = '../node_modules/react-native/scripts/react-native-xcode.sh'
+    const postHogWrapped = addPostHogWithBundledScriptsToBundleShellScript(reactNativeCommand)
+    const sentryWrapped = addSentryWithBundledScriptsToBundleShellScript(postHogWrapped)
+
+    expect(sentryWrapped).toBe(`/bin/sh ${SENTRY_REACT_NATIVE_XCODE_PATH} ${postHogWrapped}`)
+    expect(sentryWrapped).not.toContain(`${SENTRY_REACT_NATIVE_XCODE_PATH} /bin/sh`)
+    expectValidShellSyntax(sentryWrapped)
   })
 
   it('preserves the full Expo backtick command when wrapping react-native-xcode.sh', () => {
@@ -132,11 +141,12 @@ describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
     expectValidShellSyntax(wrapped)
   })
 
-  it('passes skipOnConflict before the react-native-xcode.sh command', () => {
+  it('exports skipOnConflict before the wrapped command so outer wrappers inherit it', () => {
     const original = 'node_modules/react-native/scripts/react-native-xcode.sh'
     const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original, true)
 
-    expect(wrapped).toContain('--posthog-skip-on-conflict -- node_modules/react-native/scripts/react-native-xcode.sh')
+    expect(wrapped).toContain('export POSTHOG_SKIP_ON_CONFLICT=1\n')
+    expect(wrapped).not.toContain('--posthog-skip-on-conflict')
     expectValidShellSyntax(wrapped)
   })
 })
@@ -153,7 +163,7 @@ describe('modifyExistingXcodeBuildScript', () => {
     const script = { shellScript: JSON.stringify('"../node_modules/react-native/scripts/react-native-xcode.sh"') }
     modifyExistingXcodeBuildScript(script, true)
     const parsed = JSON.parse(script.shellScript)
-    expect(parsed).toContain('--posthog-skip-on-conflict --')
+    expect(parsed).toContain('export POSTHOG_SKIP_ON_CONFLICT=1')
   })
 
   it('updates skipOnConflict on an already wrapped bundle phase', () => {
@@ -161,11 +171,23 @@ describe('modifyExistingXcodeBuildScript', () => {
     modifyExistingXcodeBuildScript(script)
     modifyExistingXcodeBuildScript(script, true)
     let parsed = JSON.parse(script.shellScript)
-    expect(parsed).toContain('--posthog-skip-on-conflict --')
+    expect(parsed).toContain('export POSTHOG_SKIP_ON_CONFLICT=1')
 
     modifyExistingXcodeBuildScript(script, false)
     parsed = JSON.parse(script.shellScript)
-    expect(parsed).not.toContain('--posthog-skip-on-conflict --')
+    expect(parsed).not.toContain('POSTHOG_SKIP_ON_CONFLICT')
+  })
+
+  it('migrates an existing shell-prefixed PostHog wrapper to a composable invocation', () => {
+    const reactNativeCommand = '../node_modules/react-native/scripts/react-native-xcode.sh'
+    const oldWrapped = `/bin/sh ${addPostHogWithBundledScriptsToBundleShellScript(reactNativeCommand)}`
+    const script = { shellScript: JSON.stringify(oldWrapped) }
+
+    modifyExistingXcodeBuildScript(script)
+
+    const parsed = JSON.parse(script.shellScript)
+    expect(parsed.startsWith('/bin/sh ')).toBe(false)
+    expect(parsed).toContain('posthog-xcode.sh')
   })
 
   it('wraps Expo backtick bundle phase shellScript without creating invalid shell syntax', () => {

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -190,6 +190,24 @@ describe('modifyExistingXcodeBuildScript', () => {
     expect(parsed).toContain('posthog-xcode.sh')
   })
 
+  it('migrates a shell-prefixed wrapper and legacy skip argument together', () => {
+    const reactNativeCommand = '../node_modules/react-native/scripts/react-native-xcode.sh'
+    const currentWrapped = addPostHogWithBundledScriptsToBundleShellScript(reactNativeCommand)
+    const legacyWrapped = `/bin/sh ${currentWrapped.replace(
+      ` ${reactNativeCommand}`,
+      ` --posthog-skip-on-conflict -- ${reactNativeCommand}`
+    )}`
+    const script = { shellScript: JSON.stringify(legacyWrapped) }
+
+    modifyExistingXcodeBuildScript(script, true)
+
+    const parsed = JSON.parse(script.shellScript)
+    expect(parsed.startsWith('/bin/sh ')).toBe(false)
+    expect(parsed).not.toContain('--posthog-skip-on-conflict --')
+    expect(parsed).toContain('export POSTHOG_SKIP_ON_CONFLICT=1')
+    expect(parsed).toContain(` ${reactNativeCommand}`)
+  })
+
   it('wraps Expo backtick bundle phase shellScript without creating invalid shell syntax', () => {
     const expoBundleScript = [
       'if [[ -z "$CLI_PATH" ]]; then',

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -113,15 +113,16 @@ describe('posthog-xcode.sh bundle command composition', () => {
     expect(resolveReactNativeXcode([])).toBe('../node_modules/react-native/scripts/react-native-xcode.sh')
   })
 
-  it('forwards the complete nested command and preserves the intermediate Hermes map', () => {
+  it('forwards nested commands, preserves the Hermes map, and resolves a hoisted fallback', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-xcode-composition-'))
     const derivedDir = path.join(tempDir, 'derived')
     const configurationDir = path.join(tempDir, 'configuration')
     const homeDir = path.join(tempDir, 'home')
-    const iosDir = path.join(tempDir, 'ios')
+    const iosDir = path.join(tempDir, 'packages', 'example', 'ios')
     const tracePath = path.join(tempDir, 'trace.log')
     const wrapperPath = path.join(tempDir, 'sentry-xcode.sh')
-    const reactNativePath = path.join(tempDir, 'node_modules', 'react-native', 'scripts', 'react-native-xcode.sh')
+    const reactNativeRoot = path.join(tempDir, 'node_modules', 'react-native')
+    const reactNativePath = path.join(reactNativeRoot, 'scripts', 'react-native-xcode.sh')
     const cliPath = path.join(homeDir, '.posthog', 'posthog-cli')
 
     try {
@@ -135,6 +136,7 @@ describe('posthog-xcode.sh bundle command composition', () => {
         fs.mkdirSync(directory, { recursive: true })
       }
       fs.writeFileSync(wrapperPath, '#!/bin/sh\necho wrapper >> "$TRACE_PATH"\n"$@"\n', { mode: 0o755 })
+      fs.writeFileSync(path.join(reactNativeRoot, 'package.json'), '{}')
       fs.writeFileSync(
         reactNativePath,
         '#!/bin/sh\necho react-native >> "$TRACE_PATH"\nrm "$PACKAGER_SOURCEMAP_FILE"\n',
@@ -147,6 +149,7 @@ describe('posthog-xcode.sh bundle command composition', () => {
         CONFIGURATION_BUILD_DIR: configurationDir,
         DERIVED_FILE_DIR: derivedDir,
         HOME: homeDir,
+        NODE_BINARY: process.execPath,
         SKIP_BUNDLING: '1',
         TRACE_PATH: tracePath,
       }

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -1,5 +1,6 @@
 import { execFileSync, execSync } from 'child_process'
 import * as fs from 'fs'
+import * as os from 'os'
 import * as path from 'path'
 
 /**
@@ -79,43 +80,95 @@ describe('posthog-xcode.sh remote URL parsing', () => {
   })
 })
 
-// Regression tests for issue #3682:
-// The Expo plugin wraps the bundle phase as:
-//   /bin/sh posthog-xcode.sh /bin/sh react-native-xcode.sh ...
-// making $1 = /bin/sh inside posthog-xcode.sh.  REACT_NATIVE_XCODE then
-// resolves to /bin/sh (a binary), so the grep/sed patch against it silently
-// no-ops and the packager sourcemap is deleted before posthog-cli reads it.
-describe('posthog-xcode.sh REACT_NATIVE_XCODE resolution', () => {
+describe('posthog-xcode.sh bundle command composition', () => {
   const scriptContents = fs.readFileSync(SCRIPT_PATH, 'utf8')
 
-  // Extract the REACT_NATIVE_XCODE_DEFAULT + resolution block from the script
-  // so the tests track the actual source and cannot silently diverge from it.
-  const extractAssignmentBlock = (): string => {
-    // Match from REACT_NATIVE_XCODE_DEFAULT=... through the closing `fi` of
-    // the if/else guard (or a plain assignment if the structure changes again).
-    const match = scriptContents.match(
-      /REACT_NATIVE_XCODE_DEFAULT="[^"]+"[\s\S]+?(?:fi|REACT_NATIVE_XCODE="\$\{[^}]+\}")/
-    )
-    if (!match) throw new Error('Could not locate REACT_NATIVE_XCODE assignment in posthog-xcode.sh')
+  const extractReactNativeXcodeResolutionBlock = (): string => {
+    const match = scriptContents.match(/REACT_NATIVE_XCODE_DEFAULT="[^"]+"[\s\S]+?\n\s*done/)
+    if (!match) throw new Error('Could not locate REACT_NATIVE_XCODE resolution in posthog-xcode.sh')
     return match[0]
   }
 
-  const resolveReactNativeXcode = (arg1: string): string => {
-    const block = extractAssignmentBlock()
-    // Run the extracted shell fragment with $1 set to the provided value and
-    // print the resulting REACT_NATIVE_XCODE variable.
-    const script = `${block}\nprintf '%s' "$REACT_NATIVE_XCODE"`
-    const escaped = arg1.replace(/'/g, `'\\''`)
-    return execSync(`/bin/bash -c 'set -- '"'"'${escaped}'"'"'; ${script}'`).toString()
+  const resolveReactNativeXcode = (args: string[]): string => {
+    const script = `${extractReactNativeXcodeResolutionBlock()}\nprintf '%s' "$REACT_NATIVE_XCODE"`
+    return execFileSync('/bin/bash', ['-c', script, 'posthog-xcode-test', ...args]).toString()
   }
 
   it.each([
-    ['RN script path', '../node_modules/react-native/scripts/react-native-xcode.sh'],
-    ['/bin/sh (issue #3682 — Expo shell-prefixed bundle phase)', '/bin/sh'],
-  ])('REACT_NATIVE_XCODE resolves to react-native-xcode.sh path when $1 is %s', (_desc, arg1) => {
-    const result = resolveReactNativeXcode(arg1)
-    expect(result).not.toBe('/bin/sh')
-    expect(result).toContain('react-native-xcode.sh')
+    ['direct RN script', ['../node_modules/react-native/scripts/react-native-xcode.sh']],
+    ['shell-prefixed RN script', ['/bin/sh', '../node_modules/react-native/scripts/react-native-xcode.sh']],
+    [
+      'nested source-map wrapper',
+      [
+        '/bin/sh',
+        '../node_modules/@sentry/react-native/scripts/sentry-xcode.sh',
+        '../node_modules/react-native/scripts/react-native-xcode.sh',
+      ],
+    ],
+  ])('locates react-native-xcode.sh in a %s command', (_desc, args) => {
+    expect(resolveReactNativeXcode(args)).toBe('../node_modules/react-native/scripts/react-native-xcode.sh')
+  })
+
+  it('falls back to the standard RN script when an outer wrapper does not forward arguments', () => {
+    expect(resolveReactNativeXcode([])).toBe('../node_modules/react-native/scripts/react-native-xcode.sh')
+  })
+
+  it('forwards the complete nested command and preserves the intermediate Hermes map', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-xcode-composition-'))
+    const derivedDir = path.join(tempDir, 'derived')
+    const configurationDir = path.join(tempDir, 'configuration')
+    const homeDir = path.join(tempDir, 'home')
+    const iosDir = path.join(tempDir, 'ios')
+    const tracePath = path.join(tempDir, 'trace.log')
+    const wrapperPath = path.join(tempDir, 'sentry-xcode.sh')
+    const reactNativePath = path.join(tempDir, 'node_modules', 'react-native', 'scripts', 'react-native-xcode.sh')
+    const cliPath = path.join(homeDir, '.posthog', 'posthog-cli')
+
+    try {
+      for (const directory of [
+        derivedDir,
+        configurationDir,
+        iosDir,
+        path.dirname(reactNativePath),
+        path.dirname(cliPath),
+      ]) {
+        fs.mkdirSync(directory, { recursive: true })
+      }
+      fs.writeFileSync(wrapperPath, '#!/bin/sh\necho wrapper >> "$TRACE_PATH"\n"$@"\n', { mode: 0o755 })
+      fs.writeFileSync(
+        reactNativePath,
+        '#!/bin/sh\necho react-native >> "$TRACE_PATH"\nrm "$PACKAGER_SOURCEMAP_FILE"\n',
+        { mode: 0o755 }
+      )
+      fs.writeFileSync(cliPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+
+      const env = {
+        ...process.env,
+        CONFIGURATION_BUILD_DIR: configurationDir,
+        DERIVED_FILE_DIR: derivedDir,
+        HOME: homeDir,
+        SKIP_BUNDLING: '1',
+        TRACE_PATH: tracePath,
+      }
+
+      execFileSync(SCRIPT_PATH, ['/bin/sh', wrapperPath, reactNativePath], {
+        cwd: iosDir,
+        env,
+        stdio: 'pipe',
+      })
+
+      expect(fs.readFileSync(tracePath, 'utf8').trim().split('\n')).toEqual(['wrapper', 'react-native'])
+      expect(fs.readFileSync(reactNativePath, 'utf8')).toContain('#rm "$PACKAGER_SOURCEMAP_FILE"')
+
+      // Sentry only passes its $1 script path to sentry-cli. When Sentry wraps
+      // PostHog, posthog-xcode.sh is therefore invoked without the original RN
+      // argument and must execute the standard script itself.
+      fs.writeFileSync(tracePath, '')
+      execFileSync(SCRIPT_PATH, [], { cwd: iosDir, env, stdio: 'pipe' })
+      expect(fs.readFileSync(tracePath, 'utf8').trim()).toBe('react-native')
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -68,6 +68,18 @@ for command_arg in "$@"; do
   esac
 done
 
+# Some outer wrappers only forward posthog-xcode.sh, without the original RN
+# script argument. Resolve hoisted installs when the standard relative path is
+# unavailable instead of assuming node_modules lives directly above ios/.
+if [ "$#" -eq 0 ] && [ ! -f "$REACT_NATIVE_XCODE_DEFAULT" ]; then
+  REACT_NATIVE_PACKAGE_JSON=$("${NODE_BINARY:-node}" --print "require.resolve('react-native/package.json')" 2>/dev/null || true)
+  RESOLVED_REACT_NATIVE_XCODE="$(dirname "$REACT_NATIVE_PACKAGE_JSON")/scripts/react-native-xcode.sh"
+  if [ -n "$REACT_NATIVE_PACKAGE_JSON" ] && [ -f "$RESOLVED_REACT_NATIVE_XCODE" ]; then
+    REACT_NATIVE_XCODE_DEFAULT="$RESOLVED_REACT_NATIVE_XCODE"
+    REACT_NATIVE_XCODE="$RESOLVED_REACT_NATIVE_XCODE"
+  fi
+fi
+
 # Check if DERIVED_FILE_DIR exists, defined by Xcode
 if [ ! -d "$DERIVED_FILE_DIR" ]; then
   echo "error: DERIVED_FILE_DIR does not exist: $DERIVED_FILE_DIR"

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -32,11 +32,11 @@ print_command_error() {
 
 # WITH_ENVIRONMENT is executed by React Native
 
-POSTHOG_UPLOAD_ARGS=""
+POSTHOG_SKIP_ON_CONFLICT_ENABLED="${POSTHOG_SKIP_ON_CONFLICT:-}"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --posthog-skip-on-conflict)
-      POSTHOG_UPLOAD_ARGS="$POSTHOG_UPLOAD_ARGS --skip-on-conflict"
+      POSTHOG_SKIP_ON_CONFLICT_ENABLED=1
       shift
       ;;
     --)
@@ -49,14 +49,24 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-REACT_NATIVE_XCODE_DEFAULT="../node_modules/react-native/scripts/react-native-xcode.sh"
-# Accept $1 only when it actually points at a shell script; guard against the
-# Expo plugin previously passing "/bin/sh" as $1 (issue #3682).
-if [[ "${1:-}" == *.sh ]]; then
-  REACT_NATIVE_XCODE="$1"
-else
-  REACT_NATIVE_XCODE="$REACT_NATIVE_XCODE_DEFAULT"
+POSTHOG_UPLOAD_ARGS=""
+if [ "$POSTHOG_SKIP_ON_CONFLICT_ENABLED" = "1" ] || [ "$POSTHOG_SKIP_ON_CONFLICT_ENABLED" = "true" ]; then
+  POSTHOG_UPLOAD_ARGS="$POSTHOG_UPLOAD_ARGS --skip-on-conflict"
 fi
+
+REACT_NATIVE_XCODE_DEFAULT="../node_modules/react-native/scripts/react-native-xcode.sh"
+REACT_NATIVE_XCODE="$REACT_NATIVE_XCODE_DEFAULT"
+# A config plugin may already wrap the React Native script. Keep the complete
+# command for execution, but locate the RN script within it so its intermediate
+# Hermes source map can be preserved before any wrapper runs.
+for command_arg in "$@"; do
+  case "$command_arg" in
+    *packager/react-native-xcode.sh|*scripts/react-native-xcode.sh)
+      REACT_NATIVE_XCODE="$command_arg"
+      break
+      ;;
+  esac
+done
 
 # Check if DERIVED_FILE_DIR exists, defined by Xcode
 if [ ! -d "$DERIVED_FILE_DIR" ]; then
@@ -125,9 +135,15 @@ if grep -q '^[[:space:]]*rm.*PACKAGER_SOURCEMAP_FILE' "$REACT_NATIVE_XCODE"; the
   echo "Patched: commented out rm PACKAGER_SOURCEMAP_FILE line"
 fi
 
-# Execute React Native Xcode script and check exit code
+# Execute the complete bundle command so other source-map wrappers keep their
+# script path and arguments. Fall back to the standard RN script when an outer
+# wrapper invokes posthog-xcode.sh without forwarding its remaining arguments.
 set +x +e # disable printing commands and allow continuing on error
-RN_XCODE_OUTPUT=$(/bin/sh -c "$REACT_NATIVE_XCODE" 2>&1)
+if [ "$#" -gt 0 ]; then
+  RN_XCODE_OUTPUT=$("$@" 2>&1)
+else
+  RN_XCODE_OUTPUT=$(/bin/sh "$REACT_NATIVE_XCODE_DEFAULT" 2>&1)
+fi
 RN_XCODE_EXIT_CODE=$?
 if [ $RN_XCODE_EXIT_CODE -eq 0 ]; then
   echo "$RN_XCODE_OUTPUT" | awk '{print "output: react-native-xcode - " $0}'

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -131,7 +131,11 @@ fi
 # lets patch the script to comment out this part if not yet
 if grep -q '^[[:space:]]*rm.*PACKAGER_SOURCEMAP_FILE' "$REACT_NATIVE_XCODE"; then
   echo "Patching React Native script to preserve sourcemap file..."
-  sed -i '' 's/^[[:space:]]*rm.*PACKAGER_SOURCEMAP_FILE/#&/' "$REACT_NATIVE_XCODE"
+  if sed --version >/dev/null 2>&1; then
+    sed -i 's/^[[:space:]]*rm.*PACKAGER_SOURCEMAP_FILE/#&/' "$REACT_NATIVE_XCODE"
+  else
+    sed -i '' 's/^[[:space:]]*rm.*PACKAGER_SOURCEMAP_FILE/#&/' "$REACT_NATIVE_XCODE"
+  fi
   echo "Patched: commented out rm PACKAGER_SOURCEMAP_FILE line"
 fi
 


### PR DESCRIPTION
## Problem

Expo apps using both `posthog-react-native/expo` and `@sentry/react-native/expo` can generate a nested iOS bundle command where Sentry receives `/bin/sh` instead of the next wrapper. The Release build can then succeed without running `react-native-xcode.sh`, producing an IPA without `main.jsbundle` and leaving the app stuck on its native splash screen. This fixes #4285.

## Changes

- Invoke `posthog-xcode.sh` directly so an outer wrapper receives the PostHog script as its command instead of `/bin/sh`.
- Preserve and execute the complete nested bundle command, while locating the underlying React Native script so its intermediate Hermes source map is retained.
- Resolve the React Native script through `NODE_BINARY` when an outer wrapper omits it and the default relative path is unavailable, supporting hoisted monorepos.
- Carry `skipOnConflict` through nested wrappers using an exported environment variable and migrate previously generated shell-prefixed PostHog commands.
- Declare the Xcode helper as a package bin target so package managers preserve its executable bit.
- Support both BSD and GNU `sed` when preserving React Native's intermediate Hermes source map.
- Add regression coverage for both PostHog/Sentry plugin orders, nested command execution, fallback execution, and existing-wrapper migration.
- Update the checked-in Expo 53 **Bundle React Native code and images** phase to use the composable PostHog command.
- Document in the changeset that projects with a checked-in `ios/` directory must rerun `npx expo prebuild --platform ios` after upgrading.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi resumed the [posthog-watcher investigation](https://github.com/PostHog/posthog-js/issues/4285#issuecomment-5099272970) and implemented the fix in a dedicated worktree. We rejected an upload opt-out because removing the Expo plugin already provides that behavior; instead, the wrappers now compose while preserving both vendors' source-map uploads. Focused tests, the full React Native unit suite (544 tests), package build, lint, shell syntax checks, and packed executable permissions were verified. A Linux CI failure in the new executable wrapper test exposed the existing BSD-only `sed -i ''` call; the script now selects the correct BSD/GNU syntax. Review feedback also led to separating legacy command migration from skip-on-conflict handling, resolving hoisted React Native fallbacks, and covering the combined legacy migration path.

The branch package was installed into `examples/example-expo-53`, the plugin was applied to its **Bundle React Native code and images** phase, and an XcodeBuildMCP Release simulator build completed successfully. The resulting app contains a 2.4 MB `main.jsbundle`, with the 11 MB source map retained in the build products. Xcode 26 required a temporary ignored-Pods workaround for an unrelated Expo 53/React Native 0.79 `fmt` consteval compilation failure; no workaround was checked in.



