### PR TITLE
fix(ai): remove undeclared OpenTelemetry dependency

### DIFF
--- a/.changeset/lean-otel-exporter.md
+++ b/.changeset/lean-otel-exporter.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Remove the undeclared OpenTelemetry core runtime dependency.

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run unit tests
         run: |
           set -o pipefail
-          pnpm test --concurrency=50% 2>&1 | tee unit-tests.log
+          pnpm test:unit --concurrency=50% 2>&1 | tee unit-tests.log
 
           if grep -Eq 'A worker process has failed to exit gracefully|Jest did not exit one second after the test run has completed|Jest has detected the following [0-9]+ open handles?' unit-tests.log; then
             echo "::error::Jest leaked resources after the unit test run"

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run unit tests
         run: |
           set -o pipefail
-          pnpm test:unit --concurrency=50% 2>&1 | tee unit-tests.log
+          pnpm test --concurrency=50% 2>&1 | tee unit-tests.log
 
           if grep -Eq 'A worker process has failed to exit gracefully|Jest did not exit one second after the test run has completed|Jest has detected the following [0-9]+ open handles?' unit-tests.log; then
             echo "::error::Jest leaked resources after the unit test run"

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -14,9 +14,10 @@
   "scripts": {
     "clean": "rimraf dist",
     "test:unit": "jest",
+    "test:module-load": "node tests/otel-module-load.cjs",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",
-    "build": "rollup -c",
+    "build": "rollup -c && pnpm test:module-load",
     "dev": "rollup -c --watch",
     "prepublishOnly": "pnpm lint && pnpm test:unit && pnpm build",
     "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
@@ -30,7 +31,6 @@
     "@openai/agents": "^0.8.0",
     "@openai/agents-core": "^0.8.0",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
     "@opentelemetry/otlp-exporter-base": "^0.200.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "eslint src tests --fix",
     "build": "rollup -c",
     "dev": "rollup -c --watch",
-    "prepublishOnly": "pnpm lint && pnpm test:unit && pnpm build",
+    "prepublishOnly": "pnpm lint && pnpm build && pnpm test:unit",
     "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
   },
   "devDependencies": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -13,8 +13,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist",
-    "test": "pnpm test:unit && pnpm test:module-load",
-    "test:unit": "jest",
+    "test:unit": "jest && pnpm test:module-load",
     "test:module-load": "node tests/otel-module-load.cjs",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -13,11 +13,12 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist",
+    "test": "pnpm test:unit && pnpm test:module-load",
     "test:unit": "jest",
     "test:module-load": "node tests/otel-module-load.cjs",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",
-    "build": "rollup -c && pnpm test:module-load",
+    "build": "rollup -c",
     "dev": "rollup -c --watch",
     "prepublishOnly": "pnpm lint && pnpm test:unit && pnpm build",
     "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"

--- a/packages/ai/src/otel/exporter.ts
+++ b/packages/ai/src/otel/exporter.ts
@@ -1,12 +1,14 @@
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
-import { ExportResultCode } from '@opentelemetry/core'
 
 import { redactSpan } from './redact'
 import { isAISpan } from './spans'
 import { warnIfPostHogAiGatewayOtelAttributes } from '../gatewayWarning'
 
 const DEFAULT_OTEL_HOST = 'https://us.i.posthog.com'
