### PR TITLE
fix(mcp): redact sensitive binary payloads

### DIFF
--- a/.changeset/secure-data-redact.md
+++ b/.changeset/secure-data-redact.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': patch
+---
+
+Redact sensitive exception messages and large binary payload encodings from MCP analytics.

--- a/packages/mcp/src/__tests__/e2e-sanitization.test.ts
+++ b/packages/mcp/src/__tests__/e2e-sanitization.test.ts
@@ -123,7 +123,7 @@ describe('E2E Sanitization - real MCP tool calls', () => {
     }
   })
 
-  it('should sanitize large base64 strings in tool call parameters', async () => {
+  it('should sanitize large binary encodings without redacting ordinary long text in tool call parameters', async () => {
     resetTodos()
     const { server, client, cleanup } = await setupTestServerAndClient()
 
@@ -141,22 +141,29 @@ describe('E2E Sanitization - real MCP tool calls', () => {
         'Upload a file as base64',
         {
           filename: z.string(),
-          data: z.string().describe('Base64-encoded file data'),
+          classicBase64: z.string().describe('Base64-encoded file data'),
+          base64Url: z.string().describe('Base64url-encoded file data'),
+          dataUrl: z.string().describe('Base64 data URL'),
+          longText: z.string(),
         },
         async (args) => ({
           content: [{ type: 'text', text: `Uploaded ${args.filename} successfully` }],
         })
       )
 
-      // Create a large base64 string (>10KB to trigger the size gate)
-      const largeBase64 = `${'A'.repeat(12_000)}=`
+      // Each binary representation exceeds the 10KB size gate.
+      const classicBase64 = `${'A'.repeat(12_000)}=`
+      const base64Url = Buffer.from(Array.from({ length: 9_000 }, (_, index) => index % 256)).toString('base64url')
+      const wrappedPayload = `${'A'.repeat(11_999)}=`.match(/.{1,76}/g)!.join('\r\n')
+      const dataUrl = `data:image/png;base64,${wrappedPayload}`
+      const longText = 'This is ordinary long text with words and punctuation. '.repeat(250)
 
       await client.request(
         {
           method: 'tools/call',
           params: {
             name: 'upload_file',
-            arguments: { filename: 'photo.png', data: largeBase64 },
+            arguments: { filename: 'photo.png', classicBase64, base64Url, dataUrl, longText },
           },
         },
         CallToolResultSchema
@@ -170,10 +177,11 @@ describe('E2E Sanitization - real MCP tool calls', () => {
       )
 
       expect(toolEvent).toBeDefined()
-      // The base64 param should be redacted in the captured event's parameters
       const args = toolEvent!.parameters?.request?.params?.arguments
-      expect(args.data).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
-      // Non-base64 params should be preserved
+      expect(args.classicBase64).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+      expect(args.base64Url).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+      expect(args.dataUrl).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+      expect(args.longText).toBe(longText)
       expect(args.filename).toBe('photo.png')
 
       await eventCapture.stop()

--- a/packages/mcp/src/__tests__/error-capture.test.ts
+++ b/packages/mcp/src/__tests__/error-capture.test.ts
@@ -55,6 +55,40 @@ describe('error capture on the tool-call path', () => {
     expect(exception?.stacktrace?.frames?.length).toBeGreaterThan(0)
   })
 
+  it('redacts PostHog tokens from both emitted error-message properties', async () => {
+    instrument(server, fakePostHog())
+    const projectToken = 'phc_123456789012345678901234567890'
+    const personalToken = 'phx_abcdefghijklmnopqrstuvwxyz1234'
+
+    server.tool!('secret_error', 'throws a sensitive error', {}, async () => {
+      throw new Error(`Project token ${projectToken} and personal token ${personalToken}`)
+    })
+
+    const result = await client.request(
+      {
+        method: 'tools/call',
+        params: { name: 'secret_error', arguments: {} },
+      },
+      CallToolResultSchema
+    )
+
+    // Sanitization applies only to analytics and must not alter the MCP result.
+    expect(result.content[0].text).toContain(projectToken)
+    await new Promise((r) => setTimeout(r, 50))
+
+    const toolCall = capture
+      .findCapturesByEvent('$mcp_tool_call')
+      .find((event) => event.properties.$mcp_tool_name === 'secret_error')
+    const exception = capture
+      .findCapturesByEvent('$exception')
+      .find((event) => event.properties.$mcp_tool_name === 'secret_error')
+    const expected = 'Project token [redacted] and personal token [redacted]'
+    const exceptionList = exception?.properties.$exception_list as Array<{ value: string }> | undefined
+
+    expect(toolCall?.properties.$mcp_error_message).toBe(expected)
+    expect(exceptionList?.[0].value).toBe(expected)
+  })
+
   it('still propagates the error result to the MCP client (does not swallow it)', async () => {
     instrument(server, fakePostHog())
 

--- a/packages/mcp/src/__tests__/sanitization.test.ts
+++ b/packages/mcp/src/__tests__/sanitization.test.ts
@@ -5,6 +5,16 @@ function makeLargeBase64(sizeInChars = 12_000): string {
   return `${'A'.repeat(sizeInChars - 1)}=`
 }
 
+function makeLargeBase64Url(sizeInBytes = 9_000): string {
+  return Buffer.from(Array.from({ length: sizeInBytes }, (_, index) => index % 256)).toString('base64url')
+}
+
+function makeLargeBase64DataUrl(sizeInChars = 12_000, lineEnding?: '\n' | '\r\n'): string {
+  const payload = makeLargeBase64(sizeInChars)
+  const encodedPayload = lineEnding ? payload.match(/.{1,76}/g)!.join(lineEnding) : payload
+  return `data:image/png;base64,${encodedPayload}`
+}
+
 function makeLargeNonBase64(sizeInChars = 12_000): string {
   return 'Hello, world! This is NOT base64. '.repeat(Math.ceil(sizeInChars / 34))
 }
@@ -233,6 +243,82 @@ describe('sanitizeEvent - parameter scanning', () => {
     expect(result.parameters.imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
   })
 
+  it('should redact large base64url strings (>10KB)', () => {
+    const largeBase64Url = makeLargeBase64Url()
+
+    const event = makeEvent({
+      parameters: { imageData: largeBase64Url },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+  })
+
+  it('should redact valid low-entropy base64url strings', () => {
+    const largeBase64Url = Buffer.alloc(9_000, 0xff).toString('base64url')
+
+    const event = makeEvent({
+      parameters: { imageData: largeBase64Url },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+  })
+
+  it('should redact large base64 data URLs (>10KB)', () => {
+    const largeDataUrl = makeLargeBase64DataUrl()
+
+    const event = makeEvent({
+      parameters: { imageData: largeDataUrl },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+  })
+
+  it.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n'],
+  ] as const)('should redact large base64 data URLs with %s-wrapped payloads', (_name, lineEnding) => {
+    const wrappedDataUrl = makeLargeBase64DataUrl(12_000, lineEnding)
+
+    const event = makeEvent({
+      parameters: { imageData: wrappedDataUrl },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+  })
+
+  it('should redact large base64 data URLs with percent-encoded payload characters', () => {
+    const payload = Buffer.from(Array.from({ length: 9_000 }, (_, index) => index % 256)).toString('base64')
+    const encodedPayload = payload.replace(/[+/=]/g, (character) => `%${character.charCodeAt(0).toString(16)}`)
+    const dataUrl = `data:application/octet-stream;base64,${encodedPayload}`
+
+    const result = sanitizeEvent(makeEvent({ parameters: { dataUrl } }))
+
+    expect(result.parameters.dataUrl).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+  })
+
+  it('should leave long non-base64 data URLs and CRLF-wrapped ordinary text unchanged', () => {
+    const dataUrlWithoutBase64 = `data:text/plain,${'ordinary text payload!'.repeat(600)}`
+    const invalidBase64DataUrl = `data:text/plain;base64,${'ordinary text payload!'.repeat(600)}`
+    const malformedDataUrl = `data:application/octet-stream;base64,${'AAAA%ZZ'.repeat(1_500)}`
+    const ordinaryText = `${'This is ordinary prose, not encoded data. '.repeat(150)}\r\n${'More ordinary prose. '.repeat(300)}`
+
+    const event = makeEvent({
+      parameters: { dataUrlWithoutBase64, invalidBase64DataUrl, malformedDataUrl, ordinaryText },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters).toEqual({ dataUrlWithoutBase64, invalidBase64DataUrl, malformedDataUrl, ordinaryText })
+  })
+
   it('should leave large non-base64 strings unchanged', () => {
     const largeText = makeLargeNonBase64()
 
@@ -326,6 +412,37 @@ describe('sanitizeEvent - parameter scanning', () => {
 
     expect(resultNull.parameters).toBeNull()
     expect(resultUndef.parameters).toBeUndefined()
+  })
+})
+
+describe('sanitizeEvent - exception values', () => {
+  it('should redact PostHog tokens from every exception value without mutating the original', () => {
+    const event = makeEvent({
+      isError: true,
+      error: {
+        $exception_list: [
+          {
+            type: 'Error',
+            value: 'Project token phc_123456789012345678901234567890',
+            mechanism: { type: 'generic', handled: true },
+          },
+          {
+            type: 'Error',
+            value: 'Personal token phx_abcdefghijklmnopqrstuvwxyz1234',
+            mechanism: { type: 'generic', handled: true },
+          },
+        ],
+        $exception_level: 'error',
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.error?.$exception_list.map((exception) => exception.value)).toEqual([
+      'Project token [redacted]',
+      'Personal token [redacted]',
+    ])
+    expect(event.error?.$exception_list[0].value).toContain('phc_')
   })
 })
 

--- a/packages/mcp/src/extensions/mcp-payloads.ts
+++ b/packages/mcp/src/extensions/mcp-payloads.ts
@@ -5,7 +5,12 @@
 
 const CONTEXT_ARGUMENT_NAME = 'context'
 const REDACTED_VALUE = '[redacted]'
+const BINARY_REDACTED_VALUE = '[binary data redacted - not supported by PostHog MCP analytics]'
 const BASE64_PATTERN = /^[A-Za-z0-9+/\n\r]+=*$/
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+={0,2}$/
+const BASE64URL_SPECIFIC_CHAR_PATTERN = /[-_]/
+const BASE64_DATA_URL_PREFIX_PATTERN = /^data:[^,\s]*;base64,/i
+const BASE64_DATA_URL_PAYLOAD_PATTERN = /^[A-Za-z0-9+/_-]+={0,2}$/
 const SIZE_GATE = 10_240
 const POSTHOG_TOKEN_PATTERN = /\bph[a-z]_[A-Za-z0-9_-]{20,}\b/g
 const SENSITIVE_KEY_PATTERN =
@@ -21,9 +26,30 @@ function shouldRedactKey(key: string): boolean {
   return SENSITIVE_KEY_PATTERN.test(key)
 }
 
+function isBase64DataUrl(value: string): boolean {
+  const prefix = BASE64_DATA_URL_PREFIX_PATTERN.exec(value)
+  if (!prefix) {
+    return false
+  }
+
+  let payload: string
+  try {
+    payload = decodeURIComponent(value.slice(prefix[0].length))
+  } catch {
+    return false
+  }
+
+  return BASE64_DATA_URL_PAYLOAD_PATTERN.test(payload.replace(/[\r\n]/g, ''))
+}
+
 function sanitizeString(value: string): string {
-  if (value.length >= SIZE_GATE && BASE64_PATTERN.test(value)) {
-    return '[binary data redacted - not supported by PostHog MCP analytics]'
+  if (
+    value.length >= SIZE_GATE &&
+    (BASE64_PATTERN.test(value) ||
+      isBase64DataUrl(value) ||
+      (BASE64URL_SPECIFIC_CHAR_PATTERN.test(value) && BASE64URL_PATTERN.test(value)))
+  ) {
+    return BINARY_REDACTED_VALUE
   }
   return value.replace(POSTHOG_TOKEN_PATTERN, REDACTED_VALUE)
 }

--- a/packages/mcp/src/extensions/sanitization.ts
+++ b/packages/mcp/src/extensions/sanitization.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2025 AgentCat, Inc. (formerly MCPcat)
 // Licensed under the MIT License: https://github.com/agentcathq/agentcat-typescript-sdk/blob/main/LICENSE
 
-import type { Event, McpEvent } from '../types'
+import type { ErrorProperties, Event, McpEvent } from '../types'
 import { sanitizeCapturedValue } from './mcp-payloads'
 
 type SanitizedRecord = Record<string, unknown>
@@ -39,7 +39,29 @@ export function sanitizeEvent<T extends Event | McpEvent>(event: T): T {
     result.userIntent = sanitizeCapturedValue(result.userIntent) as string
   }
 
+  if (result.error != null) {
+    result.error = sanitizeExceptionValues(result.error)
+  }
+
   return result
+}
+
+/**
+ * Sanitizes exception messages before they fan out to both the primary MCP
+ * event's error-message property and the `$exception` sibling.
+ */
+function sanitizeExceptionValues(error: ErrorProperties): ErrorProperties {
+  if (!Array.isArray(error.$exception_list)) {
+    return error
+  }
+
+  return {
+    ...error,
+    $exception_list: error.$exception_list.map((exception) => ({
+      ...exception,
+      value: sanitizeCapturedValue(exception.value) as string,
+    })),
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

MCP analytics sanitization could allow sensitive data to reach PostHog when PostHog tokens appeared in captured exception messages or when large binary payloads used base64url or base64 data-URL encodings rather than classic base64.

## Changes

- Sanitize exception values before they fan out to both `$mcp_error_message` on MCP events and the sibling `$exception` event.
- Extend the existing size-gated binary redaction to cover classic base64, base64url, and base64 data URLs, including line-wrapped and percent-encoded payloads.
- Add unit and end-to-end coverage for exception-token redaction, base64/base64url/data-URL payloads, and preservation of ordinary long text.
- Keep detection intentionally heuristic and size-gated: payloads below the threshold or in unrecognized encodings are not classified as binary unless another sanitizer rule applies.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common
- [x] @posthog/mcp

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed the scoped fix and PR submission. The Pi coding agent (OpenAI) reviewed the existing implementation, added the requested changeset, ran the MCP test/lint/build validation, and prepared this draft PR. The implementation retains the existing size-gated heuristic rather than broadening redaction to all long strings, to limit false positives.
