### PR TITLE
fix(browser): preserve slim extension bundle ABI

### DIFF
--- a/.changeset/fuzzy-pandas-wave.md
+++ b/.changeset/fuzzy-pandas-wave.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix extension bundles when used with the slim no-external browser build.

--- a/packages/browser/playground/slim-bundle/index.html
+++ b/packages/browser/playground/slim-bundle/index.html
@@ -7,7 +7,6 @@
     <div id="status">loading...</div>
 
     <script type="module">
-        import posthog from '/dist/module.slim.js'
         import {
             AllExtensions,
             FeatureFlagsExtensions,
@@ -23,6 +22,10 @@
             SiteAppsExtensions,
             TracingExtensions,
         } from '/dist/extension-bundles.js'
+
+        const bundle = new URLSearchParams(window.location.search).get('bundle')
+        const slimBundle = bundle === 'no-external' ? 'module.slim.no-external.js' : 'module.slim.js'
+        const { default: posthog } = await import(`/dist/${slimBundle}`)
 
         window.posthog = posthog
         window.AllExtensions = AllExtensions

--- a/packages/browser/playwright/mocked/slim-bundle.spec.ts
+++ b/packages/browser/playwright/mocked/slim-bundle.spec.ts
@@ -13,9 +13,16 @@ import { PostHog } from '@/posthog-core'
  * For example, `_internalEventEmitter` might be mangled to `ti` in extension-bundles
  * but `oe` in module.slim, so `PostHogFeatureFlags.reloadFeatureFlags()` crashes with:
  *   TypeError: Cannot read properties of undefined (reading 'emit')
+ *
+ * module.slim.no-external intentionally preserves private property names, so the
+ * extension bundle must reserve every private property exchanged across that boundary.
  */
 
 const SLIM_BUNDLE_URL = '/playground/slim-bundle/index.html'
+const SLIM_BUNDLES = [
+    { name: 'module.slim.js', url: SLIM_BUNDLE_URL },
+    { name: 'module.slim.no-external.js', url: `${SLIM_BUNDLE_URL}?bundle=no-external` },
+] as const
 
 /** Helper: wait for ES modules on the page to finish loading. */
 async function waitForSlimBundleReady(page: import('@playwright/test').Page) {
@@ -107,286 +114,356 @@ test.describe('slim bundle + extension bundles (#3313)', () => {
         })
     })
 
-    // ── FeatureFlagsExtensions ──────────────────────────────────────────
+    for (const slimBundle of SLIM_BUNDLES) {
+        test.describe(slimBundle.name, () => {
+            // ── FeatureFlagsExtensions ──────────────────────────────────────────
 
-    test('FeatureFlagsExtensions: init does not crash', async ({ page }) => {
-        const errors: string[] = []
-        page.on('pageerror', (error) => errors.push(error.message))
+            test('FeatureFlagsExtensions: init does not crash', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
 
-        await page.goto(SLIM_BUNDLE_URL)
-        await waitForSlimBundleReady(page)
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
 
-        const initError = await initPostHogWithExtensions(page, 'FeatureFlagsExtensions')
-        await page.waitForTimeout(1000)
+                const initError = await initPostHogWithExtensions(page, 'FeatureFlagsExtensions')
+                await page.waitForTimeout(1000)
 
-        expect(initError).toBeNull()
-        expect(errors).toEqual([])
-    })
+                expect(initError).toBeNull()
+                expect(errors).toEqual([])
+            })
 
-    test('FeatureFlagsExtensions: reloadFeatureFlags does not crash', async ({ page }) => {
-        const errors: string[] = []
-        page.on('pageerror', (error) => errors.push(error.message))
+            test('FeatureFlagsExtensions: reloadFeatureFlags does not crash', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
 
-        await page.goto(SLIM_BUNDLE_URL)
-        await waitForSlimBundleReady(page)
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
 
-        const error = await page.evaluate(() => {
-            try {
-                const ph = (window as any).posthog as PostHog
-                const extensions = (window as any).FeatureFlagsExtensions
-                ph.init('test-token', {
-                    api_host: 'https://localhost:1234',
-                    debug: true,
-                    ip: false,
-                    capture_pageview: false,
-                    __extensionClasses: { ...extensions },
-                    opt_out_useragent_filter: true,
-                } as Partial<PostHogConfig>)
-                ph.reloadFeatureFlags()
-                return null
-            } catch (e: any) {
-                return e.message
-            }
-        })
+                const error = await page.evaluate(() => {
+                    try {
+                        const ph = (window as any).posthog as PostHog
+                        const extensions = (window as any).FeatureFlagsExtensions
+                        ph.init('test-token', {
+                            api_host: 'https://localhost:1234',
+                            debug: true,
+                            ip: false,
+                            capture_pageview: false,
+                            __extensionClasses: { ...extensions },
+                            opt_out_useragent_filter: true,
+                        } as Partial<PostHogConfig>)
+                        ph.reloadFeatureFlags()
+                        return null
+                    } catch (e: any) {
+                        return e.message
+                    }
+                })
 
-        await page.waitForTimeout(1000)
-        expect(error).toBeNull()
-        expect(errors).toEqual([])
-    })
+                await page.waitForTimeout(1000)
+                expect(error).toBeNull()
+                expect(errors).toEqual([])
+            })
 
-    test('FeatureFlagsExtensions: getFeatureFlag works with bootstrapped flags', async ({ page }) => {
-        const errors: string[] = []
-        page.on('pageerror', (error) => errors.push(error.message))
+            test('FeatureFlagsExtensions: getFeatureFlag works with bootstrapped flags', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
 
-        await page.goto(SLIM_BUNDLE_URL)
-        await waitForSlimBundleReady(page)
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
 
-        const flagValue = await page.evaluate(() => {
-            try {
-                const ph = (window as any).posthog as PostHog
-                const extensions = (window as any).FeatureFlagsExtensions
-                ph.init('test-token', {
-                    api_host: 'https://localhost:1234',
-                    debug: true,
-                    ip: false,
-                    capture_pageview: false,
-                    __extensionClasses: { ...extensions },
-                    opt_out_useragent_filter: true,
-                    bootstrap: { featureFlags: { 'test-flag': true } },
-                } as Partial<PostHogConfig>)
-                return { value: ph.getFeatureFlag('test-flag'), error: null }
-            } catch (e: any) {
-                return { value: null, error: e.message }
-            }
-        })
+                const flagValue = await page.evaluate(() => {
+                    try {
+                        const ph = (window as any).posthog as PostHog
+                        const extensions = (window as any).FeatureFlagsExtensions
+                        ph.init('test-token', {
+                            api_host: 'https://localhost:1234',
+                            debug: true,
+                            ip: false,
+                            capture_pageview: false,
+                            __extensionClasses: { ...extensions },
+                            opt_out_useragent_filter: true,
+                            bootstrap: { featureFlags: { 'test-flag': true } },
+                        } as Partial<PostHogConfig>)
+                        return { value: ph.getFeatureFlag('test-flag'), error: null }
+                    } catch (e: any) {
+                        return { value: null, error: e.message }
+                    }
+                })
 
-        expect(flagValue.error).toBeNull()
-        expect(flagValue.value).toBe(true)
-        expect(errors).toEqual([])
-    })
+                expect(flagValue.error).toBeNull()
+                expect(flagValue.value).toBe(true)
+                expect(errors).toEqual([])
+            })
 
