### PR TITLE
fix(core): preserve events added during queue flush

### DIFF
--- a/.changeset/queue-flush-preserve-new-events.md
+++ b/.changeset/queue-flush-preserve-new-events.md
@@ -1,6 +1,8 @@
 ---
 '@posthog/core': patch
 'posthog-node': patch
+'posthog-react-native': patch
+'posthog-js-lite': patch
 ---
 
 Preserve events added to a full queue while an earlier batch is being flushed.

--- a/.changeset/queue-flush-preserve-new-events.md
+++ b/.changeset/queue-flush-preserve-new-events.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Preserve events added to a full queue while an earlier batch is being flushed.

--- a/.changeset/queue-flush-preserve-new-events.md
+++ b/.changeset/queue-flush-preserve-new-events.md
@@ -1,5 +1,6 @@
 ---
 '@posthog/core': patch
+'posthog-node': patch
 ---
 
 Preserve events added to a full queue while an earlier batch is being flushed.

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -318,6 +318,59 @@ describe('PostHog Core', () => {
       expect(batches[1]).toMatchObject([{ event: 'second' }, { event: 'third' }])
     })
 
+    it('preserves replacement events captured into a full queue during an in-flight flush', async () => {
+      jest.useRealTimers()
+      ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
+        flushAt: 3,
+        maxQueueSize: 3,
+        flushInterval: 0,
+        fetchRetryCount: 0,
+        preloadFeatureFlags: false,
+      })
+
+      const batches: any[][] = []
+      let resolveFirstFetch!: () => void
+      mocks.fetch.mockImplementation(async (_, options) => {
+        batches.push(JSON.parse((options.body || '') as string).batch)
+        if (batches.length === 1) {
+          await new Promise<void>((resolve) => (resolveFirstFetch = resolve))
+        }
+        return {
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+        }
+      })
+
+      posthog.capture('initial-1')
+      posthog.capture('initial-2')
+      posthog.capture('initial-3')
+      const inFlight = posthog.flush()
+      await waitForPromises() // first flush has snapshotted the full queue and is mid-fetch
+
+      posthog.capture('replacement-1')
+      posthog.capture('replacement-2')
+      posthog.capture('replacement-3')
+
+      resolveFirstFetch()
+      await inFlight
+
+      const queuedEvents = (posthog.getPersistedProperty<any[]>(PostHogPersistedProperty.Queue) || []).map(
+        (item) => item.message.event
+      )
+      expect(queuedEvents).toEqual(['replacement-1', 'replacement-2', 'replacement-3'])
+
+      await posthog.flush()
+
+      expect(batches).toHaveLength(2)
+      expect(batches[0]).toMatchObject([{ event: 'initial-1' }, { event: 'initial-2' }, { event: 'initial-3' }])
+      expect(batches[1]).toMatchObject([
+        { event: 'replacement-1' },
+        { event: 'replacement-2' },
+        { event: 'replacement-3' },
+      ])
+    })
+
     it('does not chain one flush per capture while flushes fail', async () => {
       jest.useRealTimers()
       ;[posthog, mocks] = createTestClient('TEST_API_KEY', {

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -1454,7 +1454,25 @@ export abstract class PostHogCoreStateless {
 
       const persistQueueChange = async (): Promise<void> => {
         const refreshedQueue = this.getPersistedProperty<PostHogQueueItem[]>(queueKey) || []
-        const newQueue = refreshedQueue.slice(batchItems.length)
+        // The live queue may have overflowed while this batch was in flight. Remove only
+        // snapshotted items: UUID survives persistence, while reference identity supports
+        // legacy queue items without a UUID.
+        const remainingBatchItems = [...batchItems]
+        const newQueue = refreshedQueue.filter((item) => {
+          const itemUuid = item.message?.uuid
+          const batchItemIndex = remainingBatchItems.findIndex(
+            (batchItem) =>
+              batchItem === item ||
+              (typeof itemUuid === 'string' && itemUuid.length > 0 && batchItem.message?.uuid === itemUuid)
+          )
+
+          if (batchItemIndex === -1) {
+            return true
+          }
+
+          remainingBatchItems.splice(batchItemIndex, 1)
+          return false
+        })
         this.setPersistedProperty<PostHogQueueItem[]>(queueKey, newQueue)
         queue = newQueue
         this._dequeuedMessagesCount += batchItems.length


### PR DESCRIPTION
## Problem

High-throughput SDK users can capture new events while a full queue is being flushed. If the queue reaches `maxQueueSize` and replaces the in-flight entries before the request completes, the flush previously removed entries by position and could discard those newly captured replacement events.

## Changes

- Remove flushed queue items by their snapshotted object identity or stable event UUID instead of slicing the live queue by batch length.
- Preserve compatibility with legacy queue items without UUIDs through the object-identity fallback.
- Add a regression test that fills the queue during an in-flight flush and verifies the replacement events remain queued and are sent by the next flush.
- Add patch changesets for `@posthog/core`, `posthog-node`, `posthog-react-native`, and `posthog-js-lite` so every SDK built on the shared stateless queue receives the fix.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [x] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

Additional library affected: `@posthog/core` (patch).

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human identified, prioritized, and reviewed the fix. A Pi coding agent reviewed the prepared diff, added release metadata, ran focused tests/lint/build validation, and opened this draft PR. The implementation uses UUID matching for persisted queue entries while retaining reference-identity matching for legacy entries without UUIDs.

