### PR TITLE
ci: use pinned Playwright image

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       # Keep this version in sync with packages/browser's @playwright/test dependency.
-      image: mcr.microsoft.com/playwright:v1.52.0-noble
+      image: mcr.microsoft.com/playwright:v1.52.0-noble@sha256:a021500a801bab0611049217ffad6b9697d827205c15babb86a53bc1a61c02d5
     env:
       POSTHOG_PROJECT_API_KEY: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
       POSTHOG_PERSONAL_API_KEY: "${{ secrets.POSTHOG_PERSONAL_API_KEY }}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,6 +32,7 @@ jobs:
       # Keep this version in sync with packages/browser's @playwright/test dependency.
       image: mcr.microsoft.com/playwright:v1.52.0-noble@sha256:a021500a801bab0611049217ffad6b9697d827205c15babb86a53bc1a61c02d5
     env:
+      HOME: /root
       POSTHOG_PROJECT_API_KEY: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
       POSTHOG_PERSONAL_API_KEY: "${{ secrets.POSTHOG_PERSONAL_API_KEY }}"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,9 +26,12 @@ jobs:
   browsers:
     name: Test on ${{ matrix.tests.name }}
     needs: affected
+    if: github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true'
     runs-on: ubuntu-22.04
+    container:
+      # Keep this version in sync with packages/browser's @playwright/test dependency.
+      image: mcr.microsoft.com/playwright:v1.52.0-noble
     env:
-      CAN_RUN_INTEGRATION_TESTS: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
       POSTHOG_PROJECT_API_KEY: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
       POSTHOG_PERSONAL_API_KEY: "${{ secrets.POSTHOG_PERSONAL_API_KEY }}"
 
@@ -38,43 +41,27 @@ jobs:
         tests:
           - name: Chromium
             projects: "--project chromium --project chromium-es5"
-            install: "chromium"
             browser: "chromium"
 
           - name: Firefox
             projects: "--project firefox"
-            install: "firefox"
             browser: "firefox"
 
           - name: Safari
             projects: "--project webkit"
-            install: "webkit"
             browser: "webkit"
 
     steps:
-      - name: Skip fork PR
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS != 'true' }}
-        run: echo "Skipping ${{ matrix.tests.name }} integration tests for fork PRs because required secrets are unavailable."
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
 
       - uses: ./.github/actions/setup
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
         with:
           build: false
 
       - name: Build packages
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
-      - name: Install Playwright Browsers
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
-        run: pnpm exec playwright install ${{ matrix.tests.install }} --with-deps --only-shell
-        working-directory: packages/browser
-
       - name: Run ${{ matrix.tests.name }} test
-        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && needs.affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -61,33 +61,28 @@ jobs:
   integration:
     name: Playwright E2E tests
     needs: affected
+    if: needs.affected.outputs.is-affected == 'true'
     runs-on: depot-ubuntu-latest-8
+    container:
+      # Keep this version in sync with packages/browser's @playwright/test dependency.
+      image: mcr.microsoft.com/playwright:v1.52.0-noble
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.affected.outputs.is-affected == 'true'
 
       - name: Setup environment
-        if: needs.affected.outputs.is-affected == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
       - name: Build package
         run: pnpm build
-        if: needs.affected.outputs.is-affected == 'true'
-
-      - name: Install Playwright Browsers
-        if: needs.affected.outputs.is-affected == 'true'
-        run: pnpm exec playwright install --with-deps
-        working-directory: packages/browser
 
       - name: Run Playwright tests
-        if: needs.affected.outputs.is-affected == 'true'
         run: pnpm exec playwright test --workers=5
         working-directory: packages/browser
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !cancelled() && needs.affected.outputs.is-affected == 'true' }}
+        if: ${{ !cancelled() }}
         with:
           name: playwright-report
           path: packages/browser/playwright-report/
@@ -97,39 +92,32 @@ jobs:
     name: Backward compatibility tests
     needs: affected
     runs-on: depot-ubuntu-latest-8
-    if: github.event_name == 'pull_request'
+    container:
+      # Keep this version in sync with packages/browser's @playwright/test dependency.
+      image: mcr.microsoft.com/playwright:v1.52.0-noble
+    if: github.event_name == 'pull_request' && needs.affected.outputs.is-affected == 'true'
     permissions:
       contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.affected.outputs.is-affected == 'true'
 
       - name: Setup environment
-        if: needs.affected.outputs.is-affected == 'true'
         uses: ./.github/actions/setup
         with:
           build: false
 
       - name: Build package
         run: pnpm build
-        if: needs.affected.outputs.is-affected == 'true'
-
-      - name: Install Playwright Browsers
-        if: needs.affected.outputs.is-affected == 'true'
-        run: pnpm exec playwright install --with-deps chromium
-        working-directory: packages/browser
 
       - name: Run backward compatibility tests
         id: compat-tests
