### PR TITLE
ci: install jq for compatibility result parsing

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -111,6 +111,9 @@ jobs:
         with:
           build: false
 
+      - name: Install jq
+        run: apt-get update && apt-get install --yes --no-install-recommends jq
+
       - name: Build package
         run: pnpm build
 


### PR DESCRIPTION

<img width="1085" height="1449" alt="image" src="https://github.com/user-attachments/assets/8ea95eaf-92f0-4e89-b66d-dc25552c06f1" />


## Problem

The backward-compatibility suite runs inside the pinned Playwright Ubuntu container, which does not include `jq`. The tests themselves pass, but the result-processing step fails to parse `compat-results.json` and posts a false compatibility warning on affected PRs.

## Changes

Install `jq` in the compatibility job before the existing result-processing step runs. This is scoped to CI and does not affect published packages.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and reviewed with a fresh read-only reviewer subagent. The fix uses the Ubuntu package already expected by the existing shell parser rather than changing its result semantics.
