### PR TITLE
fix(surveys): only wait for feature flags on surveys that repeat

### DIFF
--- a/.changeset/survey-flag-load-wait-scope.md
+++ b/.changeset/survey-flag-load-wait-scope.md
@@ -1,0 +1,16 @@
+---
+'posthog-js': patch
+'@posthog/core': patch
+---
+
+fix(surveys): only wait for feature flags on surveys that repeat
+
+Surveys stopped being shown while feature flags were still loading, even when a cached
+enabled value for their internal targeting flag was already available. Popover and widget
+surveys recovered on the next evaluation, but a survey your own code renders (type `api`)
+is evaluated once, so it was dropped for that page load and never reappeared.
+
+That wait is only needed for surveys that repeat, where stored per-survey state is keyed by
+iteration and cannot be relied on to record that someone already answered. Other surveys
+keep one stable key that already prevents a repeat display, so they are now evaluated
+against the cached flag right away.

--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -18,6 +18,7 @@ import {
     SurveyQuestion,
     SurveyQuestionBranchingType,
     SurveyQuestionType,
+    SurveySchedule,
     SurveyType,
 } from '../posthog-surveys-types'
 import { FlagsResponse, PostHogConfig, Properties, RemoteConfig } from '../types'
@@ -44,6 +45,8 @@ describe('surveys', () => {
             'survey-targeting-flag-key2': false,
             'enabled-internal-targeting-flag-key': true,
             'disabled-internal-targeting-flag-key': false,
+            'survey-targeting-835605292e': true,
+            'survey-targeting-b3276efeb6-custom': true,
         },
         surveys: true,
     } as unknown as FlagsResponse
