### PR TITLE
feat(browser-common): expand extension client context and persistence

### DIFF
--- a/.changeset/browser-common-client-context.md
+++ b/.changeset/browser-common-client-context.md
@@ -2,4 +2,4 @@
 '@posthog/browser-common': minor
 ---
 
-Add richer client request and identity context alongside batched key-value persistence operations.
+Add richer client request and identity context alongside initialized, synchronously buffered batch key-value persistence operations.

--- a/.changeset/browser-common-client-context.md
+++ b/.changeset/browser-common-client-context.md
@@ -1,0 +1,5 @@
+---
+'@posthog/browser-common': minor
+---
+
+Add richer client request and identity context alongside batched key-value persistence operations.

--- a/.changeset/browser-persistence-batch-unregister.md
+++ b/.changeset/browser-persistence-batch-unregister.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Support removing multiple persisted properties in one operation.

--- a/packages/browser-common/.agents/skills/develop-extension/SKILL.md
+++ b/packages/browser-common/.agents/skills/develop-extension/SKILL.md
@@ -86,13 +86,16 @@ header, or path.
   cannot mutate them.
 - **Keep disposables.** Store and release values returned by listeners, dynamic-property registration, and timer or
   patch wrappers. Use `createDisposable(teardown)` for idempotent synchronous cleanup.
-- **Reads are sync; I/O is awaitable.** Identity, session, and `projectToken` are synchronous. Capture, requests, and
-  KV are awaitable; remote-config outcomes are delivered through `onRemoteConfig`.
+- **Initialize KV, then use it synchronously.** `client.kv.initialize()` may be awaitable while a host hydrates its
+  memory buffer. Once initialization completes, KV reads, writes, and removals are synchronous; the host owns ordered
+  durable flushing. Identity, session, and `projectToken` are also synchronous, while capture and requests are
+  awaitable and remote-config outcomes are delivered through `onRemoteConfig`.
 - **Design for async readiness.** Setup may occur before remote config loads or after events have already been captured.
   Guard work after each `await` so disposal cannot be followed by late installation.
-- **Persist through `client.kv`, not globals.** Browser-v1 keys are passed verbatim to persistence. Unknown keys may be
-  captured as event properties, collisions can overwrite SDK state, and reset clears them. Use stable extension-owned
-  keys and define their exposure policy.
+- **Persist through `client.kv`, not globals.** Complete `client.kv.initialize()` during setup before using the
+  synchronous buffer. Browser-v1 keys are passed verbatim to persistence. Unknown keys may be captured as event
+  properties, collisions can overwrite SDK state, and reset clears them. Use stable extension-owned keys and define
+  their exposure policy.
 - **browser-common owns shared extensions outright.** SDKs construct shared extensions and call `setup(client)` and
   optional `dispose()`; they do not wrap or subclass extension implementations.
 

--- a/packages/browser-common/README.md
+++ b/packages/browser-common/README.md
@@ -62,9 +62,10 @@ What an extension is given in `setup` — the adapter shared by extensions on th
 - **storage and logging**: `kv`, `logger`
 
 Identity, session, SDK metadata, and the public project token are always-ready synchronous reads. `capture` and
-`sendRequest` are awaitable. `onRemoteConfig` immediately replays the latest known success or failure and then reports
-subsequent outcomes. Extensions that want a named log prefix can create a child with
-`client.logger.createLogger('[myExtension]')`.
+`sendRequest` are awaitable. For `sendRequest`, `sentAt` controls `sent_at` placement on POST requests; GET query mode
+uses the cache-busting `_` parameter instead, and GET body mode has no effect. `onRemoteConfig` immediately replays the
+latest known success or failure and then reports subsequent outcomes. Extensions that want a named log prefix can
+create a child with `client.logger.createLogger('[myExtension]')`.
 
 Initialize KV during asynchronous setup before using its synchronous buffer:
 

--- a/packages/browser-common/README.md
+++ b/packages/browser-common/README.md
@@ -54,17 +54,34 @@ synchronous callback into idempotent teardown.
 
 What an extension is given in `setup` — the adapter shared by extensions on that host SDK instance:
 
-- **identity and session**: `distinctId`, `anonymousId`, `groups`, `session`
+- **identity and session**: `distinctId`, `anonymousId`, `deviceId`, `groups`, `session`, `initialPersonProperties`
+- **SDK metadata**: `library`
 - **events**: `capture(...)`, `registerDynamicEventProperties(...)`, `onEvent(...)`
 - **server config**: `onRemoteConfig(...)`
-- **transport**: `projectToken`, `sendRequest(path, init?)`
+- **transport**: `projectToken`, `sendRequest(path, init?)`, including `compression` and `sentAt` options
 - **storage and logging**: `kv`, `logger`
 
