### PR TITLE
fix(surveys): keep hosted-survey prefill metadata and prevent thumbs loss

### DIFF
--- a/.changeset/hosted-survey-prefill-metadata-thumbs.md
+++ b/.changeset/hosted-survey-prefill-metadata-thumbs.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix hosted (external) surveys with URL prefill: the auto-submitted response now includes caller-provided event properties (extra URL query params), and a later manual submit no longer clears the prefilled answer from the partial-response merge.

--- a/packages/browser/playwright/mocked/surveys/url-prefill.spec.ts
+++ b/packages/browser/playwright/mocked/surveys/url-prefill.spec.ts
@@ -1,0 +1,93 @@
+import { getSurveyResponseKey } from '@/extensions/surveys/surveys-extension-utils'
+import { pollUntilEventCaptured } from '../utils/event-capture-utils'
+import { expect, test } from '../utils/posthog-playwright-test-base'
+import { start } from '../utils/setup'
+
+const thumbsQuestion = {
+    type: 'rating',
+    question: 'Was this helpful?',
+    id: 'thumbs_1',
+    display: 'emoji',
+    scale: 3,
+    skipSubmitButton: true,
+}
+
+const followUpQuestion = {
+    type: 'open',
+    question: 'Tell us more',
+    id: 'follow_up_1',
+    optional: true,
+}
+
+const prefillSurvey = {
+    id: 'prefill-123',
+    name: 'Email feedback survey',
+    type: 'popover',
+    start_date: '2021-01-01T00:00:00Z',
+    enable_partial_responses: true,
+    questions: [thumbsQuestion, followUpQuestion],
+}
+
+test.describe('surveys - URL prefill with auto-submit', () => {
+    test('keeps the auto-submitted answer and caller properties on the follow-up submission', async ({
+        page,
+        context,
+    }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({ json: { surveys: [prefillSurvey] } })
+        })
+
+        await start(
+            {
+                options: {
+                    disable_surveys_automatic_display: true,
+                    surveys: { prefillFromUrl: true },
+                },
+                flagsResponseOverrides: { surveys: true },
+                url: './playground/cypress/index.html?q0=3&account_number=12345',
+            },
+            page,
+            context
+        )
+        await surveysAPICall
+
+        // The hosted survey page renders on demand and passes the custom URL params as properties.
+        await page.evaluate((survey) => {
+            const ph = (window as any).posthog
+            const container = document.createElement('div')
+            container.id = 'hosted-survey-container'
+            document.body.appendChild(container)
+            ph.surveys['_surveyManager'].renderSurvey(survey, container, { account_number: '12345' })
+        }, prefillSurvey as any)
+
+        await pollUntilEventCaptured(page, 'survey sent')
+        const autoSubmitted = await page
+            .capturedEvents()
+            .then((events) => events.filter((e) => e.event === 'survey sent'))
+        expect(autoSubmitted).toHaveLength(1)
+        expect(autoSubmitted[0]!.properties).toEqual(
+            expect.objectContaining({
+                [getSurveyResponseKey('thumbs_1')]: 3,
+                $survey_completed: false,
+                account_number: '12345',
+            })
+        )
+
+        await page.locator('#hosted-survey-container textarea').fill('it was great')
+        await page.locator('#hosted-survey-container .form-submit').click()
+
+        await expect
+            .poll(async () => (await page.capturedEvents()).filter((e) => e.event === 'survey sent').length)
+            .toBe(2)
+        const sentEvents = await page.capturedEvents().then((events) => events.filter((e) => e.event === 'survey sent'))
+        expect(sentEvents[1]!.properties).toEqual(
+            expect.objectContaining({
+                $survey_submission_id: autoSubmitted[0]!.properties['$survey_submission_id'],
+                [getSurveyResponseKey('thumbs_1')]: 3,
+                [getSurveyResponseKey('follow_up_1')]: 'it was great',
+                $survey_completed: true,
+                account_number: '12345',
+            })
+        )
+    })
+})

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -7,7 +7,7 @@ import {
     useHideSurveyOnURLChange,
     usePopupVisibility,
 } from '../../extensions/surveys'
