### PR TITLE
fix(browser): identify anonymous users with matching IDs

### DIFF
--- a/.changeset/tidy-spiders-identify.md
+++ b/.changeset/tidy-spiders-identify.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix `identify()` creating a person profile when the supplied ID already matches an anonymously persisted distinct ID.

--- a/packages/browser/src/__tests__/personProcessing.test.ts
+++ b/packages/browser/src/__tests__/personProcessing.test.ts
@@ -265,6 +265,46 @@ describe('person processing', () => {
             })
         })
 
+        it('should carry a later gclid landing from an anonymous pageview onto identify without changing direct first-touch attribution', async () => {
+            // arrange: persist a direct first touch, then simulate a later browser session and SDK instance
+            const persistenceName = uuidv7()
+            const directUrl = 'https://example.com/landing'
+            mockReferrerGetter.mockReturnValue('')
+            mockURLGetter.mockReturnValue(directUrl)
+            const { posthog: firstVisitPosthog } = await setup('identified_only', undefined, persistenceName)
+            firstVisitPosthog.capture('direct first visit')
+            firstVisitPosthog.sessionManager!.resetSessionId()
+            firstVisitPosthog.sessionPersistence!.clear()
+            window.sessionStorage.clear()
+
+            const gclid = 'google-click-id'
+            mockURLGetter.mockReturnValue(`https://example.com/landing?gclid=${gclid}`)
+            const { posthog, beforeSendMock } = await setup('identified_only', undefined, persistenceName)
+
+            // act
+            posthog.capture('$pageview')
+            posthog.identify(distinctId)
+
+            // assert
+            const anonymousPageview = beforeSendMock.mock.calls[0][0]
+            expect(anonymousPageview.event).toBe('$pageview')
+            expect(anonymousPageview.properties.gclid).toBe(gclid)
+            expect(anonymousPageview.properties.$process_person_profile).toBe(false)
+            expect(anonymousPageview.$set_once).toBeUndefined()
+
+            const identifyCall = beforeSendMock.mock.calls[1][0]
+            expect(identifyCall.event).toBe('$identify')
+            expect(identifyCall.properties.gclid).toBe(gclid)
+            expect(identifyCall.properties.$process_person_profile).toBe(true)
+            expect(identifyCall.$set_once).toMatchObject({
+                $initial_current_url: directUrl,
+                $initial_referrer: '$direct',
+                $initial_referring_domain: '$direct',
+                $initial_gclid: null,
+                gclid,
+            })
+        })
+
         it('should preserve initial referrer info across a separate session', async () => {
             // arrange
             mockReferrerGetter.mockReturnValue('https://referrer1.com')

--- a/packages/browser/src/__tests__/posthog-core.identify.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.identify.test.ts
@@ -215,8 +215,8 @@ describe('identify()', () => {
                         event: '$identify',
                     })
                 )
-                expect(instance.featureFlags.reloadFeatureFlags).toHaveBeenCalledTimes(1)
-                expect(instance.unregister).toHaveBeenCalledWith('$flag_call_reported')
+                expect(instance.featureFlags.reloadFeatureFlags).not.toHaveBeenCalled()
+                expect(instance.unregister).not.toHaveBeenCalledWith('$flag_call_reported')
             })
 
             it('captures exactly one $set event with properties and does not duplicate it on the next identify', () => {
@@ -233,6 +233,8 @@ describe('identify()', () => {
                         }),
                     })
                 )
+                expect(instance.featureFlags.reloadFeatureFlags).toHaveBeenCalledTimes(1)
+                expect(instance.unregister).not.toHaveBeenCalledWith('$flag_call_reported')
             })
 
             it('does not let an existing property cache suppress the identity-state transition event', () => {
@@ -246,6 +248,8 @@ describe('identify()', () => {
                 expect(beforeSendMock).toHaveBeenCalledTimes(1)
                 expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$set' }))
                 expect(instance.persistence!.get_property(USER_STATE)).toBe('identified')
+                expect(instance.featureFlags.reloadFeatureFlags).toHaveBeenCalledTimes(1)
+                expect(instance.unregister).not.toHaveBeenCalledWith('$flag_call_reported')
             })
         })
 

