### PR TITLE
fix(replay): avoid false-positive network body redaction

### DIFF
--- a/.changeset/strict-network-body-sensitive-number-detection.md
+++ b/.changeset/strict-network-body-sensitive-number-detection.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/browser-common': patch
+---
+
+Avoid redacting session replay network bodies when timestamps or UUID fragments resemble social security or credit card numbers.

--- a/packages/browser-common/src/utils/autocapture-utils.ts
+++ b/packages/browser-common/src/utils/autocapture-utils.ts
@@ -527,9 +527,10 @@ const networkCCLengths = [16, 15, 14, 13]
 const coreSSNPattern = `\\d{3}-?\\d{2}-?\\d{4}`
 // Create the Anchored version of the regex by adding '^' at the start and '$' at the end
 const anchoredSSNRegex = new RegExp(`^(${coreSSNPattern})$`)
-// Network bodies require identifier boundaries and exclude invalid SSN/ITIN number groups.
+// Network bodies exclude invalid SSN/ITIN groups and candidates within longer digit runs.
 const networkSSNPattern = `(?!000|666)[0-9]{3}-?(?!00)[0-9]{2}-?(?!0000)[0-9]{4}`
-const unanchoredSSNRegex = new RegExp(`(?:^|[^0-9A-Za-z_])(?:${networkSSNPattern})(?=$|[^0-9A-Za-z_])`)
+const networkSSNCandidateRegex = new RegExp(`(^|[^0-9])(${networkSSNPattern})(?=$|([^0-9]))`, 'g')
+const identifierCharacterRegex = /[0-9A-Za-z_]/
 
 function passesLuhnCheck(value: string): boolean {
     let sum = 0
@@ -578,6 +579,30 @@ function containsCreditCardNumber(value: string): boolean {
     return false
 }
 
+function containsSSN(value: string): boolean {
+    networkSSNCandidateRegex.lastIndex = 0
+    let match: RegExpExecArray | null
+
+    while ((match = networkSSNCandidateRegex.exec(value))) {
+        const characterBefore = match[1]
+        const characterAfter = match[3]
+
+        // UUID fragments and similar identifiers have identifier characters on both sides.
+        if (
+            characterBefore &&
+            characterAfter &&
+            identifierCharacterRegex.test(characterBefore) &&
+            identifierCharacterRegex.test(characterAfter)
+        ) {
+            continue
+        }
+
+        return true
+    }
+
+    return false
+}
+
 /*
  * Check whether a string value should be "captured" or if it may contain sensitive data
  * using a variety of heuristics.
@@ -603,8 +628,8 @@ export function shouldCaptureValue(value: string, anchorRegexes = true): boolean
         }
 
         // check to see if input value looks like a social security number
-        const ssnRegex = anchorRegexes ? anchoredSSNRegex : unanchoredSSNRegex
-        if (ssnRegex.test(value)) {
+        const containsSocialSecurityNumber = anchorRegexes ? anchoredSSNRegex.test(value) : containsSSN(value)
+        if (containsSocialSecurityNumber) {
             return false
         }
     }

--- a/packages/browser-common/src/utils/autocapture-utils.ts
+++ b/packages/browser-common/src/utils/autocapture-utils.ts
@@ -519,15 +519,64 @@ export function isSensitiveElement(el: Element): boolean {
 const coreCCPattern = `(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11})`
 // Create the Anchored version of the regex by adding '^' at the start and '$' at the end
 const anchoredCCRegex = new RegExp(`^(?:${coreCCPattern})$`)
-// The Unanchored version is essentially the core pattern, usable as is for partial matches
-const unanchoredCCRegex = new RegExp(coreCCPattern)
+// Network bodies are free-form strings, so only inspect complete, delimited number-like runs.
+const networkCCCandidateRegex = /(^|[^0-9A-Za-z_])([0-9][0-9 -]*[0-9])(?=$|[^0-9A-Za-z_])/g
+const networkCCLengths = [16, 15, 14, 13]
 
 // Define the core pattern for matching SSNs with optional dashes
 const coreSSNPattern = `\\d{3}-?\\d{2}-?\\d{4}`
 // Create the Anchored version of the regex by adding '^' at the start and '$' at the end
 const anchoredSSNRegex = new RegExp(`^(${coreSSNPattern})$`)
-// The Unanchored version is essentially the core pattern itself, usable for partial matches
-const unanchoredSSNRegex = new RegExp(`(${coreSSNPattern})`)
+// Network bodies require identifier boundaries and exclude invalid SSN/ITIN number groups.
+const networkSSNPattern = `(?!000|666)[0-9]{3}-?(?!00)[0-9]{2}-?(?!0000)[0-9]{4}`
+const unanchoredSSNRegex = new RegExp(`(?:^|[^0-9A-Za-z_])(?:${networkSSNPattern})(?=$|[^0-9A-Za-z_])`)
+
+function passesLuhnCheck(value: string): boolean {
+    let sum = 0
+    let shouldDouble = false
+
+    for (let i = value.length - 1; i >= 0; i--) {
+        let digit = value.charCodeAt(i) - 48
+        if (shouldDouble) {
+            digit *= 2
+            if (digit > 9) {
+                digit -= 9
+            }
+        }
+        sum += digit
+        shouldDouble = !shouldDouble
+    }
+
+    return sum % 10 === 0
+}
+
+function containsCreditCardNumber(value: string): boolean {
+    networkCCCandidateRegex.lastIndex = 0
+    let match: RegExpExecArray | null
+
+    while ((match = networkCCCandidateRegex.exec(value))) {
+        const matchedCandidate = match[2]
+        if (!matchedCandidate) {
+            continue
+        }
+
+        const candidate = matchedCandidate.replace(/[- ]/g, '')
+
+        for (let start = 0; start < candidate.length; start++) {
+            for (const length of networkCCLengths) {
+                const end = start + length
+                if (end <= candidate.length) {
+                    const possibleCardNumber = candidate.slice(start, end)
+                    if (anchoredCCRegex.test(possibleCardNumber) && passesLuhnCheck(possibleCardNumber)) {
+                        return true
+                    }
+                }
+            }
+        }
+    }
+
+    return false
+}
 
 /*
  * Check whether a string value should be "captured" or if it may contain sensitive data
@@ -546,8 +595,10 @@ export function shouldCaptureValue(value: string, anchorRegexes = true): boolean
 
         // check to see if input value looks like a credit card number
         // see: https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s20.html
-        const ccRegex = anchorRegexes ? anchoredCCRegex : unanchoredCCRegex
-        if (ccRegex.test((value || '').replace(/[- ]/g, ''))) {
+        const containsCreditCard = anchorRegexes
+            ? anchoredCCRegex.test((value || '').replace(/[- ]/g, ''))
+            : containsCreditCardNumber(value)
+        if (containsCreditCard) {
             return false
         }
 

--- a/packages/browser-common/tests/utils/autocapture-utils.spec.ts
+++ b/packages/browser-common/tests/utils/autocapture-utils.spec.ts
@@ -55,12 +55,15 @@ describe('autocapture utils', () => {
             expect(shouldCaptureValue('{"ssn":"123456789"}', false)).toBe(false)
             expect(shouldCaptureValue('{"ssn":"123-456789"}', false)).toBe(false)
             expect(shouldCaptureValue('{"ssn":"12345-6789"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"note":"SSN123-45-6789"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"note":"123-45-6789SSN"}', false)).toBe(false)
             expect(shouldCaptureValue('{"itin":"912-70-1234"}', false)).toBe(false)
         })
 
         it('does not treat timestamps, UUID fragments, or invalid SSN groups as sensitive in network bodies', () => {
             expect(shouldCaptureValue('{"version":"1785400913428"}', false)).toBe(true)
             expect(shouldCaptureValue('{"id":"a2086e30-2564-40d2-b260-074641cd3b89"}', false)).toBe(true)
+            expect(shouldCaptureValue('{"id":"prefix123-45-6789suffix"}', false)).toBe(true)
             expect(shouldCaptureValue('{"ssn":"000-12-3456"}', false)).toBe(true)
             expect(shouldCaptureValue('{"ssn":"666-12-3456"}', false)).toBe(true)
             expect(shouldCaptureValue('{"ssn":"123-00-4567"}', false)).toBe(true)

--- a/packages/browser-common/tests/utils/autocapture-utils.spec.ts
+++ b/packages/browser-common/tests/utils/autocapture-utils.spec.ts
@@ -32,6 +32,41 @@ describe('autocapture utils', () => {
             expect(shouldCaptureValue('123-45-6789')).toBe(false)
         })
 
+        it('detects delimited credit card numbers in network bodies', () => {
+            expect(shouldCaptureValue('{"card":"4242 4242 4242 4242"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"card":"4242-4242-4242-4242"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"card":"4556 617 778 508"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"card":"4222222222222"}', false)).toBe(false)
+        })
+
+        it('detects credit card numbers next to numeric metadata', () => {
+            expect(shouldCaptureValue('{"card":"4242 4242 4242 4242 123"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"card":"123 4242 4242 4242 4242"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"card":"4242 4242 4242 4242 12345678901234567"}', false)).toBe(false)
+        })
+
+        it('does not treat invalid or identifier-like card numbers as sensitive in network bodies', () => {
+            expect(shouldCaptureValue('{"id":"4242 4242 4242 4241"}', false)).toBe(true)
+            expect(shouldCaptureValue('{"id":"prefix4242424242424242suffix"}', false)).toBe(true)
+        })
+
+        it('detects structurally valid, delimited SSNs and ITINs in network bodies', () => {
+            expect(shouldCaptureValue('{"ssn":"123-45-6789"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"ssn":"123456789"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"ssn":"123-456789"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"ssn":"12345-6789"}', false)).toBe(false)
+            expect(shouldCaptureValue('{"itin":"912-70-1234"}', false)).toBe(false)
+        })
+
+        it('does not treat timestamps, UUID fragments, or invalid SSN groups as sensitive in network bodies', () => {
+            expect(shouldCaptureValue('{"version":"1785400913428"}', false)).toBe(true)
+            expect(shouldCaptureValue('{"id":"a2086e30-2564-40d2-b260-074641cd3b89"}', false)).toBe(true)
+            expect(shouldCaptureValue('{"ssn":"000-12-3456"}', false)).toBe(true)
+            expect(shouldCaptureValue('{"ssn":"666-12-3456"}', false)).toBe(true)
+            expect(shouldCaptureValue('{"ssn":"123-00-4567"}', false)).toBe(true)
+            expect(shouldCaptureValue('{"ssn":"123-45-0000"}', false)).toBe(true)
+        })
+
         it('captures regular text values', () => {
             expect(shouldCaptureValue('save changes')).toBe(true)
         })

--- a/packages/browser/src/__tests__/extensions/replay/config.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/config.test.ts
@@ -444,6 +444,40 @@ describe('config', () => {
             })
         })
 
+        it.each([
+            ['timestamp', '{"version":"1785400913428"}'],
+            [
+                'UUID containing an SSN-shaped substring',
+                '{"personalizationOptionId":"a2086e30-2564-40d2-b260-074641cd3b89"}',
+            ],
+        ])('does not redact a network body containing a %s', (_description, body) => {
+            const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
+            const cleaned = networkOptions.maskRequestFn!({
+                name: 'something',
+                requestBody: body,
+                responseBody: body,
+            } as Partial<CapturedNetworkRequest> as CapturedNetworkRequest)
+            expect(cleaned).toEqual({
+                name: 'something',
+                requestBody: body,
+                responseBody: body,
+            })
+        })
+
+        it('does not capture SSN data in network bodies', () => {
+            const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
+            const cleaned = networkOptions.maskRequestFn!({
+                name: 'something',
+                requestBody: '{"ssn":"123-45-6789"}',
+                responseBody: '{"ssn":"123456789"}',
+            } as Partial<CapturedNetworkRequest> as CapturedNetworkRequest)
+            expect(cleaned).toEqual({
+                name: 'something',
+                requestBody: '[SessionRecording] Request body redacted',
+                responseBody: '[SessionRecording] Response body redacted',
+            })
+        })
+
         it('does not capture CC data', () => {
             const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
             const cleaned = networkOptions.maskRequestFn!({


### PR DESCRIPTION
## Problem

Session replay scans recorded request and response bodies for credit-card and SSN-shaped values before capture. The unanchored patterns can mistake timestamps and numeric fragments inside UUIDs for sensitive values, replacing otherwise safe GraphQL bodies with a redaction marker.

## Changes

- Require identifier boundaries and structurally valid groups when detecting SSN/ITIN-shaped values in network bodies.
- Detect payment card candidates as delimited numeric runs, then validate issuer shape and Luhn checksum while still finding cards next to numeric metadata.
- Preserve the existing conservative handling of compact, partially formatted SSNs, ITINs, and 13-digit Visa PANs.
- Add unit and replay integration coverage for the reported timestamp and UUID false positives and sensitive-data regression cases.
- Apply the fix directly without a new defaults version or configuration option.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and reviewed with Pi's isolated `autoreview` workflow. Review findings led to retaining redaction for PANs next to numeric metadata, compact 13-digit Visa PANs, ITINs, and partially formatted SSNs. The final autoreview found no blocking issues. The change was verified with focused browser-common and replay tests, lint, dependency builds, and the fast array bundle-size comparison.