-        if: needs.affected.outputs.is-affected == 'true'
         continue-on-error: true
         run: |
           PLAYWRIGHT_JSON_OUTPUT_FILE=compat-results.json pnpm exec playwright test --config playwright.config.compat.ts --project chromium-compat --workers=5 --reporter=json
         working-directory: packages/browser
 
       - name: Process compat test results
-        if: needs.affected.outputs.is-affected == 'true'
         id: process-results
         working-directory: packages/browser
         env:
@@ -245,7 +233,7 @@ jobs:
             </details>
 
       - name: Delete compat comment if tests pass
-        if: ${{ steps.process-results.outputs.has_failures == 'false' && needs.affected.outputs.is-affected == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.process-results.outputs.has_failures == 'false' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-passing-comment
         with:
@@ -267,7 +255,7 @@ jobs:
             })
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !cancelled() && needs.affected.outputs.is-affected == 'true' }}
+        if: ${{ !cancelled() }}
         with:
           name: playwright-compat-report
           path: packages/browser/playwright-report/

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: depot-ubuntu-latest-8
     container:
       # Keep this version in sync with packages/browser's @playwright/test dependency.
-      image: mcr.microsoft.com/playwright:v1.52.0-noble
+      image: mcr.microsoft.com/playwright:v1.52.0-noble@sha256:a021500a801bab0611049217ffad6b9697d827205c15babb86a53bc1a61c02d5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -94,7 +94,7 @@ jobs:
     runs-on: depot-ubuntu-latest-8
     container:
       # Keep this version in sync with packages/browser's @playwright/test dependency.
-      image: mcr.microsoft.com/playwright:v1.52.0-noble
+      image: mcr.microsoft.com/playwright:v1.52.0-noble@sha256:a021500a801bab0611049217ffad6b9697d827205c15babb86a53bc1a61c02d5
     if: github.event_name == 'pull_request' && needs.affected.outputs.is-affected == 'true'
     permissions:
       contents: read

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -66,6 +66,8 @@ jobs:
     container:
       # Keep this version in sync with packages/browser's @playwright/test dependency.
       image: mcr.microsoft.com/playwright:v1.52.0-noble@sha256:a021500a801bab0611049217ffad6b9697d827205c15babb86a53bc1a61c02d5
+    env:
+      HOME: /root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -95,6 +97,8 @@ jobs:
     container:
       # Keep this version in sync with packages/browser's @playwright/test dependency.
       image: mcr.microsoft.com/playwright:v1.52.0-noble@sha256:a021500a801bab0611049217ffad6b9697d827205c15babb86a53bc1a61c02d5
+    env:
+      HOME: /root
     if: github.event_name == 'pull_request' && needs.affected.outputs.is-affected == 'true'
     permissions:
       contents: read

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -83,7 +83,7 @@
         "@babel/preset-typescript": "catalog:",
         "@jest/globals": "^29.7.0",
         "@jridgewell/sourcemap-codec": "^1.5.5",
-        "@playwright/test": "^1.52.0",
+        "@playwright/test": "1.52.0",
         "@posthog-tooling/rollup-utils": "workspace:*",
         "@posthog/rrweb": "workspace:*",
         "@posthog/rrweb-plugin-console-record": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,7 +342,7 @@ importers:
         specifier: ^1.5.5
         version: 1.5.5
       '@playwright/test':
-        specifier: ^1.52.0
+        specifier: 1.52.0
         version: 1.52.0
       '@posthog-tooling/rollup-utils':
         specifier: workspace:*


### PR DESCRIPTION
## Problem

Playwright CI jobs repeatedly install browser binaries and operating-system dependencies. Recent runs spent roughly 17.7 runner-minutes in browser setup, with the Depot jobs spending most of that time installing system packages.

## Changes

- Run browser, integration, and compatibility tests in the official Playwright `v1.52.0-noble` image, pinned to manifest digest `sha256:a021500a801bab0611049217ffad6b9697d827205c15babb86a53bc1a61c02d5`, which already contains the matching browsers and system dependencies.
- Pin `@playwright/test` to `1.52.0` so its expected browser revisions stay aligned with the container image.
- Gate container jobs at the job level so unaffected and fork PRs do not pull the image.
- Set the container home to `/root` so Firefox can run under the image's default root user in GitHub Actions.
- Remove redundant Playwright installation steps and matrix fields.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using GitHub CLI, actionlint, pnpm, and Docker. A browser cache was considered first, but run logs showed the Depot installation time was dominated by system package installation, so an exact-version Playwright image was chosen instead. The image manifest digest and matching browser revisions were verified, and Chromium, Firefox, and WebKit were launched successfully from it. Firefox was also launched with the same `HOME=/root` configuration used in CI.
