### PR TITLE
fix(ai): prefer resolved OpenAI service tier

### DIFF
--- a/.changeset/ai-openai-service-tier-model-params.md
+++ b/.changeset/ai-openai-service-tier-model-params.md
@@ -2,4 +2,4 @@
 '@posthog/ai': patch
 ---
 
-fix(ai): capture OpenAI `service_tier` in `$ai_model_parameters`, preferring the tier reported by the response so PostHog can accurately attribute costs when `auto` resolves to another tier
+fix(ai): capture OpenAI `service_tier` in `$ai_model_parameters` so PostHog can correctly attribute costs for flex and priority tier requests

--- a/.changeset/ai-openai-service-tier-model-params.md
+++ b/.changeset/ai-openai-service-tier-model-params.md
@@ -2,4 +2,4 @@
 '@posthog/ai': patch
 ---
 
-fix(ai): capture OpenAI `service_tier` in `$ai_model_parameters` so PostHog can correctly attribute costs for flex and priority tier requests
+fix(ai): capture OpenAI `service_tier` in `$ai_model_parameters`, preferring the tier reported by the response so PostHog can accurately attribute costs when `auto` resolves to another tier

--- a/.changeset/curly-lions-smile.md
+++ b/.changeset/curly-lions-smile.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+fix(ai): prefer the OpenAI `service_tier` reported by the response for accurate cost attribution

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -113,6 +113,7 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
               const contentBlocks: FormattedContent = []
               let accumulatedContent = ''
               let modelFromResponse: string | undefined
+              let serviceTierFromResponse: string | undefined
               let firstTokenTime: number | undefined
               let usage: {
                 inputTokens?: number
@@ -144,6 +145,9 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 }
                 if (!systemFingerprintFromResponse && chunk.system_fingerprint) {
                   systemFingerprintFromResponse = chunk.system_fingerprint
+                }
+                if (chunk.service_tier != null) {
+                  serviceTierFromResponse = chunk.service_tier
                 }
 
                 const choice = chunk?.choices?.[0]
@@ -250,7 +254,7 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 latency,
                 timeToFirstToken,
                 baseURL: this.baseURL,
-                modelParameters: getModelParams(body),
+                modelParameters: getModelParams(body, serviceTierFromResponse),
                 httpStatus: 200,
                 usage,
                 completionId: completionIdFromResponse,
@@ -299,7 +303,7 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
               output: formatResponseOpenAI(result),
               latency,
               baseURL: this.baseURL,
