### PR TITLE
fix(replay): skip base64 image recompression when it cannot shrink the payload

### DIFF
--- a/.changeset/skip-recompress-small-data-urls.md
+++ b/.changeset/skip-recompress-small-data-urls.md
@@ -1,5 +1,4 @@
 ---
-'@posthog/rrweb-snapshot': patch
 'posthog-js': patch
 ---
 

--- a/.changeset/skip-recompress-small-data-urls.md
+++ b/.changeset/skip-recompress-small-data-urls.md
@@ -1,0 +1,6 @@
+---
+'@posthog/rrweb-snapshot': patch
+'posthog-js': patch
+---
+
+Session replay no longer freezes the page re-encoding base64 images that are already small. When canvas recording is enabled, every `<img>` with a `data:` URL was synchronously redrawn and re-encoded through `canvas.toDataURL` during full snapshots and attribute mutations. The encode cost scales with pixel dimensions, not payload size, so a page of base64 lazy-load placeholders (measured: 18 images of 4096x3072 at ~33KB each) blocked the main thread for 7+ seconds to produce outputs that were larger than the inputs. Recompression now skips data URLs under 100KB (where it cannot save meaningful payload), keeps the original when the re-encoded output is not smaller, and memoizes by input so repeated snapshots and src-swapping mutations never pay for the same image twice. Genuinely large base64 images are still recompressed as before.

--- a/packages/rrweb/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb/rrweb-snapshot/src/utils.ts
@@ -490,6 +490,21 @@ const STRIPED_PLACEHOLDER_SVG =
   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzPgogICAgPHBhdHRlcm4gaWQ9InN0cmlwZXMiIHBhdHRlcm5Vbml0cz0idXNlclNwYWNlT25Vc2UiIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+CiAgICAgIDxyZWN0IHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0iYmxhY2siLz4KICAgICAgPHBhdGggZD0iTTggMEgxNkwwIDE2VjhMOCAwWiIgZmlsbD0iIzJEMkQyRCIvPgogICAgICA8cGF0aCBkPSJNMTYgOFYxNkg4TDE2IDhaIiBmaWxsPSIjMkQyRDJEIi8+CiAgICA8L3BhdHRlcm4+CiAgPC9kZWZzPgogIDxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjc3RyaXBlcykiLz4KPC9zdmc+Cg==';
 
 const MAX_IMAGE_DIMENSION_FOR_RECOMPRESSION = 4096;
