### PR TITLE
ci: make browser integration checks fork-safe

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,6 @@ jobs:
   browsers:
     name: Test on ${{ matrix.tests.name }}
     needs: affected
-    if: github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true'
     runs-on: ubuntu-22.04
     container:
       # Keep this version in sync with packages/browser's @playwright/test dependency.
@@ -53,16 +52,24 @@ jobs:
             browser: "webkit"
 
     steps:
+      - name: Skip integration tests
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository || needs.affected.outputs.is-affected != 'true' }}
+        run: echo "Skipping ${{ matrix.tests.name }} integration tests because the browser package is unaffected or required secrets are unavailable for fork PRs."
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
 
       - uses: ./.github/actions/setup
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
         with:
           build: false
 
       - name: Build packages
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
       - name: Run ${{ matrix.tests.name }} test
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Problem

Contributor PRs from forks can be blocked indefinitely by the required `Test on Chromium`, `Test on Firefox`, and `Test on Safari` checks. The Playwright matrix job is currently gated at the job level, so GitHub never creates those required check contexts for fork PRs or PRs that do not affect `posthog-js`. This was surfaced by #4072.

## Changes

- Always create the Chromium, Firefox, and Safari matrix jobs.
- Complete those jobs early when the PR is from a fork or does not affect the browser package.
- Continue running the full integration tests only for same-repository PRs that affect `posthog-js`, where the required secrets are available.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent in a dedicated worktree. The change follows the existing fork-safe TestCafe workflow pattern, was validated with `actionlint`, and received an independent reviewer-agent pass. No changeset was added because this only changes CI behavior.