-    // ── ErrorTrackingExtensions ─────────────────────────────────────────
+            // ── ErrorTrackingExtensions ─────────────────────────────────────────
 
-    test('ErrorTrackingExtensions: captureException does not crash', async ({ page }) => {
-        const errors: string[] = []
-        page.on('pageerror', (error) => errors.push(error.message))
+            test('ErrorTrackingExtensions: captureException does not crash', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
 
-        await page.goto(SLIM_BUNDLE_URL)
-        await waitForSlimBundleReady(page)
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
 
-        const error = await page.evaluate(() => {
-            try {
-                const ph = (window as any).posthog as PostHog
-                const extensions = (window as any).ErrorTrackingExtensions
-                ph.init('test-token', {
-                    api_host: 'https://localhost:1234',
-                    debug: true,
-                    ip: false,
-                    capture_pageview: false,
-                    __extensionClasses: { ...extensions },
-                    opt_out_useragent_filter: true,
-                } as Partial<PostHogConfig>)
-                ph.captureException(new Error('test error'), { extra: 'data' })
-                return null
-            } catch (e: any) {
-                return e.message
-            }
-        })
+                const error = await page.evaluate(() => {
+                    try {
+                        const ph = (window as any).posthog as PostHog
+                        const extensions = (window as any).ErrorTrackingExtensions
+                        ph.init('test-token', {
+                            api_host: 'https://localhost:1234',
+                            debug: true,
+                            ip: false,
+                            capture_pageview: false,
+                            __extensionClasses: { ...extensions },
+                            opt_out_useragent_filter: true,
+                        } as Partial<PostHogConfig>)
+                        ph.captureException(new Error('test error'), { extra: 'data' })
+                        return null
+                    } catch (e: any) {
+                        return e.message
+                    }
+                })
 
-        await page.waitForTimeout(1000)
-        expect(error).toBeNull()
-        expect(errors).toEqual([])
-    })
+                await page.waitForTimeout(1000)
+                expect(error).toBeNull()
+                expect(errors).toEqual([])
+            })
 
-    // ── ToolbarExtensions ───────────────────────────────────────────────
+            // ── ToolbarExtensions ───────────────────────────────────────────────
 