-              modelParameters: getModelParams(body),
+              modelParameters: getModelParams(body, result.service_tier),
               httpStatus: 200,
               usage: {
                 inputTokens: result.usage?.prompt_tokens ?? 0,
@@ -396,6 +400,7 @@ export class WrappedResponses extends AzureOpenAI.Responses {
             try {
               let finalContent: any[] = []
               let modelFromResponse: string | undefined
+              let serviceTierFromResponse: string | undefined
               let firstTokenTime: number | undefined
               let usage: {
                 inputTokens?: number
@@ -420,6 +425,9 @@ export class WrappedResponses extends AzureOpenAI.Responses {
                   }
                   if (!completionIdFromResponse && chunk.response.id) {
                     completionIdFromResponse = chunk.response.id
+                  }
+                  if (chunk.response.service_tier != null) {
+                    serviceTierFromResponse = chunk.response.service_tier
                   }
                 }
                 if (
@@ -451,7 +459,7 @@ export class WrappedResponses extends AzureOpenAI.Responses {
                 latency,
                 timeToFirstToken,
                 baseURL: this.baseURL,
-                modelParameters: getModelParams(body),
+                modelParameters: getModelParams(body, serviceTierFromResponse),
                 httpStatus: 200,
                 usage,
                 completionId: completionIdFromResponse,
@@ -496,7 +504,7 @@ export class WrappedResponses extends AzureOpenAI.Responses {
               output: result.output,
               latency,
               baseURL: this.baseURL,
-              modelParameters: getModelParams(body),
+              modelParameters: getModelParams(body, result.service_tier),
               httpStatus: 200,
               usage: {
                 inputTokens: result.usage?.input_tokens ?? 0,
@@ -560,7 +568,7 @@ export class WrappedResponses extends AzureOpenAI.Responses {
           output: result.output,
           latency,
           baseURL: this.baseURL,
-          modelParameters: getModelParams(body),
+          modelParameters: getModelParams(body, result.service_tier),
           httpStatus: 200,
           usage: {
             inputTokens: result.usage?.input_tokens ?? 0,

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -176,6 +176,7 @@ export class WrappedCompletions extends Completions {
               const contentBlocks: FormattedContent = []
               let accumulatedContent = ''
               let modelFromResponse: string | undefined
+              let serviceTierFromResponse: string | undefined
               let firstTokenTime: number | undefined
               let stopReason: string | undefined
               let usage: {
@@ -211,6 +212,9 @@ export class WrappedCompletions extends Completions {
                 }
                 if (!systemFingerprintFromResponse && chunk.system_fingerprint) {
                   systemFingerprintFromResponse = chunk.system_fingerprint
+                }
+                if (chunk.service_tier != null) {
+                  serviceTierFromResponse = chunk.service_tier
                 }
 
                 const choice = chunk?.choices?.[0]
@@ -329,7 +333,7 @@ export class WrappedCompletions extends Completions {
                 latency,
                 timeToFirstToken,
                 baseURL: this.baseURL,
-                modelParameters: getModelParams(body),
+                modelParameters: getModelParams(body, serviceTierFromResponse),
                 httpStatus: 200,
                 usage: {
                   inputTokens: usage.inputTokens,
@@ -391,7 +395,7 @@ export class WrappedCompletions extends Completions {
               output: formattedOutput,
               latency,
               baseURL: this.baseURL,
-              modelParameters: getModelParams(body),
+              modelParameters: getModelParams(body, result.service_tier),
               httpStatus: 200,
               usage: {
                 inputTokens: result.usage?.prompt_tokens ?? 0,
@@ -492,6 +496,7 @@ export class WrappedResponses extends Responses {
             try {
               let finalContent: unknown[] = []
               let modelFromResponse: string | undefined
+              let serviceTierFromResponse: string | undefined
               let firstTokenTime: number | undefined
               let stopReason: string | undefined
               let usage: {
@@ -520,6 +525,9 @@ export class WrappedResponses extends Responses {
                   }
                   if (!completionIdFromResponse && chunk.response.id) {
                     completionIdFromResponse = chunk.response.id
+                  }
+                  if (chunk.response.service_tier != null) {
+                    serviceTierFromResponse = chunk.response.service_tier
                   }
 
                   const chunkWebSearchCount = calculateWebSearchCount(chunk.response)
@@ -566,7 +574,7 @@ export class WrappedResponses extends Responses {
                 latency,
                 timeToFirstToken,
                 baseURL: this.baseURL,
-                modelParameters: getModelParams(body),
+                modelParameters: getModelParams(body, serviceTierFromResponse),
                 httpStatus: 200,
                 usage: {
                   inputTokens: usage.inputTokens,
@@ -631,7 +639,7 @@ export class WrappedResponses extends Responses {
               output: formattedOutput,
               latency,
               baseURL: this.baseURL,
-              modelParameters: getModelParams(body),
+              modelParameters: getModelParams(body, result.service_tier),
               httpStatus: 200,
               usage: {
                 inputTokens: result.usage?.input_tokens ?? 0,
@@ -709,7 +717,7 @@ export class WrappedResponses extends Responses {
             output: result.output,
             latency,
             baseURL: this.baseURL,
-            modelParameters: getModelParams(body),
+            modelParameters: getModelParams(body, result.service_tier),
             httpStatus: 200,
             usage: {
               inputTokens: result.usage?.input_tokens ?? 0,

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -106,7 +106,8 @@ export const getModelParams = (
         | TranscriptionCreateParams
       ) &
         MonitoringParams)
-    | null
+    | null,
+  responseServiceTier?: string | null
 ): Record<string, any> => {
   if (!params) {
     return {}
@@ -133,6 +134,9 @@ export const getModelParams = (
     if (key in params && (params as any)[key] !== undefined) {
       modelParams[key] = (params as any)[key]
     }
+  }
+  if (responseServiceTier != null) {
+    modelParams.service_tier = responseServiceTier
   }
   return modelParams
 }

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -1,7 +1,7 @@
 import { PostHog } from 'posthog-node'
 import { PostHogAzureOpenAI } from '../src/openai/azure'
 import openaiModule from 'openai'
-import { collectUnhandledRejections } from './test-utils'
+import { collectUnhandledRejections, flushPromises } from './test-utils'
 
 let mockAzureEmbeddingResponse: any = {}
 
@@ -926,5 +926,160 @@ describe('PostHogAzureOpenAI - cache token reporting convention', () => {
     expect(properties['$ai_cache_read_input_tokens']).toBe(27929)
     expect(properties['$ai_cache_reporting_exclusive']).toBe(expectedFlag)
     ;(ChatMock.Completions as any).prototype.create = originalCreate
+  })
+})
+
+describe('PostHogAzureOpenAI - response service tier', () => {
+  let mockPostHogClient: PostHog
+  let client: PostHogAzureOpenAI
+
+  const createMockAsyncIterator = <T>(chunks: T[]): { [Symbol.asyncIterator](): AsyncIterator<T> } => ({
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk
+      }
+    },
+  })
+
+  const mockResponsesResult = (serviceTier: 'default' | 'flex') => ({
+    id: 'resp-service-tier',
+    model: 'gpt-4',
+    object: 'response',
+    created_at: 1234567890,
+    status: 'completed',
+    output: [],
+    usage: null,
+    service_tier: serviceTier,
+  })
+
+  const capturedServiceTier = (): string => {
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    return captureArgs[0].properties['$ai_model_parameters'].service_tier
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPostHogClient = new (PostHog as any)()
+    client = new PostHogAzureOpenAI({
+      apiKey: 'mock-azure-key',
+      posthog: mockPostHogClient as any,
+    })
+  })
+
+  test('prefers the response tier for non-streaming chat completions', async () => {
+    const ChatMock: any = openaiModule.Chat
+    ;(ChatMock.Completions as any).prototype.create = jest.fn().mockResolvedValue({
+      id: 'chatcmpl-service-tier',
+      model: 'gpt-4',
+      object: 'chat.completion',
+      created: 1234567890,
+      choices: [],
+      service_tier: 'flex',
+    })
+
+    await client.chat.completions.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+      service_tier: 'auto',
+      posthogDistinctId: 'test-id',
+    })
+
+    expect(capturedServiceTier()).toBe('flex')
+  })
+
+  test('prefers the final response tier for streaming chat completions', async () => {
+    const chunks = [
+      {
+        id: 'chatcmpl-service-tier',
+        model: 'gpt-4',
+        object: 'chat.completion.chunk',
+        created: 1234567890,
+        choices: [],
+        service_tier: 'default',
+      },
+      {
+        id: 'chatcmpl-service-tier',
+        model: 'gpt-4',
+        object: 'chat.completion.chunk',
+        created: 1234567890,
+        choices: [],
+        service_tier: 'flex',
+      },
+    ]
+    const ChatMock: any = openaiModule.Chat
+    ;(ChatMock.Completions as any).prototype.create = jest.fn().mockResolvedValue({
+      tee: jest.fn().mockReturnValue([createMockAsyncIterator(chunks), createMockAsyncIterator(chunks)]),
+    })
+
+    const stream = await client.chat.completions.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+      service_tier: 'auto',
+      stream: true,
+      posthogDistinctId: 'test-id',
+    })
+    for await (const _chunk of stream) {
+      // consume the stream so the analytics copy reaches the final chunk
+    }
+    await flushPromises()
+
+    expect(capturedServiceTier()).toBe('flex')
+  })
+
+  test.each([
+    {
+      api: 'responses.create',
+      method: 'create',
+      invoke: () =>
+        client.responses.create({
+          model: 'gpt-4',
+          input: 'Hello',
+          service_tier: 'auto',
+          posthogDistinctId: 'test-id',
+        }),
+    },
+    {
+      api: 'responses.parse',
+      method: 'parse',
+      invoke: () =>
+        client.responses.parse({
+          model: 'gpt-4',
+          input: 'Hello',
+          service_tier: 'auto',
+          posthogDistinctId: 'test-id',
+        } as any),
+    },
+  ])('prefers the response tier for non-streaming $api', async ({ method, invoke }) => {
+    const ResponsesMock: any = openaiModule.Responses
+    ResponsesMock.prototype[method] = jest.fn().mockResolvedValue(mockResponsesResult('flex'))
+
+    await invoke()
+
+    expect(capturedServiceTier()).toBe('flex')
+  })
+
+  test('prefers the final response tier for streaming responses', async () => {
+    const chunks = [
+      { type: 'response.created', response: mockResponsesResult('default') },
+      { type: 'response.completed', response: mockResponsesResult('flex') },
+    ]
+    const ResponsesMock: any = openaiModule.Responses
+    ResponsesMock.prototype.create = jest.fn().mockResolvedValue({
+      tee: jest.fn().mockReturnValue([createMockAsyncIterator(chunks), createMockAsyncIterator(chunks)]),
+    })
+
+    const stream = await client.responses.create({
+      model: 'gpt-4',
+      input: 'Hello',
+      service_tier: 'auto',
+      stream: true,
+      posthogDistinctId: 'test-id',
+    })
+    for await (const _chunk of stream) {
+      // consume the stream so the analytics copy reaches the final chunk
+    }
+    await flushPromises()
+
+    expect(capturedServiceTier()).toBe('flex')
   })
 })

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -619,6 +619,108 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(properties['foo']).toBe('bar')
   })
 
+  describe('response service tier', () => {
+    test('prefers the response tier for non-streaming chat completions', async () => {
+      mockOpenAiChatResponse.service_tier = 'flex'
+
+      await client.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Hello' }],
+        service_tier: 'auto',
+        posthogDistinctId: 'test-id',
+      })
+
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      expect(captureArgs[0].properties['$ai_model_parameters'].service_tier).toBe('flex')
+    })
+
+    test('prefers the final response tier for streaming chat completions', async () => {
+      mockStreamChunks[0].service_tier = 'default'
+      mockStreamChunks[mockStreamChunks.length - 1].service_tier = 'priority'
+
+      const stream = await client.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Hello' }],
+        service_tier: 'auto',
+        stream: true,
+        posthogDistinctId: 'test-id',
+      })
+      for await (const _chunk of stream) {
+        // consume the stream so the analytics copy reaches the final chunk
+      }
+      await flushPromises()
+
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      expect(captureArgs[0].properties['$ai_model_parameters'].service_tier).toBe('priority')
+    })
+
+    test.each([
+      {
+        api: 'responses.create',
+        invoke: () =>
+          client.responses.create({
+            model: 'gpt-4',
+            input: 'Hello',
+            service_tier: 'auto',
+            posthogDistinctId: 'test-id',
+          }),
+      },
+      {
+        api: 'responses.parse',
+        invoke: () =>
+          client.responses.parse({
+            model: 'gpt-4',
+            input: 'Hello',
+            service_tier: 'auto',
+            posthogDistinctId: 'test-id',
+          } as any),
+      },
+    ])('prefers the response tier for non-streaming $api', async ({ invoke }) => {
+      mockOpenAiParsedResponse.service_tier = 'default'
+
+      await invoke()
+
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      expect(captureArgs[0].properties['$ai_model_parameters'].service_tier).toBe('default')
+    })
+
+    test('prefers the final response tier for streaming responses', async () => {
+      const chunks = [
+        {
+          type: 'response.created',
+          sequence_number: 0,
+          response: { ...mockOpenAiParsedResponse, service_tier: 'default' as const },
+        },
+        {
+          type: 'response.completed',
+          sequence_number: 1,
+          response: { ...mockOpenAiParsedResponse, service_tier: 'flex' as const },
+        },
+      ]
+      const ResponsesMock: any = openaiModule.Responses
+      ResponsesMock.prototype.create = jest.fn().mockImplementation(() =>
+        createMockAPIPromise({
+          tee: jest.fn().mockReturnValue([createMockAsyncIterator(chunks), createMockAsyncIterator(chunks)]),
+        })
+      )
+
+      const stream = await client.responses.create({
+        model: 'gpt-4',
+        input: 'Hello',
+        service_tier: 'auto',
+        stream: true,
+        posthogDistinctId: 'test-id',
+      })
+      for await (const _chunk of stream) {
+        // consume the stream so the analytics copy reaches the final chunk
+      }
+      await flushPromises()
+
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      expect(captureArgs[0].properties['$ai_model_parameters'].service_tier).toBe('flex')
+    })
+  })
+
   conditionalTest('reasoning and cache tokens', async () => {
     // Set up mock response with standard token usage
     mockOpenAiChatResponse.usage = {

--- a/packages/ai/tests/utils.test.ts
+++ b/packages/ai/tests/utils.test.ts
@@ -220,6 +220,16 @@ describe('getModelParams', () => {
     }
   })
 
+  it('prefers the response service_tier over the requested service_tier', () => {
+    const params = { model: 'gpt-4o', service_tier: 'auto' } as any
+    expect(getModelParams(params, 'flex')).toEqual({ service_tier: 'flex' })
+  })
+
+  it.each([null, undefined])('keeps the requested service_tier when the response tier is %s', (responseTier) => {
+    const params = { model: 'gpt-4o', service_tier: 'auto' } as any
+    expect(getModelParams(params, responseTier)).toEqual({ service_tier: 'auto' })
+  })
+
   it('omits service_tier when not provided', () => {
     const params = { model: 'gpt-4o', temperature: 0.5 } as any
     const result = getModelParams(params)


### PR DESCRIPTION
## Problem

OpenAI can resolve a requested `service_tier: 'auto'` to a different processing tier such as `default` or `flex`. The request-only capture added in #4072 therefore cannot always identify the tier that was actually billed, which can lead to inaccurate cost attribution.

## Changes

- Prefer the latest non-null `service_tier` reported by successful OpenAI responses while retaining the requested tier as a fallback.
- Apply the behavior to OpenAI and Azure OpenAI Chat Completions and Responses API paths, including streaming, non-streaming, and parsed responses.
- Keep error captures on the requested tier when a completed response tier is unavailable.
- Add regression coverage for response precedence, streaming final-tier precedence, and null or missing response fallback.
- Add a dedicated `@posthog/ai` changeset for the resolved-tier behavior without modifying the changeset from #4072.

Follow-up to #4072 and discussion https://github.com/PostHog/posthog-js/pull/4072#discussion_r3636466279.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently reviewed with its reviewer subagent. The implementation prefers response metadata only when non-null, keeps request metadata as the compatibility fallback, and covers both OpenAI and Azure OpenAI wrapper paths.
