### PR TITLE
ci: generate backward compatibility Playwright report

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -125,7 +125,7 @@ jobs:
         if: needs.affected.outputs.is-affected == 'true'
         continue-on-error: true
         run: |
-          PLAYWRIGHT_JSON_OUTPUT_FILE=compat-results.json pnpm exec playwright test --config playwright.config.compat.ts --project chromium-compat --workers=5 --reporter=json
+          PLAYWRIGHT_JSON_OUTPUT_FILE=compat-results.json pnpm exec playwright test --config playwright.config.compat.ts --project chromium-compat --workers=5 --reporter=json,html
         working-directory: packages/browser
 
       - name: Process compat test results


### PR DESCRIPTION
## Problem

The backward compatibility job requests Playwright's JSON reporter so it can process test results. This overrides the HTML reporter configured in `playwright.config.compat.ts`, so `packages/browser/playwright-report/` is not created and the artifact upload emits a warning instead of preserving a diagnostic report.

## Changes

Run the JSON and HTML Playwright reporters together. The JSON report remains available at `compat-results.json` for workflow processing, while the HTML report is generated at the path expected by the artifact upload step.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent (session `019fa9c9-9516-7be8-ac6a-7e9a43a79f13`; transcript not published). We chose to generate the intended HTML artifact rather than suppress the missing-file warning. Validation used Playwright's list mode and confirmed that the combined reporters create both `compat-results.json` and `playwright-report/index.html`.
