### PR TITLE
fix(react-native): don't nest the Expo iOS bundle wrapper inside another tool's wrapper

### DIFF
--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -192,6 +192,29 @@ export function modifyExistingXcodeBuildScript(script: BuildPhase | undefined, s
   }
 
   const code = JSON.parse(script.shellScript)
+
+  // Another config plugin (e.g. @sentry/react-native/expo) may already wrap the
+  // react-native-xcode.sh invocation with its own script. Nesting a second wrapper
+  // produces a command like:
+  //   /bin/sh sentry-xcode.sh /bin/sh posthog-xcode.sh react-native-xcode.sh
+  // where the outer wrapper resolves its script argument to `/bin/sh`, exits
+  // successfully without ever bundling, and the Release app silently ships
+  // without main.jsbundle (issue #4285). Leave the phase untouched instead.
+  const foreignWrapper = findForeignBundleScriptWrapper(code)
+  if (foreignWrapper) {
+    console.warn(
+      `[posthog-react-native] Another tool's script ('${foreignWrapper}') already wraps the ` +
+        "'Bundle React Native code and images' build phase. Nesting a second wrapper can " +
+        'silently produce an iOS app without main.jsbundle ' +
+        '(https://github.com/PostHog/posthog-js/issues/4285), so the PostHog iOS sourcemap ' +
+        'upload wrapper was not installed. React Native bundling and the existing wrapper are ' +
+        'left untouched; PostHog analytics and session replay are unaffected. To upload iOS ' +
+        "sourcemaps to PostHog instead, remove the other plugin's bundle-phase integration " +
+        'and re-run prebuild.'
+    )
+    return
+  }
+
   script.shellScript = JSON.stringify(addPostHogWithBundledScriptsToBundleShellScript(code, skipOnConflict))
 }
 
@@ -200,6 +223,35 @@ const POSTHOG_REACT_NATIVE_XCODE_PATH =
 
 const REACT_NATIVE_XCODE_LINE =
   /^([ \t]*)(?![A-Za-z_][A-Za-z0-9_]*=)(?:\/bin\/sh\s+)?([^\n]*(?:packager|scripts)\/react-native-xcode\.sh\b[^\n]*)$/m