+// below this, recompression cannot save enough payload to justify a
+// synchronous canvas encode, whose cost scales with pixel count (not bytes)
+// and can block the main thread for hundreds of ms per image
+const MIN_DATA_URL_LENGTH_FOR_RECOMPRESSION = 100_000;
+const MAX_RECOMPRESSION_CACHE_ENTRIES = 10;
+
+type RecompressionCacheEntry = {
+  type?: string;
+  quality?: number;
+  result: string;
+};
+
+// full snapshots and attribute mutations serialize the same image repeatedly,
+// so each unique data URL should only ever be encoded once
+const recompressionCache = new Map<string, RecompressionCacheEntry>();
 
 export function recompressBase64Image(
   img: HTMLImageElement,
@@ -497,6 +512,10 @@ export function recompressBase64Image(
   type?: string,
   quality?: number,
 ): string {
+  if (dataURL.length < MIN_DATA_URL_LENGTH_FOR_RECOMPRESSION) {
+    return dataURL;
+  }
+
   if (!img.complete || img.naturalWidth === 0) {
     return dataURL;
   }
@@ -507,6 +526,11 @@ export function recompressBase64Image(
     img.naturalHeight > MAX_IMAGE_DIMENSION_FOR_RECOMPRESSION
   ) {
     return dataURL;
+  }
+
+  const cached = recompressionCache.get(dataURL);
+  if (cached && cached.type === type && cached.quality === quality) {
+    return cached.result;
   }
 
   try {
@@ -521,8 +545,16 @@ export function recompressBase64Image(
 
     ctx.drawImage(img, 0, 0);
     const recompressed = canvas.toDataURL(type || 'image/webp', quality ?? 0.4);
+    // re-encoding an already optimized image can produce a larger file
+    const result =
+      recompressed.length < dataURL.length ? recompressed : dataURL;
 
-    return recompressed;
+    if (recompressionCache.size >= MAX_RECOMPRESSION_CACHE_ENTRIES) {
+      recompressionCache.clear();
+    }
+    recompressionCache.set(dataURL, { type, quality, result });
+
+    return result;
   } catch (err) {
     return dataURL;
   }

--- a/packages/rrweb/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb/rrweb-snapshot/src/utils.ts
@@ -550,7 +550,12 @@ export function recompressBase64Image(
       recompressed.length < dataURL.length ? recompressed : dataURL;
 
     if (recompressionCache.size >= MAX_RECOMPRESSION_CACHE_ENTRIES) {
-      recompressionCache.clear();
+      // evict only the oldest entry (Map preserves insertion order) so
+      // pages with many unique images keep the rest of the cache warm
+      const oldestKey = recompressionCache.keys().next().value;
+      if (oldestKey !== undefined) {
+        recompressionCache.delete(oldestKey);
+      }
     }
     recompressionCache.set(dataURL, { type, quality, result });
 

--- a/packages/rrweb/rrweb-snapshot/test/integration.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/integration.test.ts
@@ -452,17 +452,22 @@ describe('base64 image compression tests', function (this: ISuite) {
     await server.close();
   });
 
-  it('should recompress base64 images with configured quality', async () => {
+  it('should recompress large base64 images with configured quality and leave small ones untouched', async () => {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto(`${serverURL}/html/base64-images.html`, {
       waitUntil: 'load',
     });
     await page.waitForSelector('#small-image', { timeout: 2000 });
     await page.waitForSelector('#medium-image', { timeout: 2000 });
+    await page.waitForSelector('#large-image', { timeout: 5000 });
 
     const result = await page.evaluate(`${code}
+      const originalSmallSrc = document.getElementById('small-image').src;
+      const originalMediumSrc = document.getElementById('medium-image').src;
+      const originalLargeSrc = document.getElementById('large-image').src;
+
       const snapshot = rrwebSnapshot.snapshot(document, {
-        dataURLOptions: { type: "image/webp", quality: 0.4, maxBase64ImageLength: 1048576 }
+        dataURLOptions: { type: "image/webp", quality: 0.4, maxBase64ImageLength: 10485760 }
       });
 
       function findImages(node, images = []) {
@@ -476,17 +481,21 @@ describe('base64 image compression tests', function (this: ISuite) {
       }
 
       const images = findImages(snapshot);
+      const byId = (id) => images.find(img => img.attributes.id === id);
 
       ({
-        smallImageSrc: images[0].attributes.src,
-        mediumImageSrc: images[1].attributes.src,
-        smallOriginalLength: images[0].attributes.src.length,
-        mediumOriginalLength: images[1].attributes.src.length
+        smallUnchanged: byId('small-image').attributes.src === originalSmallSrc,
+        mediumUnchanged: byId('medium-image').attributes.src === originalMediumSrc,
+        largeSrcPrefix: byId('large-image').attributes.src.substring(0, 30),
+        largeIsSmaller: byId('large-image').attributes.src.length < originalLargeSrc.length
       });
     `);
 
-    expect(result.smallImageSrc).toMatch(/^data:image\/webp;base64,/);
-    expect(result.mediumImageSrc).toMatch(/^data:image\/webp;base64,/);
+    // small data URLs are not worth a synchronous canvas encode
+    expect(result.smallUnchanged).toBe(true);
+    expect(result.mediumUnchanged).toBe(true);
+    expect(result.largeSrcPrefix).toMatch(/^data:image\/webp;base64,/);
+    expect(result.largeIsSmaller).toBe(true);
 
     await page.close();
   });
@@ -597,13 +606,13 @@ describe('base64 image compression tests', function (this: ISuite) {
       const smallImage = images.find(img => img.attributes.id === 'small-image');
 
       ({
-        isWebP: smallImage.attributes.src.startsWith('data:image/webp'),
+        isOriginalPng: smallImage.attributes.src.startsWith('data:image/png'),
         isNotPlaceholder: !smallImage.attributes.src.includes('svg+xml'),
         srcLength: smallImage.attributes.src.length
       });
     `);
 
-    expect(result.isWebP).toBe(true);
+    expect(result.isOriginalPng).toBe(true);
     expect(result.isNotPlaceholder).toBe(true);
     expect(result.srcLength).toBeGreaterThan(0);
     expect(result.srcLength).toBeLessThan(1048576);

--- a/packages/rrweb/rrweb-snapshot/test/utils.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/utils.test.ts
@@ -548,6 +548,28 @@ describe('utils', () => {
       expect(toDataURL).toHaveBeenCalledTimes(2);
     });
 
+    it('evicts only the oldest entry when the cache is full', () => {
+      const img = makeImg(800, 600);
+      // one more than MAX_RECOMPRESSION_CACHE_ENTRIES
+      const dataURLs = Array.from({ length: 11 }, () =>
+        makeDataURL(200_000),
+      );
+      for (const dataURL of dataURLs) {
+        recompressBase64Image(img, dataURL, 'image/webp', 0.4);
+      }
+      expect(toDataURL).toHaveBeenCalledTimes(11);
+
+      // the 10 most recent entries are still cached
+      for (const dataURL of dataURLs.slice(1)) {
+        recompressBase64Image(img, dataURL, 'image/webp', 0.4);
+      }
+      expect(toDataURL).toHaveBeenCalledTimes(11);
+
+      // only the oldest entry was evicted and needs re-encoding
+      recompressBase64Image(img, dataURLs[0], 'image/webp', 0.4);
+      expect(toDataURL).toHaveBeenCalledTimes(12);
+    });
+
     it('returns the original for images that are not loaded', () => {
       const dataURL = makeDataURL(200_000);
       expect(recompressBase64Image(makeImg(0, 0, false), dataURL)).toBe(

--- a/packages/rrweb/rrweb-snapshot/test/utils.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/utils.test.ts
@@ -1,7 +1,16 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, test, expect } from 'vitest';
+import {
+  describe,
+  it,
+  test,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
 import {
   createMirror,
   escapeImportStatement,
@@ -9,6 +18,7 @@ import {
   fixSafariColons,
   hasEmptyShorthandLonghand,
   isNodeMetaEqual,
+  recompressBase64Image,
   stringifyStylesheet,
 } from '../src/utils';
 import { NodeType } from '@posthog/rrweb-types';
@@ -457,6 +467,101 @@ describe('utils', () => {
       expect(mirror.has(5)).toBe(false);
 
       document.body.removeChild(iframe);
+    });
+  });
+
+  describe('recompressBase64Image()', () => {
+    const makeImg = (
+      naturalWidth: number,
+      naturalHeight: number,
+      complete = true,
+    ) => {
+      const img = document.createElement('img');
+      Object.defineProperty(img, 'complete', { value: complete });
+      Object.defineProperty(img, 'naturalWidth', { value: naturalWidth });
+      Object.defineProperty(img, 'naturalHeight', { value: naturalHeight });
+      return img;
+    };
+    // unique per call so the module-level memoization cache never leaks
+    // state between tests
+    let uniqueId = 0;
+    const makeDataURL = (length: number) =>
+      `data:image/png;base64,${'a'.repeat(length)}#${uniqueId++}`;
+
+    let toDataURL: MockInstance;
+    let getContext: MockInstance;
+
+    beforeEach(() => {
+      getContext = vi
+        .spyOn(HTMLCanvasElement.prototype, 'getContext')
+        .mockReturnValue({
+          drawImage: vi.fn(),
+        } as unknown as CanvasRenderingContext2D);
+      toDataURL = vi
+        .spyOn(HTMLCanvasElement.prototype, 'toDataURL')
+        .mockReturnValue('data:image/webp;base64,tiny');
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('does not touch the canvas for data URLs too small to be worth recompressing', () => {
+      const dataURL = makeDataURL(50_000);
+      expect(
+        recompressBase64Image(makeImg(4096, 3072), dataURL, 'image/webp', 0.4),
+      ).toBe(dataURL);
+      expect(getContext).not.toHaveBeenCalled();
+      expect(toDataURL).not.toHaveBeenCalled();
+    });
+
+    it('recompresses large data URLs', () => {
+      const dataURL = makeDataURL(200_000);
+      expect(
+        recompressBase64Image(makeImg(800, 600), dataURL, 'image/webp', 0.4),
+      ).toBe('data:image/webp;base64,tiny');
+      expect(toDataURL).toHaveBeenCalledWith('image/webp', 0.4);
+    });
+
+    it('keeps the original when recompression does not make it smaller', () => {
+      const dataURL = makeDataURL(200_000);
+      toDataURL.mockReturnValue(
+        `data:image/webp;base64,${'b'.repeat(300_000)}`,
+      );
+      expect(recompressBase64Image(makeImg(800, 600), dataURL)).toBe(dataURL);
+    });
+
+    it('encodes each unique data URL only once', () => {
+      const dataURL = makeDataURL(200_000);
+      const img = makeImg(800, 600);
+      const first = recompressBase64Image(img, dataURL, 'image/webp', 0.4);
+      const second = recompressBase64Image(img, dataURL, 'image/webp', 0.4);
+      expect(second).toBe(first);
+      expect(toDataURL).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-encodes when type or quality changes', () => {
+      const dataURL = makeDataURL(200_000);
+      const img = makeImg(800, 600);
+      recompressBase64Image(img, dataURL, 'image/webp', 0.4);
+      recompressBase64Image(img, dataURL, 'image/webp', 0.8);
+      expect(toDataURL).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns the original for images that are not loaded', () => {
+      const dataURL = makeDataURL(200_000);
+      expect(recompressBase64Image(makeImg(0, 0, false), dataURL)).toBe(
+        dataURL,
+      );
+      expect(toDataURL).not.toHaveBeenCalled();
+    });
+
+    it('returns the original for images larger than the dimension cap', () => {
+      const dataURL = makeDataURL(200_000);
+      expect(recompressBase64Image(makeImg(5000, 3000), dataURL)).toBe(
+        dataURL,
+      );
+      expect(toDataURL).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Problem

A customer reported multi-second full-page freezes on their commerce sites whenever session replay starts (Zendesk 65361, inbox report [019f8e6c](https://us.posthog.com/project/2/inbox/019f8e6c-7e09-7d48-837f-0be8c0c3478b)). Their Chrome trace showed one ~3.9s uninterruptible task with 99.6% of CPU in `posthog-recorder.js`, and deferring recorder startup only moved the freeze to mid-scroll.

Reproducing on their live page (getfastr.com/frontend-visual-designer) with a CDP profiler found that the dominant cost is not the DOM walk (the page has only ~6.3k nodes) and not stylesheet inlining (~9ms total for all sheets). **98% of a reproduced 7,029ms freeze sat inside `HTMLCanvasElement.toDataURL`**, called 21 times at 330-560ms each from `transformAttribute` → `recompressBase64Image`.

The mechanism:

- The customer has canvas recording enabled, which sets `dataURLOptions: { type: 'image/webp', quality }`. With those set, `recompressBase64Image` redraws **every** `<img>` with a `data:` src through a fresh canvas and re-encodes it, during full snapshots **and** attribute mutations ([mutation.ts:671](https://github.com/PostHog/posthog-js/blob/main/packages/rrweb/rrweb/src/record/mutation.ts#L671)).
- The page uses the common base64 LQIP lazy-load pattern: during load it has 18 `<img>` placeholders of ~33KB each with natural dimensions 4096x3072, which slips under the existing `MAX_IMAGE_DIMENSION_FOR_RECOMPRESSION = 4096` guard.
- Encode cost scales with **pixel count, not payload size**, so each tiny placeholder costs a ~12.6-megapixel synchronous webp encode (~400ms), and the re-encoded output (43KB) is **larger** than the input (33KB).
- The placeholders get swapped to real srcs moments after load, which is why the freeze needs a hard refresh plus immediate scrolling to reproduce, exactly as the customer described. Src swaps back to `data:` URLs (carousels, virtualized lists) hit the same cost per mutation, matching the mid-scroll lockups across their client fleet.

[#4320](https://github.com/PostHog/posthog-js/pull/4320) (stylesheet budget) and [#4233](https://github.com/PostHog/posthog-js/pull/4233) (snapshot time-slicing) address real costs on other pages, but neither removes this one: #4320 does not touch img handling, and #4233 yields between nodes while this is a single-node cost. Related: #4217.

## Changes

Three guards in `recompressBase64Image` (`packages/rrweb/rrweb-snapshot/src/utils.ts`), no API changes:

1. **Skip data URLs under 100KB.** Recompression exists to shrink oversized payloads; below this size it cannot save enough to justify a synchronous canvas encode whose cost is set by pixel dimensions, not bytes.
2. **Keep the original when re-encoding does not make it smaller.** Previously a larger webp output happily replaced a smaller png input.
3. **Memoize by input data URL** (small bounded cache), so repeated full snapshots and src-swapping mutations never pay for the same image twice.

Genuinely large base64 images (over 100KB, within the 4096px dimension cap) are recompressed exactly as before, and the `maxBase64ImageLength` placeholder cap is unchanged.

## Measured on the customer's live page

Chrome via Playwright with the recorder swapped for this branch's build, hard refresh plus immediate scrolling, 3 runs:

| | production 1.409.0 | this branch |
| --- | --- | --- |
| worst main-thread task | 7,029ms / 8,042ms | 372ms (2 of 3 runs: none over 200ms) |
| `toDataURL` total | ~6,910ms (21 calls) | 3-15ms |

The remaining ~370ms is the ordinary DOM serialization walk, which is #4233's territory.

## Test strategy

- New unit tests for `recompressBase64Image` covering the size gate, the not-smaller guard, memoization (including type/quality changes), and the pre-existing loading/dimension guards.
- Updated the two puppeteer integration tests that asserted small images get re-encoded: they now assert small images pass through untouched and large ones still shrink to webp. The oversized-placeholder and dimension-cap tests are unchanged.
- Full `rrweb-snapshot` suite green locally (211 passed, 1 skipped).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by PostHog Code (Claude) from a support escalation and its inbox report. Tools: repo read/edit, vitest, and Playwright with a CDP profiler against the customer's live page for both root-cause profiling and before/after measurement.

Decisions worth a reviewer's attention:

- **The earlier diagnosis pointed elsewhere.** The inbox report and #4320 attribute this class of freeze to the snapshot DOM walk and stylesheet inlining. Both are real on other pages, but on this customer's page they measure ~9ms combined; the freeze is image recompression. The three fixes are complementary, not competing.
- **Rejected: making the encode async.** `transformAttribute` is synchronous and on the mutation hot path; restructuring it is invasive. The observed waste is encodes that cannot pay for themselves, so refusing those achieves the win in a few lines.
- **Rejected: keying the size gate on pixel dimensions.** Payload length is what recompression can actually save; a dimension threshold would also skip genuinely heavy small-dimension images.
- **100KB threshold:** webp at quality 0.4 rarely beats an already-encoded image by more than tens of KB; below 100KB the possible saving is small against a worst-case multi-hundred-ms synchronous encode. The threshold is a constant, not user config, to keep the surface minimal.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
