### PR TITLE
fix(browser): keep dead-click mutation observer alive on WebKit

### DIFF
--- a/.changeset/quiet-dates-observe.md
+++ b/.changeset/quiet-dates-observe.md
@@ -1,5 +1,7 @@
 ---
 '@posthog/browser-common': patch
+'@posthog/core': patch
+'@posthog/rrweb-utils': patch
 'posthog-js': patch
 ---
 

--- a/.changeset/quiet-dates-observe.md
+++ b/.changeset/quiet-dates-observe.md
@@ -1,0 +1,6 @@
+---
+'@posthog/browser-common': patch
+'posthog-js': patch
+---
+
+Fix dead-click false positives on WebKit when the SDK uses an iframe-sourced MutationObserver fallback.

--- a/packages/browser-common/package.json
+++ b/packages/browser-common/package.json
@@ -83,6 +83,7 @@
         "@rslib/core": "catalog:",
         "@types/jest": "catalog:",
         "jest": "catalog:",
+        "jest-environment-jsdom": "catalog:",
         "ts-jest": "catalog:",
         "typescript": "catalog:"
     }

--- a/packages/browser-common/src/utils/prototype-utils.ts
+++ b/packages/browser-common/src/utils/prototype-utils.ts
@@ -7,7 +7,7 @@
  * after a number of performance reports from Angular users
  */
 
-import { isFunction, isNativeFunction } from '@posthog/core'
+import { isFunction, isNativeFunction, isWebKit } from '@posthog/core'
 
 import { logger } from './logger'
 import { isAngularZonePresent } from './type-utils'
@@ -51,7 +51,7 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
                 // MutationObserver callbacks from its realm to be silently dropped.
                 // Keep the iframe alive for the lifetime of the cached constructor.
                 // See https://webkit.org/b/179224 and the equivalent rrweb fallback.
-                if (name === 'MutationObserver' && isWebKit(assignableWindow)) {
+                if (name === 'MutationObserver' && isWebKit(assignableWindow.navigator?.userAgent ?? '')) {
                     sandbox.classList.add('rr-block', 'ph-no-capture')
                     keepSandboxAttached = true
                 }
@@ -73,11 +73,6 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
     }
 
     return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
-}
-
-function isWebKit(assignableWindow: BrowserWindow): boolean {
-    const userAgent = assignableWindow.navigator?.userAgent ?? ''
-    return userAgent.includes('AppleWebKit') && !userAgent.includes('Chrome')
 }
 
 export function getNativeMutationObserverImplementation(assignableWindow: BrowserWindow): typeof MutationObserver {

--- a/packages/browser-common/src/utils/prototype-utils.ts
+++ b/packages/browser-common/src/utils/prototype-utils.ts
@@ -37,18 +37,32 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
 
     const document = assignableWindow.document
     if (document && isFunction(document.createElement)) {
+        let sandbox: HTMLIFrameElement | undefined
+        let keepSandboxAttached = false
         try {
-            const sandbox = document.createElement('iframe')
+            sandbox = document.createElement('iframe')
             sandbox.hidden = true
             document.head.appendChild(sandbox)
             const contentWindow = sandbox.contentWindow
             if (contentWindow && (contentWindow as any)[name]) {
                 impl = (contentWindow as any)[name] as NativeImplementationsCache[T]
+
+                // WebKit tears down a detached iframe's ScriptExecutionContext, causing
+                // MutationObserver callbacks from its realm to be silently dropped.
+                // Keep the iframe alive for the lifetime of the cached constructor.
+                // See https://webkit.org/b/179224 and the equivalent rrweb fallback.
+                if (name === 'MutationObserver' && isSafari(assignableWindow)) {
+                    sandbox.classList.add('rr-block', 'ph-no-capture')
+                    keepSandboxAttached = true
+                }
             }
-            document.head.removeChild(sandbox)
         } catch (e) {
             // Could not create sandbox iframe, just use assignableWindow.xxx
             logger.warn(`Could not create sandbox iframe for ${name} check, bailing to assignableWindow.${name}: `, e)
+        } finally {
+            if (!keepSandboxAttached && sandbox?.parentNode) {
+                sandbox.parentNode.removeChild(sandbox)
+            }
         }
     }
 
@@ -59,6 +73,11 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
     }
 
     return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