@@ -566,6 +569,75 @@ describe('surveys', () => {
             linked_flag_key: 'linked-flag-key',
             targeting_flag_key: 'survey-targeting-flag-key',
         } as unknown as Survey
+
+        const apiSurveyWithCachedTargetingFlags: Survey = {
+            id: 'api-survey-with-cached-targeting-flags',
+            name: 'API survey with cached targeting flags',
+            type: SurveyType.API,
+            schedule: SurveySchedule.Once,
+            start_date: new Date().toISOString(),
+            end_date: null,
+            targeting_flag_key: 'survey-targeting-835605292e',
+            internal_targeting_flag_key: 'survey-targeting-b3276efeb6-custom',
+            questions: [
+                {
+                    type: SurveyQuestionType.Rating,
+                    question: 'How satisfied are you?',
+                    display: 'number',
+                    scale: 5,
+                    lowerBoundLabel: 'Not satisfied',
+                    upperBoundLabel: 'Very satisfied',
+                },
+            ],
+        } as unknown as Survey
+
+        // Waiting for flags before trusting the internal targeting flag is only safe for
+        // iteration-based surveys, whose stored seen key rolls over. Applying it to a `once`
+        // survey with a cached enabled flag denies eligibility for the whole pre-flags window,
+        // and API surveys never get a second evaluation to recover on.
+        const deferredBeforeFlagsLoad = {
+            eligible: false,
+            reason: 'Feature flags have not loaded yet; deferring internal targeting flag check',
+        }
+
+        it.each([
+            { schedule: SurveySchedule.Once, currentIteration: null, expected: { eligible: true } },
+            { schedule: SurveySchedule.Once, currentIteration: 0, expected: { eligible: true } },
+            { schedule: SurveySchedule.Once, currentIteration: 1, expected: deferredBeforeFlagsLoad },
+            { schedule: SurveySchedule.Recurring, currentIteration: null, expected: deferredBeforeFlagsLoad },
+            { schedule: SurveySchedule.Recurring, currentIteration: 2, expected: deferredBeforeFlagsLoad },
+        ])(
+            'checks a $schedule survey on iteration $currentIteration against a cached internal targeting flag before flags load',
+            ({ schedule, currentIteration, expected }) => {
+                instance.featureFlags.hasLoadedFlags = false
+                const surveyManager = (surveys as any)._surveyManager as SurveyManager
+
+                expect(
+                    surveyManager.checkSurveyEligibility({
+                        ...apiSurveyWithCachedTargetingFlags,
+                        schedule,
+                        current_iteration: currentIteration,
+                    } as Survey)
+                ).toEqual(expected)
+            }
+        )
+
+        // A caller that asks once gets exactly one answer, so a `once` survey wrongly deferred here
+        // is lost for that page rather than delayed. Both rows share one fixture and one call, which
+        // keeps the result attributable to the flag-loading state.
+        it.each([
+            { state: 'have not loaded', hasLoadedFlags: false },
+            { state: 'have loaded', hasLoadedFlags: true },
+        ])('returns a cached-eligible API survey to a one-shot caller when flags $state', ({ hasLoadedFlags }) => {
+            instance.featureFlags.hasLoadedFlags = hasLoadedFlags
+            instance.persistence?.register({ $surveys: [apiSurveyWithCachedTargetingFlags] })
+            const callback = jest.fn()
+
+            surveys.getActiveMatchingSurveys(callback)
+
+            expect(callback).toHaveBeenCalledTimes(1)
+            expect(callback).toHaveBeenCalledWith([apiSurveyWithCachedTargetingFlags])
+        })
 
         it('returns surveys that are active', () => {
             surveysResponse = { surveys: [draftSurvey, activeSurvey, completedSurvey] }

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -24,6 +24,7 @@ import {
     doesSurveyActivateByAction,
     doesSurveyActivateByEvent,
     IN_APP_SURVEY_TYPES,
+    isSurveyIterationBased,
     isSurveyRunning,
     SURVEY_LOGGER as logger,
 } from '../utils/survey-utils'
@@ -593,7 +594,23 @@ export class SurveyManager {
         // SDK serves the previous value from cache until the next /flags load. Trusting that stale
         // value on a revisit re-displays the survey and records a duplicate response, so wait until
         // flags have actually (re)loaded this session before relying on the internal targeting flag.
-        if (survey.internal_targeting_flag_key && !this._posthog.featureFlags?.hasLoadedFlags) {
+        //
+        // Only iteration-based surveys need that wait: their stored seen state is keyed by iteration
+        // and rolls over, leaving the flag as the sole duplicate gate. Any other survey keeps one
+        // stable seen key that already blocks re-display, and waiting there costs real eligibility,
+        // permanently so for a caller that asks once and never asks again.
+        //
+        // The gap this accepts: a response recorded on another device, or a cleared localStorage,
+        // leaves no seen key here while this browser can still hold a cached enabled flag, so the
+        // survey can display once more before the next /flags load corrects it. A zero-delay popover
+        // is already rendered by then and no later evaluation withdraws it. Waiting on flags closes
+        // that gap but drops every impression in the pre-flags window, which is the larger loss, so
+        // do not widen this condition back out without replacing what it costs.
+        if (
+            survey.internal_targeting_flag_key &&
+            isSurveyIterationBased(survey) &&
+            !this._posthog.featureFlags?.hasLoadedFlags
+        ) {
             return {
                 satisfied: false,
                 reason: 'Feature flags have not loaded yet; deferring internal targeting flag check',

--- a/packages/browser/src/utils/survey-utils.ts
+++ b/packages/browser/src/utils/survey-utils.ts
@@ -3,7 +3,7 @@ import { getSurveyIterationKey } from '@posthog/core/surveys'
 import { DisplaySurveyOptions, Survey, SurveyType, DisplaySurveyType } from '../posthog-surveys-types'
 import { createLogger } from '@posthog/browser-common/utils/logger'
 
-export { doesSurveyActivateByEvent, getSurveyInteractionProperty } from '@posthog/core/surveys'
+export { doesSurveyActivateByEvent, getSurveyInteractionProperty, isSurveyIterationBased } from '@posthog/core/surveys'
 
 export const SURVEY_LOGGER = createLogger('[Surveys]')
 

--- a/packages/core/src/surveys/activation.ts
+++ b/packages/core/src/surveys/activation.ts
@@ -26,3 +26,15 @@ export function canSurveyActivateRepeatedly(survey: SurveyForRepeatActivation): 
     survey.schedule === SurveySchedule.Always
   )
 }
+
+type SurveyForIterationCheck = Pick<Survey, 'schedule' | 'current_iteration'>
+
+/**
+ * True when a survey is meant to come back around on its own: a recurring schedule, or an
+ * iteration already under way. Stored display state is keyed by iteration
+ * (see `getSurveyIterationKey`), so for these surveys it rolls over and stops being a
+ * dependable "already answered" record; other surveys keep one stable key for good.
+ */
+export function isSurveyIterationBased(survey: SurveyForIterationCheck): boolean {
+  return survey.schedule === SurveySchedule.Recurring || (survey.current_iteration ?? 0) > 0
+}

--- a/packages/core/src/surveys/index.ts
+++ b/packages/core/src/surveys/index.ts
@@ -16,5 +16,5 @@ export {
   getLanguageFromStoredPersonProperties,
   normalizeLanguageCode,
 } from './translations'
-export { canSurveyActivateRepeatedly, doesSurveyActivateByEvent } from './activation'
+export { canSurveyActivateRepeatedly, doesSurveyActivateByEvent, isSurveyIterationBased } from './activation'
 export { getSurveyIterationKey, isSurveyKeyForSurvey, type SurveyWithIteration } from './keys'


### PR DESCRIPTION
## Problem

Surveys stopped being offered while feature flags were still loading, even when an enabled value for their internal targeting flag was already cached.

Popover and widget surveys recover on the next tick of the display loop, so they only lose fast-bouncing users. A survey the embedding app renders itself (`type: 'api'`) is evaluated once: `callSurveysAndEvaluateDisplayLogic` filters its retry loop to popover and widget, and `getSurveys` serves cached definitions synchronously, so a one-shot `getActiveMatchingSurveys` caller sees the pre-flags answer and is never called again. For those integrations the survey silently disappeared on warm page loads.

The pattern in our own `onSurveysLoaded` docstring is one of the affected ones, since `onSurveysLoaded` fires on the surveys fetch and nothing re-fires it when flags land.

Note this reaches every customer regardless of their pinned version: `loadExternalDependency` requests `/static/surveys.js?v=<version>` unless `strict_script_versioning` is set, so the `?v=` is a cache-buster and the CDN serves the currently deployed extension bundle (`cache-control: max-age=14400`).

## Changes

The wait was introduced in #4206 to stop a repeating survey re-displaying off a stale internal targeting flag and recording a duplicate response. That risk is real, but it is specific to surveys that repeat: their stored seen state is keyed by iteration (`getSurveyIterationKey` -> `id_2`), so it rolls over and stops being a dependable record that someone already answered, leaving the flag as the only duplicate gate.

Every other survey keeps one stable seen key, and the existing `getSurveySeen` gate already blocks re-display. So for those the wait prevented nothing and cost real eligibility.

This scopes the wait to iteration-based surveys via a shared `isSurveyIterationBased` predicate, placed next to `canSurveyActivateRepeatedly` so the scheduling rules stay in one place. #4206's own regression tests are unchanged and still pass, so repeating surveys are still held back until flags load.

Deliberately not addressed here: a repeating `api` survey still gets one pre-flags answer and no second evaluation. Closing that needs survey callbacks to re-run when flags load, which is a larger change than this fix.

### One trade-off worth a maintainer's opinion

A cross-model review raised this, and I want it seen rather than buried: for a `once` survey, a response recorded on **another device** (or a cleared `localStorage`) leaves no `seenSurvey_*` key in this browser, while this browser can still hold a cached enabled internal flag. So the survey can display one extra time before the next `/flags` load corrects it, and for a zero-delay popover it is already rendered by then (`_surveyTimeouts` no longer holds it, so `cancelSurvey` cannot withdraw it).

This is the pre-#4206 behavior, which stood for a long time without reports, and it cannot be resolved locally: nothing in the browser distinguishes "cached value is correct" from "cached value is stale because another device answered". The choice is one possible duplicate impression for a cross-device user, versus losing every impression in the pre-flags window for everyone. I took the first, and left a comment at the call site recording the accepted gap so the next person does not re-widen the condition without weighing what it costs. Happy to be overruled, since it is a product judgment more than a code one.

### Docs follow-up (separate PR)

`contents/docs/surveys/implementing-custom-surveys.mdx` needs a companion change in `PostHog/posthog.com`: its `getActiveMatchingSurveys` example is a one-shot call in a `useEffect`, which is the exact shape this bug hits, and the surrounding text claims the method "always returns an active survey if the user meets the display conditions". That claim needs a caveat regardless of this fix, since a repeating survey still depends on flags having loaded.

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/core

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code (PostHog Code) after a report of a large drop in survey submissions, using the PostHog MCP for read-only event queries and Codex for a cross-model review of this branch.

Route to the diagnosis, including one wrong turn worth recording:

- Response rate per impression *rose* across the drop, and the targeted population was flat, so rendering, submission, and targeting were all ruled out. The loss was upstream, in eligibility.
- The affected project's `$lib_version` was well below the release carrying #4206, which initially looked like it exonerated the SDK. That was wrong: the surveys extension loads from an unversioned CDN path, so `$lib_version` describes the host bundle, not the extension. Fetching the deployed `surveys.js` from both regions confirmed the guard is live for everyone.
- Per-survey reach then split as the guard predicts rather than collapsing org-wide, which ruled out a flags quota block and pointed at the eligibility gate.

On the fix itself: reverting #4206 was rejected because it would reintroduce the duplicate-response bug. A marker-based approach (record a pending interaction, clear it on the next flags load) was also rejected as it needs correct ordering between the interaction and the flag refresh across page loads, which is more machinery than the problem needs. Scoping by iteration is what actually distinguishes "the flag is the only gate" from "localStorage already gates this."

Verification: 1680 passed / 4 skipped across 49 suites under the repo's jest config. As a negative control, removing only the new `isSurveyIterationBased(survey)` term fails exactly the two new `once`-schedule cases while the recurring cases stay green, so the tests are pinned to this discriminator and not to the guard as a whole. Verifying locally requires building `@posthog/browser-common` and `@posthog/core` first, since the browser jest config maps their sub-paths to source but resolves bare specifiers through `dist`. No manual browser testing was performed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
