### PR TITLE
fix(node): schedule feature flag polling after requests settle

### DIFF
--- a/.changeset/feature-flag-poll-after-settlement.md
+++ b/.changeset/feature-flag-poll-after-settlement.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+Schedule local feature flag polls after each request settles.

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -6521,6 +6521,82 @@ describe('ETag support for local evaluation polling', () => {
   })
 })
 
+describe('local evaluation poll scheduling', () => {
+  let posthog: PostHog
+
+  jest.useFakeTimers()
+
+  afterEach(async () => {
+    jest.useRealTimers()
+    await posthog.shutdown(100).catch(() => undefined)
+    jest.useFakeTimers()
+  })
+
+  it('schedules the next poll after a slow fetch completes', async () => {
+    let resolveFetch!: (response: any) => void
+    const deferredFetch = new Promise<any>((resolve) => {
+      resolveFetch = resolve
+    })
+    const mockFetch = jest.fn(() => deferredFetch)
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      fetch: mockFetch,
+      featureFlagsPollingInterval: 1000,
+      ...posthogImmediateResolveOptions,
+    })
+
+    const initialLoad = posthog.reloadFeatureFlags()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(1000)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    resolveFetch({
+      status: 200,
+      json: () => Promise.resolve({ flags: [], group_type_mapping: {}, cohorts: {} }),
+      headers: { get: () => null },
+    })
+    await initialLoad
+
+    await jest.advanceTimersByTimeAsync(999)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not schedule another poll when stopped during a slow fetch', async () => {
+    let resolveFetch!: (response: any) => void
+    const deferredFetch = new Promise<any>((resolve) => {
+      resolveFetch = resolve
+    })
+    const mockFetch = jest.fn(() => deferredFetch)
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      fetch: mockFetch,
+      featureFlagsPollingInterval: 1000,
+      ...posthogImmediateResolveOptions,
+    })
+
+    const initialLoad = posthog.reloadFeatureFlags()
+    await posthog.featureFlagsPoller?.stopPoller()
+
+    resolveFetch({
+      status: 200,
+      json: () => Promise.resolve({ flags: [], group_type_mapping: {}, cohorts: {} }),
+      headers: { get: () => null },
+    })
+    await initialLoad
+    await jest.advanceTimersByTimeAsync(1000)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('error handling and backoff', () => {
   let posthog: PostHog
 
@@ -6566,6 +6642,27 @@ describe('error handling and backoff', () => {
 
     return mockFetch
   }
+
+  it.each([401, 403, 429])('should schedule the next poll using updated backoff after %i', async (statusCode) => {
+    const mockFetch = createMockFetch(statusCode)
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      fetch: mockFetch,
+      featureFlagsPollingInterval: 1000,
+      ...posthogImmediateResolveOptions,
+    })
+
+    await posthog.reloadFeatureFlags()
+    expect(mockFetch.callCount).toBe(1)
+
+    await jest.advanceTimersByTimeAsync(1999)
+    expect(mockFetch.callCount).toBe(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(mockFetch.callCount).toBe(2)
+  })
 
   it('should block on-demand fetches during backoff period after 401', async () => {
     const mockFetch = createMockFetch(401)

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -107,6 +107,7 @@ class FeatureFlagsPoller {
   onLoad?: (count: number) => void
   private cacheProvider?: FlagDefinitionCacheProvider
   private loadingPromise?: Promise<void>
+  private pollerStopped: boolean = false
   private flagsEtag?: string
   private nextFetchAllowedAt?: number
   private strictLocalEvaluation: boolean
@@ -823,8 +824,6 @@ class FeatureFlagsPoller {
       this.poller = undefined
     }
 
-    this.poller = setTimeout(() => this.loadFeatureFlags(true), this.getPollingInterval())
-
     try {
       let shouldFetch = true
       if (this.cacheProvider) {
@@ -975,6 +974,10 @@ class FeatureFlagsPoller {
       if (err instanceof ClientError) {
         this.onError?.(err)
       }
+    } finally {
+      if (!this.pollerStopped) {
+        this.poller = setTimeout(() => this.loadFeatureFlags(true), this.getPollingInterval())
+      }
     }
   }
 
@@ -1024,7 +1027,9 @@ class FeatureFlagsPoller {
   }
 
   async stopPoller(timeoutMs: number = 30000): Promise<void> {
+    this.pollerStopped = true
     clearTimeout(this.poller)
+    this.poller = undefined
 
     if (this.cacheProvider) {
       try {


### PR DESCRIPTION
## Problem

Node SDK clients using local feature flag evaluation schedule the next definitions poll before the current request finishes. When a definitions request takes longer than the configured polling interval, the timer fires while the original request is still in flight and is deduplicated, leaving no timer to trigger a later poll. The old scheduling point also calculates the delay before response-driven backoff state is updated.

## Changes

- Schedule each feature flag definitions poll in the request's `finally` block so the delay starts after the request settles and uses the latest backoff state.
- Track poller shutdown so an in-flight request cannot schedule another timer after `stopPoller()`.
- Add focused tests for slow requests, shutdown during an in-flight request, and response-driven backoff scheduling.
- Add a patch changeset for `posthog-node`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed and reviewed this high-priority fix; Pi's coding agent prepared the changeset, reran focused validation, and opened this PR. The local agent runner does not expose a shareable session URL.

The implementation keeps the existing polling and backoff model, moving only the timer scheduling point and adding a shutdown guard. Focused feature flag tests and Node package lint pass. The dependency-aware build was also attempted, but its declaration generation resolved `@posthog/core` through another linked review worktree in the shared local dependency setup and failed on unrelated `getInjectedReleaseId` declarations.