### PR TITLE
ci: install npm OIDC support only when publishing

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -28,11 +28,6 @@ runs:
         cache: false
         install: false
 
-    # Ensure latest npm with OIDC support (npm 11.5.1+)
-    - name: Ensure modern npm (OIDC support)
-      shell: bash
-      run: npm install -g npm@11.6.4
-
     - name: Install package.json dependencies with pnpm
       if: ${{ inputs.install == 'true' }}
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,10 @@ jobs:
               with:
                   path: ${{ steps.get-package-path.outputs.path }}
 
+            - name: Ensure modern npm (OIDC support)
+              if: steps.check-package-version.outputs.is-new-version == 'true'
+              run: npm install -g npm@11.6.4
+
             - name: Install and build dependencies
               if: steps.check-package-version.outputs.is-new-version == 'true'
               run: pnpm install --frozen-lockfile && pnpm build


### PR DESCRIPTION
## Problem

The shared workspace setup action installs `npm@11.6.4` on every invocation, even though modern npm is only required for OIDC publishing. This repeats an unnecessary global npm installation across roughly 50 CI jobs.

## Changes

- Remove the npm upgrade from the shared setup action.
- Install `npm@11.6.4` in the release publish job only when the package version is new and will be published.
- Validate the modified action and workflow as YAML and with `git diff --check`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi in a dedicated worktree. The npm upgrade was moved rather than parameterized so it runs only after the release workflow confirms that a package has a new version to publish. No SDK package changes or changeset are required.
