### PR TITLE
fix(core): identify anonymous user when id already matches persisted distinct id

### DIFF
--- a/.changeset/vivid-snakes-teach.md
+++ b/.changeset/vivid-snakes-teach.md
@@ -1,5 +1,8 @@
 ---
 '@posthog/core': patch
+'posthog-node': patch
+'posthog-react-native': patch
+'posthog-js-lite': patch
 ---
 
-Fix `identify()` leaving a user anonymous when the supplied ID already matches the persisted distinct ID (for example after a non-identified bootstrap seeded the same ID). The user is now marked identified and a person-processed `$set` event is captured. Ports the same fix from posthog-js (browser) to the shared core used by React Native and Node.
+Fix `identify()` leaving a user anonymous when the supplied ID already matches the persisted distinct ID (for example after a non-identified bootstrap seeded the same ID). The user is now marked identified and a person-processed `$set` event is captured. Ports the same fix from posthog-js (browser) to the shared core used by React Native, Node, and posthog-js-lite.

--- a/.changeset/vivid-snakes-teach.md
+++ b/.changeset/vivid-snakes-teach.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Fix `identify()` leaving a user anonymous when the supplied ID already matches the persisted distinct ID (for example after a non-identified bootstrap seeded the same ID). The user is now marked identified and a person-processed `$set` event is captured. Ports the same fix from posthog-js (browser) to the shared core used by React Native and Node.

--- a/packages/core/src/__tests__/posthog.identify.spec.ts
+++ b/packages/core/src/__tests__/posthog.identify.spec.ts
@@ -182,6 +182,77 @@ describe('PostHog Core', () => {
       expect(mocks.storage.setItem).not.toHaveBeenCalledWith('distinct_id', 'id-1')
     })
 
