### PR TITLE
feat(ai): map openai-agents groupId to $ai_session_id

### DIFF
--- a/.changeset/openai-agents-group-id-session.md
+++ b/.changeset/openai-agents-group-id-session.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': minor
+---
+
+The OpenAI Agents SDK `groupId` now also maps to `$ai_session_id` on `$ai_trace` and span events, so grouped runs show up as sessions in PostHog AI observability. `$ai_group_id` is still emitted alongside it.

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -256,6 +256,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
       ...errorProperties,
     }
     if (groupId) {
+      properties.$ai_session_id = groupId
       properties.$ai_group_id = groupId
     }
     return properties
@@ -341,7 +342,11 @@ export class PostHogTracingProcessor implements TracingProcessor {
         properties.$ai_latency = latency
       }
 
+      // The Agents SDK groupId links traces from one conversation, which is exactly
+      // what PostHog calls a session. $ai_group_id is still emitted for anyone
+      // already querying it.
       if (groupId) {
+        properties.$ai_session_id = groupId
         properties.$ai_group_id = groupId
       }
 

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -118,13 +118,24 @@ describe('PostHogTracingProcessor', () => {
       expect(call.properties.$ai_latency).toBeDefined()
     })
 
-    it('includes group_id in trace events', async () => {
+    it('includes group_id in trace and span events as both session and group id', async () => {
       const trace = createMockTrace({ groupId: 'group_abc' })
-      await processor.onTraceStart(trace as any)
-      await processor.onTraceEnd(trace as any)
+      const span = createMockSpan({ spanData: { type: 'generation', model: 'gpt-4o' } })
 
-      const call = mockClient.capture.mock.calls[0][0]
-      expect(call.properties.$ai_group_id).toBe('group_abc')
+      await processor.onTraceStart(trace as any)
+      mockClient.capture.mockClear()
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+      const spanCall = mockClient.capture.mock.calls[0][0]
+
+      await processor.onTraceEnd(trace as any)
+      const traceCall = mockClient.capture.mock.calls[1][0]
+
+      expect(spanCall.properties.$ai_session_id).toBe('group_abc')
+      expect(spanCall.properties.$ai_group_id).toBe('group_abc')
+      expect(traceCall.properties.$ai_session_id).toBe('group_abc')
+      expect(traceCall.properties.$ai_group_id).toBe('group_abc')
     })
 
     it('includes trace metadata in trace events', async () => {


### PR DESCRIPTION
## Problem

The OpenAI Agents SDK's `groupId` is documented as a "grouping identifier to link multiple traces from the same conversation or process" — that is exactly a PostHog session. We were writing it only to `$ai_session_id`'s near-namesake `$ai_group_id`, which nothing in AI observability reads, so grouped runs never showed up as sessions.

`groupId` is the only per-conversation channel this integration exposes (`RunConfig({ groupId })` / `withTrace({ groupId })`), and it's already read per trace and threaded into every span event — it just landed under a name with no consumer.

## Changes

Emit `$ai_session_id` alongside the existing `$ai_group_id` at both assignment sites in `packages/ai/src/openai-agents/processor.ts` — `_baseProperties` (every span event) and the `$ai_trace` event. Both properties are set, so anything already querying `$ai_group_id` keeps working.

Same fix as PostHog/posthog-python#819.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). The naming bug surfaced in the Python SDK while auditing which AI integrations can carry a session id; `openai-agents` is the only integration in either SDK that reused the framework's own native field instead of a per-call properties channel, which is where the name drifted. Checked the rest of `packages/ai` — `groupId` exists only in the OpenAI Agents SDK, so nothing else is affected.

Started as a straight rename to match the Python change, then switched to emitting both names so existing `$ai_group_id` queries don't break.

Extended the existing `includes group_id in trace events` test to cover span events too, and to assert both properties. Verified it fails without the source change and passes with it; the full `packages/ai/tests/openai-agents.test.ts` suite passes (61 tests). No manual end-to-end run against a live agent.