-import { retrieveSurveyShadow } from '../../extensions/surveys/surveys-extension-utils'
+import { getInProgressSurveyState, retrieveSurveyShadow } from '../../extensions/surveys/surveys-extension-utils'
 import {
     Survey,
     SurveyQuestionBranchingType,
@@ -1160,6 +1160,91 @@ describe('SurveyManager', () => {
                     $survey_completed: false,
                 })
             )
+        })
+
+        it('should include caller-provided properties in the auto-submitted prefill event', () => {
+            const survey: Survey = {
+                id: 'prefill-survey-props',
+                name: 'Prefill Survey Props',
+                type: SurveyType.Popover,
+                enable_partial_responses: true,
+                questions: [
+                    {
+                        id: 'q1',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate us',
+                        scale: 10,
+                        skipSubmitButton: true,
+                    },
+                    {
+                        id: 'q2',
+                        type: SurveyQuestionType.Open,
+                        question: 'Any feedback?',
+                    },
+                ],
+                appearance: {},
+                conditions: null,
+                start_date: '2021-01-01T00:00:00.000Z',
+                end_date: null,
+                current_iteration: null,
+                current_iteration_start_date: null,
+                feature_flag_keys: [],
+                linked_flag_key: null,
+                targeting_flag_key: null,
+                internal_targeting_flag_key: null,
+            }
+
+            window.location.search = '?q0=8'
+            ;(surveyManager as any)._handleUrlPrefill(survey, null, { account_number: 'A12345', month: 'January' })
+
+            expect(mockPostHog.capture).toHaveBeenCalledWith(
+                'survey sent',
+                expect.objectContaining({
+                    $survey_id: 'prefill-survey-props',
+                    $survey_response_q1: 8,
+                    account_number: 'A12345',
+                    month: 'January',
+                })
+            )
+        })
+
+        it('should persist auto-advanced questions as visited so a later manual submit keeps prefilled answers', () => {
+            const survey: Survey = {
+                id: 'prefill-survey-visited',
+                name: 'Prefill Survey Visited',
+                type: SurveyType.Popover,
+                enable_partial_responses: true,
+                questions: [
+                    {
+                        id: 'q1',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate us',
+                        scale: 10,
+                        skipSubmitButton: true,
+                    },
+                    {
+                        id: 'q2',
+                        type: SurveyQuestionType.Open,
+                        question: 'Any feedback?',
+                    },
+                ],
+                appearance: {},
+                conditions: null,
+                start_date: '2021-01-01T00:00:00.000Z',
+                end_date: null,
+                current_iteration: null,
+                current_iteration_start_date: null,
+                feature_flag_keys: [],
+                linked_flag_key: null,
+                targeting_flag_key: null,
+                internal_targeting_flag_key: null,
+            }
+
+            window.location.search = '?q0=8'
+            ;(surveyManager as any)._handleUrlPrefill(survey)
+
+            const state = getInProgressSurveyState(survey)
+            expect(state?.visitedIndices).toEqual([0])
         })
 
         it('should NOT auto-submit when skipSubmitButton is false, even with enable_partial_responses true', () => {

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -801,7 +801,7 @@ describe('SurveyManager', () => {
         })
     })
 