-    test('ToolbarExtensions: loadToolbar does not crash', async ({ page }) => {
-        const errors: string[] = []
-        page.on('pageerror', (error) => errors.push(error.message))
+            test('ToolbarExtensions: loadToolbar does not crash', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
 
-        await page.goto(SLIM_BUNDLE_URL)
-        await waitForSlimBundleReady(page)
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
 
-        const error = await page.evaluate(() => {
-            try {
-                const ph = (window as any).posthog as PostHog
-                const extensions = (window as any).ToolbarExtensions
-                ph.init('test-token', {
-                    api_host: 'https://localhost:1234',
-                    debug: true,
-                    ip: false,
-                    capture_pageview: false,
-                    __extensionClasses: { ...extensions },
-                    opt_out_useragent_filter: true,
-                } as Partial<PostHogConfig>)
-                // loadToolbar returns false when there are no toolbar params — that's fine,
-                // we just want to make sure it doesn't throw.
-                ph.loadToolbar({})
-                return null
-            } catch (e: any) {
-                return e.message
-            }
-        })
+                const error = await page.evaluate(() => {
+                    try {
+                        const ph = (window as any).posthog as PostHog
+                        const extensions = (window as any).ToolbarExtensions
+                        ph.init('test-token', {
+                            api_host: 'https://localhost:1234',
+                            debug: true,
+                            ip: false,
+                            capture_pageview: false,
+                            __extensionClasses: { ...extensions },
+                            opt_out_useragent_filter: true,
+                        } as Partial<PostHogConfig>)
+                        // loadToolbar returns false when there are no toolbar params — that's fine,
+                        // we just want to make sure it doesn't throw.
+                        ph.loadToolbar({})
+                        return null
+                    } catch (e: any) {
+                        return e.message
+                    }
+                })
 
-        await page.waitForTimeout(1000)
-        expect(error).toBeNull()
-        expect(errors).toEqual([])
-    })
+                await page.waitForTimeout(1000)
+                expect(error).toBeNull()
+                expect(errors).toEqual([])
+            })
 
-    // ── SurveysExtensions ───────────────────────────────────────────────
+            // ── SurveysExtensions ───────────────────────────────────────────────
 