--- a/packages/browser/src/__tests__/posthog-core.identify.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.identify.test.ts
@@ -184,6 +184,69 @@ describe('identify()', () => {
         beforeEach(() => {
             // set the current/old identity
             instance.persistence!.props['distinct_id'] = 'a-new-id'
+            instance.persistence!.set_property(USER_STATE, 'identified')
+        })
+
+        describe('when the persisted user state is anonymous', () => {
+            beforeEach(() => {
+                instance.persistence!.set_property(USER_STATE, 'anonymous')
+            })
+
+            it('marks the user identified and captures one person-processed $set event', () => {
+                instance.identify('a-new-id')
+
+                expect(instance.persistence!.get_property(USER_STATE)).toBe('identified')
+                expect(beforeSendMock).toHaveBeenCalledTimes(1)
+                expect(beforeSendMock).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        event: '$set',
+                        properties: expect.objectContaining({
+                            $process_person_profile: true,
+                            $set: {},
+                            $set_once: {},
+                        }),
+                        $set_once: expect.objectContaining({
+                            $initial_current_url: expect.any(String),
+                        }),
+                    })
+                )
+                expect(beforeSendMock).not.toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        event: '$identify',
+                    })
+                )
+                expect(instance.featureFlags.reloadFeatureFlags).toHaveBeenCalledTimes(1)
+                expect(instance.unregister).toHaveBeenCalledWith('$flag_call_reported')
+            })
+
+            it('captures exactly one $set event with properties and does not duplicate it on the next identify', () => {
+                instance.identify('a-new-id', { email: 'john@example.com' }, { howOftenAmISet: 'once!' })
+                instance.identify('a-new-id', { email: 'john@example.com' }, { howOftenAmISet: 'once!' })
+
+                expect(beforeSendMock).toHaveBeenCalledTimes(1)
+                expect(beforeSendMock).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        event: '$set',
+                        properties: expect.objectContaining({
+                            $set: { email: 'john@example.com' },
+                            $set_once: expect.objectContaining({ howOftenAmISet: 'once!' }),
+                        }),
+                    })
+                )
+            })
+
+            it('does not let an existing property cache suppress the identity-state transition event', () => {
+                const properties = { email: 'john@example.com' }
+                instance.setPersonProperties(properties)
+                beforeSendMock.mockClear()
+                instance.persistence!.set_property(USER_STATE, 'anonymous')
+
+                instance.identify('a-new-id', properties)
+
+                expect(beforeSendMock).toHaveBeenCalledTimes(1)
+                expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$set' }))
+                expect(instance.persistence!.get_property(USER_STATE)).toBe('identified')
+            })
         })
 
         it('does not capture or set user properties', () => {
@@ -270,8 +333,9 @@ describe('identify()', () => {
             expect(instance.featureFlags.reloadFeatureFlags).toHaveBeenCalled()
         })
 
-        it('does not reload feature flags if identity does not change', () => {
+        it('does not reload feature flags if identity and identified state do not change', () => {
             instance.persistence!.props['distinct_id'] = 'a-new-id'
+            instance.persistence!.set_property(USER_STATE, 'identified')
 
             instance.identify('a-new-id')
 
@@ -279,8 +343,9 @@ describe('identify()', () => {
             expect(instance.featureFlags.reloadFeatureFlags).not.toHaveBeenCalled()
         })
 
-        it('reloads feature flags if identity does not change but properties do', () => {
+        it('updates feature flag properties without reloading if identity and identified state do not change', () => {
             instance.persistence!.props['distinct_id'] = 'a-new-id'
+            instance.persistence!.set_property(USER_STATE, 'identified')
 
             instance.identify('a-new-id', { email: 'john@example.com' }, { howOftenAmISet: 'once!' })
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2610,9 +2610,12 @@ export class PostHog implements PostHogInterface {
         const isKnownAnonymous =
             (this.persistence.get_property(USER_STATE) || USER_STATE_ANONYMOUS) === USER_STATE_ANONYMOUS
 
+        const identityDidChange = new_distinct_id !== previous_distinct_id
+        const anonymousStateDidChange = !identityDidChange && isKnownAnonymous
+
         // send an $identify event any time the distinct_id is changing and the old ID is an anonymous ID
         // - logic on the server will determine whether or not to do anything with it.
-        if (new_distinct_id !== previous_distinct_id && isKnownAnonymous) {
+        if (identityDidChange && isKnownAnonymous) {
             this.persistence.set_property(USER_STATE, USER_STATE_IDENTIFIED)
 
             // Update current user properties
@@ -2639,6 +2642,21 @@ export class PostHog implements PostHogInterface {
             // let the reload feature flag request know to send this previous distinct id
             // for flag consistency
             this.featureFlags?.setAnonymousDistinctId(previous_distinct_id)
+        } else if (anonymousStateDidChange) {
+            this.persistence.set_property(USER_STATE, USER_STATE_IDENTIFIED)
+
+            const setProperties = userPropertiesToSet || {}
+            const setOnceProperties = userPropertiesToSetOnce || {}
+            this.setPersonPropertiesForFlags({ $set: setProperties, $set_once: setOnceProperties }, false)
+            this.capture('$set', { $set: setProperties, $set_once: setOnceProperties })
+
+            // This transition must create/update the person even when an identical property call was cached earlier.
+            // Cache only after capture so deduplication cannot suppress the transition event.
+            this._cachedPersonProperties = getPersonPropertiesHash(
+                new_distinct_id,
+                userPropertiesToSet,
+                userPropertiesToSetOnce
+            )
         } else if (userPropertiesToSet || userPropertiesToSetOnce) {
             // If the distinct_id is not changing, but we have user properties to set, we can check if they have changed
             // and if so, send a $set event
@@ -2646,9 +2664,9 @@ export class PostHog implements PostHogInterface {
             this.setPersonProperties(userPropertiesToSet, userPropertiesToSetOnce)
         }
 
-        // Reload active feature flags if the user identity changes.
+        // Reload active feature flags if the user identity or known identity state changes.
         // Note we don't reload this on property changes as these get processed async
-        if (new_distinct_id !== previous_distinct_id) {
+        if (identityDidChange || anonymousStateDidChange) {
             this.reloadFeatureFlags()
             // also clear any stored flag calls
             this.unregister(FLAG_CALL_REPORTED)

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2611,7 +2611,7 @@ export class PostHog implements PostHogInterface {
             (this.persistence.get_property(USER_STATE) || USER_STATE_ANONYMOUS) === USER_STATE_ANONYMOUS
 
         const identityDidChange = new_distinct_id !== previous_distinct_id
-        const anonymousStateDidChange = !identityDidChange && isKnownAnonymous
+        const shouldTransitionToIdentified = !identityDidChange && isKnownAnonymous
 
         // send an $identify event any time the distinct_id is changing and the old ID is an anonymous ID
         // - logic on the server will determine whether or not to do anything with it.
@@ -2642,7 +2642,7 @@ export class PostHog implements PostHogInterface {
             // let the reload feature flag request know to send this previous distinct id
             // for flag consistency
             this.featureFlags?.setAnonymousDistinctId(previous_distinct_id)
-        } else if (anonymousStateDidChange) {
+        } else if (shouldTransitionToIdentified) {
             this.persistence.set_property(USER_STATE, USER_STATE_IDENTIFIED)
 
             const setProperties = userPropertiesToSet || {}
@@ -2664,12 +2664,14 @@ export class PostHog implements PostHogInterface {
             this.setPersonProperties(userPropertiesToSet, userPropertiesToSetOnce)
         }
 
-        // Reload active feature flags if the user identity or known identity state changes.
-        // Note we don't reload this on property changes as these get processed async
-        if (identityDidChange || anonymousStateDidChange) {
+        // Reload active feature flags if the distinct ID changes. Clear stored flag calls because they belong to the
+        // previous identity. A same-ID transition only needs a reload when the caller supplied properties that can
+        // affect flag evaluation; the anonymous/identified state itself is not part of the /flags request.
+        if (identityDidChange) {
             this.reloadFeatureFlags()
-            // also clear any stored flag calls
             this.unregister(FLAG_CALL_REPORTED)
+        } else if (shouldTransitionToIdentified && (userPropertiesToSet || userPropertiesToSetOnce)) {
+            this.reloadFeatureFlags()
         }
     }
 


### PR DESCRIPTION
## Problem

When `identify()` is called with an ID that already matches the persisted `distinct_id` while the SDK still considers the user anonymous, the call enables person processing but emits no event and leaves `$user_state` anonymous. The person profile and stored attribution are therefore not updated until a later event happens to be captured.

## Changes

- Treat a matching-ID anonymous `identify()` call as an identity-state transition.
- Mark the user identified and emit one person-processed `$set` event, including any supplied properties and the SDK's automatic initial/session attribution.
- Avoid emitting `$identify` when the anonymous and identified IDs are equal.
- Reload feature flags for a same-ID transition only when the caller supplies properties that can affect flag evaluation. Preserve reported flag calls because the distinct ID did not change.
- Bypass a previously cached person-property hash for the required transition event, then cache the emitted values to preserve subsequent deduplication.
- Add regression coverage for a direct first touch followed by an anonymous `gclid` landing and identification, confirming current attribution reaches `$identify` without changing the original first-touch values.

Validation:

- `pnpm --dir packages/browser test:unit` — 123 suites passed, 5,079 tests passed.
- `pnpm --dir packages/browser lint`
- `pnpm --dir packages/browser exec tsc -b --pretty false`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently reviewed with Pi's reviewer subagent. We chose a person-processed `$set` instead of a same-ID `$identify`, because there is no anonymous ID to merge in this state. We also avoided reloading flags for a state-only transition because `$user_state` is not part of the `/flags` request. Campaign null semantics and SPA campaign refresh were intentionally kept out of scope.
