### PR TITLE
fix(node): isolate NestJS context per subscription

### DIFF
--- a/.changeset/nestjs-subscription-context.md
+++ b/.changeset/nestjs-subscription-context.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+Isolate NestJS request context per Observable subscription.

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -1,5 +1,5 @@
 import type { IncomingHttpHeaders } from 'node:http'
-import { of, throwError, lastValueFrom } from 'rxjs'
+import { defer, of, throwError, lastValueFrom } from 'rxjs'
 
 import { PostHog } from '@/entrypoints/index.node'
 import { PostHogInterceptor } from '@/extensions/nestjs'
@@ -229,6 +229,100 @@ describe('PostHogInterceptor', () => {
       expect(event).toBeDefined()
       expect(event.distinct_id).toBe('user-xyz')
       expect(event.properties.$session_id).toBe('session-abc')
+    })
+
+    it('should isolate request contexts when observables are created before subscription', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
+      const capturedContexts: Record<string, any> = {}
+      const createHandler = (request: string) => ({
+        handle: () =>
+          defer(() => {
+            capturedContexts[request] = posthog.getContext()
+            return of(request)
+          }),
+      })
+
+      const firstRequest = interceptor.intercept(
+        createMockContext({
+          headers: {
+            'x-posthog-session-id': 'session-first',
+            'x-posthog-distinct-id': 'user-first',
+          },
+          path: '/first',
+        }),
+        createHandler('first')
+      )
+      const secondRequest = interceptor.intercept(
+        createMockContext({
+          headers: {
+            'x-posthog-session-id': 'session-second',
+            'x-posthog-distinct-id': 'user-second',
+          },
+          path: '/second',
+        }),
+        createHandler('second')
+      )
+
+      await lastValueFrom(firstRequest)
+      await lastValueFrom(secondRequest)
+
+      expect(capturedContexts.first).toMatchObject({
+        sessionId: 'session-first',
+        distinctId: 'user-first',
+        properties: { $request_path: '/first' },
+      })
+      expect(capturedContexts.second).toMatchObject({
+        sessionId: 'session-second',
+        distinctId: 'user-second',
+        properties: { $request_path: '/second' },
+      })
+    })
+
+    it('should give headerless requests a fresh context at subscription', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
+      const capturedContexts: Record<string, any> = {}
+      const createHandler = (request: string) => ({
+        handle: () =>
+          defer(() => {
+            capturedContexts[request] = posthog.getContext()
+            return of(request)
+          }),
+      })
+
+      posthog.enterContext({
+        sessionId: 'ambient-session',
+        distinctId: 'ambient-user',
+        properties: { ambient: true },
+      })
+
+      const headerRequest = interceptor.intercept(
+        createMockContext({
+          headers: {
+            'x-posthog-session-id': 'request-session',
+            'x-posthog-distinct-id': 'request-user',
+          },
+        }),
+        createHandler('with-headers')
+      )
+      const headerlessRequest = interceptor.intercept(
+        createMockContext({ headers: {}, path: '/headerless' }),
+        createHandler('headerless')
+      )
+
+      await lastValueFrom(headerRequest)
+      await lastValueFrom(headerlessRequest)
+
+      expect(capturedContexts['with-headers']).toMatchObject({
+        sessionId: 'request-session',
+        distinctId: 'request-user',
+      })
+      expect(capturedContexts['with-headers'].properties.ambient).toBeUndefined()
+      expect(capturedContexts.headerless).toMatchObject({
+        properties: { $request_path: '/headerless' },
+      })
+      expect(capturedContexts.headerless.sessionId).toBeUndefined()
+      expect(capturedContexts.headerless.distinctId).toBeUndefined()
+      expect(capturedContexts.headerless.properties.ambient).toBeUndefined()
     })
 
     it('should pass through successful responses', async () => {

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -95,30 +95,35 @@ export class PostHogInterceptor implements NestInterceptor {
       properties,
     }
 
-    // Use enterContext so the context propagates through RxJS Observable
-    // subscription and catchError handlers, not just the synchronous callback.
-    this.posthog.enterContext(contextData)
+    return new Observable((subscriber) =>
+      this.posthog.withContext(
+        contextData,
+        () => {
+          let source = next.handle()
 
-    let source = next.handle()
+          if (this.captureExceptions) {
+            source = source.pipe(
+              catchError((exception: unknown) => {
+                if (ErrorTracking.isPreviouslyCapturedError(exception)) {
+                  return throwError(() => exception)
+                }
+                const status = getExceptionStatus(exception)
+                if (status !== undefined && status < this.minStatusToCapture) {
+                  return throwError(() => exception)
+                }
+                const responseStatus = status ?? response?.statusCode
+                const additionalProperties: Record<string, any> | undefined =
+                  responseStatus !== undefined ? { $response_status_code: responseStatus } : undefined
+                this.posthog.captureException(exception, distinctId, additionalProperties)
+                return throwError(() => exception)
+              })
+            )
+          }
 
-    if (this.captureExceptions) {
-      source = source.pipe(
-        catchError((exception: unknown) => {
-          if (ErrorTracking.isPreviouslyCapturedError(exception)) {
-            return throwError(() => exception)
-          }
-          const status = getExceptionStatus(exception)
-          if (status !== undefined && status < this.minStatusToCapture) {
-            return throwError(() => exception)
-          }
-          const responseStatus = status ?? response?.statusCode
-          const additionalProperties: Record<string, any> | undefined =
-            responseStatus !== undefined ? { $response_status_code: responseStatus } : undefined
-          this.posthog.captureException(exception, distinctId, additionalProperties)
-          return throwError(() => exception)
-        })
+          return source.subscribe(subscriber)
+        },
+        { fresh: true }
       )
-    }
-    return source
+    )
   }
 }


### PR DESCRIPTION
## Problem

NestJS requests can create interceptor Observables before subscribing to them. The interceptor previously entered request context during Observable creation, so a later request could overwrite that context before the first subscription ran. This could attribute PostHog calls and captured exceptions to the wrong request, and headerless requests could inherit ambient identifiers and properties.

## Changes

- Create the intercepted Observable so each subscription runs `next.handle()` and exception handling inside its own PostHog context.
- Use a fresh context per subscription to prevent ambient or previous-request values from leaking into the request.
- Add regression coverage for delayed subscriptions across multiple requests and headerless requests with ambient context.
- Add a patch changeset for `posthog-node`.

Validation:
- `pnpm --config.verify-deps-before-run=false --filter posthog-node test:unit -- src/__tests__/extensions/nestjs.spec.ts --runInBand`
- `pnpm --config.verify-deps-before-run=false --filter posthog-node lint`
- `pnpm --config.verify-deps-before-run=false --filter posthog-node build`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed and reviewed this high-priority fix. Pi's coding agent reviewed the prepared diff, added release metadata, reran focused NestJS tests and Node package lint/build, and opened this draft PR. The local agent runner does not expose a shareable session URL.

The implementation keeps the public interceptor behavior intact while moving context entry to Observable subscription time and explicitly starting from a fresh request context. Agent-authored changes require human review before merge.
