### PR TITLE
test(browser): analyze KeyValueStore persistence policies

### DIFF
--- a/packages/browser/src/__tests__/persistence-key-policy.test.ts
+++ b/packages/browser/src/__tests__/persistence-key-policy.test.ts
@@ -224,6 +224,17 @@ const collectPersistenceKeyIdentifiers = (): ScanResult => {
                 return
             }
 
+            // The extension KeyValueStore boundary intentionally accepts caller-owned keys verbatim.
+            if (
+                filePath.endsWith('/extensions/browser-client.ts') &&
+                expression &&
+                ts.isIdentifier(expression) &&
+                expression.text === 'key' &&
+                ['set', 'remove'].includes(getEnclosingClassMethodName(node) ?? '')
+            ) {
+                return
+            }
+
             const resolution = resolvePolicyIdentifiers(expression, variableInitializers)
 
             resolution.identifiers.forEach((identifier) => identifiers.add(identifier))

--- a/packages/browser/src/__tests__/persistence-key-policy.test.ts
+++ b/packages/browser/src/__tests__/persistence-key-policy.test.ts
@@ -2,14 +2,24 @@ import fs from 'fs'
 import path from 'path'
 import * as ts from 'typescript'
 
+import { isUndefined } from '@posthog/core'
+
 import * as constants from '../constants'
 import { getPersistenceKeyPolicy, PERSISTENCE_KEY_POLICY, PERSISTENCE_STORAGE_GROUPS } from '../persistence-key-policy'
 
 const PERSISTENCE_OBJECT_METHODS = new Set(['register', 'register_once'])
 const PERSISTENCE_SINGLE_KEY_METHODS = new Set(['set_property', 'unregister'])
+const KEY_VALUE_STORE_SINGLE_KEY_METHODS = new Set(['set', 'remove'])
 const SESSION_OBJECT_METHODS = new Set(['register_for_session'])
 const SESSION_SINGLE_KEY_METHODS = new Set(['unregister_for_session'])
 const INTERNAL_SINGLE_KEY_METHODS = new Set(['_register_single', '_setProp', '_deleteProp'])