-Identity, session, and the public project token are always-ready synchronous
-reads. Operations that may perform I/O, including `capture`, `sendRequest`,
-and `kv`, are awaitable. `onRemoteConfig` immediately replays the latest known
-success or failure and then reports subsequent outcomes. Extensions that want a
-named log prefix can create a child with `client.logger.createLogger('[myExtension]')`.
+Identity, session, SDK metadata, and the public project token are always-ready synchronous reads. `capture` and
+`sendRequest` are awaitable. `onRemoteConfig` immediately replays the latest known success or failure and then reports
+subsequent outcomes. Extensions that want a named log prefix can create a child with
+`client.logger.createLogger('[myExtension]')`.
+
+Initialize KV during asynchronous setup before using its synchronous buffer:
+
+```ts
+await client.kv.initialize()
+const state = client.kv.get<{ first: boolean; second: string }>(['first', 'second'])
+client.kv.set({ ...state, first: true })
+client.kv.remove(['first', 'second'])
+```
+
+Initialization is idempotent and may be asynchronous while a host hydrates its buffer. After it completes, reads,
+writes, and removals are synchronous; batch reads, object writes, and multi-key removals operate on related values
+coherently. The host owns ordered durable flushing.
+
+KV keys map directly to shared host persistence: reset clears them, collisions can overwrite host state, and unknown
+keys may be captured as event properties. Use stable extension-owned keys with an explicit exposure policy, and do not
+store sensitive values unless their transmission is approved.
 
 ### Host runtime
 

