### PR TITLE
fix(react): restore UMD CommonJS interop

### DIFF
--- a/.changeset/react-umd-cjs-interop.md
+++ b/.changeset/react-umd-cjs-interop.md
@@ -1,0 +1,8 @@
+---
+'posthog-js': patch
+'@posthog/react': patch
+---
+
+fix(react): restore CommonJS default import interop in UMD bundles
+
+React hooks used without a `PostHogProvider` now receive the default PostHog instance again when the UMD build is loaded through CommonJS.

--- a/.changeset/react-umd-cjs-interop.md
+++ b/.changeset/react-umd-cjs-interop.md
@@ -1,6 +1,5 @@
 ---
 'posthog-js': patch
-'@posthog/react': patch
 ---
 
 fix(react): restore CommonJS default import interop in UMD bundles

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,7 @@ jobs:
       package-name: posthog-js
       additional-paths: |
         packages/browser/
+        packages/react/
         .github/workflows/integration.yml
         .github/workflows/check-affected.yml
         .github/actions/is-affected/action.yaml

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -51,6 +51,7 @@ const buildUmd = {
         file: 'dist/umd/index.js',
         name: 'PosthogReact',
         format: 'umd',
+        interop: 'compat',
         sourcemap: true,
         esModule: false,
         globals: {
@@ -92,6 +93,7 @@ const buildSlimUmd = {
         file: 'dist/umd/slim/index.js',
         name: 'PosthogReactSlim',
         format: 'umd',
+        interop: 'compat',
         sourcemap: true,
         esModule: false,
         globals: {
@@ -130,6 +132,7 @@ const buildSurveysUmd = {
         file: 'dist/umd/surveys/index.js',
         name: 'PosthogReactSurveys',
         format: 'umd',
+        interop: 'compat',
         sourcemap: true,
         esModule: false,
         globals: {

--- a/packages/react/src/__tests__/umd-bundle.test.ts
+++ b/packages/react/src/__tests__/umd-bundle.test.ts
@@ -11,8 +11,8 @@ jest.mock('posthog-js', () => ({
 }))
 
 describe('UMD bundle', () => {
-    it('unwraps the posthog-js CommonJS namespace for the default instance', async () => {
-        const { usePostHog } = await import('../../dist/umd/index.js')
+    it('unwraps the posthog-js CommonJS namespace for the default instance', () => {
+        const { usePostHog } = jest.requireActual('../../dist/umd/index.js')
 
         const { result } = renderHook(() => usePostHog())
 

--- a/packages/react/src/__tests__/umd-bundle.test.ts
+++ b/packages/react/src/__tests__/umd-bundle.test.ts
@@ -1,0 +1,23 @@
+import { renderHook } from '@testing-library/react'
+
+const mockPostHogInstance = {
+    capture: jest.fn(),
+    isFeatureEnabled: jest.fn(),
+}
+
+jest.mock('posthog-js', () => ({
+    default: mockPostHogInstance,
+    posthog: mockPostHogInstance,
+}))
+
+describe('UMD bundle', () => {
+    it('unwraps the posthog-js CommonJS namespace for the default instance', async () => {
+        const { usePostHog } = await import('../../dist/umd/index.js')
+
+        const { result } = renderHook(() => usePostHog())
+
+        expect(result.current).toBe(mockPostHogInstance)
+        expect(result.current.capture).toBe(mockPostHogInstance.capture)
+        expect(result.current.isFeatureEnabled).toBe(mockPostHogInstance.isFeatureEnabled)
+    })
+})


### PR DESCRIPTION
## Problem

CommonJS consumers of the React UMD bundle receive the raw `posthog-js` module namespace as the default fallback instance. Hooks used without a `PostHogProvider` therefore expose no `capture` or `isFeatureEnabled` methods and fail at runtime.

This regressed when the React build moved from Rollup 2 to Rollup 4, whose default external-module interop differs from the previous compatibility behavior.

Closes #4310.

## Changes

- Set explicit compatibility interop for all React UMD outputs, preserving the behavior from before the Rollup upgrade.
- Add a generated-bundle regression test that loads the UMD entry point synchronously with a CommonJS-shaped `posthog-js` namespace and verifies `usePostHog()` returns its default instance.
- Add a patch changeset for `posthog-js`. The standalone `@posthog/react@1.10.3` bundle still contains the working Rollup 2 output, so only the React artifacts embedded in `posthog-js` need a release.
- Treat `packages/react/` changes as affecting browser integration CI so the required Chromium, Firefox, and Safari checks are emitted.

Verification:

- `cd packages/react && pnpm build`
- `cd packages/react && pnpm test:unit --runInBand` (101 tests)
- `cd packages/react && pnpm lint`
- `pnpm exec prettier --check packages/react/rollup.config.mjs packages/react/src/__tests__/umd-bundle.test.ts .changeset/react-umd-cjs-interop.md`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent after reproducing the regression against the published working and broken bundles. The fix restores Rollup's former compatibility interop at the build boundary rather than normalizing module namespaces in application code. After CI exposed that a dynamic import in the test was incompatible with the package TypeScript module target, the test was switched to Jest's synchronous actual-module loader. Browser integration affected-path detection was also updated because React artifacts are embedded in `posthog-js`; without it, required browser check contexts were skipped and never reported. The final local diff was also checked with Pi's isolated autoreview helper.
