### PR TITLE
fix(ai): capture Agents Chat Completions usage

### DIFF
--- a/.changeset/complete-agent-usage.md
+++ b/.changeset/complete-agent-usage.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Capture Chat Completions usage from OpenAI Agents spans.

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -483,7 +483,11 @@ export class PostHogTracingProcessor implements TracingProcessor {
     groupId: string | null,
     errorProperties: Record<string, any>
   ): void {
-    const usage = spanData.usage ?? {}
+    // OpenAI Agents 0.8 stores the raw Chat Completions response in output[0].
+    // Canonical generation fields take precedence when the SDK provides them.
+    const rawResponse = spanData.output?.[0]
+    const usage = spanData.usage ?? rawResponse?.usage ?? {}
+    const model = spanData.model ?? (rawResponse?.model as string | undefined)
     const inputTokens = (usage.input_tokens as number) || (usage as any).prompt_tokens || 0
     const outputTokens = (usage.output_tokens as number) || (usage as any).completion_tokens || 0
 
@@ -501,7 +505,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
 
     const properties: Record<string, any> = {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
-      $ai_model: spanData.model,
+      $ai_model: model,
       // Best-effort: Agents SDK only sets model_config.base_url for chat-completions
       // calls with no model settings; Responses and normal chat calls omit it, so ''.
       $ai_base_url: typeof modelConfig.base_url === 'string' ? modelConfig.base_url : '',
@@ -511,6 +515,16 @@ export class PostHogTracingProcessor implements TracingProcessor {
       $ai_input_tokens: inputTokens,
       $ai_output_tokens: outputTokens,
       $ai_total_tokens: inputTokens + outputTokens,
+    }
+
+    // Raw Chat Completions usage keeps token details under provider-specific fields.
+    const promptTokenDetails = (usage as any).prompt_tokens_details
+    const completionTokenDetails = (usage as any).completion_tokens_details
+    if (completionTokenDetails?.reasoning_tokens) {
+      properties.$ai_reasoning_tokens = completionTokenDetails.reasoning_tokens
+    }
+    if (promptTokenDetails?.cached_tokens) {
+      properties.$ai_cache_read_input_tokens = promptTokenDetails.cached_tokens
     }
 
     if (usage.details) {

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -486,7 +486,9 @@ export class PostHogTracingProcessor implements TracingProcessor {
     // OpenAI Agents 0.8 stores the raw Chat Completions response in output[0].
     // Canonical generation fields take precedence when the SDK provides them.
     const rawResponse = spanData.output?.[0]
-    const usage = spanData.usage ?? rawResponse?.usage ?? {}
+    const rawResponseUsage = rawResponse?.usage
+    const usage = spanData.usage ?? rawResponseUsage ?? {}
+    const usesRawResponseUsage = spanData.usage === undefined && rawResponseUsage !== undefined
     const model = spanData.model ?? (rawResponse?.model as string | undefined)
     const inputTokens = (usage.input_tokens as number) || (usage as any).prompt_tokens || 0
     const outputTokens = (usage.output_tokens as number) || (usage as any).completion_tokens || 0
@@ -515,6 +517,11 @@ export class PostHogTracingProcessor implements TracingProcessor {
       $ai_input_tokens: inputTokens,
       $ai_output_tokens: outputTokens,
       $ai_total_tokens: inputTokens + outputTokens,
+    }
+
+    if (usesRawResponseUsage) {
+      // Chat Completions prompt tokens include cached tokens rather than reporting them exclusively.
+      properties.$ai_cache_reporting_exclusive = false
     }
 
     // Raw Chat Completions usage keeps token details under provider-specific fields.

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -279,6 +279,104 @@ describe('PostHogTracingProcessor', () => {
       expect(call.properties.$ai_model_parameters).toEqual({ temperature: 0.7, max_tokens: 100 })
     })
 
+    it('maps OpenAI Agents 0.8 non-streamed Chat Completions response metadata', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          model: 'configured-model',
+          output: [
+            {
+              id: 'chatcmpl_nonstreamed',
+              object: 'chat.completion',
+              model: 'resolved-model',
+              choices: [{ message: { role: 'assistant', content: 'Hello!' }, finish_reason: 'stop', index: 0 }],
+              usage: {
+                prompt_tokens: 12,
+                completion_tokens: 7,
+                total_tokens: 19,
+                prompt_tokens_details: { cached_tokens: 5 },
+                completion_tokens_details: { reasoning_tokens: 3 },
+              },
+            },
+          ],
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const properties = mockClient.capture.mock.calls[0][0].properties
+      expect(properties.$ai_model).toBe('configured-model')
+      expect(properties.$ai_input_tokens).toBe(12)
+      expect(properties.$ai_output_tokens).toBe(7)
+      expect(properties.$ai_total_tokens).toBe(19)
+      expect(properties.$ai_cache_read_input_tokens).toBe(5)
+      expect(properties.$ai_reasoning_tokens).toBe(3)
+    })
+
+    it('maps OpenAI Agents 0.8 streamed Chat Completions response metadata', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          output: [
+            {
+              id: 'FAKE_ID',
+              object: 'chat.completion',
+              model: 'streamed-model',
+              choices: [{ message: { role: 'assistant', content: 'Hello from a stream!' }, index: 0 }],
+              usage: {
+                prompt_tokens: 18,
+                completion_tokens: 9,
+                total_tokens: 27,
+              },
+            },
+          ],
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const properties = mockClient.capture.mock.calls[0][0].properties
+      expect(properties.$ai_model).toBe('streamed-model')
+      expect(properties.$ai_input_tokens).toBe(18)
+      expect(properties.$ai_output_tokens).toBe(9)
+      expect(properties.$ai_total_tokens).toBe(27)
+    })
+
+    it('prefers canonical generation usage over raw response usage', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          usage: {
+            input_tokens: 4,
+            output_tokens: 6,
+            details: { reasoning_tokens: 2, cache_read_input_tokens: 3, cache_creation_input_tokens: 1 },
+          },
+          output: [
+            {
+              usage: {
+                prompt_tokens: 40,
+                completion_tokens: 60,
+                completion_tokens_details: { reasoning_tokens: 20 },
+              },
+            },
+          ],
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const properties = mockClient.capture.mock.calls[0][0].properties
+      expect(properties.$ai_input_tokens).toBe(4)
+      expect(properties.$ai_output_tokens).toBe(6)
+      expect(properties.$ai_total_tokens).toBe(10)
+      expect(properties.$ai_reasoning_tokens).toBe(2)
+      expect(properties.$ai_cache_read_input_tokens).toBe(3)
+      expect(properties.$ai_cache_creation_input_tokens).toBe(1)
+    })
+
     it('defaults $ai_base_url to empty when model_config has no base_url', async () => {
       const span = createMockSpan({
         spanData: { type: 'generation', model: 'gpt-4o', model_config: { temperature: 0.7 } },

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -311,6 +311,7 @@ describe('PostHogTracingProcessor', () => {
       expect(properties.$ai_output_tokens).toBe(7)
       expect(properties.$ai_total_tokens).toBe(19)
       expect(properties.$ai_cache_read_input_tokens).toBe(5)
+      expect(properties.$ai_cache_reporting_exclusive).toBe(false)
       expect(properties.$ai_reasoning_tokens).toBe(3)
     })
 
@@ -375,6 +376,7 @@ describe('PostHogTracingProcessor', () => {
       expect(properties.$ai_reasoning_tokens).toBe(2)
       expect(properties.$ai_cache_read_input_tokens).toBe(3)
       expect(properties.$ai_cache_creation_input_tokens).toBe(1)
+      expect(properties).not.toHaveProperty('$ai_cache_reporting_exclusive')
     })
 
     it('defaults $ai_base_url to empty when model_config has no base_url', async () => {


### PR DESCRIPTION
## Problem

OpenAI Agents Chat Completions spans could omit model and token usage because those fields are nested in raw response data.

## Changes

- Extract Chat Completions model and usage from raw Agents span output when canonical fields are absent.
- Preserve canonical span fields when present.
- Add coverage for prompt, completion, cached, and reasoning token details.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently checked with Pi autoreview. The change was kept isolated in its own worktree and validated with the full `packages/ai` Jest suite, TypeScript, ESLint, and Rollup build. Human review is required before merge.
