### PR TITLE
fix(error-tracking): fail open when a suppression rule cannot be evaluated

### DIFF
--- a/.changeset/tidy-donkeys-repeat.md
+++ b/.changeset/tidy-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fail open when an error tracking suppression rule cannot be evaluated, so an unknown operator or a key outside `$exception_types` / `$exception_values` no longer drops the exception.

--- a/packages/browser/src/__tests__/posthog-exceptions.test.ts
+++ b/packages/browser/src/__tests__/posthog-exceptions.test.ts
@@ -172,6 +172,39 @@ describe('PostHogExceptions', () => {
             expect(captureMock).toBeCalled()
         })
 
+        test.each([
+            [
+                'an operator the SDK does not implement',
+                createSuppressionRule('AND', [
+                    {
+                        key: '$lib',
+                        value: 'is_not_set',
+                        operator: 'is_not_set',
+                        type: 'event_property',
+                    } as unknown as ErrorTrackingSuppressionRuleValue,
+                ]),
+            ],
+            [
+                'a negative operator on a key the SDK cannot resolve',
+                createSuppressionRule('OR', [
+                    {
+                        key: '$host',
+                        value: '(\\.|^)posthog\\.com$',
+                        operator: 'not_regex',
+                        type: 'event_property',
+                    } as unknown as ErrorTrackingSuppressionRuleValue,
+                ]),
+            ],
+            ['values that are not an array', { type: 'AND', values: null } as unknown as ErrorTrackingSuppressionRule],
+        ])('captures the exception when a rule uses %s', (_description, suppressionRule) => {
+            exceptions.onRemoteConfig({
+                ok: true,
+                config: { errorTracking: { suppressionRules: [suppressionRule] } } as RemoteConfig,
+            })
+            exceptions.sendExceptionEvent({ $exception_list: [{ type: 'TypeError', value: 'This is a type error' }] })
+            expect(captureMock).toBeCalled()
+        })
+
         it('captures an exception if there are no targets on the rule', () => {
             const suppressionRule = createSuppressionRule('OR', [
                 {

--- a/packages/browser/src/posthog-exceptions.ts
+++ b/packages/browser/src/posthog-exceptions.ts
@@ -218,31 +218,45 @@ export class PostHogExceptions implements Extension {
             return false
         }
 
-        const exceptionValues = exceptionList.reduce(
-            (acc, { type, value }) => {
-                if (isString(type) && type.length > 0) {
-                    acc['$exception_types'].push(type)
+        try {
+            const exceptionValues = exceptionList.reduce(
+                (acc, { type, value }) => {
+                    if (isString(type) && type.length > 0) {
+                        acc['$exception_types'].push(type)
+                    }
+                    if (isString(value) && value.length > 0) {
+                        acc['$exception_values'].push(value)
+                    }
+                    return acc
+                },
+                {
+                    $exception_types: [] as string[],
+                    $exception_values: [] as string[],
                 }
-                if (isString(value) && value.length > 0) {
-                    acc['$exception_values'].push(value)
-                }
-                return acc
-            },
-            {
-                $exception_types: [] as string[],
-                $exception_values: [] as string[],
-            }
-        )
+            )
 
-        return this._suppressionRules.some((rule) => {
-            const results = rule.values.map((v) => {
-                const compare = propertyComparisons[v.operator]
-                const targets = isArray(v.value) ? v.value : [v.value]
-                const values = exceptionValues[v.key] ?? []
-                return targets.length > 0 ? compare(targets, values) : false
+            return this._suppressionRules.some((rule) => {
+                const results = rule.values.map((v) => {
+                    const compare: ((targets: string[], values: string[]) => boolean) | undefined =
+                        propertyComparisons[v.operator]
+                    const values: string[] | undefined = exceptionValues[v.key]
+
+                    if (!compare || !values) {
+                        return false
+                    }
+
+                    const targets = isArray(v.value) ? v.value : [v.value]
+                    return targets.length > 0 ? compare(targets, values) : false
+                })
+                return rule.type === 'OR' ? results.some(Boolean) : results.every(Boolean)
             })
-            return rule.type === 'OR' ? results.some(Boolean) : results.every(Boolean)
-        })
+        } catch (error) {
+            // Suppression only ever filters what we capture, so failing to evaluate it must not cost
+            // us the exception. Letting this throw reaches the handler in sendExceptionEvent, which
+            // drops the event entirely.
+            logger.warn('Failed to evaluate suppression rules. Capturing the exception.', error)
+            return false
+        }
     }
 
     private _isExtensionException(exceptionList: ErrorTracking.ExceptionList): boolean {


### PR DESCRIPTION
## Problem

`_matchesSuppressionRule` treats remote config as if it matched the declared TypeScript types. It doesn't — the types describe what the server is expected to send, not what it can send. Two ways that goes wrong:

**1. An operator the SDK doesn't implement throws, and the exception is dropped.**

```ts
const compare = propertyComparisons[v.operator]
```

`propertyComparisons` implements `exact`, `is_not`, `regex`, `not_regex`, `icontains`, `not_icontains`, `gt`, `lt`. Anything else (`is_not_set`, `is_set`, date and range operators) reads back as `undefined` and throws on call. The error propagates to the handler in `sendExceptionEvent`:

```ts
} catch (error) {
    logger.error('Failed to process exception event. Ignoring this exception.', error)
    return
}
```

So the exception is discarded. `rule.values.map(...)` evaluates every leaf eagerly, so an `AND` rule whose first leaf is already false still reaches the throwing leaf. One such rule suppresses effectively all browser exception capture for the team, silently, until the rule changes.

**2. A key the matcher can't resolve reads as a match under the negative operators.**

`exceptionValues` only holds `$exception_types` and `$exception_values`, both derived from `$exception_list`. Any other key falls back to `[]`. The negative operators are `every`-based, and `[].every(...)` is `true`, so a leaf like `$host not_regex <pattern>` evaluates to true for every exception. Under `OR` that alone suppresses everything — and inverts the rule's intent, since the pattern was there to spare matching hosts.

Worth noting these keys aren't merely missing: `$lib` and `$host` don't exist yet at this point in the pipeline. They're added by `calculateEventProperties` inside `capture()`, which runs after the suppression check.

## Change

Skip leaves that can't be evaluated instead of matching or throwing on them, and wrap the matcher so anything left over captures the exception rather than losing it.

```ts
const compare: ((targets: string[], values: string[]) => boolean) | undefined = propertyComparisons[v.operator]
const values: string[] | undefined = exceptionValues[v.key]

if (!compare || !values) {
    return false
}
```

Returning `false` for the leaf is fail-open in both directions: under `AND` the rule stops matching, under `OR` it degrades to the leaves that can be evaluated. Suppression only ever filters what we capture, so its failure mode should be capturing too much, never too little.

## Notes for reviewers

- Behavior for rules that were already evaluable is unchanged.
- `ErrorTrackingSuppressionRuleValue` declares `key: '$exception_types' | '$exception_values'` and `operator: PropertyMatchType`. That's why neither case was caught at compile time. Widening it to reflect what the wire can actually carry is worth doing separately, since it's an exported type.
- `surveys-extension-utils.tsx` and `product-tours.tsx` index `propertyComparisons` unguarded in the same way. They haven't been handed an unknown operator yet, but the same guard applies. Left out to keep this scoped to error tracking.
- The matcher still ignores `samplingRate`, so a client-side match drops 100% rather than the configured share. Separate fix.

## How did you test this code?

Three cases added to `posthog-exceptions.test.ts`, covering an unimplemented operator, a negative operator on an unresolvable key, and a rule whose `values` isn't an array. Each maps to one of the guards. Verified all three fail on `main` and pass with the change; the rest of the file's 24 cases pass either way.

Local `pnpm install` couldn't run in my environment (TLS interception), so eslint and a full workspace typecheck weren't run locally — prettier and the unit suite were. Leaving those to CI.