+// OpenTelemetry's ExportResultCode.SUCCESS is 0. Keep this local so loading the
+// published subpath does not require the exporter package's transitive dependencies.
+const EXPORT_SUCCESS = 0
 
 function normalizeToken(value?: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
@@ -91,13 +93,13 @@ export class PostHogTraceExporter extends OTLPTraceExporter {
     if (this.disabled) {
       // Intentionally report success: missing or blank tokens disable exporting as a compatibility no-op.
       // Reporting failure would make OpenTelemetry treat every span as an export error.
-      resultCallback({ code: ExportResultCode.SUCCESS })
+      resultCallback({ code: EXPORT_SUCCESS })
       return
     }
 
     const aiSpans = spans.filter(isAISpan)
     if (aiSpans.length === 0) {
-      resultCallback({ code: ExportResultCode.SUCCESS })
+      resultCallback({ code: EXPORT_SUCCESS })
       return
     }
     for (const span of aiSpans) {

--- a/packages/ai/tests/otel-module-load.cjs
+++ b/packages/ai/tests/otel-module-load.cjs
@@ -1,0 +1,75 @@
+const { execFileSync } = require('node:child_process')
+const { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { dirname, join } = require('node:path')
+
+const packageRoot = join(__dirname, '..')
+const fixtureRoot = mkdtempSync(join(tmpdir(), 'posthog-ai-otel-module-load-'))
+
+function findPackageRoot(packageName) {
+  let directory = dirname(require.resolve(packageName, { paths: [packageRoot] }))
+  while (directory !== dirname(directory)) {
+    try {
+      const packageJson = JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8'))
+      if (packageJson.name === packageName) {
+        return directory
+      }
+    } catch {
+      // Keep walking up from the resolved entry point.
+    }
+    directory = dirname(directory)
+  }
+  throw new Error(`Could not find package root for ${packageName}`)
+}
+
+function linkDependency(packageName) {
+  const destination = join(fixtureRoot, 'node_modules', ...packageName.split('/'))
+  mkdirSync(dirname(destination), { recursive: true })
+  symlinkSync(findPackageRoot(packageName), destination, 'junction')
+}
+
+try {
+  const installedPackage = join(fixtureRoot, 'node_modules', '@posthog', 'ai')
+  mkdirSync(installedPackage, { recursive: true })
+  cpSync(join(packageRoot, 'dist'), join(installedPackage, 'dist'), { recursive: true })
+  writeFileSync(
+    join(installedPackage, 'package.json'),
+    JSON.stringify({
+      name: '@posthog/ai',
+      exports: {
+        './otel': {
+          require: './dist/otel/index.cjs',
+          import: './dist/otel/index.mjs',
+        },
+      },
+    })
+  )
+
+  // Reproduce a strict package-manager layout: only @posthog/ai's declared
+  // OpenTelemetry peers are available at its level. Their dependencies remain
+  // nested inside their own package layouts.
+  linkDependency('@opentelemetry/api')
+  linkDependency('@opentelemetry/exporter-trace-otlp-http')
+  linkDependency('@opentelemetry/sdk-trace-base')
+
+  const assertCoreIsNotDirectlyResolvable = `
+    try {
+      require.resolve('@opentelemetry/core')
+      throw new Error('@opentelemetry/core unexpectedly resolved from the fixture root')
+    } catch (error) {
+      if (error.code !== 'MODULE_NOT_FOUND') throw error
+    }
+  `
+
+  execFileSync(process.execPath, ['--eval', `${assertCoreIsNotDirectlyResolvable}\nrequire('@posthog/ai/otel')`], {
+    cwd: fixtureRoot,
+    stdio: 'inherit',
+  })
+  execFileSync(
+    process.execPath,
+    ['--input-type=module', '--eval', `await import('@posthog/ai/otel')`],
+    { cwd: fixtureRoot, stdio: 'inherit' }
+  )
+} finally {
+  rmSync(fixtureRoot, { recursive: true, force: true })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,9 +250,6 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
-      '@opentelemetry/core':
-        specifier: ^2.0.0
-        version: 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.200.0
         version: 0.200.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Problem

The published OpenTelemetry exporter subpath imported an undeclared runtime package, so it could fail in strict package-manager layouts.

## Changes

- Remove the runtime import of @opentelemetry/core while preserving the exporter result contract.
- Remove the unnecessary development dependency and lockfile entry.
- Run a strict published-module loading check as part of the AI package unit-test suite.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently checked with Pi autoreview. The change was kept isolated in its own worktree and validated with the full `packages/ai` Jest suite, TypeScript, ESLint, and Rollup build. Human review is required before merge.