+}
+
+function isSafari(assignableWindow: BrowserWindow): boolean {
+    const userAgent = assignableWindow.navigator?.userAgent ?? ''
+    return userAgent.includes('Safari') && !userAgent.includes('Chrome')
 }
 
 export function getNativeMutationObserverImplementation(assignableWindow: BrowserWindow): typeof MutationObserver {

--- a/packages/browser-common/src/utils/prototype-utils.ts
+++ b/packages/browser-common/src/utils/prototype-utils.ts
@@ -51,7 +51,7 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
                 // MutationObserver callbacks from its realm to be silently dropped.
                 // Keep the iframe alive for the lifetime of the cached constructor.
                 // See https://webkit.org/b/179224 and the equivalent rrweb fallback.
-                if (name === 'MutationObserver' && isSafari(assignableWindow)) {
+                if (name === 'MutationObserver' && isWebKit(assignableWindow)) {
                     sandbox.classList.add('rr-block', 'ph-no-capture')
                     keepSandboxAttached = true
                 }
@@ -75,9 +75,9 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
     return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
 }
 
-function isSafari(assignableWindow: BrowserWindow): boolean {
+function isWebKit(assignableWindow: BrowserWindow): boolean {
     const userAgent = assignableWindow.navigator?.userAgent ?? ''
-    return userAgent.includes('Safari') && !userAgent.includes('Chrome')
+    return userAgent.includes('AppleWebKit') && !userAgent.includes('Chrome')
 }
 
 export function getNativeMutationObserverImplementation(assignableWindow: BrowserWindow): typeof MutationObserver {

--- a/packages/browser-common/tests/utils/prototype-utils.spec.ts
+++ b/packages/browser-common/tests/utils/prototype-utils.spec.ts
@@ -6,6 +6,8 @@ const SAFARI_UA =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Safari/605.1.15'
 const CHROME_IOS_UA =
     'Mozilla/5.0 (iPhone; CPU iPhone OS 18_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/136.0.7103.56 Mobile/15E148 Safari/604.1'
+const WKWEBVIEW_UA =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 18_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
 const CHROME_UA =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
 
@@ -36,17 +38,20 @@ describe('getNativeMutationObserverImplementation iframe fallback', () => {
         jest.restoreAllMocks()
     })
 
-    it.each([SAFARI_UA, CHROME_IOS_UA])('keeps the fallback iframe attached on WebKit', async (userAgent) => {
-        setUserAgent(userAgent)
+    it.each([SAFARI_UA, CHROME_IOS_UA, WKWEBVIEW_UA])(
+        'keeps the fallback iframe attached on WebKit',
+        async (userAgent) => {
+            setUserAgent(userAgent)
 
-        expect(await getFreshNativeMutationObserver()).toBeDefined()
+            expect(await getFreshNativeMutationObserver()).toBeDefined()
 
-        const iframe = document.querySelector('iframe')
-        expect(iframe).not.toBeNull()
-        expect(iframe?.hidden).toBe(true)
-        expect(iframe?.classList.contains('rr-block')).toBe(true)
-        expect(iframe?.classList.contains('ph-no-capture')).toBe(true)
-    })
+            const iframe = document.querySelector('iframe')
+            expect(iframe).not.toBeNull()
+            expect(iframe?.hidden).toBe(true)
+            expect(iframe?.classList.contains('rr-block')).toBe(true)
+            expect(iframe?.classList.contains('ph-no-capture')).toBe(true)
+        }
+    )
 
     it('removes the fallback iframe on Chromium', async () => {
         setUserAgent(CHROME_UA)

--- a/packages/browser-common/tests/utils/prototype-utils.spec.ts
+++ b/packages/browser-common/tests/utils/prototype-utils.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const SAFARI_UA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Safari/605.1.15'
+const CHROME_IOS_UA =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 18_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/136.0.7103.56 Mobile/15E148 Safari/604.1'
+const CHROME_UA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
+
+function setUserAgent(userAgent: string): void {
+    Object.defineProperty(window.navigator, 'userAgent', {
+        value: userAgent,
+        configurable: true,
+    })
+}
+
+async function getFreshNativeMutationObserver(): Promise<typeof MutationObserver> {
+    jest.resetModules()
+    const { getNativeMutationObserverImplementation } = await import('../../src/utils/prototype-utils')
+    return getNativeMutationObserverImplementation(window)
+}
+
+describe('getNativeMutationObserverImplementation iframe fallback', () => {
+    const originalUserAgent = window.navigator.userAgent
+
+    beforeEach(() => {
+        ;(window as any).Zone = {}
+    })
+
+    afterEach(() => {
+        document.querySelectorAll('iframe').forEach((iframe) => iframe.remove())
+        delete (window as any).Zone
+        setUserAgent(originalUserAgent)
+        jest.restoreAllMocks()
+    })
+
+    it.each([SAFARI_UA, CHROME_IOS_UA])('keeps the fallback iframe attached on WebKit', async (userAgent) => {
+        setUserAgent(userAgent)
+
+        expect(await getFreshNativeMutationObserver()).toBeDefined()
+
+        const iframe = document.querySelector('iframe')
+        expect(iframe).not.toBeNull()
+        expect(iframe?.hidden).toBe(true)
+        expect(iframe?.classList.contains('rr-block')).toBe(true)
+        expect(iframe?.classList.contains('ph-no-capture')).toBe(true)
+    })
+
+    it('removes the fallback iframe on Chromium', async () => {
+        setUserAgent(CHROME_UA)
+
+        expect(await getFreshNativeMutationObserver()).toBeDefined()
+
+        expect(document.querySelector('iframe')).toBeNull()
+    })
+
+    it('falls back to the window implementation when iframe creation fails', async () => {
+        jest.spyOn(document, 'createElement').mockImplementation(() => {
+            throw new Error('blocked')
+        })
+
+        expect(await getFreshNativeMutationObserver()).toBeDefined()
+    })
+})

--- a/packages/browser/playwright/mocked/dead-clicks.spec.ts
+++ b/packages/browser/playwright/mocked/dead-clicks.spec.ts
@@ -30,6 +30,53 @@ test.describe('Dead clicks', () => {
         expect(deadClick.properties.$dead_click_absolute_timeout).toBe(true)
     })
 
+    test('does not capture a dead click when a fallback observer sees a DOM update', async ({ page, context }) => {
+        await context.addInitScript(() => {
+            // Force getNativeMutationObserverImplementation through its iframe fallback.
+            ;(window as any).Zone = {}
+        })
+        await start(
+            {
+                options: {
+                    capture_dead_clicks: {
+                        mutation_threshold_ms: 300,
+                    },
+                },
+                url: '/playground/cypress/index.html',
+            },
+            page,
+            context
+        )
+
+        await page.waitForFunction(() => {
+            const win = window as any
+            return !!win.posthog?.deadClicksAutocapture?.lazyLoadedDeadClicksAutocapture
+        })
+
+        await page.evaluate(() => {
+            const button = document.createElement('button')
+            button.id = 'mutating-button'
+            button.textContent = 'Next day'
+            const label = document.createElement('span')
+            label.id = 'mutating-label'
+            label.textContent = 'Day 1'
+            button.onclick = () => {
+                label.textContent = 'Day 2'
+            }
+            document.body.append(button, label)
+        })
+
+        await page.waitForTimeout(100)
+        await page.resetCapturedEvents()
+
+        await page.locator('#mutating-button').click()
+        await expect(page.locator('#mutating-label')).toHaveText('Day 2')
+        await page.waitForTimeout(1500)
+
+        const deadClicks = (await page.capturedEvents()).filter((event) => event.event === '$dead_click')
+        expect(deadClicks).toHaveLength(0)
+    })
+
     test('captures dead swipes when configured to', async ({ page, context }) => {
         await start(startOptions, page, context)
 

--- a/packages/core/src/__tests__/browser-utils.spec.ts
+++ b/packages/core/src/__tests__/browser-utils.spec.ts
@@ -1,0 +1,12 @@
+import { isWebKit } from '../utils/browser-utils'
+
+describe('isWebKit', () => {
+  it.each([
+    ['Safari', 'Mozilla/5.0 AppleWebKit/605.1.15 Version/18.4 Safari/605.1.15', true],
+    ['Chrome on iOS', 'Mozilla/5.0 AppleWebKit/605.1.15 CriOS/136.0 Mobile/15E148 Safari/604.1', true],
+    ['WKWebView', 'Mozilla/5.0 AppleWebKit/605.1.15 Mobile/15E148', true],
+    ['desktop Chrome', 'Mozilla/5.0 AppleWebKit/537.36 Chrome/136.0.0.0 Safari/537.36', false],
+  ])('detects %s', (_browser, userAgent, expected) => {
+    expect(isWebKit(userAgent)).toBe(expected)
+  })
+})

--- a/packages/core/src/utils/browser-utils.ts
+++ b/packages/core/src/utils/browser-utils.ts
@@ -1,0 +1,5 @@
+import { includes } from './string-utils'
+
+export function isWebKit(userAgent: string): boolean {
+  return includes(userAgent, 'AppleWebKit') && !includes(userAgent, 'Chrome')
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,6 +1,7 @@
 import { FetchLike } from '../types'
 
 export * from './bot-detection'
+export * from './browser-utils'
 export * from './bucketed-rate-limiter'
 export * from './number-utils'
 export * from './string-utils'

--- a/packages/rrweb/rrweb/test/untainted-prototype.test.ts
+++ b/packages/rrweb/rrweb/test/untainted-prototype.test.ts
@@ -6,7 +6,7 @@
 // same-origin iframe when the page's globals have been monkey-patched. On
 // WebKit/Safari a detached iframe's ScriptExecutionContext is torn down and
 // MutationObserver.deliver() silently drops callbacks (webkit.org/b/179224),
-// so on Safari the iframe must stay attached for the lifetime of the page.
+// so on WebKit the iframe must stay attached for the lifetime of the page.
 // Ported from upstream rrweb #1854.
 //
 // In jsdom no prototype method has a native-code toString, so every call takes
@@ -14,6 +14,8 @@
 
 const SAFARI_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15';
+const WKWEBVIEW_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
 const CHROME_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36';
 
@@ -46,7 +48,7 @@ describe('getUntaintedPrototype iframe fallback', () => {
     vi.restoreAllMocks();
   });
 
-  it('removes the fallback iframe on non-Safari browsers', async () => {
+  it('removes the fallback iframe on non-WebKit browsers', async () => {
     setUserAgent(CHROME_UA);
     const getUntaintedPrototype = await freshGetUntaintedPrototype();
 
@@ -68,6 +70,16 @@ describe('getUntaintedPrototype iframe fallback', () => {
     expect(iframes[0].getAttribute('__rrwebUntaintedPrototype')).toBe(
       'MutationObserver',
     );
+  });
+
+  it('keeps the fallback iframe attached in WKWebView', async () => {
+    setUserAgent(WKWEBVIEW_UA);
+    const getUntaintedPrototype = await freshGetUntaintedPrototype();
+
+    const prototype = getUntaintedPrototype('MutationObserver');
+
+    expect(prototype).toBeDefined();
+    expect(keepaliveIframes().length).toBe(1);
   });
 
   it('hides the kept iframe and blocks it from being recorded', async () => {

--- a/packages/rrweb/utils/package.json
+++ b/packages/rrweb/utils/package.json
@@ -38,5 +38,7 @@
         "vite": "catalog:",
         "vite-plugin-dts": "catalog:"
     },
-    "dependencies": {}
+    "dependencies": {
+        "@posthog/core": "workspace:^"
+    }
 }

--- a/packages/rrweb/utils/src/index.ts
+++ b/packages/rrweb/utils/src/index.ts
@@ -2,6 +2,8 @@
 // Copyright (c) 2012 Functional Software, Inc. dba Sentry
 // Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
+import { isWebKit } from '@posthog/core';
+
 type PrototypeOwner = Node | ShadowRoot | MutationObserver | Element;
 type TypeofPrototypeOwner =
   | typeof Node
@@ -123,14 +125,14 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
     // WebKit tears down an iframe's ScriptExecutionContext when it is detached
     // from the DOM, and MutationObserver.deliver() silently drops callbacks when
     // its scriptExecutionContext() is null (webkit.org/b/179224), so prototypes
-    // taken from a detached iframe stop working on Safari.
+    // taken from a detached iframe stop working on WebKit.
     // Adapted from upstream rrweb #1854, with one difference: the iframe stays
     // attached for the lifetime of the page instead of being removed on recorder
     // teardown. Observers are torn down per-document here (e.g. a same-origin
     // iframe being removed), and the cached prototype must outlive any one of
     // them; removing the shared iframe on the first teardown - or reusing the
     // cache after a stop/restart cycle - would silently break the survivors.
-    if (isSafari()) {
+    if (isWebKit(navigator.userAgent)) {
       // both the upstream default block class and the PostHog one, so the
       // recorder never serializes this iframe whichever config is in use
       iframeEl.classList.add('rr-block', 'ph-no-capture');
@@ -146,11 +148,6 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
       document.body.removeChild(iframeEl);
     }
   }
-}
-
-function isSafari(): boolean {
-  const ua = navigator.userAgent;
-  return ua.includes('Safari') && !ua.includes('Chrome');
 }
 
 const untaintedAccessorCache: Record<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1609,6 +1609,10 @@ importers:
         version: 4.5.4(@types/node@26.1.1)(rollup@4.53.3)(typescript@5.8.2)(vite@6.4.2(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.48.0)(yaml@2.8.0))
 
   packages/rrweb/utils:
+    dependencies:
+      '@posthog/core':
+        specifier: workspace:^
+        version: link:../../core
     devDependencies:
       vite:
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,6 +534,9 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.8.2))
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 29.7.0
       ts-jest:
         specifier: 'catalog:'
         version: 29.4.11(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.8.2)))(typescript@5.8.2)


### PR DESCRIPTION
## Problem

Dead-click autocapture can report false positives on WebKit when the page's `MutationObserver` is patched or Angular Zone is present. In that fallback path, the SDK takes a native observer constructor from a temporary iframe and removes the iframe before constructing the observer. WebKit then silently drops callbacks from that detached realm, so visible DOM updates can still be classified as dead clicks.

This addresses #4315 and aligns the dead-click and rrweb iframe-lifetime workarounds.

## Changes

- Add a shared `isWebKit` engine check to `@posthog/core` and reuse it from browser-common and rrweb-utils.
- Keep the iframe supplying a fallback `MutationObserver` attached on Safari, iOS browsers, and WKWebView for the lifetime of the cached constructor.
- Hide and mark retained iframes with `rr-block` and `ph-no-capture` so replay and autocapture ignore them.
- Preserve iframe cleanup on Chromium and when iframe creation or constructor lookup fails.
- Add shared detector coverage plus browser-common and rrweb fallback coverage for Safari, Chrome on iOS, WKWebView, and desktop Chromium.
- Add a Playwright regression that forces the dead-click fallback and verifies an immediate DOM update does not emit `$dead_click` across WebKit, Chromium, and Firefox.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common
- [x] @posthog/core
- [x] @posthog/rrweb-utils

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and validated with Playwright, an independent Pi reviewer subagent, and isolated Pi autoreview. Autoreview identified that Safari-token detection excluded WKWebView; the final implementation centralizes WebKit detection in `@posthog/core` and reuses it for both observer fallbacks. The final autoreview was clean.

A fast `array.js` comparison against `origin/main` reported 0.00% minified change, effectively 0.00% gzip change, and a 0.10% Brotli reduction.
