### PR TITLE
fix(types): add _isIdentified() to the public PostHog interface

### DIFF
--- a/.changeset/types-is-identified.md
+++ b/.changeset/types-is-identified.md
@@ -1,0 +1,6 @@
+---
+'@posthog/types': patch
+'posthog-js': patch
+---
+
+Add `_isIdentified()` to the public `PostHog` interface in `@posthog/types`, so TypeScript users can call it on `window.posthog` and inside the `loaded` config callback, as recommended in https://posthog.com/docs/product-analytics/cutting-costs#only-call-identify-once-per-session

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3763,7 +3763,7 @@ export class PostHog implements PostHogInterface {
      * Returns whether the current user is identified, based on the persisted user state.
      *
      * @remarks
-     * A user becomes identified via `identify()`, `alias()`, or identified bootstrap data.
+     * A user becomes identified via `identify()` or an identified bootstrap (`bootstrap.isIdentifiedID: true`).
      * Useful for gating `identify()` so it's only called once per session, as recommended in
      * https://posthog.com/docs/product-analytics/cutting-costs#only-call-identify-once-per-session
      *

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3759,6 +3759,27 @@ export class PostHog implements PostHogInterface {
         return name
     }
 
+    /**
+     * Returns whether the current user is identified, based on the persisted user state.
+     *
+     * @remarks
+     * A user becomes identified via `identify()`, `alias()`, or identified bootstrap data.
+     * Useful for gating `identify()` so it's only called once per session, as recommended in
+     * https://posthog.com/docs/product-analytics/cutting-costs#only-call-identify-once-per-session
+     *
+     * {@label Identification}
+     *
+     * @example
+     * ```js
+     * if (!posthog._isIdentified()) {
+     *     posthog.identify('distinct_id')
+     * }
+     * ```
+     *
+     * @public
+     *
+     * @returns Whether the current user is identified
+     */
     _isIdentified(): boolean {
         return (
             this.persistence?.get_property(USER_STATE) === USER_STATE_IDENTIFIED ||

--- a/packages/types/src/__tests__/posthog-interface.spec.ts
+++ b/packages/types/src/__tests__/posthog-interface.spec.ts
@@ -60,11 +60,6 @@ function extractClassPublicMethods(filePath: string, className: string): string[
                 if (ts.isMethodDeclaration(member) && member.name) {
                     const methodName = member.name.getText(sourceFile)
 
-                    // Skip private methods (starting with _)
-                    if (methodName.startsWith('_')) {
-                        return
-                    }
-
                     // Get the full text including leading comments
                     const fullStart = member.getFullStart()
                     const start = member.getStart(sourceFile)

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -187,7 +187,7 @@ export interface PostHog {
     /**
      * Returns whether the current user is identified, based on the persisted user state.
      *
-     * A user becomes identified via `identify()`, `alias()`, or identified bootstrap data.
+     * A user becomes identified via `identify()` or an identified bootstrap (`bootstrap.isIdentifiedID: true`).
      * Useful for gating `identify()` so it's only called once per session, as recommended in
      * https://posthog.com/docs/product-analytics/cutting-costs#only-call-identify-once-per-session
      *

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -185,6 +185,17 @@ export interface PostHog {
     get_distinct_id(): string
 
     /**
+     * Returns whether the current user is identified, based on the persisted user state.
+     *
+     * A user becomes identified via `identify()`, `alias()`, or identified bootstrap data.
+     * Useful for gating `identify()` so it's only called once per session, as recommended in
+     * https://posthog.com/docs/product-analytics/cutting-costs#only-call-identify-once-per-session
+     *
+     * @returns Whether the current user is identified
+     */
+    _isIdentified(): boolean
+
+    /**
      * Reset the user's identity and start a new session.
      *
      * @param {boolean} [reset_device_id] Whether to generate a new device ID as well as a new distinct ID.


### PR DESCRIPTION
## Problem

Our docs recommend gating `identify()` with `_isIdentified()` ([Cutting costs: only call identify() once per session](https://posthog.com/docs/product-analytics/cutting-costs#only-call-identify-once-per-session)), and the method is public on the `PostHog` class (the published `dist/module.d.ts` includes it). But the hand-maintained `PostHog` interface in `@posthog/types` omitted it.

That bites TypeScript users in two places:

1. Snippet users who type `window.posthog` with `@posthog/types`.
2. Everyone using the `loaded` config callback, because its parameter is typed via `PostHogInterface` (an `Omit<...>` over the types-package interface), so TS reports the method doesn't exist.

This surfaced in support ticket #65074: a customer needed exactly this check inside `loaded` to gate a `reset()` call, couldn't find the method on the typed parameter, and shipped an async polling workaround that reintroduced the race condition they were trying to avoid.

## Change

- Add `_isIdentified(): boolean` to the `PostHog` interface in `packages/types/src/posthog.ts`, with JSDoc pointing at the docs recommendation.
- Mark the class method `@public` in `packages/browser/src/posthog-core.ts` (JSDoc only, no runtime change).
- Remove the interface parity test's blanket skip of underscore-prefixed methods, so the `@public` JSDoc tag is the single source of truth for what belongs in the interface. No other underscore method carries `@public`, so this changes nothing else, and the test now permanently enforces this addition (it fails with "missing from interface" without the types change).

## Verification

- `@posthog/types` unit tests pass (parity test was red before the interface addition, green after).
- `posthog-js` typecheck passes (the class `implements PostHogInterface`, so TS validates compatibility).
- A scratch typecheck of the customer scenario compiles: `loaded: (ph) => { if (!ph._isIdentified()) ph.identify('...') }`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*