### PR TITLE
ci: use setup-node toolcache for Node provisioning

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -5,8 +5,7 @@ inputs:
   node_version:
     description: "Node.js version to use"
     required: false
-    # TODO: Keep this in sync with .nvmrc until pnpm/setup can read it via
-    # https://github.com/jasongin/nvs/pull/315.
+    # Keep this in sync with .nvmrc.
     default: "24"
   install:
     description: "Whether to install dependencies"
@@ -20,11 +19,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup pnpm and Node.js
+    - name: Setup Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: ${{ inputs.node_version }}
+        package-manager-cache: false
+
+    - name: Setup pnpm
       uses: pnpm/setup@5d160c5bc68a09337ad0d5654e237e03253b5879 # v1
       with:
-        # TODO: pnpm/setup does not read .nvmrc yet; use the input default above for now.
-        runtime: node@${{ inputs.node_version }}
         cache: false
         install: false
 

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -18,12 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup pnpm and Node.js
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Setup pnpm
         uses: pnpm/setup@5d160c5bc68a09337ad0d5654e237e03253b5879 # v1
         with:
-          # TODO: pnpm/setup does not read .nvmrc yet; keep this in sync with .nvmrc.
-          # https://github.com/jasongin/nvs/pull/315
-          runtime: node@24
           cache: false
           install: false
 

--- a/.github/workflows/check-affected.yml
+++ b/.github/workflows/check-affected.yml
@@ -42,10 +42,15 @@ jobs:
 
           git fetch --no-tags --unshallow origin "${REFS[@]}"
 
-      - name: Setup pnpm and Node.js
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Setup pnpm
         uses: pnpm/setup@5d160c5bc68a09337ad0d5654e237e03253b5879 # v1
         with:
-          runtime: node@24
           cache: false
           install: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -831,12 +831,15 @@ jobs:
                       pnpm-workspace.yaml
                       tooling/release
 
-            - name: Setup pnpm and Node.js
+            - name: Setup Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: 24
+                  package-manager-cache: false
+
+            - name: Setup pnpm
               uses: pnpm/setup@5d160c5bc68a09337ad0d5654e237e03253b5879 # v1
               with:
-                  # TODO: pnpm/setup does not read .nvmrc yet. Keep this in sync with .nvmrc
-                  # until https://github.com/jasongin/nvs/pull/315 lands.
-                  runtime: node@24
                   cache: false
                   install: false
 


### PR DESCRIPTION
## Problem

The release package matrix provisions Node independently in every SDK job through `pnpm runtime set`. This downloads Node directly from `nodejs.org` even though GitHub-hosted runners already provide the requested Node version in their toolcache.

Transient Node download timeouts have consequently failed otherwise unrelated release jobs, including the `@posthog/openfeature-web-provider` job in [run 30467054780](https://github.com/PostHog/posthog-js/actions/runs/30467054780/job/90629525467). The affected SDK varies because each matrix cell performs its own download.

## Changes

- Provision Node with the pinned `actions/setup-node` action so GitHub's runner toolcache is used first.
- Keep `pnpm/setup` for pnpm provisioning, but stop asking it to download a Node runtime.
- Apply the same setup ordering to the shared setup action, bundled-size workflow, affected-package workflow, and release S3 upload jobs.
- Keep package-manager caching explicitly disabled; dependency caching is separate from Node runtime provisioning.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and GitHub CLI in a dedicated worktree. An independent Pi reviewer checked the workflow syntax, action ordering, pinned action inputs, and repository-wide removal of `runtime: node@...`. We intentionally kept package-manager caches disabled and changed only Node provisioning; the modified YAML files were parsed successfully and the diff passed whitespace validation. No public session link is available.
