### PR TITLE
fix(ai): name langchain spans from the bare runName string

### DIFF
--- a/.changeset/langchain-run-name-string.md
+++ b/.changeset/langchain-run-name-string.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Fix LangChain spans being named after their class instead of the runnable. LangChain passes `runName` as a bare string, which the name resolver skipped because it only inspected object arguments, so every tool span was captured as `DynamicStructuredTool` rather than the tool's own name.

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -562,10 +562,17 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
   private _getLangchainRunName(serialized: any, ...args: any): string | undefined {
     if (args && args.length > 0) {
       for (const arg of args) {
-        if (arg && typeof arg === 'object' && 'name' in arg) {
-          return arg.name
-        } else if (arg && typeof arg === 'object' && 'runName' in arg) {
-          return arg.runName
+        // LangChain hands runName through as a bare string, not wrapped in an object
+        if (typeof arg === 'string' && arg) {
+          return arg
+        }
+        if (arg && typeof arg === 'object') {
+          if (arg.name) {
+            return arg.name
+          }
+          if (arg.runName) {
+            return arg.runName
+          }
         }
       }
     }

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -687,6 +687,29 @@ describe('LangChainCallbackHandler', () => {
   })
 })
 
+describe('LangChainCallbackHandler span naming', () => {
+  it('names a tool span from runName rather than the serialized class', () => {
+    const handler = new LangChainCallbackHandler({ client: mockPostHogClient })
+    jest.clearAllMocks()
+
+    const serialized = {
+      lc: 1,
+      type: 'constructor' as const,
+      id: ['langchain', 'tools', 'DynamicStructuredTool'],
+      kwargs: {},
+    }
+    const runId = 'run_tool_name'
+
+    // LangChain calls this with (tool, input, runId, parentRunId, tags, metadata, runName)
+    handler.handleToolStart(serialized, '{"city":"Paris"}', runId, 'parent_run', [], {}, 'get_weather')
+    handler.handleToolEnd('sunny', runId, 'parent_run')
+
+    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    expect(captureCall[0].event).toBe('$ai_span')
+    expect(captureCall[0].properties['$ai_span_name']).toBe('get_weather')
+  })
+})
+
 describe('LangChainCallbackHandler trace/span state sanitization', () => {
   it('redacts base64 data URLs from $ai_input_state and $ai_output_state', () => {
     const handler = new LangChainCallbackHandler({ client: mockPostHogClient })


### PR DESCRIPTION
## Problem

Every LangChain tool span is captured with `$ai_span_name` set to the runnable's class rather than its actual name — in a typical agent, every tool span in the UI reads `DynamicStructuredTool`, so they're indistinguishable.

LangChain does hand us the right name: `handleToolStart` and `handleChainStart` receive `runName` as their last argument and forward it to `_getLangchainRunName` as `(metadata, tags, runName)`. But the resolver only inspected arguments where `typeof arg === 'object'`, so the bare string was skipped and it fell through to `serialized.id[last]`. Setting `runName` in the run config doesn't help, so there's no user-side workaround.

## Changes

`_getLangchainRunName` now accepts a bare string argument as the run name. Two details worth a reviewer's eye:

- The string branch is first, matching the precedence the Python SDK documents (`_get_langchain_run_name`: explicit name → `serialized.name` → `serialized.id[-1]`). Only `runName` can arrive as a string in these call paths — `tags` is a `string[]`, which is an object.
- The object branches now test the value rather than key presence. `_setLLMMetadata` calls this with `{ extraParams, runName }`, where `'runName' in arg` is true even when `runName` is `undefined` — that returned `undefined` and skipped the `serialized.name` fallback entirely.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Found while comparing the JS and Python LangChain handlers against a running agent for docs work — the tool span came back named `DynamicStructuredTool` while the callback was being handed `get_weather`.

Added a `handleToolStart` → `handleToolEnd` test asserting `$ai_span_name`. Verified it fails on `main` (`Received: "DynamicStructuredTool"`) and passes with the fix; `tests/callbacks.test.ts` passes (15 tests). Six suites in `packages/ai` fail to resolve `posthog-node` in my local partial workspace install — they fail identically on a clean `main` checkout here, so they're unrelated to this change; CI runs the full workspace.

Kept the change inside `_getLangchainRunName` rather than normalizing `runName` into an object at each call site — the resolver is the piece with the documented precedence, and the call sites already match LangChain's own callback signatures.
