### PR TITLE
docs(ai): use projectToken in Vercel AI examples

### DIFF
--- a/examples/example-ai-vercel-ai/anthropic-streaming.ts
+++ b/examples/example-ai-vercel-ai/anthropic-streaming.ts
@@ -15,7 +15,7 @@ const sdk = new NodeSDK({
     }),
     spanProcessors: [
         new PostHogSpanProcessor({
-            apiKey: process.env.POSTHOG_API_KEY!,
+            projectToken: process.env.POSTHOG_API_KEY!,
             host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
         }),
     ],

--- a/examples/example-ai-vercel-ai/anthropic.ts
+++ b/examples/example-ai-vercel-ai/anthropic.ts
@@ -14,7 +14,7 @@ const sdk = new NodeSDK({
     }),
     spanProcessors: [
         new PostHogSpanProcessor({
-            apiKey: process.env.POSTHOG_API_KEY!,
+            projectToken: process.env.POSTHOG_API_KEY!,
             host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
         }),
     ],

--- a/examples/example-ai-vercel-ai/generate-object.ts
+++ b/examples/example-ai-vercel-ai/generate-object.ts
@@ -15,7 +15,7 @@ const sdk = new NodeSDK({
     }),
     spanProcessors: [
         new PostHogSpanProcessor({
-            apiKey: process.env.POSTHOG_API_KEY!,
+            projectToken: process.env.POSTHOG_API_KEY!,
             host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
         }),
     ],

--- a/examples/example-ai-vercel-ai/generate-text.ts
+++ b/examples/example-ai-vercel-ai/generate-text.ts
@@ -15,7 +15,7 @@ const sdk = new NodeSDK({
     }),
     spanProcessors: [
         new PostHogSpanProcessor({
-            apiKey: process.env.POSTHOG_API_KEY!,
+            projectToken: process.env.POSTHOG_API_KEY!,
             host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
         }),
     ],

--- a/examples/example-ai-vercel-ai/google-streaming.ts
+++ b/examples/example-ai-vercel-ai/google-streaming.ts
@@ -15,7 +15,7 @@ const sdk = new NodeSDK({
     }),
     spanProcessors: [
         new PostHogSpanProcessor({
-            apiKey: process.env.POSTHOG_API_KEY!,
+            projectToken: process.env.POSTHOG_API_KEY!,
             host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
         }),
     ],

--- a/examples/example-ai-vercel-ai/google.ts
+++ b/examples/example-ai-vercel-ai/google.ts
@@ -14,7 +14,7 @@ const sdk = new NodeSDK({
     }),
     spanProcessors: [
         new PostHogSpanProcessor({
-            apiKey: process.env.POSTHOG_API_KEY!,
+            projectToken: process.env.POSTHOG_API_KEY!,
             host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
         }),
     ],

--- a/examples/example-ai-vercel-ai/stream-object.ts
+++ b/examples/example-ai-vercel-ai/stream-object.ts
@@ -15,7 +15,7 @@ const sdk = new NodeSDK({
     }),
     spanProcessors: [
         new PostHogSpanProcessor({
-            apiKey: process.env.POSTHOG_API_KEY!,
+            projectToken: process.env.POSTHOG_API_KEY!,
             host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
         }),
     ],

--- a/examples/example-ai-vercel-ai/stream-text.ts
+++ b/examples/example-ai-vercel-ai/stream-text.ts
@@ -14,7 +14,7 @@ const sdk = new NodeSDK({
     }),
     spanProcessors: [
         new PostHogSpanProcessor({
-            apiKey: process.env.POSTHOG_API_KEY!,
+            projectToken: process.env.POSTHOG_API_KEY!,
             host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
         }),
     ],


### PR DESCRIPTION
## Problem

The existing Vercel AI examples pass `apiKey` to `PostHogSpanProcessor`, but the public processor option is `projectToken`. TypeScript users get a compile error, while JavaScript users get a disabled processor and no exported spans.

Related to #4317. The companion PostHog/posthog#75213 corrects the generic OpenTelemetry installation guide.

## Changes

Updated all eight existing `examples/example-ai-vercel-ai` integrations to pass the PostHog project token through the supported `projectToken` option. Provider-specific `apiKey` options remain unchanged.

No published library code changed, so this PR does not require a package release or changeset.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

Validation:

- `git diff --check`
- Installed the example in a temporary workspace with `@posthog/ai@8.4.3`
- `pnpm exec tsc --noEmit`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently reviewed by a Pi reviewer agent. The change is intentionally limited to the invalid `PostHogSpanProcessor` option; provider API key options and the existing environment variable name are unchanged. No public agent session link is available.

