### PR TITLE
ci: wait for npm propagation before downstream upgrade

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -39,13 +39,36 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
-                node-version: 24
+                  node-version: 24
 
             - name: Setup pnpm
               uses: pnpm/setup@5d160c5bc68a09337ad0d5654e237e03253b5879 # v1
               with:
-                cache: false
-                install: false
+                  cache: false
+                  install: false
+
+            - name: Wait for package to become available on npm
+              shell: bash
+              timeout-minutes: 16
+              env:
+                  PACKAGE_NAME: ${{ github.event.inputs.package_name }}
+                  PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
+              run: |
+                  for attempt in $(seq 1 30); do
+                      published_version=$(pnpm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null || true)
+                      if [ "$published_version" = "$PACKAGE_VERSION" ]; then
+                          echo "$PACKAGE_NAME@$PACKAGE_VERSION is available on npm."
+                          exit 0
+                      fi
+
+                      if [ "$attempt" -eq 30 ]; then
+                          echo "::error::$PACKAGE_NAME@$PACKAGE_VERSION did not become available on npm within 15 minutes."
+                          exit 1
+                      fi
+
+                      echo "$PACKAGE_NAME@$PACKAGE_VERSION is not available on npm yet (attempt $attempt/30). Retrying in 30 seconds..."
+                      sleep 30
+                  done
 
             - name: Install new package version in main repo
               id: pnpm-upgrade


### PR DESCRIPTION
## Problem

The downstream PostHog upgrade workflow can start before a newly published `posthog-js` version is readable from npm. npm accepted `posthog-js@1.408.2`, but the package remained unavailable for about ten minutes, causing the downstream install and its retry to fail with `ERR_PNPM_NO_MATCHING_VERSION`.

## Changes

- Poll npm for the exact requested package version every 30 seconds before starting the downstream install.
- Allow up to 15 minutes for npm propagation.
- Emit a clear workflow error if the package is still unavailable after the timeout.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and GitHub CLI. Bounded polling was chosen instead of a fixed delay so the workflow tolerates variable npm propagation times while retaining a clear failure after 15 minutes. Validation included Prettier, YAML parsing, diff checks, and a live npm version probe.
