### PR TITLE
fix(ai): resolve Agents APIs through declared peer

### DIFF
--- a/.changeset/linked-agent-peers.md
+++ b/.changeset/linked-agent-peers.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Resolve OpenAI Agents APIs through the declared peer dependency.

--- a/packages/ai/src/openai-agents/index.ts
+++ b/packages/ai/src/openai-agents/index.ts
@@ -45,7 +45,7 @@ export type InstrumentOptions = PostHogTracingProcessorOptions
  * ```
  */
 export async function instrument(options: InstrumentOptions): Promise<PostHogTracingProcessor> {
-  const { addTraceProcessor } = await import('@openai/agents-core')
+  const { addTraceProcessor } = await import('@openai/agents')
 
   const processor = new PostHogTracingProcessor({
     client: options.client,

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -16,7 +16,7 @@ import type {
   SpeechSpanData,
   SpeechGroupSpanData,
   MCPListToolsSpanData,
-} from '@openai/agents-core'
+} from '@openai/agents'
 import { MAX_OUTPUT_SIZE, toContentString, truncate, utf8ByteLength, withPrivacyMode } from '../utils'
 import { version } from '../../package.json'
 import { warnIfPostHogAiGateway } from '../gatewayWarning'

--- a/packages/ai/tests/openai-agents-resolution.test.ts
+++ b/packages/ai/tests/openai-agents-resolution.test.ts
@@ -1,0 +1,110 @@
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { dirname, join, resolve } from 'path'
+import { execFileSync } from 'child_process'
+
+const packageRoot = resolve(__dirname, '..')
+const repositoryRoot = resolve(packageRoot, '../..')
+const fixtureRoot = join(tmpdir(), 'posthog-ai-openai-agents-resolution-')
+const fixtures: string[] = []
+
+function linkPackage(fixture: string, packageName: string, target: string): void {
+  const link = join(fixture, 'node_modules', ...packageName.split('/'))
+  mkdirSync(dirname(link), { recursive: true })
+  symlinkSync(target, link, 'junction')
+}
+
+function createIsolatedFixture(): string {
+  const fixture = mkdtempSync(fixtureRoot)
+  fixtures.push(fixture)
+
+  const installedPackage = join(fixture, 'node_modules', '@posthog', 'ai')
+  mkdirSync(installedPackage, { recursive: true })
+  cpSync(join(packageRoot, 'dist'), join(installedPackage, 'dist'), { recursive: true })
+  cpSync(join(packageRoot, 'package.json'), join(installedPackage, 'package.json'))
+
+  // Only expose peers declared by @posthog/ai. @openai/agents-core must remain
+  // reachable solely as an implementation dependency of @openai/agents.
+  linkPackage(fixture, '@openai/agents', resolve(packageRoot, 'node_modules/@openai/agents'))
+  linkPackage(fixture, 'posthog-node', resolve(packageRoot, 'node_modules/posthog-node'))
+
+  expect(existsSync(join(fixture, 'node_modules', '@openai', 'agents-core'))).toBe(false)
+
+  return fixture
+}
+
+beforeAll(() => {
+  execFileSync(process.execPath, [resolve(repositoryRoot, 'node_modules/rollup/dist/bin/rollup'), '-c'], {
+    cwd: packageRoot,
+    stdio: 'pipe',
+  })
+})
+
+afterAll(() => {
+  for (const fixture of fixtures) {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+describe('@posthog/ai/openai-agents package resolution', () => {
+  it('loads and instruments at runtime with only the declared @openai/agents peer', () => {
+    const fixture = createIsolatedFixture()
+    const testFile = join(fixture, 'runtime.cjs')
+
+    writeFileSync(
+      testFile,
+      `const assert = require('node:assert/strict')
+const { instrument, PostHogTracingProcessor } = require('@posthog/ai/openai-agents')
+
+instrument({ client: { capture() {} } }).then((processor) => {
+  assert.ok(processor instanceof PostHogTracingProcessor)
+})
+`
+    )
+
+    execFileSync(process.execPath, [testFile], { cwd: fixture, stdio: 'pipe' })
+  })
+
+  it('resolves its public types with only declared peers installed', () => {
+    const fixture = createIsolatedFixture()
+    const testFile = join(fixture, 'types.ts')
+
+    writeFileSync(
+      testFile,
+      `import {
+  instrument,
+  type DistinctIdResolver,
+  type InstrumentOptions,
+  type PostHogTracingProcessor,
+} from '@posthog/ai/openai-agents'
+
+declare const options: InstrumentOptions
+const processor: Promise<PostHogTracingProcessor> = instrument(options)
+const resolver: DistinctIdResolver = (trace) => {
+  // @ts-expect-error Trace is resolved from the declared @openai/agents peer, not any.
+  return trace.notARealTraceProperty
+}
+void processor
+void resolver
+`
+    )
+
+    execFileSync(
+      process.execPath,
+      [
+        resolve(repositoryRoot, 'node_modules/typescript/bin/tsc'),
+        '--noEmit',
+        '--strict',
+        '--skipLibCheck',
+        '--target',
+        'ES2022',
+        '--module',
+        'NodeNext',
+        '--moduleResolution',
+        'NodeNext',
+        testFile,
+      ],
+      { cwd: fixture, stdio: 'pipe' }
+    )
+  })
+})

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -1,6 +1,6 @@
 import { PostHogTracingProcessor } from '../src/openai-agents/processor'
 
-// Mock types matching @openai/agents-core interfaces
+// Mock types matching @openai/agents interfaces
 interface MockTrace {
   type: 'trace'
   traceId: string
@@ -1100,7 +1100,7 @@ describe('PostHogTracingProcessor', () => {
 })
 
 const mockAddTraceProcessor = jest.fn()
-jest.mock('@openai/agents-core', () => ({
+jest.mock('@openai/agents', () => ({
   addTraceProcessor: mockAddTraceProcessor,
 }))
 


### PR DESCRIPTION
## Problem

The OpenAI Agents integration imported @openai/agents-core directly even though consumers are only required to install the declared @openai/agents peer.

## Changes

- Resolve runtime and type APIs through @openai/agents.
- Keep instrumentation behavior unchanged for existing consumers.
- Add strict dependency-resolution coverage.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently checked with Pi autoreview. The change was kept isolated in its own worktree and validated with the full `packages/ai` Jest suite, TypeScript, ESLint, and Rollup build. Human review is required before merge.
