### PR TITLE
feat(browser-common): stream remote config outcomes

### DIFF
--- a/.changeset/browser-common-remote-config-outcomes.md
+++ b/.changeset/browser-common-remote-config-outcomes.md
@@ -1,5 +1,5 @@
 ---
-'@posthog/browser-common': patch
+'@posthog/browser-common': minor
 ---
 
 Stream replayable remote config outcomes through shared browser extension clients.

--- a/.changeset/browser-common-remote-config-outcomes.md
+++ b/.changeset/browser-common-remote-config-outcomes.md
@@ -1,0 +1,5 @@
+---
+'@posthog/browser-common': patch
+---
+
+Stream replayable remote config outcomes through shared browser extension clients.

--- a/packages/browser-common/.agents/skills/develop-extension/SKILL.md
+++ b/packages/browser-common/.agents/skills/develop-extension/SKILL.md
@@ -52,26 +52,27 @@ export class MyExtension implements Extension {
 ```
 
 - `name` is unique within one client and is used for diagnostics and de-duplication.
-- `setup(client)` may be async when it needs KV or remote-config state.
+- `setup(client)` may be async when it needs KV or other asynchronous state.
 - `dispose()` is optional, synchronous, idempotent, and best-effort.
 - Static SDK configuration belongs in explicit constructor options, not in `Client`.
 
 ## Client capabilities
 
-| Need                           | Use                                                           |
-| ------------------------------ | ------------------------------------------------------------- |
-| current identity               | `client.distinctId`, `client.anonymousId`, `client.groups`    |
-| current session                | `client.session`                                              |
-| record an event                | `await client.capture(event, properties?, options?)`          |
-| add properties to every event  | `client.registerDynamicEventProperties(() => ({ … }))`        |
-| react to finalized events      | `client.onEvent(({ event, properties }) => …)`                |
-| call a PostHog endpoint        | `await client.sendRequest(path, init?)`                       |
-| read or react to server config | `await client.getRemoteConfig()` / `client.onRemoteConfig(…)` |
-| persist small state            | `client.kv`                                                   |
-| log                            | `client.logger`                                               |
+| Need                          | Use                                                        |
+| ----------------------------- | ---------------------------------------------------------- |
+| current identity              | `client.distinctId`, `client.anonymousId`, `client.groups` |
+| current session               | `client.session`                                           |
+| record an event               | `await client.capture(event, properties?, options?)`       |
+| add properties to every event | `client.registerDynamicEventProperties(() => ({ … }))`     |
+| react to finalized events     | `client.onEvent(({ event, properties }) => …)`             |
+| call a PostHog endpoint       | `await client.sendRequest(path, init?)`                    |
+| react to server config        | `client.onRemoteConfig(…)`                                 |
+| persist small state           | `client.kv`                                                |
+| log                           | `client.logger`                                            |
 
 Create an extension-named child logger with `client.logger.createLogger('[myExtension]')` when its messages need a
-prefix.
+prefix. `onRemoteConfig` immediately replays the latest known outcome; narrow on `result.ok` before reading
+`result.config` and define safe behavior for `{ ok: false }`.
 
 `sendRequest` is a low-level transport bridge. Select the configured origin with `target` (`api`, `flags`, or
 `assets`) and construct endpoint authentication using `client.projectToken` in the required query parameter, body,
@@ -85,8 +86,8 @@ header, or path.
   cannot mutate them.
 - **Keep disposables.** Store and release values returned by listeners, dynamic-property registration, and timer or
   patch wrappers. Use `createDisposable(teardown)` for idempotent synchronous cleanup.
-- **Reads are sync; I/O is awaitable.** Identity, session, and `projectToken` are synchronous. Capture, requests, KV,
-  and remote config are awaitable.
+- **Reads are sync; I/O is awaitable.** Identity, session, and `projectToken` are synchronous. Capture, requests, and
+  KV are awaitable; remote-config outcomes are delivered through `onRemoteConfig`.
 - **Design for async readiness.** Setup may occur before remote config loads or after events have already been captured.
   Guard work after each `await` so disposal cannot be followed by late installation.
 - **Persist through `client.kv`, not globals.** Browser-v1 keys are passed verbatim to persistence. Unknown keys may be
@@ -128,7 +129,7 @@ export class FeatureFlagsExtension implements Extension {
 | `instance.get_distinct_id()`                                  | `client.distinctId`                                     |
 | `instance.get_property(k)` / `persistence`                    | `client.kv.get(k)`                                      |
 | `instance.config.X` (static)                                  | constructor option                                      |
-| `instance.config.X` (server-driven)                           | `client.getRemoteConfig()` / `onRemoteConfig`           |
+| `instance.config.X` (server-driven)                           | `client.onRemoteConfig(...)`                            |
 | `instance.sessionManager.checkAndGetSessionAndWindowId(true)` | `client.session`                                        |
 | `_addCaptureHook` / observing events                          | `client.onEvent(...)`                                   |
 | registering an enricher                                       | `client.registerDynamicEventProperties(fn)`             |

--- a/packages/browser-common/README.md
+++ b/packages/browser-common/README.md
@@ -56,14 +56,15 @@ What an extension is given in `setup` — the adapter shared by extensions on th
 
 - **identity and session**: `distinctId`, `anonymousId`, `groups`, `session`
 - **events**: `capture(...)`, `registerDynamicEventProperties(...)`, `onEvent(...)`
-- **server config**: `getRemoteConfig()` and `onRemoteConfig(...)`
+- **server config**: `onRemoteConfig(...)`
 - **transport**: `projectToken`, `sendRequest(path, init?)`
 - **storage and logging**: `kv`, `logger`
 
 Identity, session, and the public project token are always-ready synchronous
 reads. Operations that may perform I/O, including `capture`, `sendRequest`,
-`kv`, and `getRemoteConfig`, are awaitable. Extensions that want a named log
-prefix can create a child with `client.logger.createLogger('[myExtension]')`.
+and `kv`, are awaitable. `onRemoteConfig` immediately replays the latest known
+success or failure and then reports subsequent outcomes. Extensions that want a
+named log prefix can create a child with `client.logger.createLogger('[myExtension]')`.
 
 ### Host runtime
 

--- a/packages/browser-common/src/client.ts
+++ b/packages/browser-common/src/client.ts
@@ -4,7 +4,7 @@ import type { Properties } from '@posthog/types'
 import type { Disposable } from './disposable'
 import type { KeyValueStore } from './persistence'
 import type { Listener } from './pubsub'
-import type { RemoteConfig } from './types/remote-config'
+import type { RemoteConfigResult } from './types/remote-config'
 
 /** Recursively marks object properties as readonly while preserving callable values. */
 export type DeepReadonly<T> = T extends (...args: never[]) => unknown
@@ -103,10 +103,8 @@ export interface Client {
     /** Fires for every captured event through a deeply readonly view. */
     readonly onEvent: Listener<CapturedEventInfo>
 
-    /** Resolves with the current remote config, awaiting the first outcome when necessary. */
-    getRemoteConfig(): Promise<DeepReadonly<RemoteConfig> | undefined>
-    /** Fires when server-provided config arrives or changes successfully. */
-    readonly onRemoteConfig: Listener<DeepReadonly<RemoteConfig>>
+    /** Replays the latest remote-config outcome on subscription and fires for subsequent outcomes. */
+    readonly onRemoteConfig: Listener<DeepReadonly<RemoteConfigResult>>
 
     /** Public project token used to authenticate endpoint-specific requests. */
     readonly projectToken: string

--- a/packages/browser-common/src/pubsub.ts
+++ b/packages/browser-common/src/pubsub.ts
@@ -3,8 +3,9 @@ import { createDisposable, type Disposable } from './disposable'
 /**
  * Call it with a handler to start listening; dispose the returned
  * {@link Disposable} to stop. There is one `Listener` per event type, so every
- * event carries its own payload type. The handler is called synchronously for
- * each future payload, and the returned disposable unregisters it.
+ * event carries its own payload type. The handler is called synchronously, and
+ * stateful listeners may replay their current value during registration when
+ * documented. The returned disposable unregisters it from future payloads.
  */
 export type Listener<T> = (handler: (payload: T) => void) => Disposable
 

--- a/packages/browser-common/src/types/remote-config.ts
+++ b/packages/browser-common/src/types/remote-config.ts
@@ -206,3 +206,6 @@ export interface RemoteConfig {
     /** Conversations widget configuration. */
     conversations?: boolean | ConversationsRemoteConfig
 }
+
+/** The latest outcome of loading remote configuration from PostHog. */
+export type RemoteConfigResult = { ok: true; config: RemoteConfig } | { ok: false }

--- a/packages/browser-common/tests/helpers/test-client.ts
+++ b/packages/browser-common/tests/helpers/test-client.ts
@@ -87,16 +87,9 @@ export class TestClient implements Client {
 
     readonly onEvent = this._eventPublisher.listener
     readonly onRemoteConfig: Client['onRemoteConfig'] = (handler) => {
-        const invoke = (result: RemoteConfigResult): void => {
-            try {
-                handler(result)
-            } catch (error) {
-                this.logger.error('Remote config listener failed', error)
-            }
-        }
-        const subscription = this._remoteConfigPublisher.listener(invoke)
+        const subscription = this._remoteConfigPublisher.listener(handler)
         if (this._remoteConfigResult) {
-            invoke(this._remoteConfigResult)
+            handler(this._remoteConfigResult)
         }
         return subscription
     }

--- a/packages/browser-common/tests/helpers/test-client.ts
+++ b/packages/browser-common/tests/helpers/test-client.ts
@@ -12,7 +12,7 @@ import type {
 import { createDisposable, type Disposable } from '../../src/disposable'
 import type { KeyValueStore } from '../../src/persistence'
 import { Publisher } from '../../src/pubsub'
-import type { RemoteConfig } from '../../src/types/remote-config'
+import type { RemoteConfig, RemoteConfigResult } from '../../src/types/remote-config'
 
 export interface TestCapturedEvent {
     event: string
@@ -79,14 +79,27 @@ export class TestClient implements Client {
     groups: Record<string, string>
     session: SessionContext
 
-    private _remoteConfig: RemoteConfig | undefined
+    private _remoteConfigResult: RemoteConfigResult | undefined
     private _requestResponse: ApiResponse
     private _dynamicEventPropertyProducers: Array<() => Record<string, unknown>> = []
     private _eventPublisher = new Publisher<CapturedEventInfo>()
-    private _remoteConfigPublisher = new Publisher<RemoteConfig>()
+    private _remoteConfigPublisher = new Publisher<RemoteConfigResult>()
 
     readonly onEvent = this._eventPublisher.listener
-    readonly onRemoteConfig = this._remoteConfigPublisher.listener
+    readonly onRemoteConfig: Client['onRemoteConfig'] = (handler) => {
+        const invoke = (result: RemoteConfigResult): void => {
+            try {
+                handler(result)
+            } catch (error) {
+                this.logger.error('Remote config listener failed', error)
+            }
+        }
+        const subscription = this._remoteConfigPublisher.listener(invoke)
+        if (this._remoteConfigResult) {
+            invoke(this._remoteConfigResult)
+        }
+        return subscription
+    }
 
     constructor(options: TestClientOptions = {}) {
         this.projectToken = options.projectToken ?? 'test-project-token'
@@ -98,7 +111,7 @@ export class TestClient implements Client {
             windowId: 'test-window-id',
             sessionStartTimestamp: 0,
         }
-        this._remoteConfig = options.remoteConfig
+        this._remoteConfigResult = options.remoteConfig ? { ok: true, config: options.remoteConfig } : undefined
         this.logger = options.logger ?? noopLogger
         this._requestResponse = options.requestResponse ?? createDefaultApiResponse()
     }
@@ -125,18 +138,18 @@ export class TestClient implements Client {
         })
     }
 
-    async getRemoteConfig(): Promise<RemoteConfig | undefined> {
-        return this._remoteConfig
-    }
-
     async sendRequest(path: string, init?: SendRequestInit): Promise<ApiResponse> {
         this.sentRequests.push({ path, init })
         return this._requestResponse
     }
 
     setRemoteConfig(remoteConfig: RemoteConfig): void {
-        this._remoteConfig = remoteConfig
-        this._remoteConfigPublisher.publish(remoteConfig)
+        this.setRemoteConfigResult({ ok: true, config: remoteConfig })
+    }
+
+    setRemoteConfigResult(result: RemoteConfigResult): void {
+        this._remoteConfigResult = result
+        this._remoteConfigPublisher.publish(result)
     }
 
     publishEvent(event: string, properties: Record<string, unknown> = {}): void {

--- a/packages/browser-common/tests/test-client.spec.ts
+++ b/packages/browser-common/tests/test-client.spec.ts
@@ -1,0 +1,34 @@
+import { createTestClient } from './helpers/test-client'
+
+describe('TestClient remote config', () => {
+    it('replays the latest outcome and publishes subsequent outcomes', () => {
+        const client = createTestClient()
+        const firstListener = jest.fn()
+        client.onRemoteConfig(firstListener)
+
+        expect(firstListener).not.toHaveBeenCalled()
+
+        const failure = { ok: false } as const
+        client.setRemoteConfigResult(failure)
+        expect(firstListener).toHaveBeenLastCalledWith(failure)
+
+        const lateListener = jest.fn()
+        client.onRemoteConfig(lateListener)
+        expect(lateListener).toHaveBeenCalledWith(failure)
+
+        const success = { ok: true, config: { supportedCompression: [] } } as const
+        client.setRemoteConfigResult(success)
+        expect(firstListener).toHaveBeenLastCalledWith(success)
+        expect(lateListener).toHaveBeenLastCalledWith(success)
+    })
+
+    it('does not swallow listener errors', () => {
+        const client = createTestClient()
+        const error = new Error('listener failed')
+        client.onRemoteConfig(() => {
+            throw error
+        })
+
+        expect(() => client.setRemoteConfigResult({ ok: false })).toThrow(error)
+    })
+})


### PR DESCRIPTION
## Problem

Shared browser extensions need to observe both successful and failed remote-config loads without racing an initial read against listener registration. The shared client contract currently only streams successful values and does not replay the latest outcome to late subscribers.

## Changes

- Stream `RemoteConfigResult` outcomes through the shared client contract.
- Replay the latest outcome immediately when a listener subscribes.
- Update the listener helper, test client, extension-authoring guidance, and README.
- Add a patch changeset for `@posthog/browser-common`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prepared with the Pi coding agent and its code-review and SDK-review workflows in a local session. The shared contract was separated from the browser-v1 implementation so each package change can be reviewed and released independently.