--- a/packages/browser-common/src/client.ts
+++ b/packages/browser-common/src/client.ts
@@ -123,7 +123,7 @@ export interface Client {
     /** Sends a request through the host SDK's transport. */
     sendRequest(path: string, init?: SendRequestInit): Promise<ApiResponse>
 
-    /** Awaitable key-value storage backed by the host client's persistence. */
+    /** Initializable, synchronously buffered key-value storage backed by the host client's persistence. */
     readonly kv: KeyValueStore
 
     /** Logger that follows the host client's debug/noise policy. */

--- a/packages/browser-common/src/client.ts
+++ b/packages/browser-common/src/client.ts
@@ -80,7 +80,7 @@ export interface SendRequestInit {
     timeoutMs?: number
     /** Compression used by the browser transport. */
     compression?: Compression | 'best-available'
-    /** Where the transport adds its sent-at timestamp. */
+    /** Where POST requests add `sent_at`. For GET, `query` adds the cache-busting `_` parameter and `body` has no effect. */
     sentAt?: 'body' | 'query'
 }
 

--- a/packages/browser-common/src/client.ts
+++ b/packages/browser-common/src/client.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@posthog/core'
 import type { Properties } from '@posthog/types'
 
+import type { Compression } from './types/compression'
 import type { Disposable } from './disposable'
 import type { KeyValueStore } from './persistence'
 import type { Listener } from './pubsub'
@@ -77,6 +78,10 @@ export interface SendRequestInit {
     transport?: RequestTransport
     /** Abort the request if it does not complete within this many milliseconds. */
     timeoutMs?: number
+    /** Compression used by the browser transport. */
+    compression?: Compression | 'best-available'
+    /** Where the transport adds its sent-at timestamp. */
+    sentAt?: 'body' | 'query'
 }
 
 /**
@@ -89,6 +94,12 @@ export interface Client {
     readonly distinctId: string
     /** The anonymous device id carried across identify calls. */
     readonly anonymousId: string
+    /** The actual persisted device id, absent in cookieless contexts. */
+    readonly deviceId: string | undefined
+    /** Live host SDK metadata. */
+    readonly library: { readonly name: string; readonly version: string }
+    /** Initial person properties used for feature evaluation. */
+    readonly initialPersonProperties: DeepReadonly<Record<string, unknown>>
     /** Active group memberships attached to events as `$groups`. */
     readonly groups: DeepReadonly<Record<string, string>>
     /** The current session, created on first read if needed. */

--- a/packages/browser-common/src/persistence.ts
+++ b/packages/browser-common/src/persistence.ts
@@ -11,17 +11,17 @@
  * JSON-serializable.
  */
 export interface KeyValueStore {
-    /**
-     * Read a value by key.
-     *
-     * @returns The stored value, or `undefined` when the key is missing.
-     */
+    /** Read several values in one storage operation. Missing keys are omitted. */
+    get<T extends object>(keys: readonly (keyof T & string)[]): Partial<T> | Promise<Partial<T>>
+    /** Read one value by key, returning `undefined` when it is missing. */
     get<T = unknown>(key: string): T | undefined | Promise<T | undefined>
     /**
      * Forward a JSON-serializable value, including nullish values, to the host's
      * native persistence. `undefined` is not portable or durable storage.
      */
     set(key: string, value: unknown): void | Promise<void>
-    /** Remove a value by key. This is the portable deletion operation. */
-    remove(key: string): void | Promise<void>
+    /** Coherently forward several related values to the host's native persistence. */
+    set(values: Record<string, unknown>): void | Promise<void>
+    /** Remove one or several values in one storage operation. */
+    remove(keyOrKeys: string | readonly string[]): void | Promise<void>
 }

--- a/packages/browser-common/src/persistence.ts
+++ b/packages/browser-common/src/persistence.ts
@@ -1,7 +1,8 @@
 /**
- * Key-value store for small extension state. Implementations backed by
- * synchronous persistence may return immediately, while asynchronous stores
- * (for example IndexedDB) may return promises. Consumers can await either.
+ * Key-value store for small extension state. A host may initialize an asynchronous
+ * backend before exposing synchronous operations over its in-memory buffer. Writes
+ * must update that buffer before returning; ordered durable flushing remains the
+ * host's responsibility. Reads treat `undefined` values as absent.
  *
  * Keys map verbatim to the host client's shared persistence. In browser-v1,
  * unknown keys are normally included as event properties, collisions overwrite
@@ -11,17 +12,19 @@
  * JSON-serializable.
  */
 export interface KeyValueStore {
-    /** Read several values in one storage operation. Missing keys are omitted. */
-    get<T extends object>(keys: readonly (keyof T & string)[]): Partial<T> | Promise<Partial<T>>
-    /** Read one value by key, returning `undefined` when it is missing. */
-    get<T = unknown>(key: string): T | undefined | Promise<T | undefined>
+    /** Populate the in-memory buffer from durable storage. Calls are idempotent. */
+    initialize(): void | Promise<void>
+    /** Read several initialized values in one operation. Missing keys are omitted. */
+    get<T extends object>(keys: readonly (keyof T & string)[]): Partial<T>
+    /** Read one initialized value by key, returning `undefined` when it is missing. */
+    get<T = unknown>(key: string): T | undefined
     /**
-     * Forward a JSON-serializable value, including nullish values, to the host's
-     * native persistence. `undefined` is not portable or durable storage.
+     * Immediately update the initialized buffer. `null` is durable; `undefined` is
+     * accepted for compatibility but treated as absent by reads and is not portable.
      */
-    set(key: string, value: unknown): void | Promise<void>
-    /** Coherently forward several related values to the host's native persistence. */
-    set(values: Record<string, unknown>): void | Promise<void>
-    /** Remove one or several values in one storage operation. */
-    remove(keyOrKeys: string | readonly string[]): void | Promise<void>
+    set(key: string, value: unknown): void
+    /** Coherently update several related values in the initialized buffer. */
+    set(values: Record<string, unknown>): void
+    /** Remove one or several values from the initialized buffer in one operation. */
+    remove(keyOrKeys: string | readonly string[]): void
 }

--- a/packages/browser-common/tests/helpers/test-client.ts
+++ b/packages/browser-common/tests/helpers/test-client.ts
@@ -76,6 +76,9 @@ export class TestClient implements Client {
 
     distinctId: string
     anonymousId: string
+    deviceId: string | undefined
+    library = { name: 'posthog-test', version: '0.0.0' }
+    initialPersonProperties: Record<string, unknown> = {}
     groups: Record<string, string>
     session: SessionContext
 
@@ -98,6 +101,7 @@ export class TestClient implements Client {
         this.projectToken = options.projectToken ?? 'test-project-token'
         this.distinctId = options.distinctId ?? 'test-distinct-id'
         this.anonymousId = options.anonymousId ?? 'test-anonymous-id'
+        this.deviceId = this.anonymousId
         this.groups = options.groups ?? {}
         this.session = options.session ?? {
             sessionId: 'test-session-id',

--- a/packages/browser-common/tests/helpers/test-client.ts
+++ b/packages/browser-common/tests/helpers/test-client.ts
@@ -1,4 +1,4 @@
-import type { Logger } from '@posthog/core'
+import { isUndefined, type Logger } from '@posthog/core'
 import type { Properties } from '@posthog/types'
 
 import type {
@@ -39,24 +39,27 @@ export interface TestClientOptions {
 export class InMemoryKeyValueStore implements KeyValueStore {
     private _values = new Map<string, unknown>()
 
-    get<T = unknown>(key: string): Promise<T | undefined>
-    get<T extends object>(keys: readonly (keyof T & string)[]): Promise<Partial<T>>
-    async get(keyOrKeys: string | readonly string[]): Promise<unknown> {
+    initialize(): void {}
+
+    get<T = unknown>(key: string): T | undefined
+    get<T extends object>(keys: readonly (keyof T & string)[]): Partial<T>
+    get(keyOrKeys: string | readonly string[]): unknown {
         if (typeof keyOrKeys === 'string') {
             return this._values.get(keyOrKeys)
         }
         const values: Record<string, unknown> = {}
         for (const key of keyOrKeys) {
-            if (this._values.has(key)) {
-                values[key] = this._values.get(key)
+            const value = this._values.get(key)
+            if (!isUndefined(value)) {
+                values[key] = value
             }
         }
         return values
     }
 
-    async set(key: string, value: unknown): Promise<void>
-    async set(values: Record<string, unknown>): Promise<void>
-    async set(keyOrValues: string | Record<string, unknown>, value?: unknown): Promise<void> {
+    set(key: string, value: unknown): void
+    set(values: Record<string, unknown>): void
+    set(keyOrValues: string | Record<string, unknown>, value?: unknown): void {
         if (typeof keyOrValues === 'string') {
             this._values.set(keyOrValues, value)
         } else {
@@ -66,7 +69,7 @@ export class InMemoryKeyValueStore implements KeyValueStore {
         }
     }
 
-    async remove(keyOrKeys: string | readonly string[]): Promise<void> {
+    remove(keyOrKeys: string | readonly string[]): void {
         if (typeof keyOrKeys === 'string') {
             this._values.delete(keyOrKeys)
         } else {

--- a/packages/browser-common/tests/helpers/test-client.ts
+++ b/packages/browser-common/tests/helpers/test-client.ts
@@ -39,16 +39,41 @@ export interface TestClientOptions {
 export class InMemoryKeyValueStore implements KeyValueStore {
     private _values = new Map<string, unknown>()
 
-    async get<T = unknown>(key: string): Promise<T | undefined> {
-        return this._values.get(key) as T | undefined
+    get<T = unknown>(key: string): Promise<T | undefined>
+    get<T extends object>(keys: readonly (keyof T & string)[]): Promise<Partial<T>>
+    async get(keyOrKeys: string | readonly string[]): Promise<unknown> {
+        if (typeof keyOrKeys === 'string') {
+            return this._values.get(keyOrKeys)
+        }
+        const values: Record<string, unknown> = {}
+        for (const key of keyOrKeys) {
+            if (this._values.has(key)) {
+                values[key] = this._values.get(key)
+            }
+        }
+        return values
     }
 
-    async set(key: string, value: unknown): Promise<void> {
-        this._values.set(key, value)
+    async set(key: string, value: unknown): Promise<void>
+    async set(values: Record<string, unknown>): Promise<void>
+    async set(keyOrValues: string | Record<string, unknown>, value?: unknown): Promise<void> {
+        if (typeof keyOrValues === 'string') {
+            this._values.set(keyOrValues, value)
+        } else {
+            for (const [key, entry] of Object.entries(keyOrValues)) {
+                this._values.set(key, entry)
+            }
+        }
     }
 
-    async remove(key: string): Promise<void> {
-        this._values.delete(key)
+    async remove(keyOrKeys: string | readonly string[]): Promise<void> {
+        if (typeof keyOrKeys === 'string') {
+            this._values.delete(keyOrKeys)
+        } else {
+            for (const key of keyOrKeys) {
+                this._values.delete(key)
+            }
+        }
     }
 }
 

--- a/packages/browser-common/tests/persistence.spec.ts
+++ b/packages/browser-common/tests/persistence.spec.ts
@@ -1,18 +1,39 @@
 import { InMemoryKeyValueStore } from './helpers/test-client'
 
 describe('InMemoryKeyValueStore', () => {
-    it('stores nullish values and only deletes through remove', async () => {
+    it('initializes synchronously and stores nullish values until removal', () => {
         const kv = new InMemoryKeyValueStore()
 
-        await kv.set('state', null)
-        await expect(kv.get('state')).resolves.toBeNull()
+        expect(kv.initialize()).toBeUndefined()
+        kv.set('state', null)
+        expect(kv.get('state')).toBeNull()
 
-        await kv.set('state', undefined)
-        await expect(kv.get('state')).resolves.toBeUndefined()
+        kv.set('state', undefined)
+        expect(kv.get('state')).toBeUndefined()
         expect(kv['_values'].has('state')).toBe(true)
 
-        await kv.set('state', 'present')
-        await kv.remove('state')
-        await expect(kv.get('state')).resolves.toBeUndefined()
+        kv.set('state', 'present')
+        kv.remove('state')
+        expect(kv.get('state')).toBeUndefined()
+    })
+
+    it('gets, sets, and removes related values in batches', () => {
+        const kv = new InMemoryKeyValueStore()
+
+        kv.set({ first: true, second: 'value', undefinedValue: undefined })
+        expect(
+            kv.get<{ first: boolean; second: string; missing: unknown; undefinedValue: undefined }>([
+                'first',
+                'missing',
+                'second',
+                'undefinedValue',
+            ])
+        ).toEqual({
+            first: true,
+            second: 'value',
+        })
+
+        kv.remove(['first', 'second'])
+        expect(kv.get<{ first: boolean; second: string }>(['first', 'second'])).toEqual({})
     })
 })

--- a/packages/browser/src/__tests__/extensions/browser-client.test.ts
+++ b/packages/browser/src/__tests__/extensions/browser-client.test.ts
@@ -33,6 +33,7 @@ function createMockPostHog(
         props,
         get_property: jest.fn((prop: string) => props[prop]),
         set_property: jest.fn((prop: string, value: Property) => (props[prop] = value)),
+        register: jest.fn((values: Properties) => Object.assign(props, values)),
         unregister: jest.fn((prop: string) => delete props[prop]),
         get_initial_props: jest.fn(() => ({ initial: 'person-property' })),
     } as unknown as PostHogPersistence
@@ -145,14 +146,18 @@ describe('BrowserClientAdapter', () => {
         expect(client?.kv.get(key)).toEqual({ prepopulated: true })
 
         expect(client?.kv.set(key, { enabled: true })).toBeUndefined()
-        expect(instance.persistence?.set_property).toHaveBeenCalledWith(key, { enabled: true })
+        expect(instance.persistence?.register).toHaveBeenCalledWith({ [key]: { enabled: true } })
         expect(instance.persistence?.props[key]).toEqual({ enabled: true })
 
         client?.kv.set(key, null)
         client?.kv.set(key, undefined)
-        expect(instance.persistence?.set_property).toHaveBeenNthCalledWith(2, key, null)
-        expect(instance.persistence?.set_property).toHaveBeenNthCalledWith(3, key, undefined)
+        expect(instance.persistence?.register).toHaveBeenNthCalledWith(2, { [key]: null })
+        expect(instance.persistence?.register).toHaveBeenNthCalledWith(3, { [key]: undefined })
         expect(instance.persistence?.unregister).not.toHaveBeenCalled()
+
+        client?.kv.set({ first: true, second: 'value' })
+        expect(instance.persistence?.register).toHaveBeenCalledTimes(4)
+        expect(instance.persistence?.register).toHaveBeenLastCalledWith({ first: true, second: 'value' })
 
         instance.persistence!.props[key] = { externallyUpdated: true }
         expect(await client?.kv.get(key)).toEqual({ externallyUpdated: true })

--- a/packages/browser/src/__tests__/extensions/browser-client.test.ts
+++ b/packages/browser/src/__tests__/extensions/browser-client.test.ts
@@ -34,7 +34,11 @@ function createMockPostHog(
         get_property: jest.fn((prop: string) => props[prop]),
         set_property: jest.fn((prop: string, value: Property) => (props[prop] = value)),
         register: jest.fn((values: Properties) => Object.assign(props, values)),
-        unregister: jest.fn((prop: string) => delete props[prop]),
+        unregister: jest.fn((keyOrKeys: string | readonly string[]) => {
+            for (const key of typeof keyOrKeys === 'string' ? [keyOrKeys] : keyOrKeys) {
+                delete props[key]
+            }
+        }),
         get_initial_props: jest.fn(() => ({ initial: 'person-property' })),
     } as unknown as PostHogPersistence
 
@@ -142,6 +146,7 @@ describe('BrowserClientAdapter', () => {
         host.add(testExtension('test', (value) => (client = value)))
 
         const key = '$extension_state'
+        expect(client?.kv.initialize()).toBeUndefined()
         instance.persistence!.props[key] = { prepopulated: true }
         expect(client?.kv.get(key)).toEqual({ prepopulated: true })
 
@@ -158,12 +163,19 @@ describe('BrowserClientAdapter', () => {
         client?.kv.set({ first: true, second: 'value' })
         expect(instance.persistence?.register).toHaveBeenCalledTimes(4)
         expect(instance.persistence?.register).toHaveBeenLastCalledWith({ first: true, second: 'value' })
+        expect(
+            client?.kv.get<{ first: boolean; second: string; missing: unknown }>(['first', 'missing', 'second'])
+        ).toEqual({ first: true, second: 'value' })
+
+        client?.kv.remove(['first', 'second'])
+        expect(instance.persistence?.unregister).toHaveBeenCalledWith(['first', 'second'])
+        expect(client?.kv.get<{ first: boolean; second: string }>(['first', 'second'])).toEqual({})
 
         instance.persistence!.props[key] = { externallyUpdated: true }
-        expect(await client?.kv.get(key)).toEqual({ externallyUpdated: true })
+        expect(client?.kv.get(key)).toEqual({ externallyUpdated: true })
 
-        await client?.kv.remove(key)
-        expect(instance.persistence?.unregister).toHaveBeenCalledWith(key)
+        client?.kv.remove(key)
+        expect(instance.persistence?.unregister).toHaveBeenLastCalledWith(key)
         expect(instance.persistence?.props[key]).toBeUndefined()
         await host.dispose()
     })

--- a/packages/browser/src/__tests__/extensions/browser-client.test.ts
+++ b/packages/browser/src/__tests__/extensions/browser-client.test.ts
@@ -34,6 +34,7 @@ function createMockPostHog(
         get_property: jest.fn((prop: string) => props[prop]),
         set_property: jest.fn((prop: string, value: Property) => (props[prop] = value)),
         unregister: jest.fn((prop: string) => delete props[prop]),
+        get_initial_props: jest.fn(() => ({ initial: 'person-property' })),
     } as unknown as PostHogPersistence
 
     const instance = {
@@ -87,6 +88,11 @@ describe('BrowserClientAdapter', () => {
         expect(secondClient).toBe(client)
         expect(client?.distinctId).toBe('distinct-id')
         expect(client?.anonymousId).toBe('anonymous-id')
+        expect(client?.deviceId).toBe('anonymous-id')
+        expect(client?.library).toEqual(
+            expect.objectContaining({ name: expect.any(String), version: expect.any(String) })
+        )
+        expect(client?.initialPersonProperties).toEqual({ initial: 'person-property' })
         expect(client?.groups).toEqual({ organization: 'org-id' })
         expect(client?.session).toEqual({
             sessionId: 'session-id',
@@ -123,6 +129,7 @@ describe('BrowserClientAdapter', () => {
         host.add(testExtension('test', (value) => (client = value)))
 
         expect(client?.anonymousId).toBe('distinct-id')
+        expect(client?.deviceId).toBeUndefined()
         expect(client?.session).toEqual({ sessionId: '', windowId: '', sessionStartTimestamp: 0 })
         await host.dispose()
     })
@@ -319,6 +326,8 @@ describe('BrowserClientAdapter', () => {
             headers: { 'X-Extension-Header': 'value' },
             transport: 'XHR',
             timeoutMs: 321,
+            compression: 'base64',
+            sentAt: 'body',
         })
 
         expect(response).toEqual({ statusCode: 201, json: { created: true }, text: '{"created":true}' })
@@ -331,6 +340,8 @@ describe('BrowserClientAdapter', () => {
                 headers: { 'X-Extension-Header': 'value' },
                 transport: 'XHR',
                 timeout: 321,
+                compression: 'base64',
+                timestampMode: 'body',
                 fireCallbackOnDrop: true,
                 callback: expect.any(Function),
             })

--- a/packages/browser/src/__tests__/persistence-key-policy.test.ts
+++ b/packages/browser/src/__tests__/persistence-key-policy.test.ts
@@ -592,7 +592,11 @@ const collectPersistenceKeyIdentifiers = (sources: SourceInput[] = productionSou
                     KEY_VALUE_STORE_SINGLE_KEY_METHODS.has(methodName) &&
                     isKeyValueStoreReceiver(receiver, checker)
                 ) {
-                    recordResolution(node.arguments[0], node, `${methodName}() on KeyValueStore`, true)
+                    if (methodName === 'set' && node.arguments.length === 1) {
+                        recordObjectLike(node.arguments[0], node, `${methodName}() on KeyValueStore`)
+                    } else {
+                        recordResolution(node.arguments[0], node, `${methodName}() on KeyValueStore`, true)
+                    }
                 }
 
                 if (methodName && SESSION_OBJECT_METHODS.has(methodName) && isRegisterForSessionReceiver(receiver)) {
@@ -845,6 +849,16 @@ describe('persistence key policy', () => {
 
         expect(knownKey.issues).toEqual([])
         expect([...knownKey.resolvedKeys]).toEqual([constants.AUTOCAPTURE_DISABLED_SERVER_SIDE])
+
+        const batchedKeys = analyze(`
+            const FIRST_KEY = '${constants.AUTOCAPTURE_DISABLED_SERVER_SIDE}'
+            const SECOND_KEY = '${constants.HEATMAPS_ENABLED_SERVER_SIDE}'
+            client.kv.set({ [FIRST_KEY]: true, [SECOND_KEY]: false })
+        `)
+        expect(batchedKeys.issues).toEqual([])
+        expect([...batchedKeys.resolvedKeys]).toEqual(
+            expect.arrayContaining([constants.AUTOCAPTURE_DISABLED_SERVER_SIDE, constants.HEATMAPS_ENABLED_SERVER_SIDE])
+        )
 
         const unknownKey = analyze(`
             const EXTENSION_KEY = '$unclassified_extension_key'

--- a/packages/browser/src/__tests__/persistence-key-policy.test.ts
+++ b/packages/browser/src/__tests__/persistence-key-policy.test.ts
@@ -591,7 +591,11 @@ const collectPersistenceKeyIdentifiers = (sources: SourceInput[] = productionSou
                     KEY_VALUE_STORE_SINGLE_KEY_METHODS.has(methodName) &&
                     isKeyValueStoreReceiver(receiver, checker)
                 ) {
-                    recordResolution(node.arguments[0], node, `${methodName}() on KeyValueStore`, true)
+                    if (methodName === 'set' && node.arguments.length === 1) {
+                        recordObjectLike(node.arguments[0], node, `${methodName}() on KeyValueStore`)
+                    } else {
+                        recordResolution(node.arguments[0], node, `${methodName}() on KeyValueStore`, true)
+                    }
                 }
 
                 if (methodName && SESSION_OBJECT_METHODS.has(methodName) && isRegisterForSessionReceiver(receiver)) {
@@ -844,6 +848,16 @@ describe('persistence key policy', () => {
 
         expect(knownKey.issues).toEqual([])
         expect([...knownKey.resolvedKeys]).toEqual([constants.AUTOCAPTURE_DISABLED_SERVER_SIDE])
+
+        const batchedKeys = analyze(`
+            const FIRST_KEY = '${constants.AUTOCAPTURE_DISABLED_SERVER_SIDE}'
+            const SECOND_KEY = '${constants.HEATMAPS_ENABLED_SERVER_SIDE}'
+            client.kv.set({ [FIRST_KEY]: true, [SECOND_KEY]: false })
+        `)
+        expect(batchedKeys.issues).toEqual([])
+        expect([...batchedKeys.resolvedKeys]).toEqual(
+            expect.arrayContaining([constants.AUTOCAPTURE_DISABLED_SERVER_SIDE, constants.HEATMAPS_ENABLED_SERVER_SIDE])
+        )
 
         const unknownKey = analyze(`
             const EXTENSION_KEY = '$unclassified_extension_key'

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -181,6 +181,18 @@ describe('persistence', () => {
             expect(reloaded.props.value).toEqual(['initial', 'updated'])
         })
 
+        it('should save once when unregistering multiple properties', () => {
+            const lib = new PostHogPersistence(makePostHogConfig('test', persistenceMode))
+            lib.register({ first: true, second: 'value', retained: 3 })
+            const saveMock: Mock = jest.fn()
+            lib.save = saveMock
+
+            lib.unregister(['first', 'second', 'missing'])
+
+            expect(lib.props).toEqual({ retained: 3 })
+            expect(lib.save).toHaveBeenCalledTimes(1)
+        })
+
         it('should rebuild storage when cookie_persisted_properties changes via update_config', () => {
             const encode = (props: any) => encodeURIComponent(JSON.stringify(props))
             const expectedProps = () => ({

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -182,6 +182,18 @@ describe('persistence', () => {
             expect(reloaded.props.value).toEqual(['initial', 'updated'])
         })
 
+        it('should save once when unregistering multiple properties', () => {
+            const lib = new PostHogPersistence(makePostHogConfig('test', persistenceMode))
+            lib.register({ first: true, second: 'value', retained: 3 })
+            const saveMock: Mock = jest.fn()
+            lib.save = saveMock
+
+            lib.unregister(['first', 'second', 'missing'])
+
+            expect(lib.props).toEqual({ retained: 3 })
+            expect(lib.save).toHaveBeenCalledTimes(1)
+        })
+
         it('should rebuild storage when cookie_persisted_properties changes via update_config', () => {
             const encode = (props: any) => encodeURIComponent(JSON.stringify(props))
             const expectedProps = () => ({

--- a/packages/browser/src/extensions/browser-client.ts
+++ b/packages/browser/src/extensions/browser-client.ts
@@ -16,6 +16,7 @@ import { ExtensionRuntime } from '@posthog/browser-common/extension-runtime'
 import { logger } from '@posthog/browser-common/utils/logger'
 import type { Logger } from '@posthog/core'
 
+import Config from '../config'
 import { DEVICE_ID } from '../constants'
 import { extendURLParams } from '../request'
 import type { PostHog } from '../posthog-core'
@@ -107,6 +108,19 @@ export class BrowserClientAdapter implements Client, Disposable {
         return (this.instance.get_property(DEVICE_ID) as string | undefined) ?? this.distinctId
     }
 
+    get deviceId(): string | undefined {
+        const value = this.instance.get_property(DEVICE_ID)
+        return typeof value === 'string' ? value : undefined
+    }
+
+    get library(): { name: string; version: string } {
+        return { name: Config.LIB_NAME, version: Config.LIB_VERSION }
+    }
+
+    get initialPersonProperties(): Record<string, unknown> {
+        return (this.instance.persistence?.get_initial_props() ?? {}) as Record<string, unknown>
+    }
+
     get groups(): Record<string, string> {
         return this.instance.getGroups() as Record<string, string>
     }
@@ -170,6 +184,8 @@ export class BrowserClientAdapter implements Client, Disposable {
             timeout: init.timeoutMs,
             fireCallbackOnDrop: true,
             transport: init.transport,
+            compression: init.compression,
+            timestampMode: init.sentAt,
         }
 
         if (init.transport === 'sendBeacon') {

--- a/packages/browser/src/extensions/browser-client.ts
+++ b/packages/browser/src/extensions/browser-client.ts
@@ -25,6 +25,8 @@ import type { CaptureOptions, EventName, Properties, QueuedRequestWithOptions, R
 class BrowserClientKeyValueStore implements KeyValueStore {
     constructor(private readonly _instance: PostHog) {}
 
+    initialize(): void {}
+
     get<T = unknown>(key: string): T | undefined
     get<T extends object>(keys: readonly (keyof T & string)[]): Partial<T>
     get(keyOrKeys: string | readonly string[]): unknown {

--- a/packages/browser/src/extensions/browser-client.ts
+++ b/packages/browser/src/extensions/browser-client.ts
@@ -14,34 +14,44 @@ import type {
 } from '@posthog/browser-common'
 import { ExtensionRuntime } from '@posthog/browser-common/extension-runtime'
 import { logger } from '@posthog/browser-common/utils/logger'
-import type { Logger } from '@posthog/core'
+import { isUndefined, type Logger } from '@posthog/core'
 
 import Config from '../config'
 import { DEVICE_ID } from '../constants'
 import { extendURLParams } from '../request'
 import type { PostHog } from '../posthog-core'
-import type {
-    CaptureOptions,
-    EventName,
-    Properties,
-    Property,
-    QueuedRequestWithOptions,
-    RemoteConfigResult,
-} from '../types'
+import type { CaptureOptions, EventName, Properties, QueuedRequestWithOptions, RemoteConfigResult } from '../types'
 
 class BrowserClientKeyValueStore implements KeyValueStore {
     constructor(private readonly _instance: PostHog) {}
 
-    get<T = unknown>(key: string): T | undefined {
-        return this._instance.persistence?.get_property(key) as T | undefined
+    get<T = unknown>(key: string): T | undefined
+    get<T extends object>(keys: readonly (keyof T & string)[]): Partial<T>
+    get(keyOrKeys: string | readonly string[]): unknown {
+        const persistence = this._instance.persistence
+        if (typeof keyOrKeys === 'string') {
+            return persistence?.get_property(keyOrKeys)
+        }
+        const values: Record<string, unknown> = {}
+        for (const key of keyOrKeys) {
+            const value = persistence?.get_property(key)
+            if (!isUndefined(value)) {
+                values[key] = value
+            }
+        }
+        return values
     }
 
-    set(key: string, value: unknown): void {
-        this._instance.persistence?.set_property(key, value as Property)
+    set(key: string, value: unknown): void
+    set(values: Record<string, unknown>): void
+    set(properties: string | Record<string, unknown>, value?: unknown): void {
+        this._instance.persistence?.register(
+            (typeof properties === 'string' ? { [properties]: value } : properties) as Properties
+        )
     }
 
-    remove(key: string): void {
-        this._instance.persistence?.unregister(key)
+    remove(keyOrKeys: string | readonly string[]): void {
+        this._instance.persistence?.unregister(keyOrKeys)
     }
 }
 

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -703,9 +703,16 @@ export class PostHogPersistence {
         return false
     }
 
-    unregister(prop: string): void {
-        if (prop in this.props) {
-            this._deleteProp(prop)
+    unregister(propOrProps: string | readonly string[]): void {
+        const props = typeof propOrProps === 'string' ? [propOrProps] : propOrProps
+        let hasChanges = false
+        for (const prop of props) {
+            if (prop in this.props) {
+                this._deleteProp(prop)
+                hasChanges = true
+            }
+        }
+        if (hasChanges) {
             this.save()
         }
     }


### PR DESCRIPTION
## Problem

Browser-common extensions need a host-neutral way to access the request semantics and identity context required by feature evaluation. Stateful extensions also need coherent batched persistence operations without depending on browser-v1 internals.

## Changes

- Add compression and sent-at request options plus device, library, and initial-person context to the shared `Client` contract.
- Implement the new context and transport forwarding in the browser-v1 client adapter.
- Allow key-value stores to initialize asynchronously, then expose synchronous reads and buffered writes while the host owns ordered durable flushing.
- Add batched KV reads, object writes, and multi-key removals to `KeyValueStore` and its browser/test implementations.
- Extend persistence-key policy checks to understand object-form KV writes.
- Document initialization and synchronous-buffer semantics for extension authors.

This is the prerequisite PR for the stacked feature-flags lifecycle migration.

### Validation

- `pnpm --dir packages/browser-common lint` — passed.
- `pnpm --dir packages/browser-common test:unit` — 14 suites passed, 76 tests passed.
- `pnpm --dir packages/browser-common build` — passed.
- Browser client/persistence focused tests — 2 suites passed, 436 tests passed.
- `cd packages/browser && pnpm typecheck` — passed.
- `pnpm bundle-size:array 3ad551fe0` — +0.51 KiB minified (+0.19%), +0.16 KiB gzip (+0.20%), +0.12 KiB Brotli (+0.17%).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi and delegated read-only review under direct human guidance. The shared client-context and KV changes were intentionally separated from the dependent feature-flags migration so this contract can be reviewed and released independently.