-    test('SurveysExtensions: getSurveys does not crash', async ({ page }) => {
-        const errors: string[] = []
-        page.on('pageerror', (error) => errors.push(error.message))
+            test('SurveysExtensions: getSurveys does not crash', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
 
-        await page.goto(SLIM_BUNDLE_URL)
-        await waitForSlimBundleReady(page)
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
 
-        const error = await page.evaluate(() => {
-            return new Promise<string | null>((resolve) => {
-                try {
-                    const ph = (window as any).posthog as PostHog
-                    const extensions = (window as any).SurveysExtensions
-                    ph.init('test-token', {
-                        api_host: 'https://localhost:1234',
-                        debug: true,
-                        ip: false,
-                        capture_pageview: false,
-                        __extensionClasses: { ...extensions },
-                        opt_out_useragent_filter: true,
-                    } as Partial<PostHogConfig>)
-                    ph.getSurveys(() => {
-                        resolve(null)
+                const error = await page.evaluate(() => {
+                    return new Promise<string | null>((resolve) => {
+                        try {
+                            const ph = (window as any).posthog as PostHog
+                            const extensions = (window as any).SurveysExtensions
+                            ph.init('test-token', {
+                                api_host: 'https://localhost:1234',
+                                debug: true,
+                                ip: false,
+                                capture_pageview: false,
+                                __extensionClasses: { ...extensions },
+                                opt_out_useragent_filter: true,
+                            } as Partial<PostHogConfig>)
+                            ph.getSurveys(() => {
+                                resolve(null)
+                            })
+                        } catch (e: any) {
+                            resolve(e.message)
+                        }
                     })
-                } catch (e: any) {
-                    resolve(e.message)
-                }
+                })
+
+                await page.waitForTimeout(1000)
+                expect(error).toBeNull()
+                expect(errors).toEqual([])
+            })
+
+            // ── AnalyticsExtensions (Autocapture) ─────────────────────────────
+
+            test('AnalyticsExtensions: autocapture init does not crash', async ({ page }) => {
+                // Autocapture accesses this.instance._shouldDisableFlags() which is mangled
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
+
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
+
+                const error = await page.evaluate(() => {
+                    try {
+                        const ph = (window as any).posthog as PostHog
+                        const extensions = (window as any).AnalyticsExtensions
+                        ph.init('test-token', {
+                            api_host: 'https://localhost:1234',
+                            debug: true,
+                            ip: false,
+                            capture_pageview: false,
+                            autocapture: true,
+                            __extensionClasses: { ...extensions },
+                            opt_out_useragent_filter: true,
+                        } as Partial<PostHogConfig>)
+                        return null
+                    } catch (e: any) {
+                        return e.message
+                    }
+                })
+
+                await page.waitForTimeout(1000)
+                expect(error).toBeNull()
+                expect(errors).toEqual([])
+            })
+
+            // ── Every extension bundle: init does not crash ───────────────────
+
+            for (const extName of [
+                'SiteAppsExtensions',
+                'SessionReplayExtensions',
+                'ExperimentsExtensions',
+                'ConversationsExtensions',
+                'LogsExtensions',
+                'ProductToursExtensions',
+                'TracingExtensions',
+            ] as const) {
+                test(`${extName}: init does not crash`, async ({ page }) => {
+                    const errors: string[] = []
+                    page.on('pageerror', (error) => errors.push(error.message))
+
+                    await page.goto(slimBundle.url)
+                    await waitForSlimBundleReady(page)
+
+                    const error = await initPostHogWithExtensions(page, extName)
+                    await page.waitForTimeout(1000)
+
+                    expect(error).toBeNull()
+                    expect(errors).toEqual([])
+                })
+            }
+
+            test('reported extension combination does not crash', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
+
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
+
+                const error = await page.evaluate(() => {
+                    try {
+                        const ph = (window as any).posthog as PostHog
+                        ph.init('test-token', {
+                            api_host: 'https://localhost:1234',
+                            debug: true,
+                            ip: false,
+                            capture_pageview: false,
+                            autocapture: true,
+                            __extensionClasses: {
+                                ...(window as any).SessionReplayExtensions,
+                                ...(window as any).AnalyticsExtensions,
+                                ...(window as any).ErrorTrackingExtensions,
+                            },
+                            opt_out_useragent_filter: true,
+                        } as Partial<PostHogConfig>)
+                        ph.captureException(new Error('test error'))
+                        return null
+                    } catch (e: any) {
+                        return e.message
+                    }
+                })
+
+                await page.waitForTimeout(1000)
+                expect(error).toBeNull()
+                expect(errors).toEqual([])
+            })
+
+            test('conversations identity callbacks do not crash', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
+
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
+
+                const error = await page.evaluate(() => {
+                    try {
+                        const ph = (window as any).posthog as PostHog
+                        ph.init('test-token', {
+                            api_host: 'https://localhost:1234',
+                            debug: true,
+                            ip: false,
+                            capture_pageview: false,
+                            __extensionClasses: { ...(window as any).ConversationsExtensions },
+                            opt_out_useragent_filter: true,
+                        } as Partial<PostHogConfig>)
+                        ph.setIdentity('user_123', 'identity_hash')
+                        ph.clearIdentity()
+                        return null
+                    } catch (e: any) {
+                        return e.message
+                    }
+                })
+
+                await page.waitForTimeout(1000)
+                expect(error).toBeNull()
+                expect(errors).toEqual([])
+            })
+
+            // ── AllExtensions ───────────────────────────────────────────────────
+
+            test('AllExtensions: init + multiple features do not crash', async ({ page }) => {
+                const errors: string[] = []
+                page.on('pageerror', (error) => errors.push(error.message))
+
+                await page.goto(slimBundle.url)
+                await waitForSlimBundleReady(page)
+
+                const result = await page.evaluate(() => {
+                    try {
+                        const ph = (window as any).posthog as PostHog
+                        const extensions = (window as any).AllExtensions
+                        ph.init('test-token', {
+                            api_host: 'https://localhost:1234',
+                            debug: true,
+                            ip: false,
+                            capture_pageview: false,
+                            __extensionClasses: { ...extensions },
+                            opt_out_useragent_filter: true,
+                            bootstrap: { featureFlags: { 'test-flag': 'variant-a' } },
+                        } as Partial<PostHogConfig>)
+
+                        // Exercise multiple TreeShakeable<T> code paths in one test:
+                        const flagValue = ph.getFeatureFlag('test-flag')
+                        ph.reloadFeatureFlags()
+                        ph.captureException(new Error('test error'))
+                        ph.loadToolbar({})
+
+                        return { flagValue, error: null }
+                    } catch (e: any) {
+                        return { flagValue: null, error: e.message }
+                    }
+                })
+
+                await page.waitForTimeout(1000)
+                expect(result.error).toBeNull()
+                expect(result.flagValue).toBe('variant-a')
+                expect(errors).toEqual([])
             })
         })
-
-        await page.waitForTimeout(1000)
-        expect(error).toBeNull()
-        expect(errors).toEqual([])
-    })
-
-    // ── AnalyticsExtensions (Autocapture) ─────────────────────────────
-
-    test('AnalyticsExtensions: autocapture init does not crash', async ({ page }) => {
-        // Autocapture accesses this.instance._shouldDisableFlags() which is mangled
-        const errors: string[] = []
-        page.on('pageerror', (error) => errors.push(error.message))
-
-        await page.goto(SLIM_BUNDLE_URL)
-        await waitForSlimBundleReady(page)
-
-        const error = await page.evaluate(() => {
-            try {
-                const ph = (window as any).posthog as PostHog
-                const extensions = (window as any).AnalyticsExtensions
-                ph.init('test-token', {
-                    api_host: 'https://localhost:1234',
-                    debug: true,
-                    ip: false,
-                    capture_pageview: false,
-                    autocapture: true,
-                    __extensionClasses: { ...extensions },
-                    opt_out_useragent_filter: true,
-                } as Partial<PostHogConfig>)
-                return null
-            } catch (e: any) {
-                return e.message
-            }
-        })
-
-        await page.waitForTimeout(1000)
-        expect(error).toBeNull()
-        expect(errors).toEqual([])
-    })
-
-    // ── Every extension bundle: init does not crash ───────────────────
-
-    for (const extName of [
-        'SiteAppsExtensions',
-        'SessionReplayExtensions',
-        'ExperimentsExtensions',
-        'ConversationsExtensions',
-        'LogsExtensions',
-        'ProductToursExtensions',
-        'TracingExtensions',
-    ] as const) {
-        test(`${extName}: init does not crash`, async ({ page }) => {
-            const errors: string[] = []
-            page.on('pageerror', (error) => errors.push(error.message))
-
-            await page.goto(SLIM_BUNDLE_URL)
-            await waitForSlimBundleReady(page)
-
-            const error = await initPostHogWithExtensions(page, extName)
-            await page.waitForTimeout(1000)
-
-            expect(error).toBeNull()
-            expect(errors).toEqual([])
-        })
     }
-
-    // ── AllExtensions ───────────────────────────────────────────────────
-
-    test('AllExtensions: init + multiple features do not crash', async ({ page }) => {
-        const errors: string[] = []
-        page.on('pageerror', (error) => errors.push(error.message))
-
-        await page.goto(SLIM_BUNDLE_URL)
-        await waitForSlimBundleReady(page)
-
-        const result = await page.evaluate(() => {
-            try {
-                const ph = (window as any).posthog as PostHog
-                const extensions = (window as any).AllExtensions
-                ph.init('test-token', {
-                    api_host: 'https://localhost:1234',
-                    debug: true,
-                    ip: false,
-                    capture_pageview: false,
-                    __extensionClasses: { ...extensions },
-                    opt_out_useragent_filter: true,
-                    bootstrap: { featureFlags: { 'test-flag': 'variant-a' } },
-                } as Partial<PostHogConfig>)
-
-                // Exercise multiple TreeShakeable<T> code paths in one test:
-                const flagValue = ph.getFeatureFlag('test-flag')
-                ph.reloadFeatureFlags()
-                ph.captureException(new Error('test error'))
-                ph.loadToolbar({})
-
-                return { flagValue, error: null }
-            } catch (e: any) {
-                return { flagValue: null, error: e.message }
-            }
-        })
-
-        await page.waitForTimeout(1000)
-        expect(result.error).toBeNull()
-        expect(result.flagValue).toBe('variant-a')
-        expect(errors).toEqual([])
-    })
 })

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -12,7 +12,9 @@ import postcssNesting from 'postcss-nesting'
 import cssnano from 'cssnano'
 import fs from 'fs'
 import path from 'path'