+    describe('when the persisted id already matches the identify id while still anonymous', () => {
+      // e.g. a non-identified bootstrap seeded the id as the anonymous id
+      beforeEach(() => {
+        ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
+          flushAt: 1,
+          bootstrap: { distinctId: 'user-123' },
+        })
+      })
+
+      const batchEvents = (): any[] =>
+        mocks.fetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/')).flatMap((c) => parseBody(c).batch)
+      const flagsCalls = (): any[] => mocks.fetch.mock.calls.filter((c) => (c[0] as string).includes('/flags/'))
+
+      it('marks the user identified and captures one person-processed $set, not $identify', async () => {
+        posthog.identify('user-123')
+        await waitForPromises()
+
+        const events = batchEvents()
+        expect(events).toHaveLength(1)
+        expect(events[0].event).toEqual('$set')
+        expect(events[0].properties.$process_person_profile).toEqual(true)
+        expect(events[0].properties.$is_identified).toEqual(true)
+        expect(events.some((e) => e.event === '$identify')).toBe(false)
+        expect(posthog.getPersistedProperty(PostHogPersistedProperty.PersonMode)).toEqual('identified')
+      })
+
+      it('does not reload feature flags on the transition when no properties are supplied', async () => {
+        posthog.identify('user-123')
+        await waitForPromises()
+
+        expect(flagsCalls()).toHaveLength(0)
+      })
+
+      it('reloads feature flags on the transition when properties are supplied', async () => {
+        posthog.identify('user-123', { email: 'john@example.com' })
+        await waitForPromises()
+
+        expect(flagsCalls()).toHaveLength(1)
+      })
+
+      it('does not emit a second $set on a repeated matching-id identify', async () => {
+        posthog.identify('user-123', { email: 'john@example.com' })
+        posthog.identify('user-123', { email: 'john@example.com' })
+        await waitForPromises()
+
+        expect(batchEvents().filter((e) => e.event === '$set')).toHaveLength(1)
+      })
+
+      it('fires the transition $set even when the same properties were already cached', async () => {
+        // Populate the person-properties cache first, then identify with identical props: the
+        // identity-state transition must still emit its $set (dedup cannot suppress it).
+        posthog.setPersonProperties({ email: 'john@example.com' })
+        await waitForPromises()
+        expect(batchEvents().filter((e) => e.event === '$set')).toHaveLength(1)
+
+        posthog.identify('user-123', { email: 'john@example.com' })
+        await waitForPromises()
+
+        expect(batchEvents().filter((e) => e.event === '$set')).toHaveLength(2)
+        expect(posthog.getPersistedProperty(PostHogPersistedProperty.PersonMode)).toEqual('identified')
+      })
+
+      it('does not upgrade an anonymous user to identified on an argument-less identify()', async () => {
+        posthog.identify()
+        await waitForPromises()
+
+        expect(batchEvents()).toHaveLength(0)
+        expect(posthog.getPersistedProperty(PostHogPersistedProperty.PersonMode)).not.toEqual('identified')
+      })
+    })
+
     it('should send $anon_distinct_id when identify is called during in-flight preload flags', async () => {
       // This test verifies the fix for the race condition where identify() calls
       // triggered during preloadFeatureFlags would drop the $anon_distinct_id.

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -349,6 +349,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       }
 
       const previousDistinctId = this.getDistinctId()
+      // Whether the caller passed an id at all — a bare identify() must not upgrade an anonymous
+      // user to identified (browser rejects it in _validateIdentifyId; core has no such guard and
+      // would otherwise fall into the matching-id transition below).
+      const idWasSupplied = !!distinctId
       distinctId = distinctId || previousDistinctId
 
       if (properties?.$groups) {
@@ -372,7 +376,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       const userPropsObj = isObject(userProps) ? (userProps as { [key: string]: JsonType }) : undefined
       const userPropsOnceObj = isObject(userPropsOnce) ? (userPropsOnce as { [key: string]: JsonType }) : undefined
 
-      if (distinctId !== previousDistinctId) {
+      const identityChanged = distinctId !== previousDistinctId
+      const shouldTransitionToIdentified = idWasSupplied && !identityChanged && !this._isIdentified()
+
+      if (identityChanged) {
         // We keep the AnonymousId to be used by flags calls and identify to link the previousId
         this.setPersistedProperty(PostHogPersistedProperty.AnonymousId, previousDistinctId)
         this.setPersistedProperty(PostHogPersistedProperty.DistinctId, distinctId)
@@ -384,6 +391,26 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
         // Update the cached person properties hash
         this._cachedPersonProperties = getPersonPropertiesHash(distinctId, userPropsObj, userPropsOnceObj)
+      } else if (shouldTransitionToIdentified) {
+        // Matching id while still anonymous (e.g. a non-identified bootstrap seeded the same id):
+        // upgrade to identified and emit one person-processed $set. There is no anonymous id to
+        // merge, so no $identify. Mirrors posthog-js (browser).
+        this.setPersistedProperty(PostHogPersistedProperty.PersonMode, 'identified')
+
+        const setProps = userPropsObj || {}
+        const setOnceProps = userPropsOnceObj || {}
+        this.setPersonPropertiesForFlags({ $set: setProps, $set_once: setOnceProps }, false)
+        this.capture('$set', { $set: setProps, $set_once: setOnceProps })
+
+        // The transition event must fire even when an identical property call was cached earlier;
+        // cache only after capture so deduplication cannot suppress it.
+        this._cachedPersonProperties = getPersonPropertiesHash(distinctId, userPropsObj, userPropsOnceObj)
+
+        // The identified state itself is not part of the flags request; reload only when the
+        // caller supplied properties that can affect flag evaluation.
+        if (userPropsObj || userPropsOnceObj) {
+          this.reloadFeatureFlags()
+        }
       } else if (userPropsObj || userPropsOnceObj) {
         // If the distinct_id is not changing, but we have user properties to set, we can check if they have changed
         // and if so, send a $set event


### PR DESCRIPTION
## Problem

Calling `identify(id)` where `id` already equals the persisted distinct ID left the user cached as anonymous while core still considered them anonymous. No identity transition fired, no person-processed event was sent, and `$is_identified` stayed false.

This is easy to hit after a non-identified bootstrap: bootstrapping seeds the bootstrap ID as the anonymous ID, so a later `identify(sameId)` matches the stored distinct ID and the transition was skipped. The shared `@posthog/core` engine powers `posthog-react-native` and `posthog-node`, so both were affected.

Ports the browser fix from #4328 to the shared core.

## Changes

When the supplied ID matches the persisted distinct ID and the user is still anonymous, core now marks the user identified and captures one person-processed `$set` (no `$identify`, since there is no anonymous ID to merge). The property hash is cached after capture so deduplication cannot suppress the transition, and flags reload only when properties that affect evaluation are supplied. An argument-less `identify()` still does not upgrade an anonymous user, matching browser behavior.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-node
- [x] posthog-react-native

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