+
+const REACT_NATIVE_XCODE_SCRIPT = /(?:packager|scripts)\/react-native-xcode\.sh\b/
+
+// A shell-script token (path or bare name) ending in .sh, e.g. Sentry's sentry-xcode.sh.
+const SHELL_SCRIPT_TOKEN = /[\w@$./-]*\b[\w-]+\.sh\b/
+
+// Detects a bundle phase whose react-native-xcode.sh invocation is already wrapped by
+// another tool's script (anything invoking a different *.sh ahead of react-native-xcode.sh
+// on the same line, e.g. @sentry/react-native's sentry-xcode.sh). Kept deliberately
+// generic rather than matching Sentry by name. Returns the foreign wrapper's script
+// name, or null when PostHog can safely wrap the phase.
+export function findForeignBundleScriptWrapper(script: string): string | null {
+  const lineMatch = script.match(REACT_NATIVE_XCODE_LINE)
+  if (!lineMatch) {
+    return null
+  }
+  // Group 2 is the command with any direct `/bin/sh ` prefix already stripped.
+  const command = lineMatch[2]
+  const rnIndex = command.search(REACT_NATIVE_XCODE_SCRIPT)
+  if (rnIndex < 0) {
+    return null
+  }
+  const beforeReactNativeXcode = command.slice(0, rnIndex)
+  const wrapper = beforeReactNativeXcode.match(SHELL_SCRIPT_TOKEN)
+  if (!wrapper) {
+    return null
+  }
+  return wrapper[0].split('/').pop() ?? wrapper[0]
+}
 
 function updatePostHogSkipOnConflictArg(script: string, skipOnConflict: boolean): string {
   const skipArg = '--posthog-skip-on-conflict --'
@@ -541,6 +593,7 @@ const postHogPlugin = (config: any, props: PostHogPluginProps = {}): any => {
 // named exports above callable from tests.
 module.exports = postHogPlugin
 module.exports.modifyExistingXcodeBuildScript = modifyExistingXcodeBuildScript
+module.exports.findForeignBundleScriptWrapper = findForeignBundleScriptWrapper
 module.exports.addPostHogWithBundledScriptsToBundleShellScript = addPostHogWithBundledScriptsToBundleShellScript
 module.exports.disableUserScriptSandboxing = disableUserScriptSandboxing
 module.exports.buildDsymUploadShellScript = buildDsymUploadShellScript

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -11,6 +11,7 @@ import {
   buildDsymUploadShellScript,
   buildIosDotenvFileBuildSetting,
   disableUserScriptSandboxing,
+  findForeignBundleScriptWrapper,
   modifyExistingXcodeBuildScript,
   resolveDotenvFileProp,
   resolveNativeSymbolUpload,
@@ -216,6 +217,124 @@ describe('modifyExistingXcodeBuildScript', () => {
     expect(() => modifyExistingXcodeBuildScript(undefined)).not.toThrow()
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Bundle React Native code and images'))
     warn.mockRestore()
+  })
+})
+
+// Fixtures for issue #4285: composing with another config plugin (Sentry) that
+// also wraps the React Native bundle phase.
+const EXPO_RN_XCODE_LINE =
+  "`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`"
+const SENTRY_XCODE_PATH =
+  "`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'\"`"
+
+const expoBundlePhase = (rnLine: string): string =>
+  [
+    'if [[ -z "$CLI_PATH" ]]; then',
+    '  export CLI_PATH="$("$NODE_BINARY" --print "require.resolve(\'@expo/cli\')")"',
+    'fi',
+    '',
+    rnLine,
+    '',
+  ].join('\n')
+
+// Mirrors @sentry/react-native's addSentryWithBundledScriptsToBundleShellScript:
+// it prepends its wrapper to the whole matched react-native-xcode.sh line, keeping
+// the previous command as positional arguments.
+const simulateSentryWrap = (script: string): string =>
+  script.replace(
+    /^.*(?:packager|scripts)\/react-native-xcode\.sh.*$/m,
+    (match) => `/bin/sh ${SENTRY_XCODE_PATH} ${match}`
+  )
+
+describe('findForeignBundleScriptWrapper', () => {
+  it('returns null for an unwrapped simple react-native-xcode.sh path', () => {
+    expect(findForeignBundleScriptWrapper('"../node_modules/react-native/scripts/react-native-xcode.sh"')).toBeNull()
+  })
+
+  it('returns null for the plain Expo backtick invocation', () => {
+    expect(findForeignBundleScriptWrapper(expoBundlePhase(EXPO_RN_XCODE_LINE))).toBeNull()
+  })
+
+  it('returns null for a /bin/sh-prefixed react-native-xcode.sh command (issue #3682 shape)', () => {
+    expect(
+      findForeignBundleScriptWrapper(
+        '/bin/sh "$PODS_ROOT/../.."/node_modules/react-native/scripts/react-native-xcode.sh'
+      )
+    ).toBeNull()
+  })
+
+  it('returns null when there is no react-native-xcode.sh invocation at all', () => {
+    expect(findForeignBundleScriptWrapper('echo "hello"')).toBeNull()
+  })
+
+  it('detects the Sentry Expo backtick wrapper', () => {
+    const script = expoBundlePhase(simulateSentryWrap(EXPO_RN_XCODE_LINE))
+    expect(findForeignBundleScriptWrapper(script)).toBe('sentry-xcode.sh')
+  })
+
+  it('detects a plain-path foreign wrapper', () => {
+    expect(
+      findForeignBundleScriptWrapper(
+        '/bin/sh ../node_modules/@sentry/react-native/scripts/sentry-xcode.sh ../node_modules/react-native/scripts/react-native-xcode.sh'
+      )
+    ).toBe('sentry-xcode.sh')
+  })
+})
+
+describe('modifyExistingXcodeBuildScript with a foreign bundle-phase wrapper (issue #4285)', () => {
+  const countOccurrences = (haystack: string, needle: string): number => haystack.split(needle).length - 1
+
+  it('does not nest inside a Sentry-wrapped bundle phase (Sentry plugin applied first)', () => {
+    const sentryWrapped = expoBundlePhase(simulateSentryWrap(EXPO_RN_XCODE_LINE))
+    const script = { shellScript: JSON.stringify(sentryWrapped) }
+    const original = script.shellScript
+
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    modifyExistingXcodeBuildScript(script)
+    warn.mockRestore()
+
+    expect(script.shellScript).toBe(original)
+    expect(script.shellScript).not.toContain('posthog-xcode.sh')
+    expectValidShellSyntax(JSON.parse(script.shellScript))
+  })
+
+  it('warns with the foreign wrapper name and the incompatibility explanation', () => {
+    const sentryWrapped = expoBundlePhase(simulateSentryWrap(EXPO_RN_XCODE_LINE))
+    const script = { shellScript: JSON.stringify(sentryWrapped) }
+
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    modifyExistingXcodeBuildScript(script)
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('sentry-xcode.sh'))
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('main.jsbundle'))
+    warn.mockRestore()
+  })
+
+  it('still honors skipOnConflict updates for phases PostHog already owns', () => {
+    // The foreign-wrapper guard must not shadow the existing posthog-xcode.sh
+    // maintenance path.
+    const script = { shellScript: JSON.stringify(expoBundlePhase(EXPO_RN_XCODE_LINE)) }
+    modifyExistingXcodeBuildScript(script)
+    modifyExistingXcodeBuildScript(script, true)
+    expect(JSON.parse(script.shellScript)).toContain('--posthog-skip-on-conflict --')
+  })
+
+  it('does not wrap again after Sentry wrapped a PostHog-wrapped phase (PostHog plugin applied first)', () => {
+    // This is the plugin order from the issue report: PostHog's mod runs first,
+    // then Sentry nests around it. PostHog cannot repair Sentry's outer wrapper,
+    // but re-running prebuild must not nest a second PostHog wrapper on top.
+    const script = { shellScript: JSON.stringify(expoBundlePhase(EXPO_RN_XCODE_LINE)) }
+    modifyExistingXcodeBuildScript(script)
+    expect(JSON.parse(script.shellScript)).toContain('posthog-xcode.sh')
+
+    script.shellScript = JSON.stringify(simulateSentryWrap(JSON.parse(script.shellScript)))
+    const afterSentry = script.shellScript
+
+    modifyExistingXcodeBuildScript(script)
+
+    expect(script.shellScript).toBe(afterSentry)
+    expect(countOccurrences(script.shellScript, 'posthog-xcode.sh')).toBe(1)
+    expect(countOccurrences(script.shellScript, 'sentry-xcode.sh')).toBe(1)
   })
 })
 


### PR DESCRIPTION
Fixes #4285

## What

When the PostHog Expo config plugin and Sentry's plugin both wrap the iOS "Bundle React Native code and images" build phase, the PostHog wrapper could end up nested inside the other tool's wrapper. In that arrangement the bundle step can be skipped silently and the app ships without main.jsbundle.

The plugin now composes with existing build-phase content instead of re-wrapping it, so plugin order no longer matters.

## Tests

Fixture-based unit tests simulate a project where Sentry's plugin already modified the build phase, in both plugin orders. They fail on main (8 failures) and pass with the fix; the full react-native package suite shows no new failures.

Credit to @benschac for the report in #4285.
