### PR TITLE
feat(node): support starts_with and ends_with in local evaluation

### DIFF
--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -1,5 +1,6 @@
 ---
 'posthog-node': minor
+'@posthog/convex': minor
 ---
 
 Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fall back to remote evaluation.

--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': minor
+---
+
+Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fall back to remote evaluation.

--- a/packages/convex/src/client/feature-flags/match-property.test.ts
+++ b/packages/convex/src/client/feature-flags/match-property.test.ts
@@ -68,6 +68,79 @@ describe('matchProperty — is_set', () => {
   })
 })
 
+describe('matchProperty — starts_with / ends_with', () => {
+  test('starts_with matches case-insensitively', () => {
+    expect(matchProperty(prop('starts_with', 'Val'), { k: 'value' })).toBe(true)
+    expect(matchProperty(prop('starts_with', 'Val'), { k: 'VALUE' })).toBe(true)
+    expect(matchProperty(prop('starts_with', 'Val'), { k: 'vaLue4' })).toBe(true)
+
+    expect(matchProperty(prop('starts_with', 'Val'), { k: 'prevalue' })).toBe(false)
+    expect(matchProperty(prop('starts_with', 'Val'), { k: 'Alakazam' })).toBe(false)
+    expect(matchProperty(prop('starts_with', 'Val'), { k: 123 })).toBe(false)
+  })
+
+  test('starts_with stringifies numeric property values', () => {
+    expect(matchProperty(prop('starts_with', '3'), { k: '3' })).toBe(true)
+    expect(matchProperty(prop('starts_with', '3'), { k: 323 })).toBe(true)
+
+    expect(matchProperty(prop('starts_with', '3'), { k: 123 })).toBe(false)
+    expect(matchProperty(prop('starts_with', '3'), { k: 'val3' })).toBe(false)
+  })
+
+  test('not_starts_with negates the match', () => {
+    expect(matchProperty(prop('not_starts_with', 'Val'), { k: 'value' })).toBe(false)
+    expect(matchProperty(prop('not_starts_with', 'Val'), { k: 'VALUE' })).toBe(false)
+
+    expect(matchProperty(prop('not_starts_with', 'Val'), { k: 'prevalue' })).toBe(true)
+    expect(matchProperty(prop('not_starts_with', 'Val'), { k: 'Alakazam' })).toBe(true)
+  })
+
+  test('ends_with matches case-insensitively', () => {
+    expect(matchProperty(prop('ends_with', 'lUe'), { k: 'value' })).toBe(true)
+    expect(matchProperty(prop('ends_with', 'lUe'), { k: 'VALUE' })).toBe(true)
+    expect(matchProperty(prop('ends_with', 'lUe'), { k: '343tfvalue' })).toBe(true)
+
+    expect(matchProperty(prop('ends_with', 'lUe'), { k: 'value2' })).toBe(false)
+    expect(matchProperty(prop('ends_with', 'lUe'), { k: 'Alakazam' })).toBe(false)
+    expect(matchProperty(prop('ends_with', 'lUe'), { k: 123 })).toBe(false)
+  })
+
+  test('ends_with stringifies numeric property values', () => {
+    expect(matchProperty(prop('ends_with', '3'), { k: '3' })).toBe(true)
+    expect(matchProperty(prop('ends_with', '3'), { k: 323 })).toBe(true)
+    expect(matchProperty(prop('ends_with', '3'), { k: 13 })).toBe(true)
+
+    expect(matchProperty(prop('ends_with', '3'), { k: 321 })).toBe(false)
+    expect(matchProperty(prop('ends_with', '3'), { k: '3val' })).toBe(false)
+  })
+
+  test('not_ends_with negates the match', () => {
+    expect(matchProperty(prop('not_ends_with', 'lUe'), { k: 'value' })).toBe(false)
+    expect(matchProperty(prop('not_ends_with', 'lUe'), { k: 'VALUE' })).toBe(false)
+
+    expect(matchProperty(prop('not_ends_with', 'lUe'), { k: 'value2' })).toBe(true)
+    expect(matchProperty(prop('not_ends_with', 'lUe'), { k: 'Alakazam' })).toBe(true)
+  })
+
+  test.each(['starts_with', 'not_starts_with', 'ends_with', 'not_ends_with'])(
+    '%s throws InconclusiveMatchError when the key is absent',
+    (op) => {
+      expect(() => matchProperty(prop(op, 'Val'), { other: 'value' })).toThrow(InconclusiveMatchError)
+      expect(() => matchProperty(prop(op, 'Val'), {})).toThrow(InconclusiveMatchError)
+    }
+  )
+
+  test.each(['starts_with', 'not_starts_with', 'ends_with', 'not_ends_with'])(
+    '%s returns false when the property value is null or undefined',
+    (op) => {
+      // The null guard fires before operator dispatch, so the not_ variants are not
+      // pure negations here — both directions return false, matching icontains.
+      expect(matchProperty(prop(op, 'Val'), { k: null })).toBe(false)
+      expect(matchProperty(prop(op, 'Val'), { k: undefined })).toBe(false)
+    }
+  )
+})
+
 describe('matchProperty — error cases', () => {
   test('throws InconclusiveMatchError when key is absent for non-is_not_set operators', () => {
     expect(() => matchProperty(prop('exact', 'x'), {})).toThrow(InconclusiveMatchError)

--- a/packages/convex/src/client/feature-flags/match-property.ts
+++ b/packages/convex/src/client/feature-flags/match-property.ts
@@ -174,6 +174,14 @@ export function matchProperty(
       return String(overrideValue).toLowerCase().includes(String(value).toLowerCase())
     case 'not_icontains':
       return !String(overrideValue).toLowerCase().includes(String(value).toLowerCase())
+    case 'starts_with':
+      return String(overrideValue).toLowerCase().startsWith(String(value).toLowerCase())
+    case 'not_starts_with':
+      return !String(overrideValue).toLowerCase().startsWith(String(value).toLowerCase())
+    case 'ends_with':
+      return String(overrideValue).toLowerCase().endsWith(String(value).toLowerCase())
+    case 'not_ends_with':
+      return !String(overrideValue).toLowerCase().endsWith(String(value).toLowerCase())
     case 'regex':
       return isValidRegex(String(value)) && String(overrideValue).match(String(value)) !== null
     case 'not_regex':

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -3083,6 +3083,69 @@ describe('match properties', () => {
     expect(matchProperty(property_b, { key: 'three' })).toBe(false)
   })
 
+  it('with operator starts_with', () => {
+    const property_a = { key: 'key', value: 'Val', operator: 'starts_with' }
+
+    expect(matchProperty(property_a, { key: 'value' })).toBe(true)
+    expect(matchProperty(property_a, { key: 'VALUE' })).toBe(true)
+    expect(matchProperty(property_a, { key: 'vaLue4' })).toBe(true)
+
+    expect(matchProperty(property_a, { key: 'prevalue' })).toBe(false)
+    expect(matchProperty(property_a, { key: 'Alakazam' })).toBe(false)
+    expect(matchProperty(property_a, { key: 123 })).toBe(false)
+
+    expect(() => matchProperty(property_a, { key2: 'value' })).toThrow(InconclusiveMatchError)
+    expect(() => matchProperty(property_a, {})).toThrow(InconclusiveMatchError)
+
+    const property_b = { key: 'key', value: '3', operator: 'starts_with' }
+
+    expect(matchProperty(property_b, { key: '3' })).toBe(true)
+    expect(matchProperty(property_b, { key: 323 })).toBe(true)
+
+    expect(matchProperty(property_b, { key: 123 })).toBe(false)
+    expect(matchProperty(property_b, { key: 'val3' })).toBe(false)
+
+    const property_c = { key: 'key', value: 'Val', operator: 'not_starts_with' }
+
+    expect(matchProperty(property_c, { key: 'value' })).toBe(false)
+    expect(matchProperty(property_c, { key: 'VALUE' })).toBe(false)
+
+    expect(matchProperty(property_c, { key: 'prevalue' })).toBe(true)
+    expect(matchProperty(property_c, { key: 'Alakazam' })).toBe(true)
+  })
+
+  it('with operator ends_with', () => {
+    const property_a = { key: 'key', value: 'lUe', operator: 'ends_with' }
+
+    expect(matchProperty(property_a, { key: 'value' })).toBe(true)
+    expect(matchProperty(property_a, { key: 'VALUE' })).toBe(true)
+    expect(matchProperty(property_a, { key: '343tfvalue' })).toBe(true)
+
+    expect(matchProperty(property_a, { key: 'value2' })).toBe(false)
+    expect(matchProperty(property_a, { key: 'Alakazam' })).toBe(false)
+    expect(matchProperty(property_a, { key: 123 })).toBe(false)
+
+    expect(() => matchProperty(property_a, { key2: 'value' })).toThrow(InconclusiveMatchError)
+    expect(() => matchProperty(property_a, {})).toThrow(InconclusiveMatchError)
+
+    const property_b = { key: 'key', value: '3', operator: 'ends_with' }
+
+    expect(matchProperty(property_b, { key: '3' })).toBe(true)
+    expect(matchProperty(property_b, { key: 323 })).toBe(true)
+    expect(matchProperty(property_b, { key: 13 })).toBe(true)
+
+    expect(matchProperty(property_b, { key: 321 })).toBe(false)
+    expect(matchProperty(property_b, { key: '3val' })).toBe(false)
+
+    const property_c = { key: 'key', value: 'lUe', operator: 'not_ends_with' }
+
+    expect(matchProperty(property_c, { key: 'value' })).toBe(false)
+    expect(matchProperty(property_c, { key: 'VALUE' })).toBe(false)
+
+    expect(matchProperty(property_c, { key: 'value2' })).toBe(true)
+    expect(matchProperty(property_c, { key: 'Alakazam' })).toBe(true)
+  })
+
   it('with operator regex', () => {
     const property_a = { key: 'key', value: '\\.com$', operator: 'regex' }
 

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -3112,6 +3112,16 @@ describe('match properties', () => {
 
     expect(matchProperty(property_c, { key: 'prevalue' })).toBe(true)
     expect(matchProperty(property_c, { key: 'Alakazam' })).toBe(true)
+
+    expect(() => matchProperty(property_c, { key2: 'value' })).toThrow(InconclusiveMatchError)
+    expect(() => matchProperty(property_c, {})).toThrow(InconclusiveMatchError)
+
+    // The null guard fires before operator dispatch, so the not_ variant is not a pure
+    // negation here — both directions return false, matching icontains.
+    expect(matchProperty(property_a, { key: null })).toBe(false)
+    expect(matchProperty(property_a, { key: undefined })).toBe(false)
+    expect(matchProperty(property_c, { key: null })).toBe(false)
+    expect(matchProperty(property_c, { key: undefined })).toBe(false)
   })
 
   it('with operator ends_with', () => {
@@ -3144,6 +3154,16 @@ describe('match properties', () => {
 
     expect(matchProperty(property_c, { key: 'value2' })).toBe(true)
     expect(matchProperty(property_c, { key: 'Alakazam' })).toBe(true)
+
+    expect(() => matchProperty(property_c, { key2: 'value' })).toThrow(InconclusiveMatchError)
+    expect(() => matchProperty(property_c, {})).toThrow(InconclusiveMatchError)
+
+    // The null guard fires before operator dispatch, so the not_ variant is not a pure
+    // negation here — both directions return false, matching icontains.
+    expect(matchProperty(property_a, { key: null })).toBe(false)
+    expect(matchProperty(property_a, { key: undefined })).toBe(false)
+    expect(matchProperty(property_c, { key: null })).toBe(false)
+    expect(matchProperty(property_c, { key: undefined })).toBe(false)
   })
 
   it('with operator regex', () => {

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -1120,6 +1120,14 @@ function matchProperty(
       return String(overrideValue).toLowerCase().includes(String(value).toLowerCase())
     case 'not_icontains':
       return !String(overrideValue).toLowerCase().includes(String(value).toLowerCase())
+    case 'starts_with':
+      return String(overrideValue).toLowerCase().startsWith(String(value).toLowerCase())
+    case 'not_starts_with':
+      return !String(overrideValue).toLowerCase().startsWith(String(value).toLowerCase())
+    case 'ends_with':
+      return String(overrideValue).toLowerCase().endsWith(String(value).toLowerCase())
+    case 'not_ends_with':
+      return !String(overrideValue).toLowerCase().endsWith(String(value).toLowerCase())
     case 'regex':
       return isValidRegex(String(value)) && String(overrideValue).match(String(value)) !== null
     case 'not_regex':


### PR DESCRIPTION
## Problem

PostHog/posthog#72992 added four case-insensitive property filter operators — `starts_with`, `not_starts_with`, `ends_with`, `not_ends_with` — across HogQL, the flags service, and the UI. The UI surface is gated behind a feature flag until server-side SDKs can evaluate these operators locally; on SDK versions without support, flags using them fall back to remote evaluation.

This adds local evaluation support for the four operators, mirroring `icontains`: both sides are stringified and lowercased, and the `not_` variants are exact negations. Filter values are single strings — server-side validation rejects list values for these operators, matching the flags service behavior.

## Changes

Adds `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` case arms to `matchProperty` in the Node SDK's feature-flag local evaluation (`packages/node/src/extensions/feature-flags/feature-flags.ts`), directly mirroring the existing `icontains` arms. Affects `posthog-node` and `@posthog/convex` (whose duplicated evaluator gets the same four operators) — browser-side matchers (surveys, web experiments, recording triggers) correspond to UI surfaces that are still held back and are intentionally out of scope.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a changeset file (minor, `posthog-node`)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code as part of rolling out local evaluation for these operators across all server-side SDKs. The implementation deliberately mirrors the existing `icontains` branch in this repo (same string coercion and case folding) and the reference behavior in the Rust flags service (`rust/feature-flags/src/properties/property_matching.rs` in PostHog/posthog). The changeset file was written by hand following the repo's existing format.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

