### PR TITLE
fix(node): bound stack source context file reads

### DIFF
--- a/.changeset/safe-stack-source-context-files.md
+++ b/.changeset/safe-stack-source-context-files.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+Secure stack source context file reads against unsafe paths and file types.

--- a/.changeset/safe-stack-source-context-files.md
+++ b/.changeset/safe-stack-source-context-files.md
@@ -2,4 +2,4 @@
 'posthog-node': patch
 ---
 
-Secure stack source context file reads against unsafe paths and file types.
+Bound stack source context reads and skip non-regular or oversized files.

--- a/packages/node/src/__tests__/extensions/error-conversion.spec.ts
+++ b/packages/node/src/__tests__/extensions/error-conversion.spec.ts
@@ -2,7 +2,7 @@ import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { constants, type ReadStream } from 'node:fs'
 import { mkdtemp, open, rename, rm, symlink, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, relative } from 'node:path'
+import { join, relative, sep } from 'node:path'
 import { createModulerModifier } from '@/extensions/error-tracking/modifiers/module.node'
 import { addSourceContext, MAX_CONTEXTLINES_FILE_SIZE } from '@/extensions/error-tracking/modifiers/context-lines.node'
 import { createRelativePathModifier } from '@/extensions/error-tracking/modifiers/relative-path.node'