+const REPOSITORY_ROOT = path.resolve(__dirname, '../../../..')
+const SOURCE_ROOTS = [path.resolve(__dirname, '..'), path.resolve(__dirname, '../../../browser-common/src')]
+const PERSISTENCE_KEY_PREFIXES = new Set([
+    constants.SESSION_RECORDING_TRIGGER_V2_GROUP_EVENT_PREFIX,
+    constants.SESSION_RECORDING_TRIGGER_V2_GROUP_URL_PREFIX,
+    constants.SESSION_RECORDING_TRIGGER_V2_GROUP_SAMPLING_PREFIX,
+])
 
 const LEGACY_RESERVED_PERSISTENCE_KEYS = new Set<string>([
     constants.PEOPLE_DISTINCT_ID_KEY,
@@ -72,18 +82,19 @@ const isPropertyAccessLike = (
     return ts.isPropertyAccessExpression(expression) || ts.isPropertyAccessChain(expression)
 }
 
-const collectVariableInitializers = (sourceFile: ts.SourceFile): Map<string, ts.Expression> => {
-    const variableInitializers = new Map<string, ts.Expression>()
-
-    const visit = (node: ts.Node) => {
-        if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
-            variableInitializers.set(node.name.text, node.initializer)
-        }
-        ts.forEachChild(node, visit)
+const getResolvedSymbol = (node: ts.Node, checker: ts.TypeChecker): ts.Symbol | undefined => {
+    const symbol = checker.getSymbolAtLocation(node)
+    if (!symbol) {
+        return undefined
     }
+    return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+}
 
-    visit(sourceFile)
-    return variableInitializers
+const getSymbolInitializer = (symbol: ts.Symbol | undefined): ts.Expression | undefined => {
+    const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0]
+    return declaration && (ts.isVariableDeclaration(declaration) || ts.isPropertyDeclaration(declaration))
+        ? declaration.initializer
+        : undefined
 }
 
 const getLine = (sourceFile: ts.SourceFile, node: ts.Node): number => {
@@ -118,6 +129,42 @@ const isSessionPersistenceReceiver = (expression: ts.Expression | undefined): bo
     return hasPropertyName(expression, ['sessionPersistence'])
 }
 
+const isKeyValueStoreReceiver = (
+    expression: ts.Expression | undefined,
+    checker: ts.TypeChecker,
+    visitedSymbols: Set<ts.Symbol> = new Set()
+): boolean => {
+    if (!expression) {
+        return false
+    }
+    if (hasPropertyName(expression, ['kv'])) {
+        return true
+    }
+
+    const symbolNode = isPropertyAccessLike(expression as ts.LeftHandSideExpression)
+        ? expression.name
+        : ts.isIdentifier(expression)
+          ? expression
+          : undefined
+    if (!symbolNode) {
+        return false
+    }
+
+    const symbol = getResolvedSymbol(symbolNode, checker)
+    if (!symbol || visitedSymbols.has(symbol)) {
+        return false
+    }
+    visitedSymbols.add(symbol)
+
+    const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0]
+    if (declaration && ts.isBindingElement(declaration)) {
+        const propertyName = declaration.propertyName ?? declaration.name
+        return ts.isIdentifier(propertyName) && propertyName.text === 'kv'
+    }
+    const initializer = getSymbolInitializer(symbol)
+    return !!initializer && isKeyValueStoreReceiver(initializer, checker, visitedSymbols)
+}
+
 const isRegisterForSessionReceiver = (expression: ts.Expression | undefined): boolean => {
     return (
         !!expression &&
@@ -129,36 +176,52 @@ const isRegisterForSessionReceiver = (expression: ts.Expression | undefined): bo
 
 interface ResolutionResult {
     identifiers: Set<string>
+    resolvedKeys: Set<string>
     rawLiterals: Set<string>
+    hasUnresolved: boolean
 }
 
 const createResolutionResult = (): ResolutionResult => ({
     identifiers: new Set<string>(),
+    resolvedKeys: new Set<string>(),
     rawLiterals: new Set<string>(),
+    hasUnresolved: false,
 })
 
 const resolvePolicyIdentifiers = (
     expression: ts.Expression | undefined,
-    variableInitializers: Map<string, ts.Expression>,
-    visitedVariables: Set<string> = new Set()
+    checker: ts.TypeChecker,
+    visitedSymbols: Set<ts.Symbol> = new Set()
 ): ResolutionResult => {
     const result = createResolutionResult()
 
-    const visit = (node: ts.Expression | undefined): void => {
+    const visitSymbol = (node: ts.Identifier, resolvesNamedConstant: boolean): boolean => {
+        const symbol = getResolvedSymbol(node, checker)
+        const initializer = getSymbolInitializer(symbol)
+        if (!symbol || !initializer || visitedSymbols.has(symbol)) {
+            return false
+        }
+
+        visitedSymbols.add(symbol)
+        visit(initializer, resolvesNamedConstant || isUpperSnakeCase(node.text))
+        return true
+    }
+
+    const visit = (node: ts.Expression | undefined, resolvesNamedConstant = false): void => {
         if (!node) {
             return
         }
 
         if (ts.isIdentifier(node)) {
-            if (isUpperSnakeCase(node.text)) {
-                result.identifiers.add(node.text)
-                return
+            if (!visitSymbol(node, resolvesNamedConstant)) {
+                result.hasUnresolved = true
             }
+            return
+        }
 
-            const initializer = variableInitializers.get(node.text)
-            if (initializer && !visitedVariables.has(node.text)) {
-                visitedVariables.add(node.text)
-                visit(initializer)
+        if (isPropertyAccessLike(node as ts.LeftHandSideExpression) && isUpperSnakeCase(node.name.text)) {
+            if (!visitSymbol(node.name, true)) {
+                result.hasUnresolved = true
             }
             return
         }
@@ -169,88 +232,286 @@ const resolvePolicyIdentifiers = (
             ts.isTypeAssertionExpression(node) ||
             ts.isNonNullExpression(node)
         ) {
-            visit(node.expression)
+            visit(node.expression, resolvesNamedConstant)
             return
         }
 
-        if (
-            ts.isStringLiteral(node) ||
-            ts.isNoSubstitutionTemplateLiteral(node) ||
-            ts.isNumericLiteral(node) ||
-            ts.isRegularExpressionLiteral(node)
-        ) {
-            result.rawLiterals.add(node.getText())
+        if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+            if (resolvesNamedConstant) {
+                result.resolvedKeys.add(node.text)
+            } else {
+                result.rawLiterals.add(node.getText())
+            }
             return
         }
 
-        if (ts.isTemplateExpression(node)) {
+        if (ts.isNumericLiteral(node) || ts.isRegularExpressionLiteral(node) || ts.isTemplateExpression(node)) {
             result.rawLiterals.add(node.getText())
             return
         }
 
         if (ts.isConditionalExpression(node)) {
-            visit(node.whenTrue)
-            visit(node.whenFalse)
+            visit(node.whenTrue, resolvesNamedConstant)
+            visit(node.whenFalse, resolvesNamedConstant)
             return
         }
 
         if (ts.isBinaryExpression(node)) {
-            visit(node.left)
-            visit(node.right)
+            visit(node.left, resolvesNamedConstant)
+            visit(node.right, resolvesNamedConstant)
+            return
         }
+
+        result.hasUnresolved = true
     }
 
     visit(expression)
     return result
 }
 
+interface KeyCompositionResult {
+    containsComposition: boolean
+    staticValue?: string
+    staticValueIsNamed: boolean
+    dynamicPrefix?: string
+    dynamicPrefixIsNamed: boolean
+    alternatives?: KeyCompositionResult[]
+}
+
+const analyzeKeyComposition = (
+    expression: ts.Expression | undefined,
+    checker: ts.TypeChecker,
+    resolvesNamedConstant = false,
+    visitedSymbols: Set<ts.Symbol> = new Set()
+): KeyCompositionResult => {
+    const unresolved = (): KeyCompositionResult => ({
+        containsComposition: false,
+        staticValueIsNamed: false,
+        dynamicPrefixIsNamed: false,
+    })
+    if (!expression) {
+        return unresolved()
+    }
+
+    if (
+        ts.isParenthesizedExpression(expression) ||
+        ts.isAsExpression(expression) ||
+        ts.isTypeAssertionExpression(expression) ||
+        ts.isNonNullExpression(expression)
+    ) {
+        return analyzeKeyComposition(expression.expression, checker, resolvesNamedConstant, visitedSymbols)
+    }
+
+    if (ts.isIdentifier(expression) || isPropertyAccessLike(expression as ts.LeftHandSideExpression)) {
+        const symbolNode = ts.isIdentifier(expression) ? expression : expression.name
+        const symbol = getResolvedSymbol(symbolNode, checker)
+        const initializer = getSymbolInitializer(symbol)
+        if (!symbol || !initializer || visitedSymbols.has(symbol)) {
+            return unresolved()
+        }
+        visitedSymbols.add(symbol)
+        return analyzeKeyComposition(
+            initializer,
+            checker,
+            resolvesNamedConstant || isUpperSnakeCase(symbolNode.text),
+            visitedSymbols
+        )
+    }
+
+    if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+        return {
+            containsComposition: false,
+            staticValue: expression.text,
+            staticValueIsNamed: resolvesNamedConstant,
+            dynamicPrefixIsNamed: false,
+        }
+    }
+
+    if (ts.isConditionalExpression(expression)) {
+        const alternatives = [
+            analyzeKeyComposition(expression.whenTrue, checker, resolvesNamedConstant, new Set(visitedSymbols)),
+            analyzeKeyComposition(expression.whenFalse, checker, resolvesNamedConstant, new Set(visitedSymbols)),
+        ]
+        return alternatives.some(({ containsComposition }) => containsComposition)
+            ? {
+                  containsComposition: true,
+                  staticValueIsNamed: false,
+                  dynamicPrefixIsNamed: false,
+                  alternatives,
+              }
+            : unresolved()
+    }
+
+    if (!ts.isBinaryExpression(expression) || expression.operatorToken.kind !== ts.SyntaxKind.PlusToken) {
+        return unresolved()
+    }
+
+    const left = analyzeKeyComposition(expression.left, checker, resolvesNamedConstant, new Set(visitedSymbols))
+    const right = analyzeKeyComposition(expression.right, checker, resolvesNamedConstant, new Set(visitedSymbols))
+    if (!isUndefined(left.staticValue) && !isUndefined(right.staticValue)) {
+        return {
+            containsComposition: true,
+            staticValue: left.staticValue + right.staticValue,
+            staticValueIsNamed: left.staticValueIsNamed && right.staticValueIsNamed,
+            dynamicPrefixIsNamed: false,
+        }
+    }
+
+    return {
+        containsComposition: true,
+        staticValueIsNamed: false,
+        dynamicPrefix: left.staticValue ?? left.dynamicPrefix,
+        dynamicPrefixIsNamed: !isUndefined(left.staticValue) ? left.staticValueIsNamed : left.dynamicPrefixIsNamed,
+    }
+}
+
+interface SourceInput {
+    filePath: string
+    sourceText: string
+}
+
 interface ScanResult {
     identifiers: Set<string>
+    resolvedKeys: Set<string>
     issues: string[]
 }
 
-const collectPersistenceKeyIdentifiers = (): ScanResult => {
+const productionSources = (): SourceInput[] =>
+    SOURCE_ROOTS.flatMap((sourceRoot) =>
+        walkFiles(sourceRoot).map((filePath) => ({ filePath, sourceText: fs.readFileSync(filePath, 'utf8') }))
+    )
+
+const createAnalysisProgram = (sources: SourceInput[]): ts.Program => {
+    const compilerOptions: ts.CompilerOptions = {
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.Node10,
+        skipLibCheck: true,
+        target: ts.ScriptTarget.Latest,
+    }
+    const sourceTexts = new Map(sources.map(({ filePath, sourceText }) => [path.resolve(filePath), sourceText]))
+    const host = ts.createCompilerHost(compilerOptions)
+    const readFile = host.readFile.bind(host)
+    const fileExists = host.fileExists.bind(host)
+    const getSourceFile = host.getSourceFile.bind(host)
+
+    host.fileExists = (filePath) => sourceTexts.has(path.resolve(filePath)) || fileExists(filePath)
+    host.readFile = (filePath) => sourceTexts.get(path.resolve(filePath)) ?? readFile(filePath)
+    host.getSourceFile = (filePath, languageVersion, onError, shouldCreateNewSourceFile) => {
+        const sourceText = sourceTexts.get(path.resolve(filePath))
+        return isUndefined(sourceText)
+            ? getSourceFile(filePath, languageVersion, onError, shouldCreateNewSourceFile)
+            : ts.createSourceFile(filePath, sourceText, languageVersion, true)
+    }
+
+    return ts.createProgram({
+        rootNames: sources.map(({ filePath }) => path.resolve(filePath)),
+        options: compilerOptions,
+        host,
+    })
+}
+
+const collectPersistenceKeyIdentifiers = (sources: SourceInput[] = productionSources()): ScanResult => {
     const identifiers = new Set<string>()
+    const resolvedKeys = new Set<string>()
     const issues: string[] = []
-    const sourceRoot = path.resolve(__dirname, '..')
+    const program = createAnalysisProgram(sources)
+    const checker = program.getTypeChecker()
 
-    for (const filePath of walkFiles(sourceRoot)) {
-        const sourceText = fs.readFileSync(filePath, 'utf8')
-        const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true)
-        const variableInitializers = collectVariableInitializers(sourceFile)
+    for (const { filePath } of sources) {
+        const sourceFile = program.getSourceFile(path.resolve(filePath))
+        if (!sourceFile) {
+            issues.push(
+                `${path.relative(REPOSITORY_ROOT, filePath)} could not be loaded for persistence policy analysis`
+            )
+            continue
+        }
+        const relativeFilePath = path.relative(REPOSITORY_ROOT, filePath)
 
-        const recordResolution = (expression: ts.Expression | undefined, node: ts.Node, context: string) => {
-            if (expression && ts.isIdentifier(expression) && ['property', 'prop'].includes(expression.text)) {
+        const recordResolution = (
+            expression: ts.Expression | undefined,
+            node: ts.Node,
+            context: string,
+            enforceResolvedKey = false
+        ) => {
+            // Policy is checked at each client.kv write; the KeyValueStore implementation only forwards that runtime key.
+            if (isForwardedKeyValueStoreKey(expression, node, checker)) {
                 return
             }
 
-            // The extension KeyValueStore boundary intentionally accepts caller-owned keys verbatim.
             if (
-                filePath.endsWith('/extensions/browser-client.ts') &&
+                !enforceResolvedKey &&
                 expression &&
                 ts.isIdentifier(expression) &&
-                expression.text === 'key' &&
-                ['set', 'remove'].includes(getEnclosingClassMethodName(node) ?? '')
+                ['property', 'prop'].includes(expression.text)
             ) {
                 return
             }
 
-            const resolution = resolvePolicyIdentifiers(expression, variableInitializers)
+            const composition = analyzeKeyComposition(expression, checker)
+            if (composition.containsComposition) {
+                const recordComposition = (result: KeyCompositionResult): void => {
+                    if (result.alternatives) {
+                        result.alternatives.forEach(recordComposition)
+                        return
+                    }
+
+                    if (!isUndefined(result.staticValue) && result.staticValueIsNamed) {
+                        resolvedKeys.add(result.staticValue)
+                        if (!getPersistenceKeyPolicy(result.staticValue)) {
+                            issues.push(
+                                `${relativeFilePath}:${getLine(sourceFile, node)} ${context} uses ${JSON.stringify(result.staticValue)}, which has no persistence key policy`
+                            )
+                        }
+                        return
+                    }
+
+                    const registeredPrefix = result.dynamicPrefix
+                        ? [...PERSISTENCE_KEY_PREFIXES].find((prefix) => result.dynamicPrefix?.indexOf(prefix) === 0)
+                        : undefined
+                    if (!registeredPrefix || !result.dynamicPrefixIsNamed) {
+                        issues.push(
+                            `${relativeFilePath}:${getLine(sourceFile, node)} ${context} forms a dynamic key without a named, registered persistence key prefix`
+                        )
+                    } else {
+                        resolvedKeys.add(registeredPrefix)
+                    }
+                }
+
+                recordComposition(composition)
+                return
+            }
+
+            const resolution = resolvePolicyIdentifiers(expression, checker)
 
             resolution.identifiers.forEach((identifier) => identifiers.add(identifier))
+            resolution.resolvedKeys.forEach((key) => {
+                resolvedKeys.add(key)
+                if (!getPersistenceKeyPolicy(key)) {
+                    issues.push(
+                        `${relativeFilePath}:${getLine(sourceFile, node)} ${context} uses ${JSON.stringify(key)}, which has no persistence key policy`
+                    )
+                }
+            })
+
+            if (resolution.hasUnresolved) {
+                issues.push(
+                    `${relativeFilePath}:${getLine(sourceFile, node)} ${context} must resolve to a persistence key constant or registered prefix in every branch`
+                )
+                return
+            }
 
             if (resolution.rawLiterals.size > 0) {
                 issues.push(
-                    `${path.relative(sourceRoot, filePath)}:${getLine(sourceFile, node)} ${context} must use constants instead of raw literal keys: ${[
+                    `${relativeFilePath}:${getLine(sourceFile, node)} ${context} must use constants instead of raw literal keys: ${[
                         ...resolution.rawLiterals,
                     ].join(', ')}`
                 )
                 return
             }
 
-            if (resolution.identifiers.size === 0) {
+            if (resolution.identifiers.size === 0 && resolution.resolvedKeys.size === 0) {
                 issues.push(
-                    `${path.relative(sourceRoot, filePath)}:${getLine(sourceFile, node)} ${context} must resolve to a persistence key constant`
+                    `${relativeFilePath}:${getLine(sourceFile, node)} ${context} must resolve to a persistence key constant`
                 )
             }
         }
@@ -282,7 +543,7 @@ const collectPersistenceKeyIdentifiers = (): ScanResult => {
 
             if (!ts.isObjectLiteralExpression(argument)) {
                 issues.push(
-                    `${path.relative(sourceRoot, filePath)}:${getLine(sourceFile, node)} ${context} must use an object literal with computed constant keys`
+                    `${relativeFilePath}:${getLine(sourceFile, node)} ${context} must use an object literal with computed constant keys`
                 )
                 return
             }
@@ -299,7 +560,7 @@ const collectPersistenceKeyIdentifiers = (): ScanResult => {
                 }
 
                 issues.push(
-                    `${path.relative(sourceRoot, filePath)}:${getLine(sourceFile, property)} ${context} must use computed constant keys`
+                    `${relativeFilePath}:${getLine(sourceFile, property)} ${context} must use computed constant keys`
                 )
             }
         }
@@ -325,6 +586,14 @@ const collectPersistenceKeyIdentifiers = (): ScanResult => {
                     recordResolution(node.arguments[0], node, `${methodName}() on persistence`)
                 }
 
+                if (
+                    methodName &&
+                    KEY_VALUE_STORE_SINGLE_KEY_METHODS.has(methodName) &&
+                    isKeyValueStoreReceiver(receiver, checker)
+                ) {
+                    recordResolution(node.arguments[0], node, `${methodName}() on KeyValueStore`, true)
+                }
+
                 if (methodName && SESSION_OBJECT_METHODS.has(methodName) && isRegisterForSessionReceiver(receiver)) {
                     recordObjectLike(node.arguments[0], node, `${methodName}()`)
                 }
@@ -348,7 +617,7 @@ const collectPersistenceKeyIdentifiers = (): ScanResult => {
         visit(sourceFile)
     }
 
-    return { identifiers, issues }
+    return { identifiers, resolvedKeys, issues }
 }
 
 const getEnclosingClassMethodName = (node: ts.Node): string | undefined => {
@@ -368,6 +637,59 @@ const getEnclosingClassMethodName = (node: ts.Node): string | undefined => {
     }
 
     return undefined
+}
+
+const isBrowserCommonKeyValueStoreSymbol = (symbol: ts.Symbol | undefined): boolean =>
+    !!symbol?.declarations?.some((declaration) => {
+        const declarationName = 'name' in declaration ? declaration.name : undefined
+        const filePath = declaration.getSourceFile().fileName.replace(/\\/g, '/')
+        return (
+            !!declarationName &&
+            ts.isIdentifier(declarationName) &&
+            declarationName.text === 'KeyValueStore' &&
+            /\/packages\/browser-common\/(?:src|dist)\/persistence(?:\.d)?\.ts$/.test(filePath)
+        )
+    })
+
+const isForwardedKeyValueStoreKey = (
+    expression: ts.Expression | undefined,
+    node: ts.Node,
+    checker: ts.TypeChecker
+): boolean => {
+    if (!expression || !ts.isIdentifier(expression)) {
+        return false
+    }
+
+    let current: ts.Node | undefined = node
+    while (current) {
+        if (ts.isMethodDeclaration(current) && current.name && ts.isIdentifier(current.name)) {
+            const keyParameter = current.parameters[0]?.name
+            if (
+                !KEY_VALUE_STORE_SINGLE_KEY_METHODS.has(current.name.text) ||
+                !keyParameter ||
+                !ts.isIdentifier(keyParameter) ||
+                getResolvedSymbol(keyParameter, checker) !== getResolvedSymbol(expression, checker)
+            ) {
+                return false
+            }
+
+            const classDeclaration = current.parent
+            if (!ts.isClassDeclaration(classDeclaration) && !ts.isClassExpression(classDeclaration)) {
+                return false
+            }
+
+            return !!classDeclaration.heritageClauses?.some(
+                (clause) =>
+                    clause.token === ts.SyntaxKind.ImplementsKeyword &&
+                    clause.types.some((type) =>
+                        isBrowserCommonKeyValueStoreSymbol(getResolvedSymbol(type.expression, checker))
+                    )
+            )
+        }
+        current = current.parent
+    }
+
+    return false
 }
 
 const isThisPropsElementAccess = (expression: ts.Expression): boolean => {
@@ -482,12 +804,7 @@ describe('persistence key policy', () => {
 
     it('classifies SDK-owned persistence keys and forbids raw literal keys at persistence write sites', () => {
         const exactPolicyKeys = new Set(Object.keys(PERSISTENCE_KEY_POLICY))
-        const prefixPolicyKeys = new Set([
-            constants.SESSION_RECORDING_TRIGGER_V2_GROUP_EVENT_PREFIX,
-            constants.SESSION_RECORDING_TRIGGER_V2_GROUP_URL_PREFIX,
-            constants.SESSION_RECORDING_TRIGGER_V2_GROUP_SAMPLING_PREFIX,
-        ])
-        const { identifiers, issues } = collectPersistenceKeyIdentifiers()
+        const { identifiers, resolvedKeys, issues } = collectPersistenceKeyIdentifiers()
 
         expect(issues).toEqual([])
 
@@ -497,11 +814,189 @@ describe('persistence key policy', () => {
             expect(value).toBeDefined()
 
             if (identifier.endsWith('_PREFIX')) {
-                expect(prefixPolicyKeys.has(value as string)).toBe(true)
+                expect(PERSISTENCE_KEY_PREFIXES.has(value as string)).toBe(true)
             } else {
                 expect(exactPolicyKeys.has(value as string)).toBe(true)
             }
         }
+
+        for (const key of resolvedKeys) {
+            expect(getPersistenceKeyPolicy(key)).toBeDefined()
+        }
+    })
+
+    it('checks direct and aliased KeyValueStore writes against the host persistence policy', () => {
+        const analyze = (sourceText: string): ScanResult =>
+            collectPersistenceKeyIdentifiers([
+                {
+                    filePath: path.join(REPOSITORY_ROOT, 'packages/browser-common/src/extensions/example.ts'),
+                    sourceText,
+                },
+            ])
+        const knownKey = analyze(`
+            const EXTENSION_KEY = '${constants.AUTOCAPTURE_DISABLED_SERVER_SIDE}'
+            client.kv.set(EXTENSION_KEY, true)
+            const store = client.kv
+            store.set(EXTENSION_KEY, true)
+            const { kv: destructuredStore } = client
+            destructuredStore.remove(EXTENSION_KEY)
+        `)
+
+        expect(knownKey.issues).toEqual([])
+        expect([...knownKey.resolvedKeys]).toEqual([constants.AUTOCAPTURE_DISABLED_SERVER_SIDE])
+
+        const unknownKey = analyze(`
+            const EXTENSION_KEY = '$unclassified_extension_key'
+            const store = client.kv
+            store.set(EXTENSION_KEY, true)
+        `)
+        expect(unknownKey.issues).toEqual([
+            expect.stringContaining(
+                'set() on KeyValueStore uses "$unclassified_extension_key", which has no persistence key policy'
+            ),
+        ])
+
+        const rawKey = analyze(`client.kv.set('$raw_extension_key', true)`)
+        expect(rawKey.issues).toEqual([
+            expect.stringContaining('set() on KeyValueStore must use constants instead of raw literal keys'),
+        ])
+
+        const dynamicPrefix = analyze(`
+            const GROUP_PREFIX = '${constants.SESSION_RECORDING_TRIGGER_V2_GROUP_EVENT_PREFIX}'
+            function persist(groupId: string): void {
+                client.kv.set(GROUP_PREFIX + groupId, true)
+            }
+        `)
+        expect(dynamicPrefix.issues).toEqual([])
+
+        const compositeExactKey = analyze(`
+            const EXTENSION_KEY = '${constants.AUTOCAPTURE_DISABLED_SERVER_SIDE}'
+            function persist(extensionId: string): void {
+                client.kv.set(EXTENSION_KEY + extensionId, true)
+            }
+        `)
+        expect(compositeExactKey.issues).toEqual([
+            expect.stringContaining(
+                'set() on KeyValueStore forms a dynamic key without a named, registered persistence key prefix'
+            ),
+        ])
+
+        const classFieldAlias = analyze(`
+            class Extension {
+                private store = client.kv
+                persist(): void {
+                    const EXTENSION_KEY = '$unclassified_extension_key'
+                    this.store.set(EXTENSION_KEY, true)
+                }
+            }
+        `)
+        expect(classFieldAlias.issues).toEqual([
+            expect.stringContaining(
+                'set() on KeyValueStore uses "$unclassified_extension_key", which has no persistence key policy'
+            ),
+        ])
+
+        const shadowedKey = analyze(`
+            const EXTENSION_KEY = '${constants.AUTOCAPTURE_DISABLED_SERVER_SIDE}'
+            function persist(EXTENSION_KEY: string): void {
+                client.kv.set(EXTENSION_KEY, true)
+            }
+        `)
+        expect(shadowedKey.issues).toEqual([
+            expect.stringContaining('set() on KeyValueStore must resolve to a persistence key constant'),
+        ])
+
+        const scopedKeys = analyze(`
+            function persistKnown(): void {
+                const EXTENSION_KEY = '${constants.AUTOCAPTURE_DISABLED_SERVER_SIDE}'
+                client.kv.set(EXTENSION_KEY, true)
+            }
+            function persistUnknown(): void {
+                const EXTENSION_KEY = '$unclassified_extension_key'
+                client.kv.set(EXTENSION_KEY, true)
+            }
+        `)
+        expect(scopedKeys.issues).toEqual([
+            expect.stringContaining(
+                'set() on KeyValueStore uses "$unclassified_extension_key", which has no persistence key policy'
+            ),
+        ])
+
+        const conditionalKey = analyze(`
+            const EXTENSION_KEY = '${constants.AUTOCAPTURE_DISABLED_SERVER_SIDE}'
+            function persist(useKnown: boolean, runtimeKey: string): void {
+                client.kv.set(useKnown ? EXTENSION_KEY : runtimeKey, true)
+            }
+        `)
+        expect(conditionalKey.issues).toEqual([
+            expect.stringContaining(
+                'set() on KeyValueStore must resolve to a persistence key constant or registered prefix in every branch'
+            ),
+        ])
+    })
+
+    it('analyzes callers instead of a KeyValueStore implementation forwarding its runtime key', () => {
+        const persistencePath = path.join(REPOSITORY_ROOT, 'packages/browser-common/src/persistence.ts')
+        const browserClientPath = path.join(REPOSITORY_ROOT, 'packages/browser/src/extensions/browser-client.ts')
+        const analyze = (sourceText: string): ScanResult =>
+            collectPersistenceKeyIdentifiers([
+                {
+                    filePath: persistencePath,
+                    sourceText: `
+                        export interface KeyValueStore {
+                            set(key: string, value: unknown): void
+                            remove(key: string): void
+                        }
+                    `,
+                },
+                { filePath: browserClientPath, sourceText },
+            ])
+        const keyValueStore = analyze(`
+            import type { KeyValueStore as BrowserKeyValueStore } from '../../../browser-common/src/persistence'
+            class Store implements BrowserKeyValueStore {
+                set(storageKey: string, value: unknown): void {
+                    persistence.set_property(storageKey, value)
+                }
+                remove(storageKey: string): void {
+                    persistence.unregister(storageKey)
+                }
+            }
+        `)
+        expect(keyValueStore.issues).toEqual([])
+
+        const unrelatedWrapper = analyze(`
+            interface KeyValueStore {
+                set(key: string, value: unknown): void
+            }
+            class Store implements KeyValueStore {
+                set(storageKey: string, value: unknown): void {
+                    persistence.set_property(storageKey, value)
+                }
+            }
+        `)
+        expect(unrelatedWrapper.issues).toEqual([
+            expect.stringContaining('set_property() on persistence must resolve to a persistence key constant'),
+        ])
+
+        const shadowedForwardingKey = analyze(`
+            import type { KeyValueStore as BrowserKeyValueStore } from '../../../browser-common/src/persistence'
+            class Store implements BrowserKeyValueStore {
+                set(storageKey: string, value: unknown): void {
+                    persistence.set_property(storageKey, value)
+                    const writeShadowedKey = (): void => {
+                        const storageKey = '$raw_extension_key'
+                        persistence.set_property(storageKey, value)
+                    }
+                    writeShadowedKey()
+                }
+                remove(storageKey: string): void {
+                    persistence.unregister(storageKey)
+                }
+            }
+        `)
+        expect(shadowedForwardingKey.issues).toEqual([
+            expect.stringContaining('set_property() on persistence must use constants instead of raw literal keys'),
+        ])
     })
 
     describe('storageGroup', () => {

--- a/packages/browser/src/extensions/browser-client.ts
+++ b/packages/browser/src/extensions/browser-client.ts
@@ -31,16 +31,16 @@ import type {
 class BrowserExtensionKeyValueStore implements KeyValueStore {
     constructor(private readonly _instance: PostHog) {}
 
-    get<T = unknown>(prop: string): T | undefined {
-        return this._instance.persistence?.get_property(prop) as T | undefined
+    get<T = unknown>(key: string): T | undefined {
+        return this._instance.persistence?.get_property(key) as T | undefined
     }
 
-    set(prop: string, value: unknown): void {
-        this._instance.persistence?.set_property(prop, value as Property)
+    set(key: string, value: unknown): void {
+        this._instance.persistence?.set_property(key, value as Property)
     }
 
-    remove(prop: string): void {
-        this._instance.persistence?.unregister(prop)
+    remove(key: string): void {
+        this._instance.persistence?.unregister(key)
     }
 }
 

--- a/packages/browser/src/extensions/browser-client.ts
+++ b/packages/browser/src/extensions/browser-client.ts
@@ -28,7 +28,7 @@ import type {
     RemoteConfigResult,
 } from '../types'
 
-class BrowserExtensionKeyValueStore implements KeyValueStore {
+class BrowserClientKeyValueStore implements KeyValueStore {
     constructor(private readonly _instance: PostHog) {}
 
     get<T = unknown>(key: string): T | undefined {
@@ -60,7 +60,7 @@ export class BrowserClientAdapter implements Client, Disposable {
     constructor(readonly instance: PostHog) {
         this._logger = logger.createLogger('[BrowserExtensions]')
         this._latestRemoteConfigResult = instance._lastRemoteConfig
-        this.kv = new BrowserExtensionKeyValueStore(instance)
+        this.kv = new BrowserClientKeyValueStore(instance)
         this.onEvent = (handler) => {
             const unsubscribe = this.instance.on('eventCaptured', (event) => {
                 try {


### PR DESCRIPTION
## Problem

The persistence key policy test only analyzes browser-v1's direct persistence writes. Shared extensions write through `Client.kv`, so SDK-owned keys in browser-common could otherwise bypass host policy coverage and unintentionally become event properties.

Stacked on #4301, which adds the browser client adapter.

## Changes

- Scan production sources in both `packages/browser` and `packages/browser-common` for direct and aliased `KeyValueStore` writes.
- Use TypeScript symbols to resolve key constants with lexical scope, including destructured and class-field store aliases.
- Require every key branch to map to a host persistence policy; dynamic keys are allowed only beneath a named, registered prefix policy.
- Model the canonical browser-common `KeyValueStore` implementation as a forwarding boundary while analyzing its SDK-owned callers.
- Add regression coverage for raw and unknown keys, aliases, shadowing, conditional and composite keys, registered prefixes, and forwarding boundaries.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prepared with the Pi coding agent and focused reviewer passes in a local session. The analysis was kept in a separate stacked PR so the browser adapter and policy enforcement remain independently reviewable.
