### PR TITLE
fix(ai): handle Vercel stream failures

### DIFF
--- a/.changeset/steady-vercel-streams.md
+++ b/.changeset/steady-vercel-streams.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Handle Vercel AI stream errors and cancellation exactly once.

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -628,85 +628,101 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
           }
         >()
 
+        const captureStreamGeneration = async (
+          captureOptions: Parameters<typeof captureAiGeneration>[1]
+        ): Promise<void> => {
+          try {
+            await captureAiGeneration(phClient, captureOptions)
+          } catch {
+            // Telemetry must never change the provider stream's behavior.
+          }
+        }
+
         try {
           const { stream, ...rest } = await model.doStream(params as any)
-          const transformStream = new TransformStream<LanguageModelStreamPart, LanguageModelStreamPart>({
-            transform(chunk, controller) {
-              // Handle streaming patterns - compatible with both V2 and V3
-              if (chunk.type === 'text-delta') {
-                if (firstTokenTime === undefined) {
-                  firstTokenTime = Date.now()
-                }
-                generatedText += chunk.delta
+          const reader = stream.getReader()
+          let inBandError: unknown
+          let hasInBandError = false
+          let finalizationPromise: Promise<void> | undefined
+
+          const observeChunk = (chunk: LanguageModelStreamPart): void => {
+            // Handle streaming patterns - compatible with both V2 and V3
+            if (chunk.type === 'text-delta') {
+              if (firstTokenTime === undefined) {
+                firstTokenTime = Date.now()
               }
-              if (chunk.type === 'reasoning-delta') {
-                if (firstTokenTime === undefined) {
-                  firstTokenTime = Date.now()
-                }
-                reasoningText += chunk.delta
+              generatedText += chunk.delta
+            }
+            if (chunk.type === 'reasoning-delta') {
+              if (firstTokenTime === undefined) {
+                firstTokenTime = Date.now()
+              }
+              reasoningText += chunk.delta
+            }
+
+            // Handle tool call chunks
+            if (chunk.type === 'tool-input-start') {
+              if (firstTokenTime === undefined) {
+                firstTokenTime = Date.now()
+              }
+              toolCallsInProgress.set(chunk.id, {
+                toolCallId: chunk.id,
+                toolName: chunk.toolName,
+                input: '',
+              })
+            }
+            if (chunk.type === 'tool-input-delta') {
+              const toolCall = toolCallsInProgress.get(chunk.id)
+              if (toolCall) {
+                toolCall.input += chunk.delta
+              }
+            }
+            if (chunk.type === 'tool-call') {
+              if (firstTokenTime === undefined) {
+                firstTokenTime = Date.now()
+              }
+              toolCallsInProgress.set(chunk.toolCallId, {
+                toolCallId: chunk.toolCallId,
+                toolName: chunk.toolName,
+                input: chunk.input,
+              })
+            }
+
+            if (chunk.type === 'error') {
+              hasInBandError = true
+              inBandError = chunk.error
+            }
+
+            if (chunk.type === 'finish') {
+              providerMetadata = chunk.providerMetadata
+              const chunkUsage = (chunk.usage as Record<string, unknown>) || {}
+              const additionalTokenValues = extractAdditionalTokenValues(providerMetadata, chunkUsage)
+              usage = {
+                inputTokens: extractTokenCount(chunk.usage?.inputTokens),
+                outputTokens: extractTokenCount(chunk.usage?.outputTokens),
+                reasoningTokens: extractReasoningTokens(chunkUsage),
+                cacheReadInputTokens: extractCacheReadTokens(chunkUsage),
+                ...additionalTokenValues,
               }
 
-              // Handle tool call chunks
-              if (chunk.type === 'tool-input-start') {
-                if (firstTokenTime === undefined) {
-                  firstTokenTime = Date.now()
-                }
-                // Initialize a new tool call
-                toolCallsInProgress.set(chunk.id, {
-                  toolCallId: chunk.id,
-                  toolName: chunk.toolName,
-                  input: '',
-                })
+              // Extract finish reason - V2 returns a string, V3 returns an object with .unified
+              const rawFinishReason = chunk.finishReason
+              if (typeof rawFinishReason === 'string') {
+                stopReason = rawFinishReason
+              } else if (rawFinishReason && typeof rawFinishReason === 'object' && 'unified' in rawFinishReason) {
+                stopReason = String(rawFinishReason.unified)
               }
-              if (chunk.type === 'tool-input-delta') {
-                // Accumulate tool call arguments
-                const toolCall = toolCallsInProgress.get(chunk.id)
-                if (toolCall) {
-                  toolCall.input += chunk.delta
-                }
-              }
-              if (chunk.type === 'tool-input-end') {
-                // Tool call is complete, keep it in the map for final processing
-              }
-              if (chunk.type === 'tool-call') {
-                if (firstTokenTime === undefined) {
-                  firstTokenTime = Date.now()
-                }
-                // Direct tool call chunk (complete tool call)
-                toolCallsInProgress.set(chunk.toolCallId, {
-                  toolCallId: chunk.toolCallId,
-                  toolName: chunk.toolName,
-                  input: chunk.input,
-                })
-              }
+            }
+          }
 
-              if (chunk.type === 'finish') {
-                providerMetadata = chunk.providerMetadata
-                const chunkUsage = (chunk.usage as Record<string, unknown>) || {}
-                const additionalTokenValues = extractAdditionalTokenValues(providerMetadata, chunkUsage)
-                usage = {
-                  inputTokens: extractTokenCount(chunk.usage?.inputTokens),
-                  outputTokens: extractTokenCount(chunk.usage?.outputTokens),
-                  reasoningTokens: extractReasoningTokens(chunkUsage),
-                  cacheReadInputTokens: extractCacheReadTokens(chunkUsage),
-                  ...additionalTokenValues,
-                }
+          const finalize = (terminalError?: unknown, isError = false): Promise<void> => {
+            if (finalizationPromise) {
+              return finalizationPromise
+            }
 
-                // Extract finish reason - V2 returns a string, V3 returns an object with .unified
-                const rawFinishReason = chunk.finishReason
-                if (typeof rawFinishReason === 'string') {
-                  stopReason = rawFinishReason
-                } else if (rawFinishReason && typeof rawFinishReason === 'object' && 'unified' in rawFinishReason) {
-                  stopReason = String(rawFinishReason.unified)
-                }
-              }
-              controller.enqueue(chunk)
-            },
-
-            flush: async () => {
+            finalizationPromise = (async () => {
               const latency = (Date.now() - startTime) / 1000
               const timeToFirstToken = firstTokenTime !== undefined ? (firstTokenTime - startTime) / 1000 : undefined
-              // Build content array similar to mapVercelOutput structure
               const content: OutputContentItem[] = []
               if (reasoningText) {
                 content.push({ type: 'reasoning', text: truncate(reasoningText) })
@@ -715,7 +731,6 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
                 content.push({ type: 'text', text: truncate(generatedText) })
               }
 
-              // Add completed tool calls to content
               for (const toolCall of toolCallsInProgress.values()) {
                 if (toolCall.toolName) {
                   content.push({
@@ -729,7 +744,6 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
                 }
               }
 
-              // Structure output like mapVercelOutput does
               const output =
                 content.length > 0
                   ? [
@@ -741,40 +755,83 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
                   : []
 
               const webSearchCount = extractWebSearchCount(providerMetadata, usage)
-
-              // Update usage with web search count and raw metadata
               const finalUsage = {
                 ...usage,
                 webSearchCount,
                 rawUsage: { usage, providerMetadata },
               }
-
               adjustAnthropicV3CacheTokens(model, modelId, provider, finalUsage)
 
-              await captureAiGeneration(phClient, {
+              const finishError =
+                stopReason === 'error' ? new Error('Vercel AI SDK stream finished with an error') : undefined
+              const error = isError
+                ? (terminalError ?? new Error('Vercel AI SDK stream failed'))
+                : hasInBandError
+                  ? (inBandError ?? new Error('Vercel AI SDK stream emitted an error chunk'))
+                  : finishError
+
+              await captureStreamGeneration({
                 ...baseOptions,
                 model: modelId,
                 provider: provider,
                 input: mergedOptions.posthogPrivacyMode ? '' : mapVercelPrompt(params.prompt as LanguageModelPrompt),
-                output: output,
+                output,
                 latency,
                 timeToFirstToken,
                 baseURL,
                 modelParameters: getModelParams(mergedParams as any),
-                httpStatus: 200,
+                httpStatus: error ? undefined : 200,
                 usage: finalUsage,
                 stopReason,
+                error,
                 tools: availableTools,
               })
+            })().catch(() => {
+              // Building telemetry must not change the provider stream's behavior.
+            })
+
+            return finalizationPromise
+          }
+
+          const instrumentedStream = new ReadableStream<LanguageModelStreamPart>(
+            {
+              async pull(controller) {
+                let result: ReadableStreamReadResult<LanguageModelStreamPart>
+                try {
+                  result = await reader.read()
+                } catch (error: unknown) {
+                  void finalize(error, true)
+                  controller.error(error)
+                  return
+                }
+
+                if (result.done) {
+                  await finalize()
+                  controller.close()
+                  return
+                }
+
+                try {
+                  observeChunk(result.value)
+                } catch {
+                  // Instrumentation must not alter or suppress provider chunks.
+                }
+                controller.enqueue(result.value)
+              },
+              cancel(reason) {
+                void finalize(reason ?? new Error('Vercel AI SDK stream was cancelled'), true)
+                return reader.cancel(reason)
+              },
             },
-          })
+            { highWaterMark: 0 }
+          )
 
           return {
-            stream: stream.pipeThrough(transformStream),
+            stream: instrumentedStream,
             ...rest,
           }
         } catch (error: unknown) {
-          await captureAiGeneration(phClient, {
+          await captureStreamGeneration({
             ...baseOptions,
             model: modelId,
             provider: provider,

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -806,8 +806,8 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
                 }
 
                 if (result.done) {
-                  await finalize()
                   controller.close()
+                  void finalize()
                   return
                 }
 

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -633,8 +633,9 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
         ): Promise<void> => {
           try {
             await captureAiGeneration(phClient, captureOptions)
-          } catch {
+          } catch (error: unknown) {
             // Telemetry must never change the provider stream's behavior.
+            console.warn('[PostHog AI] Failed to capture Vercel stream telemetry:', error)
           }
         }
 
@@ -786,8 +787,9 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
                 error,
                 tools: availableTools,
               })
-            })().catch(() => {
+            })().catch((error: unknown) => {
               // Building telemetry must not change the provider stream's behavior.
+              console.warn('[PostHog AI] Failed to capture Vercel stream telemetry:', error)
             })
 
             return finalizationPromise

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -40,6 +40,21 @@ const v3TokenUsage = (input: number, output: number, reasoning?: number) => ({
   outputTokens: { total: output, text: output - (reasoning ?? 0), reasoning: reasoning },
 })
 
+const settlePromptly = async <T>(promise: Promise<T>): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error('Operation did not settle promptly')), 250)
+  })
+
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
 // Create a mock V3 model (AI SDK 6)
 const createMockV3Model = (modelId: string): LanguageModelV3 => {
   const mockResponses = {
@@ -547,6 +562,250 @@ describe('Vercel AI SDK - Dual Version Support', () => {
           $ai_provider: 'openai',
         })
       )
+    })
+
+    it.each(['v2', 'v3'] as const)(
+      'should capture in-band error chunks with partial output in %s streams',
+      async (version) => {
+        const streamError = new Error('provider error chunk')
+        const streamParts = [
+          { type: 'text-delta' as const, id: 'text-1', delta: 'partial response' },
+          { type: 'error' as const, error: streamError },
+        ]
+        const baseModel = createMockStreamingModel(version, streamParts as any)
+        const model = withTracing(baseModel, mockPostHogClient, {
+          posthogDistinctId: 'test-user',
+          posthogTraceId: `test-${version}-error-chunk`,
+        })
+
+        const result = await model.doStream({ prompt: [] })
+        const receivedParts: unknown[] = []
+        const reader = result.stream.getReader()
+        for (;;) {
+          const readResult = await reader.read()
+          if (readResult.done) {
+            break
+          }
+          receivedParts.push(readResult.value)
+        }
+
+        expect(receivedParts).toEqual(streamParts)
+        expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+        const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+        expect(captureCall[0].properties).toEqual(
+          expect.objectContaining({
+            $ai_is_error: true,
+            $ai_error: expect.stringContaining('provider error chunk'),
+            $ai_output_choices: [{ role: 'assistant', content: 'partial response' }],
+          })
+        )
+      }
+    )
+
+    it.each(['v2', 'v3'] as const)(
+      'should capture error finish reasons with partial output in %s streams',
+      async (version) => {
+        const finishPart =
+          version === 'v2'
+            ? {
+                type: 'finish' as const,
+                usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 },
+                finishReason: 'error' as const,
+              }
+            : {
+                type: 'finish' as const,
+                usage: v3TokenUsage(4, 2),
+                finishReason: { unified: 'error' as const, raw: 'provider_error' },
+              }
+        const streamParts = [{ type: 'text-delta' as const, id: 'text-1', delta: 'partial response' }, finishPart]
+        const baseModel = createMockStreamingModel(version, streamParts as any)
+        const model = withTracing(baseModel, mockPostHogClient, {
+          posthogDistinctId: 'test-user',
+          posthogTraceId: `test-${version}-error-finish`,
+        })
+
+        const result = await model.doStream({ prompt: [] })
+        const receivedParts: unknown[] = []
+        const reader = result.stream.getReader()
+        for (;;) {
+          const readResult = await reader.read()
+          if (readResult.done) {
+            break
+          }
+          receivedParts.push(readResult.value)
+        }
+
+        expect(receivedParts).toEqual(streamParts)
+        expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+        const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+        expect(captureCall[0].properties).toEqual(
+          expect.objectContaining({
+            $ai_is_error: true,
+            $ai_error: expect.stringContaining('stream finished with an error'),
+            $ai_stop_reason: 'error',
+            $ai_output_choices: [{ role: 'assistant', content: 'partial response' }],
+          })
+        )
+      }
+    )
+
+    it.each(['v2', 'v3'] as const)(
+      'should preserve source errors and capture partial output once in %s streams',
+      async (version) => {
+        const sourceError = new Error('source stream failed')
+        let pullCount = 0
+        const sourceStream = new ReadableStream({
+          pull(controller) {
+            if (pullCount++ === 0) {
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'partial response' })
+            } else {
+              controller.error(sourceError)
+            }
+          },
+        })
+        const baseModel = createMockStreamingModel(version, [] as any) as any
+        baseModel.doStream = jest.fn().mockResolvedValue({ stream: sourceStream })
+        const model = withTracing(baseModel, mockPostHogClient, {
+          posthogDistinctId: 'test-user',
+          posthogTraceId: `test-${version}-source-error`,
+        })
+
+        const result = await model.doStream({ prompt: [] })
+        const reader = result.stream.getReader()
+        expect(await reader.read()).toEqual({
+          done: false,
+          value: { type: 'text-delta', id: 'text-1', delta: 'partial response' },
+        })
+        await expect(reader.read()).rejects.toBe(sourceError)
+
+        expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+        const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+        expect(captureCall[0].properties).toEqual(
+          expect.objectContaining({
+            $ai_is_error: true,
+            $ai_error: expect.stringContaining('source stream failed'),
+            $ai_output_choices: [{ role: 'assistant', content: 'partial response' }],
+          })
+        )
+      }
+    )
+
+    it.each(['v2', 'v3'] as const)(
+      'should propagate cancellation and capture partial output once in %s streams',
+      async (version) => {
+        const cancelSource = jest.fn()
+        const sourceStream = new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'partial response' })
+          },
+          cancel: cancelSource,
+        })
+        const baseModel = createMockStreamingModel(version, [] as any) as any
+        baseModel.doStream = jest.fn().mockResolvedValue({ stream: sourceStream })
+        const model = withTracing(baseModel, mockPostHogClient, {
+          posthogDistinctId: 'test-user',
+          posthogTraceId: `test-${version}-cancel`,
+        })
+        const cancelReason = new Error('consumer cancelled')
+
+        const result = await model.doStream({ prompt: [] })
+        const reader = result.stream.getReader()
+        expect((await reader.read()).done).toBe(false)
+        await reader.cancel(cancelReason)
+
+        expect(cancelSource).toHaveBeenCalledTimes(1)
+        expect(cancelSource).toHaveBeenCalledWith(cancelReason)
+        expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+        const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+        expect(captureCall[0].properties).toEqual(
+          expect.objectContaining({
+            $ai_is_error: true,
+            $ai_error: expect.stringContaining('consumer cancelled'),
+            $ai_output_choices: [{ role: 'assistant', content: 'partial response' }],
+          })
+        )
+      }
+    )
+
+    it.each(['v2', 'v3'] as const)(
+      'should reject reads promptly when immediate telemetry never settles in %s streams',
+      async (version) => {
+        const sourceError = new Error('source stream failed')
+        const sourceStream = new ReadableStream({
+          pull(controller) {
+            controller.error(sourceError)
+          },
+        })
+        const baseModel = createMockStreamingModel(version, [] as any) as any
+        baseModel.doStream = jest.fn().mockResolvedValue({ stream: sourceStream })
+        ;(mockPostHogClient.captureImmediate as jest.Mock).mockReturnValue(new Promise<void>(() => undefined))
+        const model = withTracing(baseModel, mockPostHogClient, {
+          posthogDistinctId: 'test-user',
+          posthogTraceId: `test-${version}-nonblocking-source-error`,
+          posthogCaptureImmediate: true,
+        })
+
+        const result = await model.doStream({ prompt: [] })
+        const reader = result.stream.getReader()
+        await expect(settlePromptly(reader.read())).rejects.toBe(sourceError)
+        await flushPromises()
+
+        expect(mockPostHogClient.captureImmediate).toHaveBeenCalledTimes(1)
+        expect(mockPostHogClient.capture).not.toHaveBeenCalled()
+      }
+    )
+
+    it.each(['v2', 'v3'] as const)(
+      'should cancel promptly when immediate telemetry never settles in %s streams',
+      async (version) => {
+        const cancelSource = jest.fn()
+        const sourceStream = new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'partial response' })
+          },
+          cancel: cancelSource,
+        })
+        const baseModel = createMockStreamingModel(version, [] as any) as any
+        baseModel.doStream = jest.fn().mockResolvedValue({ stream: sourceStream })
+        ;(mockPostHogClient.captureImmediate as jest.Mock).mockReturnValue(new Promise<void>(() => undefined))
+        const model = withTracing(baseModel, mockPostHogClient, {
+          posthogDistinctId: 'test-user',
+          posthogTraceId: `test-${version}-nonblocking-cancel`,
+          posthogCaptureImmediate: true,
+        })
+        const cancelReason = new Error('consumer cancelled')
+
+        const result = await model.doStream({ prompt: [] })
+        const reader = result.stream.getReader()
+        expect((await reader.read()).done).toBe(false)
+        await expect(settlePromptly(reader.cancel(cancelReason))).resolves.toBeUndefined()
+        await flushPromises()
+
+        expect(cancelSource).toHaveBeenCalledTimes(1)
+        expect(cancelSource).toHaveBeenCalledWith(cancelReason)
+        expect(mockPostHogClient.captureImmediate).toHaveBeenCalledTimes(1)
+        expect(mockPostHogClient.capture).not.toHaveBeenCalled()
+      }
+    )
+
+    it.each(['v2', 'v3'] as const)('should not fail %s streams when immediate telemetry rejects', async (version) => {
+      const telemetryError = new Error('telemetry delivery failed')
+      ;(mockPostHogClient.captureImmediate as jest.Mock).mockRejectedValue(telemetryError)
+      const streamParts = [{ type: 'text-delta' as const, id: 'text-1', delta: 'unchanged' }]
+      const baseModel = createMockStreamingModel(version, streamParts as any)
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: `test-${version}-telemetry-error`,
+        posthogCaptureImmediate: true,
+      })
+
+      const result = await model.doStream({ prompt: [] })
+      const reader = result.stream.getReader()
+      await expect(reader.read()).resolves.toEqual({ done: false, value: streamParts[0] })
+      await expect(reader.read()).resolves.toEqual({ done: true, value: undefined })
+
+      expect(mockPostHogClient.captureImmediate).toHaveBeenCalledTimes(1)
+      expect(mockPostHogClient.capture).not.toHaveBeenCalled()
     })
 
     it.each([

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -740,7 +740,9 @@ describe('Vercel AI SDK - Dual Version Support', () => {
         })
 
         const result = await model.doStream({ prompt: [] })
-        const reader = result.stream.getReader()
+        const reader = (
+          result.stream as ReadableStream<LanguageModelV2StreamPart | LanguageModelV3StreamPart>
+        ).getReader()
         await expect(reader.read()).resolves.toEqual({ done: false, value: streamParts[0] })
         await expect(settlePromptly(reader.read())).resolves.toEqual({ done: true, value: undefined })
         await flushPromises()

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -196,6 +196,10 @@ describe('Vercel AI SDK - Dual Version Support', () => {
     mockPostHogClient = new (PostHog as any)()
   })
 
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   describe('V3 Model (AI SDK 6)', () => {
     it('should wrap a V3 model and track generation', async () => {
       const baseModel = createMockV3Model('gpt-4')
@@ -815,6 +819,7 @@ describe('Vercel AI SDK - Dual Version Support', () => {
 
     it.each(['v2', 'v3'] as const)('should not fail %s streams when immediate telemetry rejects', async (version) => {
       const telemetryError = new Error('telemetry delivery failed')
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
       ;(mockPostHogClient.captureImmediate as jest.Mock).mockRejectedValue(telemetryError)
       const streamParts = [{ type: 'text-delta' as const, id: 'text-1', delta: 'unchanged' }]
       const baseModel = createMockStreamingModel(version, streamParts as any)
@@ -828,9 +833,11 @@ describe('Vercel AI SDK - Dual Version Support', () => {
       const reader = result.stream.getReader()
       await expect(reader.read()).resolves.toEqual({ done: false, value: streamParts[0] })
       await expect(reader.read()).resolves.toEqual({ done: true, value: undefined })
+      await flushPromises()
 
       expect(mockPostHogClient.captureImmediate).toHaveBeenCalledTimes(1)
       expect(mockPostHogClient.capture).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith('[PostHog AI] Failed to capture Vercel stream telemetry:', telemetryError)
     })
 
     it.each([

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -728,6 +728,29 @@ describe('Vercel AI SDK - Dual Version Support', () => {
     )
 
     it.each(['v2', 'v3'] as const)(
+      'should close promptly when immediate telemetry never settles in %s streams',
+      async (version) => {
+        const streamParts = [{ type: 'text-delta' as const, id: 'text-1', delta: 'complete response' }]
+        const baseModel = createMockStreamingModel(version, streamParts as any)
+        ;(mockPostHogClient.captureImmediate as jest.Mock).mockReturnValue(new Promise<void>(() => undefined))
+        const model = withTracing(baseModel, mockPostHogClient, {
+          posthogDistinctId: 'test-user',
+          posthogTraceId: `test-${version}-nonblocking-completion`,
+          posthogCaptureImmediate: true,
+        })
+
+        const result = await model.doStream({ prompt: [] })
+        const reader = result.stream.getReader()
+        await expect(reader.read()).resolves.toEqual({ done: false, value: streamParts[0] })
+        await expect(settlePromptly(reader.read())).resolves.toEqual({ done: true, value: undefined })
+        await flushPromises()
+
+        expect(mockPostHogClient.captureImmediate).toHaveBeenCalledTimes(1)
+        expect(mockPostHogClient.capture).not.toHaveBeenCalled()
+      }
+    )
+
+    it.each(['v2', 'v3'] as const)(
       'should reject reads promptly when immediate telemetry never settles in %s streams',
       async (version) => {
         const sourceError = new Error('source stream failed')


### PR DESCRIPTION
## Problem

Vercel AI streams could miss in-band errors, capture duplicates, or delay provider errors while telemetry completed.

## Changes

- Unify Vercel stream finalization across successful, failed, and cancelled streams.
- Capture error and partial state exactly once without blocking provider delivery on telemetry.
- Add coverage for error parts, source failures, cancellation, and error finishes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently checked with Pi autoreview. The change was kept isolated in its own worktree and validated with the full `packages/ai` Jest suite, TypeScript, ESLint, and Rollup build. Human review is required before merge.