@@ -161,6 +161,21 @@ describe('error conversion', () => {
       await addSourceContext([frame])
 
       expect(frame.context_line).toBe('linked context')
+    })
+
+    it('preserves filesystem semantics for paths traversing symlink parents', async () => {
+      const sourceRoot = await makeTemporaryDirectory(tmpdir())
+      const linkedTarget = await makeTemporaryDirectory(sourceRoot)
+      await writeFile(join(sourceRoot, 'source.ts'), 'target context\n')
+      const linkRoot = await makeTemporaryDirectory(tmpdir())
+      await writeFile(join(linkRoot, 'source.ts'), 'lexically normalized context\n')
+      const linkedDirectory = join(linkRoot, 'linked-directory')
+      await symlink(linkedTarget, linkedDirectory, 'dir')
+      const frame = makeFrame(`${linkedDirectory}${sep}..${sep}source.ts`)
+
+      await addSourceContext([frame])
+
+      expect(frame.context_line).toBe('target context')
     })
 
     it('reads from the validated descriptor when the source path is replaced', async () => {

--- a/packages/node/src/__tests__/extensions/error-conversion.spec.ts
+++ b/packages/node/src/__tests__/extensions/error-conversion.spec.ts
@@ -1,6 +1,10 @@
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import { constants } from 'node:fs'
+import { mkdtemp, open, realpath, rename, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
 import { createModulerModifier } from '@/extensions/error-tracking/modifiers/module.node'
-import { addSourceContext } from '@/extensions/error-tracking/modifiers/context-lines.node'
+import { addSourceContext, MAX_CONTEXTLINES_FILE_SIZE } from '@/extensions/error-tracking/modifiers/context-lines.node'
 import { createRelativePathModifier } from '@/extensions/error-tracking/modifiers/relative-path.node'
 
 describe('error conversion', () => {
@@ -53,5 +57,141 @@ describe('error conversion', () => {
     expect(exceptionList.length).toEqual(2)
     expect(exceptionList[0].value).toEqual('test error')
     expect(exceptionList[1].value).toEqual('Object captured as exception with keys: error_code')
+  })
+
+  describe('source context file safety', () => {
+    const originalWorkingDirectory = process.cwd()
+    const temporaryPaths: string[] = []
+
+    function makeFrame(filename: string, lineno = 1): CoreErrorTracking.StackFrame {
+      return {
+        platform: 'node:javascript',
+        filename,
+        function: 'test',
+        lineno,
+        colno: 1,
+        in_app: true,
+      }
+    }
+
+    async function makeTemporaryDirectory(parent: string): Promise<string> {
+      const path = await mkdtemp(join(parent, 'posthog-context-lines-'))
+      temporaryPaths.push(path)
+      return path
+    }
+
+    afterEach(async () => {
+      process.chdir(originalWorkingDirectory)
+      await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+    })
+
+    it('preserves source context for regular application files', async () => {
+      const directory = await makeTemporaryDirectory(process.cwd())
+      const sourceFile = join(directory, 'application.ts')
+      await writeFile(sourceFile, 'first\nsecond\nthrow new Error("test")\nfourth\n')
+      const frame = makeFrame(sourceFile, 3)
+
+      await addSourceContext([frame])
+
+      expect(frame.pre_context).toEqual(['first', 'second'])
+      expect(frame.context_line).toBe('throw new Error("test")')
+      expect(frame.post_context).toEqual(['fourth'])
+    })
+
+    it('scopes successful and failed source caches to the canonical project root', async () => {
+      const rootA = await makeTemporaryDirectory(tmpdir())
+      const rootB = await makeTemporaryDirectory(tmpdir())
+      const cachedFilename = 'cached.ts'
+      const failedFilename = 'failed.ts'
+      const rootASourceFile = join(rootA, cachedFilename)
+      await writeFile(rootASourceFile, 'root A context\n')
+
+      process.chdir(rootA)
+      const rootACachedFrame = makeFrame(cachedFilename)
+      const rootAFailedFrame = makeFrame(failedFilename)
+      await addSourceContext([rootACachedFrame, rootAFailedFrame])
+      expect(rootACachedFrame.context_line).toBe('root A context')
+      expect(rootAFailedFrame.context_line).toBeUndefined()
+
+      await symlink(rootASourceFile, join(rootB, cachedFilename))
+      await writeFile(join(rootB, failedFilename), 'root B context\n')
+      process.chdir(rootB)
+      const rootBOutsideFrame = makeFrame(cachedFilename)
+      const rootBValidFrame = makeFrame(failedFilename)
+
+      await addSourceContext([rootBOutsideFrame, rootBValidFrame])
+
+      expect(rootBOutsideFrame.context_line).toBeUndefined()
+      expect(rootBValidFrame.context_line).toBe('root B context')
+    })
+
+    it('does not read regular files outside the project root', async () => {
+      const directory = await makeTemporaryDirectory(tmpdir())
+      const outsideFile = join(directory, 'outside.ts')
+      await writeFile(outsideFile, 'outside secret\n')
+      const frames = [makeFrame(outsideFile), makeFrame(relative(process.cwd(), outsideFile))]
+
+      await addSourceContext(frames)
+
+      expect(frames[0].context_line).toBeUndefined()
+      expect(frames[1].context_line).toBeUndefined()
+    })
+
+    it('does not follow project symlinks to files outside the project root', async () => {
+      const outsideDirectory = await makeTemporaryDirectory(tmpdir())
+      const outsideFile = join(outsideDirectory, 'outside.ts')
+      await writeFile(outsideFile, 'outside secret\n')
+      const projectDirectory = await makeTemporaryDirectory(process.cwd())
+      const linkedFile = join(projectDirectory, 'linked.ts')
+      await symlink(await realpath(outsideFile), linkedFile)
+      const frame = makeFrame(linkedFile)
+
+      await addSourceContext([frame])
+
+      expect(frame.context_line).toBeUndefined()
+    })
+
+    it('rejects a source path replaced after its descriptor is opened', async () => {
+      const directory = await makeTemporaryDirectory(process.cwd())
+      const sourceFile = join(directory, 'application.ts')
+      const openedFile = join(directory, 'opened.ts')
+      const replacementFile = join(directory, 'replacement.ts')
+      await writeFile(sourceFile, 'original context\n')
+      await writeFile(replacementFile, 'replacement context\n')
+      const openSourceFile = jest.fn(async () => {
+        const fileHandle = await open(sourceFile, constants.O_RDONLY | constants.O_NOFOLLOW)
+        await rename(sourceFile, openedFile)
+        await rename(replacementFile, sourceFile)
+        return fileHandle
+      })
+      const frame = makeFrame(sourceFile)
+
+      await addSourceContext([frame], openSourceFile)
+
+      expect(openSourceFile).toHaveBeenCalledTimes(1)
+      expect(frame.context_line).toBeUndefined()
+    })
+
+    it('does not read oversized regular files', async () => {
+      const directory = await makeTemporaryDirectory(process.cwd())
+      const sourceFile = join(directory, 'oversized.ts')
+      await writeFile(sourceFile, '')
+      await truncate(sourceFile, MAX_CONTEXTLINES_FILE_SIZE + 1)
+      const frame = makeFrame(sourceFile)
+
+      await addSourceContext([frame])
+
+      expect(frame.context_line).toBeUndefined()
+    })
+
+    if (process.platform !== 'win32') {
+      it.each(['/dev/null', '/dev/zero'])('does not read special file %s', async (specialFile) => {
+        const frame = makeFrame(specialFile)
+
+        await addSourceContext([frame])
+
+        expect(frame.context_line).toBeUndefined()
+      })
+    }
   })
 })

--- a/packages/node/src/__tests__/extensions/error-conversion.spec.ts
+++ b/packages/node/src/__tests__/extensions/error-conversion.spec.ts
@@ -1,6 +1,6 @@
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
-import { constants } from 'node:fs'
-import { mkdtemp, open, realpath, rename, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import { constants, type ReadStream } from 'node:fs'
+import { mkdtemp, open, rename, rm, symlink, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
 import { createModulerModifier } from '@/extensions/error-tracking/modifiers/module.node'
@@ -59,7 +59,7 @@ describe('error conversion', () => {
     expect(exceptionList[1].value).toEqual('Object captured as exception with keys: error_code')
   })
 
-  describe('source context file safety', () => {
+  describe('source context file reads', () => {
     const originalWorkingDirectory = process.cwd()
     const temporaryPaths: string[] = []
 
@@ -98,13 +98,14 @@ describe('error conversion', () => {
       expect(frame.post_context).toEqual(['fourth'])
     })
 
-    it('scopes successful and failed source caches to the canonical project root', async () => {
+    it('scopes successful and failed source caches to the working directory', async () => {
       const rootA = await makeTemporaryDirectory(tmpdir())
       const rootB = await makeTemporaryDirectory(tmpdir())
       const cachedFilename = 'cached.ts'
       const failedFilename = 'failed.ts'
-      const rootASourceFile = join(rootA, cachedFilename)
-      await writeFile(rootASourceFile, 'root A context\n')
+      await writeFile(join(rootA, cachedFilename), 'root A context\n')
+      await writeFile(join(rootB, cachedFilename), 'root B context\n')
+      await writeFile(join(rootB, failedFilename), 'root B context\n')
 
       process.chdir(rootA)
       const rootACachedFrame = makeFrame(cachedFilename)
@@ -113,53 +114,66 @@ describe('error conversion', () => {
       expect(rootACachedFrame.context_line).toBe('root A context')
       expect(rootAFailedFrame.context_line).toBeUndefined()
 
-      await symlink(rootASourceFile, join(rootB, cachedFilename))
-      await writeFile(join(rootB, failedFilename), 'root B context\n')
       process.chdir(rootB)
-      const rootBOutsideFrame = makeFrame(cachedFilename)
+      const rootBCachedFrame = makeFrame(cachedFilename)
       const rootBValidFrame = makeFrame(failedFilename)
+      await addSourceContext([rootBCachedFrame, rootBValidFrame])
 
-      await addSourceContext([rootBOutsideFrame, rootBValidFrame])
-
-      expect(rootBOutsideFrame.context_line).toBeUndefined()
+      expect(rootBCachedFrame.context_line).toBe('root B context')
       expect(rootBValidFrame.context_line).toBe('root B context')
     })
 
-    it('does not read regular files outside the project root', async () => {
+    it('preserves source context for regular files outside the working directory', async () => {
       const directory = await makeTemporaryDirectory(tmpdir())
       const outsideFile = join(directory, 'outside.ts')
-      await writeFile(outsideFile, 'outside secret\n')
+      await writeFile(outsideFile, 'outside context\n')
       const frames = [makeFrame(outsideFile), makeFrame(relative(process.cwd(), outsideFile))]
 
       await addSourceContext(frames)
 
-      expect(frames[0].context_line).toBeUndefined()
-      expect(frames[1].context_line).toBeUndefined()
+      expect(frames[0].context_line).toBe('outside context')
+      expect(frames[1].context_line).toBe('outside context')
     })
 
-    it('does not follow project symlinks to files outside the project root', async () => {
-      const outsideDirectory = await makeTemporaryDirectory(tmpdir())
-      const outsideFile = join(outsideDirectory, 'outside.ts')
-      await writeFile(outsideFile, 'outside secret\n')
-      const projectDirectory = await makeTemporaryDirectory(process.cwd())
-      const linkedFile = join(projectDirectory, 'linked.ts')
-      await symlink(await realpath(outsideFile), linkedFile)
+    it('preserves absolute source context when the working directory was removed', async () => {
+      const removedDirectory = await makeTemporaryDirectory(tmpdir())
+      const sourceDirectory = await makeTemporaryDirectory(tmpdir())
+      const sourceFile = join(sourceDirectory, 'source.ts')
+      await writeFile(sourceFile, 'absolute context\n')
+      process.chdir(removedDirectory)
+      await rm(removedDirectory, { recursive: true, force: true })
+      const frame = makeFrame(sourceFile)
+
+      await addSourceContext([frame])
+
+      expect(frame.context_line).toBe('absolute context')
+    })
+
+    it('preserves source context for symlinked regular files', async () => {
+      const sourceDirectory = await makeTemporaryDirectory(tmpdir())
+      const sourceFile = join(sourceDirectory, 'source.ts')
+      await writeFile(sourceFile, 'linked context\n')
+      const linkDirectory = await makeTemporaryDirectory(tmpdir())
+      const linkedFile = join(linkDirectory, 'linked.ts')
+      await symlink(sourceFile, linkedFile)
       const frame = makeFrame(linkedFile)
 
       await addSourceContext([frame])
 
-      expect(frame.context_line).toBeUndefined()
+      expect(frame.context_line).toBe('linked context')
     })
 
-    it('rejects a source path replaced after its descriptor is opened', async () => {
-      const directory = await makeTemporaryDirectory(process.cwd())
+    it('reads from the validated descriptor when the source path is replaced', async () => {
+      const directory = await makeTemporaryDirectory(tmpdir())
       const sourceFile = join(directory, 'application.ts')
       const openedFile = join(directory, 'opened.ts')
       const replacementFile = join(directory, 'replacement.ts')
       await writeFile(sourceFile, 'original context\n')
       await writeFile(replacementFile, 'replacement context\n')
-      const openSourceFile = jest.fn(async () => {
-        const fileHandle = await open(sourceFile, constants.O_RDONLY | constants.O_NOFOLLOW)
+      const openSourceFile = jest.fn(async (path: string, flags: number) => {
+        expect(path).toBe(sourceFile)
+        expect(flags & constants.O_NONBLOCK).toBe(constants.O_NONBLOCK)
+        const fileHandle = await open(path, flags)
         await rename(sourceFile, openedFile)
         await rename(replacementFile, sourceFile)
         return fileHandle
@@ -169,11 +183,47 @@ describe('error conversion', () => {
       await addSourceContext([frame], openSourceFile)
 
       expect(openSourceFile).toHaveBeenCalledTimes(1)
+      expect(frame.context_line).toBe('original context')
+    })
+
+    it('closes the descriptor when stream initialization fails', async () => {
+      const directory = await makeTemporaryDirectory(tmpdir())
+      const sourceFile = join(directory, 'source.ts')
+      await writeFile(sourceFile, 'source context\n')
+      const fileHandle = await open(sourceFile, constants.O_RDONLY)
+      const closeSourceFile = jest.spyOn(fileHandle, 'close')
+      jest.spyOn(fileHandle, 'createReadStream').mockImplementation(() => {
+        throw new Error('stream initialization failed')
+      })
+      const frame = makeFrame(sourceFile)
+
+      await addSourceContext([frame], async () => fileHandle)
+
+      expect(closeSourceFile).toHaveBeenCalledTimes(1)
       expect(frame.context_line).toBeUndefined()
     })
 
+    it('destroys the stream after collecting an early line range', async () => {
+      const directory = await makeTemporaryDirectory(tmpdir())
+      const sourceFile = join(directory, 'source.ts')
+      await writeFile(sourceFile, 'source context\n'.repeat(100_000))
+      const fileHandle = await open(sourceFile, constants.O_RDONLY)
+      const createSourceStream = fileHandle.createReadStream.bind(fileHandle)
+      let sourceStream: ReadStream | undefined
+      jest.spyOn(fileHandle, 'createReadStream').mockImplementation((options) => {
+        sourceStream = createSourceStream(options)
+        return sourceStream
+      })
+      const frame = makeFrame(sourceFile)
+
+      await addSourceContext([frame], async () => fileHandle)
+
+      expect(frame.context_line).toBe('source context')
+      expect(sourceStream?.destroyed).toBe(true)
+    })
+
     it('does not read oversized regular files', async () => {
-      const directory = await makeTemporaryDirectory(process.cwd())
+      const directory = await makeTemporaryDirectory(tmpdir())
       const sourceFile = join(directory, 'oversized.ts')
       await writeFile(sourceFile, '')
       await truncate(sourceFile, MAX_CONTEXTLINES_FILE_SIZE + 1)

--- a/packages/node/src/__tests__/extensions/error-conversion.spec.ts
+++ b/packages/node/src/__tests__/extensions/error-conversion.spec.ts
@@ -1,4 +1,5 @@
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import { execFileSync } from 'node:child_process'
 import { constants, type ReadStream } from 'node:fs'
 import { mkdtemp, open, rename, rm, symlink, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -187,7 +188,9 @@ describe('error conversion', () => {
       await writeFile(replacementFile, 'replacement context\n')
       const openSourceFile = jest.fn(async (path: string, flags: number) => {
         expect(path).toBe(sourceFile)
-        expect(flags & constants.O_NONBLOCK).toBe(constants.O_NONBLOCK)
+        if (process.platform !== 'win32') {
+          expect(flags & constants.O_NONBLOCK).toBe(constants.O_NONBLOCK)
+        }
         const fileHandle = await open(path, flags)
         await rename(sourceFile, openedFile)
         await rename(replacementFile, sourceFile)
@@ -243,15 +246,28 @@ describe('error conversion', () => {
       await writeFile(sourceFile, '')
       await truncate(sourceFile, MAX_CONTEXTLINES_FILE_SIZE + 1)
       const frame = makeFrame(sourceFile)
+      const logger = { debug: jest.fn() }
 
-      await addSourceContext([frame])
+      await addSourceContext([frame], undefined, logger)
 
       expect(frame.context_line).toBeUndefined()
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining(`oversized file ${sourceFile}`))
     })
 
     if (process.platform !== 'win32') {
       it.each(['/dev/null', '/dev/zero'])('does not read special file %s', async (specialFile) => {
         const frame = makeFrame(specialFile)
+
+        await addSourceContext([frame])
+
+        expect(frame.context_line).toBeUndefined()
+      })
+
+      it('does not block when the source path is a FIFO', async () => {
+        const directory = await makeTemporaryDirectory(tmpdir())
+        const fifoPath = join(directory, 'source.fifo')
+        execFileSync('mkfifo', [fifoPath])
+        const frame = makeFrame(fifoPath)
 
         await addSourceContext([frame])
 

--- a/packages/node/src/entrypoints/index.node.ts
+++ b/packages/node/src/entrypoints/index.node.ts
@@ -27,7 +27,11 @@ export class PostHog extends PostHogBackendClient {
         new CoreErrorTracking.PrimitiveCoercer(),
       ],
       CoreErrorTracking.createStackParser('node:javascript', CoreErrorTracking.nodeStackLineParser),
-      [createModulerModifier(), addSourceContext, createRelativePathModifier()]
+      [
+        createModulerModifier(),
+        (frames) => addSourceContext(frames, undefined, this._logger),
+        createRelativePathModifier(),
+      ]
     )
   }
 }

--- a/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
@@ -5,7 +5,7 @@
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { constants, type ReadStream } from 'node:fs'
 import { open, type FileHandle } from 'node:fs/promises'
-import { isAbsolute, normalize, resolve } from 'node:path'
+import { isAbsolute } from 'node:path'
 import { createInterface } from 'node:readline'
 
 const LRU_FILE_CONTENTS_CACHE = new CoreErrorTracking.ReduceableCache<string, Record<number, string>>(25)
@@ -51,15 +51,14 @@ export async function addSourceContext(
       continue
     }
 
-    const filePath = resolveSourcePath(filename, basePath)
-    if (filePath === undefined) {
+    if (!isAbsolute(filename) && basePath === undefined) {
       continue
     }
-    const filesToLinesOutput = filesToLines[filePath]
+    const filesToLinesOutput = filesToLines[filename]
     if (!filesToLinesOutput) {
-      filesToLines[filePath] = []
+      filesToLines[filename] = []
     }
-    filesToLines[filePath].push(frame.lineno)
+    filesToLines[filename].push(frame.lineno)
   }
 
   const files = Object.keys(filesToLines)
@@ -69,8 +68,13 @@ export async function addSourceContext(
 
   const readlinePromises: Promise<void>[] = []
   for (const file of files) {
+    const cacheKey = makeSourceCacheKey(file, basePath)
+    if (cacheKey === undefined) {
+      continue
+    }
+
     // If we failed to read this before, dont try reading it again.
-    if (LRU_FILE_CONTENTS_FS_READ_FAILED.get(file)) {
+    if (LRU_FILE_CONTENTS_FS_READ_FAILED.get(cacheKey)) {
       continue
     }
 
@@ -83,12 +87,12 @@ export async function addSourceContext(
     filesToLineRanges.sort((a, b) => a - b)
     // Check if the contents are already in the cache and if we can avoid reading the file again.
     const ranges = makeLineReaderRanges(filesToLineRanges)
-    if (ranges.every((r) => rangeExistsInContentCache(file, r))) {
+    if (ranges.every((r) => rangeExistsInContentCache(cacheKey, r))) {
       continue
     }
 
-    const cache = emplace(LRU_FILE_CONTENTS_CACHE, file, {})
-    readlinePromises.push(getContextLinesFromFile(file, ranges, cache, openSourceFile))
+    const cache = emplace(LRU_FILE_CONTENTS_CACHE, cacheKey, {})
+    readlinePromises.push(getContextLinesFromFile(file, ranges, cache, cacheKey, openSourceFile))
   }
 
   // The promise rejections are caught in order to prevent them from short circuiting Promise.all
@@ -139,11 +143,12 @@ async function getContextLinesFromFile(
   path: string,
   ranges: ReadlineRange[],
   output: Record<number, string>,
+  cacheKey: string,
   openSourceFile: OpenSourceFile
 ): Promise<void> {
   const fileHandle = await openRegularSourceFile(path, openSourceFile)
   if (fileHandle === undefined) {
-    LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
+    LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
     return
   }
   const openedFileHandle = fileHandle
@@ -174,7 +179,7 @@ async function getContextLinesFromFile(
         end: MAX_CONTEXTLINES_FILE_SIZE - 1,
       })
     } catch {
-      LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
+      LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
       destroyStreamAndResolve()
       return
     }
@@ -185,7 +190,7 @@ async function getContextLinesFromFile(
         input: stream,
       })
     } catch {
-      LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
+      LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
       destroyStreamAndResolve(stream)
       return
     }
@@ -206,7 +211,7 @@ async function getContextLinesFromFile(
     // to prevent Promise.all from short circuiting the rest.
     function onStreamError(): void {
       // Mark the file as failed to prevent repeated read attempts.
-      LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
+      LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
       lineReaded.close()
       lineReaded.removeAllListeners()
       destroyStreamAndResolve(stream)
@@ -258,8 +263,8 @@ function addSourceContextToFrames(
   for (const frame of frames) {
     // Only add context if we have a filename and it hasn't already been added
     if (frame.filename && frame.context_line === undefined && typeof frame.lineno === 'number') {
-      const filePath = resolveSourcePath(frame.filename, basePath)
-      const contents = filePath === undefined ? undefined : cache.get(filePath)
+      const cacheKey = makeSourceCacheKey(frame.filename, basePath)
+      const contents = cacheKey === undefined ? undefined : cache.get(cacheKey)
       if (contents === undefined) {
         continue
       }
@@ -359,11 +364,11 @@ function shouldSkipContextLinesForFrame(frame: CoreErrorTracking.StackFrame): bo
   return false
 }
 
-function resolveSourcePath(path: string, basePath: string | undefined): string | undefined {
+function makeSourceCacheKey(path: string, basePath: string | undefined): string | undefined {
   if (isAbsolute(path)) {
-    return normalize(path)
+    return JSON.stringify([null, path])
   }
-  return basePath === undefined ? undefined : resolve(basePath, path)
+  return basePath === undefined ? undefined : JSON.stringify([basePath, path])
 }
 
 /**

--- a/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
-import { constants } from 'node:fs'
-import { open, realpath, stat, type FileHandle } from 'node:fs/promises'
-import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { constants, type ReadStream } from 'node:fs'
+import { open, type FileHandle } from 'node:fs/promises'
+import { isAbsolute, normalize, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
 
 const LRU_FILE_CONTENTS_CACHE = new CoreErrorTracking.ReduceableCache<string, Record<number, string>>(25)
@@ -28,6 +28,12 @@ export async function addSourceContext(
   // keep a lookup map of which files we've already enqueued to read,
   // so we don't enqueue the same file multiple times which would cause multiple i/o reads
   const filesToLines: Record<string, number[]> = {}
+  let basePath: string | undefined
+  try {
+    basePath = process.cwd()
+  } catch {
+    // Absolute source paths can still be processed when the working directory was removed.
+  }
 
   // Maps preserve insertion order, so we iterate in reverse, starting at the
   // outermost frame and closer to where the exception has occurred (poor mans priority)
@@ -45,11 +51,15 @@ export async function addSourceContext(
       continue
     }
 
-    const filesToLinesOutput = filesToLines[filename]
-    if (!filesToLinesOutput) {
-      filesToLines[filename] = []
+    const filePath = resolveSourcePath(filename, basePath)
+    if (filePath === undefined) {
+      continue
     }
-    filesToLines[filename].push(frame.lineno)
+    const filesToLinesOutput = filesToLines[filePath]
+    if (!filesToLinesOutput) {
+      filesToLines[filePath] = []
+    }
+    filesToLines[filePath].push(frame.lineno)
   }
 
   const files = Object.keys(filesToLines)
@@ -57,22 +67,10 @@ export async function addSourceContext(
     return frames
   }
 
-  let projectRoot: string
-  try {
-    projectRoot = await realpath(process.cwd())
-  } catch {
-    return frames
-  }
-  if (resolve(projectRoot, '..') === projectRoot) {
-    return frames
-  }
-
   const readlinePromises: Promise<void>[] = []
   for (const file of files) {
-    const cacheKey = makeCacheKey(projectRoot, file)
-
     // If we failed to read this before, dont try reading it again.
-    if (LRU_FILE_CONTENTS_FS_READ_FAILED.get(cacheKey)) {
+    if (LRU_FILE_CONTENTS_FS_READ_FAILED.get(file)) {
       continue
     }
 
@@ -85,12 +83,12 @@ export async function addSourceContext(
     filesToLineRanges.sort((a, b) => a - b)
     // Check if the contents are already in the cache and if we can avoid reading the file again.
     const ranges = makeLineReaderRanges(filesToLineRanges)
-    if (ranges.every((r) => rangeExistsInContentCache(cacheKey, r))) {
+    if (ranges.every((r) => rangeExistsInContentCache(file, r))) {
       continue
     }
 
-    const cache = emplace(LRU_FILE_CONTENTS_CACHE, cacheKey, {})
-    readlinePromises.push(getContextLinesFromFile(file, ranges, cache, cacheKey, projectRoot, openSourceFile))
+    const cache = emplace(LRU_FILE_CONTENTS_CACHE, file, {})
+    readlinePromises.push(getContextLinesFromFile(file, ranges, cache, openSourceFile))
   }
 
   // The promise rejections are caught in order to prevent them from short circuiting Promise.all
@@ -99,7 +97,7 @@ export async function addSourceContext(
   // Perform the same loop as above, but this time we can assume all files are in the cache
   // and attempt to add source context to frames.
   if (frames && frames.length > 0) {
-    addSourceContextToFrames(frames, LRU_FILE_CONTENTS_CACHE, projectRoot)
+    addSourceContextToFrames(frames, LRU_FILE_CONTENTS_CACHE, basePath)
   }
 
   // Once we're finished processing an exception reduce the files held in the cache
@@ -110,57 +108,25 @@ export async function addSourceContext(
 }
 
 /**
- * Check whether a path is contained by the application root.
+ * Opens a bounded regular file without blocking on special files such as FIFOs.
+ * File validation and content reads use the same descriptor so path replacement cannot change what is read.
  */
-function isPathWithinRoot(path: string, projectRoot: string): boolean {
-  const relativePath = relative(projectRoot, path)
-  return relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath)
-}
-
-/**
- * Open a source file without allowing a parsed stack frame to escape the application root.
- *
- * O_NOFOLLOW rejects a final symlink. After opening, the descriptor's identity is compared with the
- * canonical path currently reachable inside the root. This also detects intermediate symlink or path
- * replacement between opening and validation. File type, size, and content reads use the returned descriptor.
- */
-async function openSafeSourceFile(
-  path: string,
-  projectRoot: string,
-  openSourceFile: OpenSourceFile
-): Promise<FileHandle | undefined> {
-  const candidatePath = resolve(projectRoot, path)
-  if (!isPathWithinRoot(candidatePath, projectRoot)) {
-    return undefined
-  }
-
+async function openRegularSourceFile(path: string, openSourceFile: OpenSourceFile): Promise<FileHandle | undefined> {
   let fileHandle: FileHandle | undefined
-  let isSafe = false
+  let isValid = false
   try {
-    fileHandle = await openSourceFile(candidatePath, constants.O_RDONLY | constants.O_NOFOLLOW)
+    fileHandle = await openSourceFile(path, constants.O_RDONLY | constants.O_NONBLOCK)
     const fileStat = await fileHandle.stat()
     if (!fileStat.isFile() || fileStat.size > MAX_CONTEXTLINES_FILE_SIZE) {
       return undefined
     }
 
-    const resolvedPath = await realpath(candidatePath)
-    if (!isPathWithinRoot(resolvedPath, projectRoot)) {
-      return undefined
-    }
-
-    // Node does not expose openat2-style path resolution. Comparing the opened descriptor's identity
-    // with the canonical in-root path ensures that validation applies to the file we will actually read.
-    const resolvedPathStat = await stat(resolvedPath)
-    if (fileStat.dev !== resolvedPathStat.dev || fileStat.ino !== resolvedPathStat.ino) {
-      return undefined
-    }
-
-    isSafe = true
+    isValid = true
     return fileHandle
   } catch {
     return undefined
   } finally {
-    if (fileHandle && !isSafe) {
+    if (fileHandle && !isValid) {
       await fileHandle.close().catch(() => {})
     }
   }
@@ -173,41 +139,55 @@ async function getContextLinesFromFile(
   path: string,
   ranges: ReadlineRange[],
   output: Record<number, string>,
-  cacheKey: string,
-  projectRoot: string,
   openSourceFile: OpenSourceFile
 ): Promise<void> {
-  const fileHandle = await openSafeSourceFile(path, projectRoot, openSourceFile)
+  const fileHandle = await openRegularSourceFile(path, openSourceFile)
   if (fileHandle === undefined) {
-    LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
+    LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
     return
   }
   const openedFileHandle = fileHandle
 
   return new Promise((resolve) => {
-    // It is important *not* to have any async code between createInterface and the 'line' event listener
-    // as it will cause the 'line' event to
-    // be emitted before the listener is attached.
-    const stream = openedFileHandle.createReadStream({
-      autoClose: false,
-      start: 0,
-      end: MAX_CONTEXTLINES_FILE_SIZE - 1,
-    })
-    const lineReaded = createInterface({
-      input: stream,
-    })
     let finished = false
 
     // We need to explicitly destroy the stream and close its descriptor to prevent memory leaks,
     // removing the listeners on the readline interface is not enough.
     // Otherwise, repeated exception captures can keep opening the same files without closing them.
-    function destroyStreamAndResolve(): void {
+    function destroyStreamAndResolve(stream?: ReadStream): void {
       if (finished) {
         return
       }
       finished = true
-      stream.destroy()
+      stream?.destroy()
       void openedFileHandle.close().then(resolve, resolve)
+    }
+
+    // It is important *not* to have any async code between createInterface and the 'line' event listener
+    // as it will cause the 'line' event to
+    // be emitted before the listener is attached.
+    let stream: ReadStream
+    try {
+      stream = openedFileHandle.createReadStream({
+        autoClose: false,
+        start: 0,
+        end: MAX_CONTEXTLINES_FILE_SIZE - 1,
+      })
+    } catch {
+      LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
+      destroyStreamAndResolve()
+      return
+    }
+
+    let lineReaded: ReturnType<typeof createInterface>
+    try {
+      lineReaded = createInterface({
+        input: stream,
+      })
+    } catch {
+      LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
+      destroyStreamAndResolve(stream)
+      return
     }
 
     // Init at zero and increment at the start of the loop because lines are 1 indexed.
@@ -216,7 +196,7 @@ async function getContextLinesFromFile(
     const range = ranges[currentRangeIndex]
     if (range === undefined) {
       // We should never reach this point, but if we do, we should resolve the promise to prevent it from hanging.
-      destroyStreamAndResolve()
+      destroyStreamAndResolve(stream)
       return
     }
     let rangeStart = range[0]
@@ -225,18 +205,18 @@ async function getContextLinesFromFile(
     // We use this inside Promise.all, so we need to resolve the promise even if there is an error
     // to prevent Promise.all from short circuiting the rest.
     function onStreamError(): void {
-      // Mark this file under the current project root as failed to prevent repeated read attempts.
-      LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
+      // Mark the file as failed to prevent repeated read attempts.
+      LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
       lineReaded.close()
       lineReaded.removeAllListeners()
-      destroyStreamAndResolve()
+      destroyStreamAndResolve(stream)
     }
 
     // We need to handle the error event to prevent the process from crashing in < Node 16
     // https://github.com/nodejs/node/pull/31603
     stream.on('error', onStreamError)
     lineReaded.on('error', onStreamError)
-    lineReaded.on('close', destroyStreamAndResolve)
+    lineReaded.on('close', () => destroyStreamAndResolve(stream))
 
     lineReaded.on('line', (line) => {
       lineNumber++
@@ -273,12 +253,13 @@ async function getContextLinesFromFile(
 function addSourceContextToFrames(
   frames: CoreErrorTracking.StackFrame[],
   cache: CoreErrorTracking.ReduceableCache<string, Record<number, string>>,
-  projectRoot: string
+  basePath: string | undefined
 ): void {
   for (const frame of frames) {
     // Only add context if we have a filename and it hasn't already been added
     if (frame.filename && frame.context_line === undefined && typeof frame.lineno === 'number') {
-      const contents = cache.get(makeCacheKey(projectRoot, frame.filename))
+      const filePath = resolveSourcePath(frame.filename, basePath)
+      const contents = filePath === undefined ? undefined : cache.get(filePath)
       if (contents === undefined) {
         continue
       }
@@ -378,11 +359,11 @@ function shouldSkipContextLinesForFrame(frame: CoreErrorTracking.StackFrame): bo
   return false
 }
 
-/**
- * Scopes cached results to the canonical project root used to validate the source path.
- */
-function makeCacheKey(projectRoot: string, file: string): string {
-  return JSON.stringify([projectRoot, file])
+function resolveSourcePath(path: string, basePath: string | undefined): string | undefined {
+  if (isAbsolute(path)) {
+    return normalize(path)
+  }
+  return basePath === undefined ? undefined : resolve(basePath, path)
 }
 
 /**

--- a/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2012 Functional Software, Inc. dba Sentry
 // Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
-import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import { ErrorTracking as CoreErrorTracking, type Logger } from '@posthog/core'
 import { constants, type ReadStream } from 'node:fs'
 import { open, type FileHandle } from 'node:fs/promises'
 import { isAbsolute } from 'node:path'
@@ -23,7 +23,8 @@ type OpenSourceFile = (path: string, flags: number) => Promise<FileHandle>
 
 export async function addSourceContext(
   frames: CoreErrorTracking.StackFrame[],
-  openSourceFile: OpenSourceFile = open
+  openSourceFile: OpenSourceFile = open,
+  logger?: Pick<Logger, 'debug'>
 ): Promise<CoreErrorTracking.StackFrame[]> {
   // keep a lookup map of which files we've already enqueued to read,
   // so we don't enqueue the same file multiple times which would cause multiple i/o reads
@@ -92,7 +93,7 @@ export async function addSourceContext(
     }
 
     const cache = emplace(LRU_FILE_CONTENTS_CACHE, cacheKey, {})
-    readlinePromises.push(getContextLinesFromFile(file, ranges, cache, cacheKey, openSourceFile))
+    readlinePromises.push(getContextLinesFromFile(file, ranges, cache, cacheKey, openSourceFile, logger))
   }
 
   // The promise rejections are caught in order to prevent them from short circuiting Promise.all
@@ -115,13 +116,23 @@ export async function addSourceContext(
  * Opens a bounded regular file without blocking on special files such as FIFOs.
  * File validation and content reads use the same descriptor so path replacement cannot change what is read.
  */
-async function openRegularSourceFile(path: string, openSourceFile: OpenSourceFile): Promise<FileHandle | undefined> {
+async function openRegularSourceFile(
+  path: string,
+  openSourceFile: OpenSourceFile,
+  logger?: Pick<Logger, 'debug'>
+): Promise<FileHandle | undefined> {
   let fileHandle: FileHandle | undefined
   let isValid = false
   try {
     fileHandle = await openSourceFile(path, constants.O_RDONLY | constants.O_NONBLOCK)
     const fileStat = await fileHandle.stat()
-    if (!fileStat.isFile() || fileStat.size > MAX_CONTEXTLINES_FILE_SIZE) {
+    if (!fileStat.isFile()) {
+      return undefined
+    }
+    if (fileStat.size > MAX_CONTEXTLINES_FILE_SIZE) {
+      logger?.debug(
+        `Skipping source context for oversized file ${path}: ${fileStat.size} bytes exceeds ${MAX_CONTEXTLINES_FILE_SIZE}`
+      )
       return undefined
     }
 
@@ -144,9 +155,10 @@ async function getContextLinesFromFile(
   ranges: ReadlineRange[],
   output: Record<number, string>,
   cacheKey: string,
-  openSourceFile: OpenSourceFile
+  openSourceFile: OpenSourceFile,
+  logger?: Pick<Logger, 'debug'>
 ): Promise<void> {
-  const fileHandle = await openRegularSourceFile(path, openSourceFile)
+  const fileHandle = await openRegularSourceFile(path, openSourceFile, logger)
   if (fileHandle === undefined) {
     LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
     return

--- a/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
@@ -3,7 +3,9 @@
 // Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
-import { createReadStream } from 'node:fs'
+import { constants } from 'node:fs'
+import { open, realpath, stat, type FileHandle } from 'node:fs/promises'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
 import { createInterface } from 'node:readline'
 
 const LRU_FILE_CONTENTS_CACHE = new CoreErrorTracking.ReduceableCache<string, Record<number, string>>(25)
@@ -14,11 +16,14 @@ const DEFAULT_LINES_OF_CONTEXT = 7
 // Exported for testing purposes.
 export const MAX_CONTEXTLINES_COLNO: number = 1000
 export const MAX_CONTEXTLINES_LINENO: number = 10000
+export const MAX_CONTEXTLINES_FILE_SIZE: number = 10 * 1024 * 1024
 
 type ReadlineRange = [start: number, end: number]
+type OpenSourceFile = (path: string, flags: number) => Promise<FileHandle>
 
 export async function addSourceContext(
-  frames: CoreErrorTracking.StackFrame[]
+  frames: CoreErrorTracking.StackFrame[],
+  openSourceFile: OpenSourceFile = open
 ): Promise<CoreErrorTracking.StackFrame[]> {
   // keep a lookup map of which files we've already enqueued to read,
   // so we don't enqueue the same file multiple times which would cause multiple i/o reads
@@ -52,10 +57,22 @@ export async function addSourceContext(
     return frames
   }
 
+  let projectRoot: string
+  try {
+    projectRoot = await realpath(process.cwd())
+  } catch {
+    return frames
+  }
+  if (resolve(projectRoot, '..') === projectRoot) {
+    return frames
+  }
+
   const readlinePromises: Promise<void>[] = []
   for (const file of files) {
+    const cacheKey = makeCacheKey(projectRoot, file)
+
     // If we failed to read this before, dont try reading it again.
-    if (LRU_FILE_CONTENTS_FS_READ_FAILED.get(file)) {
+    if (LRU_FILE_CONTENTS_FS_READ_FAILED.get(cacheKey)) {
       continue
     }
 
@@ -68,12 +85,12 @@ export async function addSourceContext(
     filesToLineRanges.sort((a, b) => a - b)
     // Check if the contents are already in the cache and if we can avoid reading the file again.
     const ranges = makeLineReaderRanges(filesToLineRanges)
-    if (ranges.every((r) => rangeExistsInContentCache(file, r))) {
+    if (ranges.every((r) => rangeExistsInContentCache(cacheKey, r))) {
       continue
     }
 
-    const cache = emplace(LRU_FILE_CONTENTS_CACHE, file, {})
-    readlinePromises.push(getContextLinesFromFile(file, ranges, cache))
+    const cache = emplace(LRU_FILE_CONTENTS_CACHE, cacheKey, {})
+    readlinePromises.push(getContextLinesFromFile(file, ranges, cache, cacheKey, projectRoot, openSourceFile))
   }
 
   // The promise rejections are caught in order to prevent them from short circuiting Promise.all
@@ -82,7 +99,7 @@ export async function addSourceContext(
   // Perform the same loop as above, but this time we can assume all files are in the cache
   // and attempt to add source context to frames.
   if (frames && frames.length > 0) {
-    addSourceContextToFrames(frames, LRU_FILE_CONTENTS_CACHE)
+    addSourceContextToFrames(frames, LRU_FILE_CONTENTS_CACHE, projectRoot)
   }
 
   // Once we're finished processing an exception reduce the files held in the cache
@@ -93,24 +110,104 @@ export async function addSourceContext(
 }
 
 /**
+ * Check whether a path is contained by the application root.
+ */
+function isPathWithinRoot(path: string, projectRoot: string): boolean {
+  const relativePath = relative(projectRoot, path)
+  return relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath)
+}
+
+/**
+ * Open a source file without allowing a parsed stack frame to escape the application root.
+ *
+ * O_NOFOLLOW rejects a final symlink. After opening, the descriptor's identity is compared with the
+ * canonical path currently reachable inside the root. This also detects intermediate symlink or path
+ * replacement between opening and validation. File type, size, and content reads use the returned descriptor.
+ */
+async function openSafeSourceFile(
+  path: string,
+  projectRoot: string,
+  openSourceFile: OpenSourceFile
+): Promise<FileHandle | undefined> {
+  const candidatePath = resolve(projectRoot, path)
+  if (!isPathWithinRoot(candidatePath, projectRoot)) {
+    return undefined
+  }
+
+  let fileHandle: FileHandle | undefined
+  let isSafe = false
+  try {
+    fileHandle = await openSourceFile(candidatePath, constants.O_RDONLY | constants.O_NOFOLLOW)
+    const fileStat = await fileHandle.stat()
+    if (!fileStat.isFile() || fileStat.size > MAX_CONTEXTLINES_FILE_SIZE) {
+      return undefined
+    }
+
+    const resolvedPath = await realpath(candidatePath)
+    if (!isPathWithinRoot(resolvedPath, projectRoot)) {
+      return undefined
+    }
+
+    // Node does not expose openat2-style path resolution. Comparing the opened descriptor's identity
+    // with the canonical in-root path ensures that validation applies to the file we will actually read.
+    const resolvedPathStat = await stat(resolvedPath)
+    if (fileStat.dev !== resolvedPathStat.dev || fileStat.ino !== resolvedPathStat.ino) {
+      return undefined
+    }
+
+    isSafe = true
+    return fileHandle
+  } catch {
+    return undefined
+  } finally {
+    if (fileHandle && !isSafe) {
+      await fileHandle.close().catch(() => {})
+    }
+  }
+}
+
+/**
  * Extracts lines from a file and stores them in a cache.
  */
-function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: Record<number, string>): Promise<void> {
+async function getContextLinesFromFile(
+  path: string,
+  ranges: ReadlineRange[],
+  output: Record<number, string>,
+  cacheKey: string,
+  projectRoot: string,
+  openSourceFile: OpenSourceFile
+): Promise<void> {
+  const fileHandle = await openSafeSourceFile(path, projectRoot, openSourceFile)
+  if (fileHandle === undefined) {
+    LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
+    return
+  }
+  const openedFileHandle = fileHandle
+
   return new Promise((resolve) => {
     // It is important *not* to have any async code between createInterface and the 'line' event listener
     // as it will cause the 'line' event to
     // be emitted before the listener is attached.
-    const stream = createReadStream(path)
+    const stream = openedFileHandle.createReadStream({
+      autoClose: false,
+      start: 0,
+      end: MAX_CONTEXTLINES_FILE_SIZE - 1,
+    })
     const lineReaded = createInterface({
       input: stream,
     })
+    let finished = false
 
-    // We need to explicitly destroy the stream to prevent memory leaks,
+    // We need to explicitly destroy the stream and close its descriptor to prevent memory leaks,
     // removing the listeners on the readline interface is not enough.
     // Otherwise, repeated exception captures can keep opening the same files without closing them.
     function destroyStreamAndResolve(): void {
+      if (finished) {
+        return
+      }
+      finished = true
       stream.destroy()
-      resolve()
+      void openedFileHandle.close().then(resolve, resolve)
     }
 
     // Init at zero and increment at the start of the loop because lines are 1 indexed.
@@ -128,8 +225,8 @@ function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: 
     // We use this inside Promise.all, so we need to resolve the promise even if there is an error
     // to prevent Promise.all from short circuiting the rest.
     function onStreamError(): void {
-      // Mark file path as failed to read and prevent multiple read attempts.
-      LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1)
+      // Mark this file under the current project root as failed to prevent repeated read attempts.
+      LRU_FILE_CONTENTS_FS_READ_FAILED.set(cacheKey, 1)
       lineReaded.close()
       lineReaded.removeAllListeners()
       destroyStreamAndResolve()
@@ -175,12 +272,13 @@ function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: 
 /** Adds context lines to frames */
 function addSourceContextToFrames(
   frames: CoreErrorTracking.StackFrame[],
-  cache: CoreErrorTracking.ReduceableCache<string, Record<number, string>>
+  cache: CoreErrorTracking.ReduceableCache<string, Record<number, string>>,
+  projectRoot: string
 ): void {
   for (const frame of frames) {
     // Only add context if we have a filename and it hasn't already been added
     if (frame.filename && frame.context_line === undefined && typeof frame.lineno === 'number') {
-      const contents = cache.get(frame.filename)
+      const contents = cache.get(makeCacheKey(projectRoot, frame.filename))
       if (contents === undefined) {
         continue
       }
@@ -281,10 +379,17 @@ function shouldSkipContextLinesForFrame(frame: CoreErrorTracking.StackFrame): bo
 }
 
 /**
+ * Scopes cached results to the canonical project root used to validate the source path.
+ */
+function makeCacheKey(projectRoot: string, file: string): string {
+  return JSON.stringify([projectRoot, file])
+}
+
+/**
  * Checks if we have all the contents that we need in the cache.
  */
-function rangeExistsInContentCache(file: string, range: ReadlineRange): boolean {
-  const contents = LRU_FILE_CONTENTS_CACHE.get(file)
+function rangeExistsInContentCache(cacheKey: string, range: ReadlineRange): boolean {
+  const contents = LRU_FILE_CONTENTS_CACHE.get(cacheKey)
   if (contents === undefined) {
     return false
   }


### PR DESCRIPTION
## Problem

Node exception enrichment reads source files named by parsed stack frames. The current implementation does not verify the file type or size, so a special file or a large newline-free file can block or consume excessive memory while source context is collected.

Source files outside `process.cwd()` and symlinked workspace files are legitimate in monorepos, serverless layers, and services launched from a different working directory, so the safeguards must preserve that existing behavior.

## Changes

- Normalize relative filenames against the working directory captured for each enrichment pass, keeping successful and failed caches isolated when the working directory changes.
- Continue supporting regular source files anywhere, including absolute paths outside the working directory and symlinked files.
- Open files with nonblocking read flags, validate from the opened descriptor that they are regular files no larger than 10 MiB, and read from that same descriptor so path replacement cannot change what is consumed.
- Bound the stream itself to 10 MiB and close both streams and descriptors on completion, errors, and initialization failures.
- Emit a debug-gated diagnostic when an oversized regular source file is skipped.
- Add coverage for normal, outside-working-directory, symlinked, replaced, oversized, and special files; working-directory changes/removal; cache isolation; and cleanup after early completion and initialization failure.
- Add a patch changeset for `posthog-node`.

Validation performed:

- `cd packages/node && ./node_modules/.bin/jest src/__tests__/extensions/error-conversion.spec.ts --runInBand` (17 tests passed)
- `./node_modules/.bin/eslint packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts packages/node/src/__tests__/extensions/error-conversion.spec.ts` (passed)
- Prettier and `git diff --check` (passed)
- Autoreview against `origin/main` (clean; no actionable findings)
- A direct TypeScript check reported existing errors elsewhere in the package but none in the changed files.
- A direct Rslib build emitted ESM/CJS bundles, then declaration generation hit the worktree's stale `@posthog/core` output (`getInjectedReleaseId` missing); this is unrelated to these changes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human reviewed the original security-hardening approach and chose a narrower reliability-focused design. Pi coding agent implemented and independently reviewed the revision. The final implementation deliberately avoids treating `process.cwd()` as a security boundary, preserving source context for legitimate outside-root and symlinked files while bounding and validating descriptor-based reads.