+import crossBundlePropertyConfig from './terser-cross-bundle-properties.cjs'
 
+const { crossBundlePrivateProperties, globallyReservedPrivateProperties } = crossBundlePropertyConfig
 const WRITE_MANGLED_PROPERTIES = process.env.WRITE_MANGLED_PROPERTIES
 const nameCachePath = './terser-mangled-names.json'
 let nameCache = {}
@@ -22,7 +24,7 @@ let nameCache = {}
 // Only property names (props) are shared; top-level variable names (vars) are
 // reset per-entry by the plugin below since each module has its own scope.
 
-const plugins = (es5, noExternal) => [
+const plugins = (es5, noExternal, preserveCrossBundleProperties) => [
     {
         name: 'reset-vars-name-cache',
         buildStart() {
@@ -177,13 +179,14 @@ const plugins = (es5, noExternal) => [
                               // we don't mangle _surveyManager as it's used by external surveys to paint them on the dom directly
                               '_surveyManager',
 
+                              // private ABI between independently emitted slim cores and extension bundles
+                              ...(preserveCrossBundleProperties
+                                  ? crossBundlePrivateProperties
+                                  : globallyReservedPrivateProperties),
+
                               // used in conversations - external bundle needs to access these on the posthog instance
                               '_conversationsManager',
                               '_conversations',
-                              '_send_request', // called by conversations external bundle
-
-                              // used in product-tours - external bundle needs to access this on the posthog instance
-                              '_addCaptureHook',
 
                               // part of setup/teardown code, preserve these out of caution
                               '_init',
@@ -346,9 +349,7 @@ const plugins = (es5, noExternal) => [
 
 const entryFilter = process.env.ENTRY
 const allEntrypoints = fs.readdirSync('./src/entrypoints')
-const entrypoints = entryFilter
-    ? allEntrypoints.filter((file) => file.startsWith(entryFilter))
-    : allEntrypoints
+const entrypoints = entryFilter ? allEntrypoints.filter((file) => file.startsWith(entryFilter)) : allEntrypoints
 
 const entrypointTargets = entrypoints.map((file) => {
     const fileParts = file.split('.')
@@ -365,7 +366,12 @@ const entrypointTargets = entrypoints.map((file) => {
 
     const fileName = fileParts.join('.')
 
-    const pluginsForThisFile = plugins(fileName.includes('es5'), fileName.includes('no-external'))
+    const preserveCrossBundleProperties = ['extension-bundles', 'module.slim'].includes(fileName)
+    const pluginsForThisFile = plugins(
+        fileName.includes('es5'),
+        fileName.includes('no-external'),
+        preserveCrossBundleProperties
+    )
 
     // we're allowed to console log in this file :)
     // eslint-disable-next-line no-console

--- a/packages/browser/scripts/check-mangled-property-consistency.js
+++ b/packages/browser/scripts/check-mangled-property-consistency.js
@@ -1,102 +1,192 @@
 #!/usr/bin/env node
 
 /**
- * Post-build check: verify that mangled property names are consistent
- * between module.slim.js and extension-bundles.js.
+ * Verify the private-property ABI between independently emitted slim cores and
+ * extension-bundles.js.
  *
- * These two bundles are compiled as separate rollup entries. If their terser
- * instances don't share a nameCache, they independently mangle `_`-prefixed
- * properties to different short names, causing runtime crashes when combined:
- *   TypeError: Cannot read properties of undefined (reading 'emit')
+ * module.slim.js and extension-bundles.js share a Terser name cache. The
+ * no-external slim build intentionally preserves property names, so properties
+ * exchanged with extension bundles must also be reserved there.
  *
  * See https://github.com/PostHog/posthog-js/issues/3313
- *
- * This script parses the source maps to extract original→mangled property
- * mappings from each bundle, then asserts every property that appears in
- * both bundles was mangled to the same name.
  */
 
 const fs = require('fs')
 const path = require('path')
 
 const { decode } = require('@jridgewell/sourcemap-codec')
+const { crossBundlePrivateProperties, knownNonAbiOverlaps } = require('../terser-cross-bundle-properties.cjs')
 
 const DIST = path.resolve(__dirname, '../dist')
 
-function extractMangledPropertyNames(jsFile, mapFile) {
+function extractPropertyNames(jsFile, mapFile, includeDefinitions = false) {
     const js = fs.readFileSync(jsFile, 'utf8')
     const map = JSON.parse(fs.readFileSync(mapFile, 'utf8'))
     const lines = js.split('\n')
     const decoded = decode(map.mappings)
-    const mappings = {} // originalName → Set<mangledName>
+    const mappings = {}
 
-    decoded.forEach((lineSegments, lineIdx) => {
-        const line = lines[lineIdx] || ''
-        lineSegments.forEach((seg) => {
-            if (seg.length < 5) return
-            const genCol = seg[0]
-            const nameIdx = seg[4]
-            const originalName = map.names[nameIdx]
+    decoded.forEach((lineSegments, lineIndex) => {
+        const line = lines[lineIndex] || ''
+        lineSegments.forEach((segment) => {
+            if (segment.length < 5) {
+                return
+            }
 
-            // Only check single-underscore-prefixed properties (the mangling regex)
-            if (!originalName || !originalName.startsWith('_') || originalName.startsWith('__')) return
+            const generatedColumn = segment[0]
+            const originalName = map.names[segment[4]]
+            if (!originalName || !originalName.startsWith('_') || originalName.startsWith('__')) {
+                return
+            }
 
-            // Only count property accesses (preceded by '.'), not local variables
-            if (genCol === 0 || line[genCol - 1] !== '.') return
+            const previousCharacter = generatedColumn === 0 ? '' : line[generatedColumn - 1]
+            const rest = line.substring(generatedColumn)
+            const isPropertyAccess = previousCharacter === '.'
+            const isMethodDeclaration = /[{},;]/.test(previousCharacter) && /^[a-zA-Z_$][a-zA-Z0-9_$]*\(/.test(rest)
+            const isObjectKey = /[{,]/.test(previousCharacter) && /^[a-zA-Z_$][a-zA-Z0-9_$]*:/.test(rest)
 
-            const rest = line.substring(genCol)
+            if (!isPropertyAccess && !(includeDefinitions && (isMethodDeclaration || isObjectKey))) {
+                return
+            }
+
             const match = rest.match(/^([a-zA-Z_$][a-zA-Z0-9_$]*)/)
-            if (match && match[1] !== originalName) {
-                if (!mappings[originalName]) mappings[originalName] = new Set()
+            if (match) {
+                if (!mappings[originalName]) {
+                    mappings[originalName] = new Set()
+                }
                 mappings[originalName].add(match[1])
             }
         })
     })
 
-    const result = {}
-    for (const [k, v] of Object.entries(mappings)) {
-        result[k] = [...v]
-    }
-    return result
+    return Object.fromEntries(
+        Object.entries(mappings).map(([originalName, emittedNames]) => [originalName, [...emittedNames].sort()])
+    )
 }
 
-const slim = extractMangledPropertyNames(
-    path.join(DIST, 'module.slim.js'),
-    path.join(DIST, 'module.slim.js.map')
-)
-const ext = extractMangledPropertyNames(
-    path.join(DIST, 'extension-bundles.js'),
-    path.join(DIST, 'extension-bundles.js.map')
-)
-
-const shared = Object.keys(ext)
-    .filter((k) => slim[k])
-    .sort()
-
-const mismatches = []
-for (const name of shared) {
-    const s = slim[name]
-    const e = ext[name]
-    // Terser should produce exactly one mangled name per property per compilation unit.
-    if (s[0] !== e[0] || s.length !== 1 || e.length !== 1) {
-        mismatches.push({ property: name, slim: s, ext: e })
-    }
+function readArtifact(fileName, includeDefinitions = false) {
+    return extractPropertyNames(path.join(DIST, fileName), path.join(DIST, `${fileName}.map`), includeDefinitions)
 }
 
-if (mismatches.length > 0) {
-    console.error(
-        `FAIL: ${mismatches.length} mangled property name(s) differ between module.slim.js and extension-bundles.js`
-    )
-    console.error('The slim bundle and extension bundles will crash when used together (see #3313)\n')
-    mismatches.forEach((m) =>
-        console.error(`  .${m.property}:  slim → .${m.slim.join(', .')}  |  ext → .${m.ext.join(', .')}`)
-    )
-    console.error(
-        '\nFix: ensure the terser nameCache is shared across entries in rollup.config.mjs'
-    )
-    process.exit(1)
-} else {
+function findDuplicates(values) {
+    return [...new Set(values.filter((value, index) => values.indexOf(value) !== index))].sort()
+}
+
+function validatePropertyClassification(observedOverlaps, abiProperties, nonAbiProperties) {
+    const errors = []
+    const duplicateAbiProperties = findDuplicates(abiProperties)
+    const duplicateNonAbiProperties = findDuplicates(nonAbiProperties)
+    const abiSet = new Set(abiProperties)
+    const nonAbiSet = new Set(nonAbiProperties)
+    const observedSet = new Set(observedOverlaps)
+    const conflicts = [...abiSet].filter((property) => nonAbiSet.has(property)).sort()
+    const classified = new Set([...abiSet, ...nonAbiSet])
+    const unknown = [...observedSet].filter((property) => !classified.has(property)).sort()
+    const stale = [...classified].filter((property) => !observedSet.has(property)).sort()
+
+    if (duplicateAbiProperties.length > 0) {
+        errors.push(`duplicate ABI properties: ${duplicateAbiProperties.join(', ')}`)
+    }
+    if (duplicateNonAbiProperties.length > 0) {
+        errors.push(`duplicate non-ABI properties: ${duplicateNonAbiProperties.join(', ')}`)
+    }
+    if (conflicts.length > 0) {
+        errors.push(`properties classified as both ABI and non-ABI: ${conflicts.join(', ')}`)
+    }
+    if (unknown.length > 0) {
+        errors.push(`unknown private-property overlaps: ${unknown.join(', ')}`)
+    }
+    if (stale.length > 0) {
+        errors.push(`stale private-property classifications: ${stale.join(', ')}`)
+    }
+
+    return errors
+}
+
+function formatNames(names) {
+    return names.length > 0 ? `.${names.join(', .')}` : '(missing from source map)'
+}
+
+function checkPair(leftName, left, rightName, right, properties) {
+    if (properties.length === 0) {
+        console.error(`FAIL: no shared private property mappings found between ${leftName} and ${rightName}`)
+        return false
+    }
+
+    const mismatches = []
+    for (const property of properties) {
+        const leftNames = left[property] || []
+        const rightNames = right[property] || []
+        if (leftNames.length !== 1 || rightNames.length !== 1 || leftNames[0] !== rightNames[0]) {
+            mismatches.push({ property, leftNames, rightNames })
+        }
+    }
+
+    if (mismatches.length > 0) {
+        console.error(`FAIL: ${mismatches.length} property name(s) differ between ${leftName} and ${rightName}`)
+        mismatches.forEach(({ property, leftNames, rightNames }) => {
+            console.error(
+                `  .${property}: ${leftName} → ${formatNames(leftNames)} | ${rightName} → ${formatNames(rightNames)}`
+            )
+        })
+        return false
+    }
+
     console.log(
-        `OK: ${shared.length} cross-bundle mangled properties are consistent between module.slim.js and extension-bundles.js`
+        `OK: ${properties.length} cross-bundle private properties are consistent between ${leftName} and ${rightName}`
     )
+    return true
+}
+
+function main() {
+    const extensionBundleAccesses = readArtifact('extension-bundles.js')
+    const slimAccesses = readArtifact('module.slim.js')
+    const extensionBundleProperties = readArtifact('extension-bundles.js', true)
+    const slimNoExternalProperties = readArtifact('module.slim.no-external.js', true)
+    const normalSlimOverlaps = Object.keys(extensionBundleAccesses)
+        .filter((property) => slimAccesses[property])
+        .sort()
+    const noExternalOverlaps = Object.keys(extensionBundleProperties)
+        .filter((property) => slimNoExternalProperties[property])
+        .sort()
+
+    const classificationErrors = validatePropertyClassification(
+        noExternalOverlaps,
+        crossBundlePrivateProperties,
+        knownNonAbiOverlaps
+    )
+    if (classificationErrors.length > 0) {
+        console.error('FAIL: no-external private-property classification is incomplete')
+        classificationErrors.forEach((error) => console.error(`  ${error}`))
+    } else {
+        console.log(`OK: ${noExternalOverlaps.length} no-external private-property overlaps are classified`)
+    }
+
+    const results = [
+        classificationErrors.length === 0,
+        checkPair('module.slim.js', slimAccesses, 'extension-bundles.js', extensionBundleAccesses, normalSlimOverlaps),
+        checkPair(
+            'module.slim.no-external.js',
+            slimNoExternalProperties,
+            'extension-bundles.js',
+            extensionBundleProperties,
+            crossBundlePrivateProperties
+        ),
+    ]
+
+    if (results.some((passed) => !passed)) {
+        console.error(
+            '\nFix: share the Terser property name cache or reserve properties that cross an unmangled artifact boundary.'
+        )
+        process.exitCode = 1
+    }
+}
+
+if (require.main === module) {
+    main()
+}
+
+module.exports = {
+    extractPropertyNames,
+    validatePropertyClassification,
 }

--- a/packages/browser/src/__tests__/check-mangled-property-consistency.test.ts
+++ b/packages/browser/src/__tests__/check-mangled-property-consistency.test.ts
@@ -1,0 +1,37 @@
+import { validatePropertyClassification } from '../../scripts/check-mangled-property-consistency'
+
+describe('mangled property consistency classification', () => {
+    const abiProperties = ['_crossesBoundary']
+    const nonAbiProperties = ['_artifactLocal']
+    const observedOverlaps = [...abiProperties, ...nonAbiProperties]
+
+    it('accepts a complete classification', () => {
+        expect(validatePropertyClassification(observedOverlaps, abiProperties, nonAbiProperties)).toEqual([])
+    })
+
+    it('rejects unknown overlaps', () => {
+        expect(
+            validatePropertyClassification([...observedOverlaps, '_unknown'], abiProperties, nonAbiProperties)
+        ).toContain('unknown private-property overlaps: _unknown')
+    })
+
+    it('rejects stale classifications', () => {
+        expect(validatePropertyClassification(abiProperties, abiProperties, nonAbiProperties)).toContain(
+            'stale private-property classifications: _artifactLocal'
+        )
+    })
+
+    it('rejects duplicate and conflicting classifications', () => {
+        expect(
+            validatePropertyClassification(
+                observedOverlaps,
+                [...abiProperties, ...abiProperties],
+                [...nonAbiProperties, ...nonAbiProperties, ...abiProperties]
+            )
+        ).toEqual([
+            'duplicate ABI properties: _crossesBoundary',
+            'duplicate non-ABI properties: _artifactLocal',
+            'properties classified as both ABI and non-ABI: _crossesBoundary',
+        ])
+    })
+})

--- a/packages/browser/terser-cross-bundle-properties.cjs
+++ b/packages/browser/terser-cross-bundle-properties.cjs
@@ -1,0 +1,44 @@
+// These properties are also used by separately emitted legacy extension bundles.
+const globallyReservedPrivateProperties = ['_addCaptureHook', '_send_request']
+
+const crossBundlePrivateProperties = [
+    ...globallyReservedPrivateProperties,
+    '_internalEventEmitter',
+    '_isFeatureFlagCacheStale',
+    '_onIdentityChanged',
+    '_onIdentityCleared',
+    '_originatedFromCaptureException',
+    '_shouldDisableFlags',
+].sort()
+
+// These names occur independently in both artifacts but are not exchanged across
+// their boundary. Keep them classified so a new, unreviewed overlap fails the build.
+const knownNonAbiOverlaps = [
+    '_POSTHOG_REMOTE_CONFIG',
+    '_batchKey',
+    '_buffer',
+    '_config',
+    '_enqueue',
+    '_events',
+    '_extends',
+    '_flush',
+    '_instance',
+    '_is_bot',
+    '_loadRemoteConfigJSON',
+    '_loadRemoteConfigJs',
+    '_loadScript',
+    '_log',
+    '_noTruncate',
+    '_onRemoteConfig',
+    '_persistence',
+    '_queue',
+    '_refreshInterval',
+    '_runBeforeSend',
+    '_startRefreshInterval',
+]
+
+module.exports = {
+    crossBundlePrivateProperties,
+    globallyReservedPrivateProperties,
+    knownNonAbiOverlaps,
+}

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,9 @@
                 ".babelrc",
                 "babel.config.js",
                 "rollup.config.mjs",
+                "scripts/check-mangled-property-consistency.js",
+                "terser-cross-bundle-properties.cjs",
+                "terser-mangled-names.json",
                 "rslib.config.mjs",
                 "vite.config.ts",
                 "vite.config.js"


### PR DESCRIPTION
## Problem

`module.slim.no-external.js` intentionally preserves private property names, while `extension-bundles.js` mangles them. Combining the two artifacts can therefore break calls across the bundle boundary at runtime.

This was reproduced locally from `origin/main` by running the extension bundle Playwright matrix against the no-external slim build: 10 of 34 Chromium cases failed, including bootstrapped feature flags (`i._r is not a function`), autocapture (`this.instance.Ur is not a function`), and conversations identity callbacks (`i._onIdentityChanged is not a function`).

This supersedes #4274 with a fresh implementation based on current `main`.

## Changes

- Define the private cross-bundle ABI and known artifact-local overlaps in one configuration shared by Rollup and the post-build checker.
- Preserve the eight private properties exchanged between slim cores and extension bundles.
- Scope the new reservations to `module.slim.js` and `extension-bundles.js`, retaining the existing global reservations required by legacy extension artifacts. This avoids increasing `array.js`.
- Extend the post-build checker to validate `module.slim.js` and `module.slim.no-external.js`, and fail on unknown, stale, duplicate, or conflicting overlap classifications.
- Run the existing extension bundle Playwright matrix against both slim variants, with focused regression coverage for the reported extension combination and conversations identity callbacks.
- Include the checker, ABI configuration, and mangled-name snapshot in Turbo build inputs.

## Verification

- Before the fix: no-external Chromium matrix reproduced 10 failures and 24 passes.
- `pnpm turbo run build --filter=posthog-js --force` — passed; 29 no-external overlaps classified, 22 normal slim mappings consistent, and 8 no-external ABI mappings consistent.
- posthog-js unit suite — 5,061 passed, 8 skipped.
- Focused checker unit tests — 4 passed.
- `pnpm --filter posthog-js test:functional -- --runInBand` — 7 passed.
- `pnpm exec playwright test playwright/mocked/slim-bundle.spec.ts --reporter=line` — 102 passed across Chromium, Firefox, and WebKit.
- `pnpm --filter posthog-js lint` — passed.
- Fast esbuild `array.js` comparison — 0.00% change.
- Production Rollup comparison: `array.js` unchanged; `module.slim.js` +213 raw/+64 gzip bytes; `extension-bundles.js` +170 raw/+38 gzip bytes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi Coding Agent with OpenAI GPT-5.6 implemented and verified the change under human direction. The implementation was built independently from current `main` after reproducing the failures from the unfixed build. Cross-bundle reservations were scoped to the slim/extension pair rather than applied globally so the main `array.js` bundle remains unchanged.