-    describe('renderSurvey with URL prefill that completes the survey', () => {
+    describe('renderSurvey with URL prefill', () => {
         let surveyManager: SurveyManager
         let originalLocation: Location
 

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -889,6 +889,74 @@ describe('SurveyManager', () => {
                 expect(surveyDiv.getElementsByClassName('thank-you-message').length).toBe(0)
             }
         })
+
+        it('retains the auto-advanced prefilled answer through a later manual submit', async () => {
+            localStorage.clear()
+            const mockPH = createMockPostHog({
+                config: {
+                    token: 'test-token',
+                    api_host: 'https://test.com',
+                    surveys: { prefillFromUrl: true },
+                },
+                getActiveMatchingSurveys: jest.fn(),
+                get_session_replay_url: jest.fn(),
+                capture: jest.fn(),
+                featureFlags: { isFeatureEnabled: jest.fn().mockReturnValue(true) },
+            })
+            surveyManager = new SurveyManager(mockPH)
+
+            const survey: Survey = {
+                id: 'prefill-merge-survey',
+                name: 'Prefill Merge Survey',
+                type: SurveyType.Popover,
+                enable_partial_responses: true,
+                questions: [
+                    {
+                        id: 'q1',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate the draft',
+                        scale: 2,
+                        display: 'emoji',
+                        skipSubmitButton: true,
+                    },
+                    { id: 'q2', type: SurveyQuestionType.Open, question: 'Tell us more' },
+                ],
+                appearance: {},
+                conditions: null,
+                start_date: '2021-01-01T00:00:00.000Z',
+                end_date: null,
+                current_iteration: null,
+                current_iteration_start_date: null,
+                feature_flag_keys: [],
+                linked_flag_key: null,
+                targeting_flag_key: null,
+                internal_targeting_flag_key: null,
+            } as unknown as Survey
+
+            // q0 (the rating) is prefilled and auto-advances; the open question is shown for manual submit.
+            window.location.search = '?q0=1'
+            const surveyDiv = document.createElement('div')
+            surveyManager.renderSurvey(survey, surveyDiv)
+
+            const textarea = surveyDiv.querySelector('textarea')
+            await act(async () => {
+                fireEvent.input(textarea!, { target: { value: 'because reasons' } })
+            })
+            const submitButton = surveyDiv.querySelector<HTMLButtonElement>('.form-submit')
+            await act(async () => {
+                fireEvent.click(submitButton!)
+            })
+
+            // The manual submit must still carry the prefilled rating, not just the open answer —
+            // both events share one submission id and merge server-side, so dropping it would clear it.
+            expect(mockPH.capture).toHaveBeenLastCalledWith(
+                'survey sent',
+                expect.objectContaining({
+                    $survey_response_q1: 1,
+                    $survey_response_q2: 'because reasons',
+                })
+            )
+        })
     })
 
     describe('timeout management', () => {

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -7,7 +7,7 @@ import {
     useHideSurveyOnURLChange,
     usePopupVisibility,
 } from '../../extensions/surveys'
-import { getInProgressSurveyState, retrieveSurveyShadow } from '../../extensions/surveys/surveys-extension-utils'
+import { retrieveSurveyShadow } from '../../extensions/surveys/surveys-extension-utils'
 import {
     Survey,
     SurveyQuestionBranchingType,
@@ -1274,45 +1274,6 @@ describe('SurveyManager', () => {
                     month: 'January',
                 })
             )
-        })
-
-        it('should persist auto-advanced questions as visited so a later manual submit keeps prefilled answers', () => {
-            const survey: Survey = {
-                id: 'prefill-survey-visited',
-                name: 'Prefill Survey Visited',
-                type: SurveyType.Popover,
-                enable_partial_responses: true,
-                questions: [
-                    {
-                        id: 'q1',
-                        type: SurveyQuestionType.Rating,
-                        question: 'Rate us',
-                        scale: 10,
-                        skipSubmitButton: true,
-                    },
-                    {
-                        id: 'q2',
-                        type: SurveyQuestionType.Open,
-                        question: 'Any feedback?',
-                    },
-                ],
-                appearance: {},
-                conditions: null,
-                start_date: '2021-01-01T00:00:00.000Z',
-                end_date: null,
-                current_iteration: null,
-                current_iteration_start_date: null,
-                feature_flag_keys: [],
-                linked_flag_key: null,
-                targeting_flag_key: null,
-                internal_targeting_flag_key: null,
-            }
-
-            window.location.search = '?q0=8'
-            ;(surveyManager as any)._handleUrlPrefill(survey)
-
-            const state = getInProgressSurveyState(survey)
-            expect(state?.visitedIndices).toEqual([0])
         })
 
         it('should NOT auto-submit when skipSubmitButton is false, even with enable_partial_responses true', () => {

--- a/packages/browser/src/__tests__/utils/survey-url-prefill.test.ts
+++ b/packages/browser/src/__tests__/utils/survey-url-prefill.test.ts
@@ -1024,6 +1024,22 @@ describe('calculatePrefillStartIndex', () => {
             expect(result.skippedResponses).toEqual({ '$survey_response_q-end': 'No' })
         })
 
+        it('should stop after max iterations when branching creates a cycle', () => {
+            const cyclicQuestion: SurveyQuestion = {
+                ...ratingQuestionWithSkip,
+                branching: {
+                    type: SurveyQuestionBranchingType.SpecificQuestion,
+                    index: 0,
+                },
+            }
+            const responses = { '$survey_response_q-rating': 7 }
+
+            const result = calculatePrefillStartIndex(createSurvey([cyclicQuestion]), [0], responses)
+
+            expect(result.startQuestionIndex).toBe(0)
+            expect(result.skippedResponses).toEqual(responses)
+        })
+
         it('should handle specific question branching', () => {
             const questionWithSpecificBranching: SurveyQuestion = {
                 type: SurveyQuestionType.Rating,

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -546,11 +546,7 @@ export class SurveyManager {
                 surveySubmissionId: submissionId,
                 responses: responses,
                 lastQuestionIndex: startQuestionIndex,
-                // Persist the auto-advanced questions as visited so a later manual submit keeps their
-                // prefilled answers instead of pruning them from the partial-response merge.
-                // skippedIndices are raw `survey.questions` indices; the manual-submit prune maps them
-                // via getDisplayOrderQuestions. These line up because prefill auto-submit only runs when
-                // enable_partial_responses is true, under which display order equals raw order (no shuffle).
+                // Mark auto-advanced questions visited so a manual submit doesn't prune their answers.
                 visitedIndices: skippedIndices,
                 surveyLanguage,
             })

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -404,7 +404,7 @@ export class SurveyManager {
         const { survey: translatedSurvey, language: surveyLanguage } = this._translateSurveyForRendering(survey)
         let isSurveyCompleted = false
         if (this._posthog.config?.surveys?.prefillFromUrl) {
-            isSurveyCompleted = this._handleUrlPrefill(translatedSurvey, surveyLanguage)
+            isSurveyCompleted = this._handleUrlPrefill(translatedSurvey, surveyLanguage, properties)
         }
 
         render(
@@ -427,7 +427,7 @@ export class SurveyManager {
         return applySurveyTranslationForUser(survey, this._posthog)
     }
 
-    private _handleUrlPrefill(survey: Survey, surveyLanguage?: string | null): boolean {
+    private _handleUrlPrefill(survey: Survey, surveyLanguage?: string | null, properties?: Properties): boolean {
         // Only handle prefill once per survey session to avoid overwriting in-progress responses
         if (this._prefillHandledSurveys.has(survey.id)) {
             return false
@@ -461,6 +461,7 @@ export class SurveyManager {
                 surveySubmissionId: submissionId,
                 posthog: this._posthog,
                 isSurveyCompleted,
+                properties,
                 surveyLanguage,
             })
         }
@@ -534,7 +535,7 @@ export class SurveyManager {
 
             // calculate which question to start at based on prefilled questions
             const prefilledIndices = Object.keys(prefillParams).map((k) => parseInt(k, 10))
-            const { startQuestionIndex, skippedResponses } = calculatePrefillStartIndex(
+            const { startQuestionIndex, skippedResponses, skippedIndices } = calculatePrefillStartIndex(
                 survey,
                 prefilledIndices,
                 responses
@@ -545,6 +546,9 @@ export class SurveyManager {
                 surveySubmissionId: submissionId,
                 responses: responses,
                 lastQuestionIndex: startQuestionIndex,
+                // Persist the auto-advanced questions as visited so a later manual submit keeps their
+                // prefilled answers instead of pruning them from the partial-response merge.
+                visitedIndices: skippedIndices,
                 surveyLanguage,
             })
 

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -548,6 +548,9 @@ export class SurveyManager {
                 lastQuestionIndex: startQuestionIndex,
                 // Persist the auto-advanced questions as visited so a later manual submit keeps their
                 // prefilled answers instead of pruning them from the partial-response merge.
+                // skippedIndices are raw `survey.questions` indices; the manual-submit prune maps them
+                // via getDisplayOrderQuestions. These line up because prefill auto-submit only runs when
+                // enable_partial_responses is true, under which display order equals raw order (no shuffle).
                 visitedIndices: skippedIndices,
                 surveyLanguage,
             })

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -433,6 +433,8 @@ export const sendSurveyEvent = ({
     }
     setSurveySeenOnLocalStorage(survey)
     posthog.capture(SurveyEventName.SENT, {
+        // Caller properties first so reserved survey fields and responses below always win on key collision.
+        ...properties,
         [SurveyEventProperties.SURVEY_NAME]: survey.name,
         [SurveyEventProperties.SURVEY_ID]: survey.id,
         [SurveyEventProperties.SURVEY_ITERATION]: survey.current_iteration,
@@ -442,7 +444,6 @@ export const sendSurveyEvent = ({
         ...(surveyLanguage && { [SurveyEventProperties.SURVEY_LANGUAGE]: surveyLanguage }),
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
         ...buildSurveyResponseProperties(responses, survey),
-        ...properties,
         $set: {
             [getSurveyInteractionProperty(survey, 'responded')]: true,
         },

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -433,8 +433,6 @@ export const sendSurveyEvent = ({
     }
     setSurveySeenOnLocalStorage(survey)
     posthog.capture(SurveyEventName.SENT, {
-        // Caller properties first so reserved survey fields and responses below always win on key collision.
-        ...properties,
         [SurveyEventProperties.SURVEY_NAME]: survey.name,
         [SurveyEventProperties.SURVEY_ID]: survey.id,
         [SurveyEventProperties.SURVEY_ITERATION]: survey.current_iteration,
@@ -444,6 +442,7 @@ export const sendSurveyEvent = ({
         ...(surveyLanguage && { [SurveyEventProperties.SURVEY_LANGUAGE]: surveyLanguage }),
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
         ...buildSurveyResponseProperties(responses, survey),
+        ...properties,
         $set: {
             [getSurveyInteractionProperty(survey, 'responded')]: true,
         },

--- a/packages/browser/src/utils/survey-url-prefill.ts
+++ b/packages/browser/src/utils/survey-url-prefill.ts
@@ -155,8 +155,7 @@ export function calculatePrefillStartIndex(
 ): { startQuestionIndex: number; skippedResponses: Record<string, any>; skippedIndices: number[] } {
     let currentIndex = 0
     const skippedResponses: Record<string, any> = {}
-    // Question indices the user auto-advanced past via prefill. These count as "visited" so a
-    // later manual submit doesn't prune their answers when pruning to responses-on-path.
+    // Auto-advanced questions, persisted as visitedIndices so a manual submit keeps their answers.
     const skippedIndices: number[] = []
 
     const MAX_ITERATIONS = survey.questions.length + 1

--- a/packages/browser/src/utils/survey-url-prefill.ts
+++ b/packages/browser/src/utils/survey-url-prefill.ts
@@ -152,9 +152,12 @@ export function calculatePrefillStartIndex(
     survey: Survey,
     prefilledIndices: number[],
     responses: Record<string, any>
-): { startQuestionIndex: number; skippedResponses: Record<string, any> } {
+): { startQuestionIndex: number; skippedResponses: Record<string, any>; skippedIndices: number[] } {
     let currentIndex = 0
     const skippedResponses: Record<string, any> = {}
+    // Question indices the user auto-advanced past via prefill. These count as "visited" so a
+    // later manual submit doesn't prune their answers when pruning to responses-on-path.
+    const skippedIndices: number[] = []
 
     const MAX_ITERATIONS = survey.questions.length + 1
     const iterations = 0
@@ -179,6 +182,7 @@ export function calculatePrefillStartIndex(
                 skippedResponses[responseKey] = responses[responseKey]
             }
         }
+        skippedIndices.push(currentIndex)
 
         // Use branching logic to determine the next question
         const response = question.id ? responses[getSurveyResponseKey(question.id)] : null
@@ -186,12 +190,12 @@ export function calculatePrefillStartIndex(
 
         if (nextStep === SurveyQuestionBranchingType.End) {
             // Survey is complete - return questions.length to indicate completion
-            return { startQuestionIndex: survey.questions.length, skippedResponses }
+            return { startQuestionIndex: survey.questions.length, skippedResponses, skippedIndices }
         }
 
         // Move to the next question (respecting branching)
         currentIndex = nextStep
     }
 
-    return { startQuestionIndex: currentIndex, skippedResponses }
+    return { startQuestionIndex: currentIndex, skippedResponses, skippedIndices }
 }

--- a/packages/browser/src/utils/survey-url-prefill.ts
+++ b/packages/browser/src/utils/survey-url-prefill.ts
@@ -159,9 +159,8 @@ export function calculatePrefillStartIndex(
     const skippedIndices: number[] = []
 
     const MAX_ITERATIONS = survey.questions.length + 1
-    let iterations = 0
+    const iterations = 0
     while (currentIndex < survey.questions.length && iterations < MAX_ITERATIONS) {
-        iterations++
         // Stop if current question is not prefilled
         if (!prefilledIndices.includes(currentIndex)) {
             break

--- a/packages/browser/src/utils/survey-url-prefill.ts
+++ b/packages/browser/src/utils/survey-url-prefill.ts
@@ -159,8 +159,9 @@ export function calculatePrefillStartIndex(
     const skippedIndices: number[] = []
 
     const MAX_ITERATIONS = survey.questions.length + 1
-    const iterations = 0
+    let iterations = 0
     while (currentIndex < survey.questions.length && iterations < MAX_ITERATIONS) {
+        iterations++
         // Stop if current question is not prefilled
         if (!prefilledIndices.includes(currentIndex)) {
             break

--- a/packages/browser/src/utils/survey-url-prefill.ts
+++ b/packages/browser/src/utils/survey-url-prefill.ts
@@ -160,8 +160,9 @@ export function calculatePrefillStartIndex(
     const skippedIndices: number[] = []
 
     const MAX_ITERATIONS = survey.questions.length + 1
-    const iterations = 0
+    let iterations = 0
     while (currentIndex < survey.questions.length && iterations < MAX_ITERATIONS) {
+        iterations++
         // Stop if current question is not prefilled
         if (!prefilledIndices.includes(currentIndex)) {
             break


### PR DESCRIPTION
## Problem

Hosted (external) surveys opened via a prefilled deep link (e.g. a thumbs-up/down question set to "Automatically submit on selection" plus an optional follow-up, linked from an email with extra query params) had two related defects:

1. **Extra URL params were dropped on auto-submit.** The hosted survey page forwards non-question query params (things like `account_number`, `month`, `year`) to `renderSurvey` as the `properties` argument. When prefill auto-submitted the answer, those properties were missing from the resulting `survey sent` event — only the answer and `distinct_id` came through.
2. **The prefilled answer was cleared if the respondent then submitted manually.** After the auto-submit, if the user typed into the optional follow-up and pressed Submit, the follow-up + metadata were saved but the originally auto-captured answer disappeared from the response.

**Why:** both break the "capture immediately, but still let people add a comment" flow that hosted surveys are meant to support — the first response is recorded without its metadata, and completing the survey silently wipes the first answer.

## Changes

- Thread the caller-provided `properties` through `renderSurvey` → `_handleUrlPrefill` into the auto-submit `sendSurveyEvent`, so extra URL params land on the auto-submitted response (they already flowed through the manual-submit and `initialResponses` paths).
- Persist the auto-advanced (prefilled) question indices as `visitedIndices` in the in-progress survey state. The manual-submit path prunes the payload to "responses on the visited path"; because prefill never recorded those indices, the prefilled answer was pruned out, and since partial responses reuse the same `$survey_submission_id`, the merge cleared it. `calculatePrefillStartIndex` now also returns the skipped indices for this.
- Unit tests for both: auto-submit includes passed properties, and prefill persists the visited indices.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: Ben Lea (ben.l@posthog.com)

Investigated a support report about hosted-survey responses, traced the two failure modes to the URL-prefill path in `packages/browser/src/extensions/surveys.tsx`, and confirmed the mechanism by reading the source (auto-submit `sendSurveyEvent` missing `properties`; prefill not persisting `visitedIndices`). The behavior was reproduced end-to-end on a test external survey — the auto-submit event carried the answer but not the metadata, and the follow-up manual submit produced a second event under the same submission id with the answer cleared.

Fixes verified with the survey unit suites (`survey-url-prefill.test.ts`, `surveys.test.ts`, 156 passing) and eslint on the changed files. No manual browser click-through was run in the agent environment.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A2AHK6CN8/p1785336747899189)*
