### PR TITLE
fix(replay): re-emit one frame per canvas after each full snapshot

### DIFF
--- a/.changeset/canvas-frame-per-snapshot-epoch.md
+++ b/.changeset/canvas-frame-per-snapshot-epoch.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix canvases staying blank after seeking in session replay by re-sending one frame per canvas after each full snapshot

--- a/packages/rrweb/rrweb/src/record/index.ts
+++ b/packages/rrweb/rrweb/src/record/index.ts
@@ -498,6 +498,7 @@ function record<T = eventWithTime>(
       isCheckout,
     );
     mutationBuffers.forEach((buf) => buf.unlock()); // generate & emit any mutations that happened during snapshotting, as can now apply against the newly built mirror
+    canvasManager.onFullSnapshot();
 
     if (recordCrossOriginIframes) {
       iframeManager.reattachIframes();

--- a/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -44,6 +44,15 @@ export class CanvasManager {
   private rafIdFlush: number | null = null;
   private refCount = 0;
   private torndown = false;
+  private resetFrameDedup: (() => void) | null = null;
+
+  // Node ids are reused across full snapshots, so the encode worker's dedup
+  // map would otherwise keep suppressing an idle canvas forever — leaving the
+  // new snapshot's epoch without any frame to repaint that canvas from after
+  // a seek. Called after each full snapshot so every canvas re-emits one frame.
+  public onFullSnapshot() {
+    this.resetFrameDedup?.();
+  }
 
   // Shared by the main document and every iframe/shadow-root observer, so reference-count
   // teardown: a single root cleaning up must not unpatch getContext / stop the FPS loop globally.
@@ -208,6 +217,10 @@ export class CanvasManager {
       // stop the capture loop; nothing can be encoded without the worker.
       cancelAnimationFrame(rafId);
       worker.terminate?.();
+      this.resetFrameDedup = null;
+    };
+    this.resetFrameDedup = () => {
+      worker.postMessage({ resetFrameDedup: true });
     };
     worker.onmessage = (e) => {
       const { id } = e.data;
@@ -396,6 +409,7 @@ export class CanvasManager {
       // this, every recorder restart leaks a worker thread plus its
       // capture-resolution OffscreenCanvas
       worker.terminate?.();
+      this.resetFrameDedup = null;
     };
   }
 

--- a/packages/rrweb/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
+++ b/packages/rrweb/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
@@ -1,6 +1,6 @@
 import { encode } from 'base64-arraybuffer';
 import type {
-  ImageBitmapDataURLWorkerParams,
+  ImageBitmapDataURLWorkerMessage,
   ImageBitmapDataURLWorkerResponse,
 } from '@posthog/rrweb-types';
 
@@ -56,7 +56,7 @@ function transparentFingerprint(width: number, height: number): string {
 
 export interface ImageBitmapDataURLRequestWorker {
   postMessage: (
-    message: ImageBitmapDataURLWorkerParams,
+    message: ImageBitmapDataURLWorkerMessage,
     transfer?: [ImageBitmap],
   ) => void;
   onmessage: (message: MessageEvent<ImageBitmapDataURLWorkerResponse>) => void;
@@ -70,7 +70,7 @@ export interface ImageBitmapDataURLRequestWorker {
 interface ImageBitmapDataURLResponseWorker {
   onmessage:
     | null
-    | ((message: MessageEvent<ImageBitmapDataURLWorkerParams>) => void);
+    | ((message: MessageEvent<ImageBitmapDataURLWorkerMessage>) => void);
   postMessage(e: ImageBitmapDataURLWorkerResponse): void;
 }
 
@@ -82,6 +82,13 @@ let reusableCtx: OffscreenCanvasRenderingContext2D | null = null;
 
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 worker.onmessage = async function (e) {
+  if ('resetFrameDedup' in e.data) {
+    // a full snapshot starts a new epoch: forget fingerprints so each canvas
+    // re-emits one frame the player can repaint from after a seek lands here.
+    // lastSentAtMap is kept — the provider keyframe cadence is independent
+    lastFingerprintMap.clear();
+    return;
+  }
   if ('OffscreenCanvas' in globalThis) {
     const {
       id,

--- a/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
@@ -361,6 +361,45 @@ describe('CanvasManager FPS observer', () => {
     expect(workerControl.instances[0].postMessage).toHaveBeenCalledTimes(1);
   });
 
+  it('posts a frame-dedup reset to the worker on a full snapshot', () => {
+    const win = {
+      document: { querySelectorAll: vi.fn(() => []) },
+      OffscreenCanvas: class {},
+    };
+
+    const manager = createCanvasManager(win);
+    manager.onFullSnapshot();
+
+    expect(workerControl.instances[0].postMessage).toHaveBeenCalledWith({
+      resetFrameDedup: true,
+    });
+  });
+
+  it('onFullSnapshot is a no-op without an FPS worker', () => {
+    const win = { document: { querySelectorAll: vi.fn(() => []) } };
+
+    const manager = createCanvasManager(win);
+
+    expect(workerControl.instances).toHaveLength(0);
+    expect(() => manager.onFullSnapshot()).not.toThrow();
+  });
+
+  it('stops posting dedup resets after teardown', () => {
+    const win = {
+      document: { querySelectorAll: vi.fn(() => []) },
+      OffscreenCanvas: class {},
+    };
+
+    const manager = createCanvasManager(win);
+    manager.acquire();
+    manager.reset();
+
+    manager.onFullSnapshot();
+
+    // the worker is terminated; a post-teardown snapshot must not message it
+    expect(workerControl.instances[0].postMessage).not.toHaveBeenCalled();
+  });
+
   it('should keep the rAF loop alive when getCanvas throws', async () => {
     const fakeCanvas = {
       width: 300,

--- a/packages/rrweb/rrweb/test/record/full-snapshot-canvas-masking.test.ts
+++ b/packages/rrweb/rrweb/test/record/full-snapshot-canvas-masking.test.ts
@@ -29,6 +29,10 @@ vi.mock('../../src/record/observers/canvas/webgl', () => ({
   default: () => () => {},
 }));
 
+const workerInstances = vi.hoisted(
+  () => [] as Array<{ postMessage: ReturnType<typeof vi.fn> }>,
+);
+
 vi.mock(
   '../../src/record/workers/image-bitmap-data-url-worker?worker&inline',
   () => ({
@@ -37,6 +41,9 @@ vi.mock(
       onerror: ((e: ErrorEvent) => void) | null = null;
       postMessage = vi.fn();
       terminate = vi.fn();
+      constructor() {
+        workerInstances.push(this);
+      }
     },
   }),
 );
@@ -51,6 +58,8 @@ describe('full snapshot canvas masking flag', () => {
     stop?.();
     stop = undefined;
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    workerInstances.length = 0;
   });
 
   it('passes the configured thunk itself to the full snapshot', () => {
@@ -114,5 +123,24 @@ describe('full snapshot canvas masking flag', () => {
     expect(JSON.stringify(fullSnapshots[1])).not.toContain('rr_dataURL');
 
     canvas.remove();
+  });
+
+  it('resets canvas frame dedup on each full snapshot so idle canvases re-emit', () => {
+    vi.stubGlobal('OffscreenCanvas', class {});
+
+    stop = record({
+      emit: vi.fn(),
+      recordCanvas: true,
+      sampling: { canvas: 4 },
+    });
+
+    expect(workerInstances).toHaveLength(1);
+    const worker = workerInstances[0];
+    // the initial full snapshot inside record() already resets once
+    worker.postMessage.mockClear();
+
+    record.takeFullSnapshot(true);
+
+    expect(worker.postMessage).toHaveBeenCalledWith({ resetFrameDedup: true });
   });
 });

--- a/packages/rrweb/rrweb/test/record/image-bitmap-data-url-worker.test.ts
+++ b/packages/rrweb/rrweb/test/record/image-bitmap-data-url-worker.test.ts
@@ -400,6 +400,35 @@ describe('image-bitmap-data-url-worker', () => {
     expect(convertToBlob).not.toHaveBeenCalled();
   });
 
+  it('keeps the keyframe clock across a dedup reset for a canvas that went blank', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      const onmessage = await loadWorker();
+
+      await onmessage(frame(1, CONTENT_A, WIDTH, HEIGHT, []));
+      await onmessage(frame(1, BLANK, WIDTH, HEIGHT, []));
+      expect(convertToBlob).toHaveBeenCalledTimes(2);
+
+      await onmessage({
+        data: { resetFrameDedup: true } as ImageBitmapDataURLWorkerMessage,
+      });
+      await onmessage(frame(1, BLANK, WIDTH, HEIGHT, []));
+      expect(postMessage).toHaveBeenLastCalledWith({ id: 1 });
+      expect(convertToBlob).toHaveBeenCalledTimes(2);
+
+      // fires only because lastSentAtMap survived the reset — a reset that
+      // cleared it would leave keyframeDue permanently false for this canvas
+      vi.advanceTimersByTime(30_000);
+      await onmessage(frame(1, BLANK, WIDTH, HEIGHT, []));
+      expect(postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 1, base64: expect.any(String) }),
+      );
+      expect(convertToBlob).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('sends a keyframe for an unchanged canvas with an empty mask region list after the interval', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     try {

--- a/packages/rrweb/rrweb/test/record/image-bitmap-data-url-worker.test.ts
+++ b/packages/rrweb/rrweb/test/record/image-bitmap-data-url-worker.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   CanvasMaskRegion,
-  ImageBitmapDataURLWorkerParams,
+  ImageBitmapDataURLWorkerMessage,
 } from '@posthog/rrweb-types';
 
 type MessageHandler = (e: {
-  data: ImageBitmapDataURLWorkerParams;
+  data: ImageBitmapDataURLWorkerMessage;
 }) => Promise<void>;
 
 const convertToBlob = vi.fn(
@@ -74,7 +74,7 @@ function frame(
   width = WIDTH,
   height = HEIGHT,
   maskRegions?: CanvasMaskRegion[],
-): { data: ImageBitmapDataURLWorkerParams } {
+): { data: ImageBitmapDataURLWorkerMessage } {
   const bitmap: FakeBitmap = { pixels, close: () => {} };
   return {
     data: {
@@ -86,7 +86,7 @@ function frame(
       displayHeight: 4,
       dataURLOptions: { type: 'image/webp', quality: 0.4 },
       maskRegions,
-    } as unknown as ImageBitmapDataURLWorkerParams,
+    } as unknown as ImageBitmapDataURLWorkerMessage,
   };
 }
 
@@ -342,6 +342,62 @@ describe('image-bitmap-data-url-worker', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('re-encodes an unchanged canvas after a dedup reset', async () => {
+    const onmessage = await loadWorker();
+
+    await onmessage(frame(1, CONTENT_A));
+    await onmessage(frame(1, CONTENT_A));
+    expect(postMessage).toHaveBeenLastCalledWith({ id: 1 });
+    expect(convertToBlob).toHaveBeenCalledTimes(1);
+
+    postMessage.mockClear();
+    await onmessage({
+      data: { resetFrameDedup: true } as ImageBitmapDataURLWorkerMessage,
+    });
+    // a reset has no in-flight snapshot to clear, so no reply
+    expect(postMessage).not.toHaveBeenCalled();
+
+    await onmessage(frame(1, CONTENT_A));
+    expect(postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 1, base64: expect.any(String) }),
+    );
+    expect(convertToBlob).toHaveBeenCalledTimes(2);
+  });
+
+  it('resets dedup for every canvas, not just one', async () => {
+    const onmessage = await loadWorker();
+
+    await onmessage(frame(1, CONTENT_A));
+    await onmessage(frame(2, CONTENT_B));
+    await onmessage({
+      data: { resetFrameDedup: true } as ImageBitmapDataURLWorkerMessage,
+    });
+    postMessage.mockClear();
+
+    await onmessage(frame(1, CONTENT_A));
+    await onmessage(frame(2, CONTENT_B));
+
+    expect(postMessage.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: 1, base64: expect.any(String) }),
+    );
+    expect(postMessage.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ id: 2, base64: expect.any(String) }),
+    );
+  });
+
+  it('still skips a blank canvas after a dedup reset', async () => {
+    const onmessage = await loadWorker();
+
+    await onmessage(frame(1, BLANK));
+    await onmessage({
+      data: { resetFrameDedup: true } as ImageBitmapDataURLWorkerMessage,
+    });
+    await onmessage(frame(1, BLANK));
+
+    expect(postMessage).toHaveBeenLastCalledWith({ id: 1 });
+    expect(convertToBlob).not.toHaveBeenCalled();
   });
 
   it('sends a keyframe for an unchanged canvas with an empty mask region list after the interval', async () => {

--- a/packages/rrweb/rrweb/test/record/image-bitmap-data-url-worker.test.ts
+++ b/packages/rrweb/rrweb/test/record/image-bitmap-data-url-worker.test.ts
@@ -400,6 +400,39 @@ describe('image-bitmap-data-url-worker', () => {
     expect(convertToBlob).not.toHaveBeenCalled();
   });
 
+  it('keeps an in-flight frame as the new epoch repaint source when a reset interleaves mid-encode', async () => {
+    const onmessage = await loadWorker();
+    let release!: () => void;
+    convertToBlob.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () =>
+            resolve({
+              type: 'image/webp',
+              arrayBuffer: () => Promise.resolve(new ArrayBuffer(4)),
+            });
+        }),
+    );
+
+    // the handler yields at convertToBlob, so the reset runs mid-encode and
+    // the continuation restores the pre-reset fingerprint afterwards
+    const inflight = onmessage(frame(1, CONTENT_A));
+    await onmessage({
+      data: { resetFrameDedup: true } as ImageBitmapDataURLWorkerMessage,
+    });
+    release();
+    await inflight;
+    expect(postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 1, base64: expect.any(String) }),
+    );
+
+    // the restored fingerprint dedupes the next tick — correct, because the
+    // in-flight reply above is already the new epoch's frame for this canvas
+    await onmessage(frame(1, CONTENT_A));
+    expect(postMessage).toHaveBeenLastCalledWith({ id: 1 });
+    expect(convertToBlob).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps the keyframe clock across a dedup reset for a canvas that went blank', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     try {

--- a/packages/rrweb/types/src/index.ts
+++ b/packages/rrweb/types/src/index.ts
@@ -564,6 +564,18 @@ export type ImageBitmapDataURLWorkerParams = {
   maskRegions?: CanvasMaskRegion[];
 };
 
+export type ImageBitmapDataURLWorkerResetParams = {
+  // sent when the recorder takes a full snapshot: node ids survive full
+  // snapshots, so without dropping the remembered fingerprints an idle canvas
+  // would never re-emit a frame and a seek rebuilt from that snapshot would
+  // find nothing to repaint it from
+  resetFrameDedup: true;
+};
+
+export type ImageBitmapDataURLWorkerMessage =
+  | ImageBitmapDataURLWorkerParams
+  | ImageBitmapDataURLWorkerResetParams;
+
 export type ImageBitmapDataURLWorkerResponse =
   | {
       id: number;


### PR DESCRIPTION
## Problem

Follow-up to #3590 (closed by #4270, which fixed the provider-configured/Flutter-web half). The raw-canvas half is still real: canvas capture only sends a frame when pixels change, so a canvas that goes idle before an interval full snapshot has no frame inside the new snapshot's window. Seeking rebuilds from that snapshot, finds nothing to repaint the canvas from, and shows it blank indefinitely. WebGL canvases (and any canvas without `rr_dataURL` in the snapshot) are hit hardest — 2D canvases are usually rescued by the snapshot still.

Root cause, verified in code: node ids are **reused** across full snapshots (`mirror.reset()` only runs on record start/stop), and PostHog's interval snapshot calls `takeFullSnapshot()` on the live recorder — same encode worker, same fingerprint dedup map. So an idle canvas stays suppressed forever, across every snapshot.

## Changes

Make every full-snapshot epoch self-contained: after each full snapshot, every painted canvas re-emits exactly one frame, so any seek target has an in-epoch frame to repaint from.

- `takeFullSnapshot` now calls `canvasManager.onFullSnapshot()`, which posts `{ resetFrameDedup: true }` to the encode worker (wired only when the FPS observer is active; cleared on teardown and worker error).
- The worker clears its fingerprint map on that message. `lastSentAtMap` is kept, so the 30s provider-keyframe cadence from #4270 is untouched. Blank canvases still compare equal to the transparent fingerprint and emit nothing.
- Types: `ImageBitmapDataURLWorkerParams` keeps its exact shape (no breaking change); a new `ImageBitmapDataURLWorkerMessage` union carries the reset variant.

The reset posts in the same synchronous task as the snapshot emit, so no capture tick can interleave and the re-emitted frame always lands after its snapshot. Worst case from an in-flight frame racing the reset is one duplicate frame.

**Validation** — 12 new unit tests (worker reset/multi-canvas/blank-skip, manager wiring/no-op/teardown, record-level pin), plus a live A/B: the same 6-canvas page (webgl idle/animating, 2d idle/animating, never-painted, cleared-to-transparent) recorded with a `main` bundle vs this branch, then replayed side by side:

| canvas | main, frames after snapshot | this PR | note |
|---|---|---|---|
| webgl-idle | 0 — blank on seek forever | 1, 25ms after the snapshot | payload byte-identical to its last frame (real pixels, not transparency) |
| 2d-idle | 0 (rescued by `rr_dataURL`) | 1 | identical replay |
| webgl/2d animating | 12 | 12 | no duplicates, identical replay |
| never painted | 0 | 0 | no invented traffic |
| cleared to transparent | 0 | 0 | stale pixels not resurrected |

Cost: ~1.8 KB per idle canvas per full-snapshot interval (default 5 min); +3 KB on a 188 KB test recording. On many-canvas dashboards the re-emits land in one capture tick — encode burst is worker-side; staggering is a possible follow-up if it ever shows up in practice.

Known limit: recording-side fix, so it only helps sessions captured after upgrading. In a hidden tab the re-emit waits for the next rAF capture tick (still strictly better than never). Cross-origin iframes (`recordCrossOriginIframes: true`, default off) aren't covered — the reset only reaches this recorder's own worker, and a parent checkout replays stored child content without telling the child frame's recorder to reset; the child's own full-snapshot cadence still resets it on its own schedule.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Continuation of the #3590 investigation from the canvas-masking stack (#4270): the seek-blank mechanism was verified in code first (id reuse across snapshots + worker dedup map surviving `takeFullSnapshot`), then the recording-side fix was chosen over a player-side cross-epoch lookback — it makes the repaint an invariant of the recording format instead of player heuristics, at the cost of only fixing new recordings. A worker-message reset was chosen over a per-frame epoch counter to keep the frame path unchanged. Validation was a local A/B harness driving real record/replay bundles in Chrome; the byte-identical re-emit also rules out the `preserveDrawingBuffer` transparent-capture concern for idle WebGL canvases.
