### PR TITLE
fix(ai): support current LangChain message metadata

### DIFF
--- a/.changeset/modern-langchain-metadata.md
+++ b/.changeset/modern-langchain-metadata.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Support current LangChain message usage and response metadata.

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -659,28 +659,17 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
       return undefined
     }
     const gen = lastGeneration[0]
+    const messageResponseMetadata = (gen as any).message?.response_metadata
+    const generationResponseMetadata = gen.generationInfo?.response_metadata
+    const stopReason =
+      messageResponseMetadata?.finish_reason ||
+      messageResponseMetadata?.stop_reason ||
+      gen.generationInfo?.finish_reason ||
+      generationResponseMetadata?.stop_reason ||
+      generationResponseMetadata?.finish_reason ||
+      gen.generationInfo?.stop_reason
 
-    // Check generationInfo for finish_reason (OpenAI format)
-    if (gen.generationInfo?.finish_reason) {
-      return String(gen.generationInfo.finish_reason)
-    }
-
-    // Check generationInfo for response_metadata.stop_reason (Anthropic format)
-    if (gen.generationInfo?.response_metadata?.stop_reason) {
-      return String(gen.generationInfo.response_metadata.stop_reason)
-    }
-
-    // Check message response_metadata for finish_reason (common LangChain format)
-    if (gen.generationInfo?.response_metadata?.finish_reason) {
-      return String(gen.generationInfo.response_metadata.finish_reason)
-    }
-
-    // Check for stop_reason directly in generationInfo
-    if (gen.generationInfo?.stop_reason) {
-      return String(gen.generationInfo.stop_reason)
-    }
-
-    return undefined
+    return stopReason != null ? String(stopReason) : undefined
   }
 
   private _parseUsageModel(usage: any, provider?: string, model?: string): [number, number, Record<string, any>] {
@@ -823,18 +812,17 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
     if (llmUsage[0] === 0 && llmUsage[1] === 0 && response.generations) {
       for (const generation of response.generations) {
         for (const genChunk of generation) {
-          // Check other paths for usage information
-          if (genChunk.generationInfo?.usage_metadata) {
-            llmUsage = this._parseUsageModel(genChunk.generationInfo.usage_metadata, provider, model)
-            return llmUsage
-          }
-
-          const messageChunk = genChunk.generationInfo ?? {}
-          const responseMetadata = messageChunk.response_metadata ?? {}
+          const message = (genChunk as any).message ?? {}
+          const messageResponseMetadata = message.response_metadata ?? {}
+          const generationInfo = genChunk.generationInfo ?? {}
+          const generationResponseMetadata = generationInfo.response_metadata ?? {}
           const chunkUsage =
-            responseMetadata['usage'] ??
-            responseMetadata['amazon-bedrock-invocationMetrics'] ??
-            messageChunk.usage_metadata
+            message.usage_metadata ??
+            messageResponseMetadata['usage'] ??
+            messageResponseMetadata['amazon-bedrock-invocationMetrics'] ??
+            generationInfo.usage_metadata ??
+            generationResponseMetadata['usage'] ??
+            generationResponseMetadata['amazon-bedrock-invocationMetrics']
           if (chunkUsage) {
             llmUsage = this._parseUsageModel(chunkUsage, provider, model)
             return llmUsage

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -79,84 +79,87 @@ describe('LangChainCallbackHandler', () => {
     expect(captureCall[0].properties.$ai_provider).toBe('openai')
   })
 
-  it('should extract usage and stop reason from AIMessage metadata without llmOutput', () => {
-    const serialized = {
-      lc: 1,
-      type: 'constructor' as const,
-      id: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
-      kwargs: {},
-    }
-    const runId = 'run_ai_message_metadata'
-
-    handler.handleLLMStart(serialized, ['Test prompt'], runId, undefined, { invocation_params: {} }, undefined, {
-      ls_model_name: 'gpt-4',
-      ls_provider: 'openai',
-    })
-    const llmResult = {
-      generations: [
-        [
-          {
-            text: 'Test response',
-            message: new AIMessage({
-              content: 'Test response',
-              usage_metadata: {
-                input_tokens: 12,
-                output_tokens: 4,
-                total_tokens: 16,
-              },
-              response_metadata: { finish_reason: 'stop' },
-            }),
+  it.each([
+    {
+      name: 'usage_metadata and finish_reason',
+      serializedId: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
+      runId: 'run_ai_message_metadata',
+      model: 'gpt-4',
+      provider: 'openai',
+      message: new AIMessage({
+        content: 'Test response',
+        usage_metadata: {
+          input_tokens: 12,
+          output_tokens: 4,
+          total_tokens: 16,
+        },
+        response_metadata: { finish_reason: 'stop' },
+      }),
+      expectedInputTokens: 12,
+      expectedOutputTokens: 4,
+      expectedStopReason: 'stop',
+    },
+    {
+      name: 'response_metadata usage and stop_reason',
+      serializedId: ['langchain', 'chat_models', 'anthropic', 'ChatAnthropic'],
+      runId: 'run_ai_message_response_metadata',
+      model: 'claude-3',
+      provider: 'anthropic',
+      message: new AIMessage({
+        content: 'Test response',
+        response_metadata: {
+          stop_reason: 'end_turn',
+          usage: {
+            input_tokens: 15,
+            output_tokens: 5,
           },
+        },
+      }),
+      expectedInputTokens: 15,
+      expectedOutputTokens: 5,
+      expectedStopReason: 'end_turn',
+    },
+  ])(
+    'should extract usage and stop reason from AIMessage $name without llmOutput',
+    ({
+      serializedId,
+      runId,
+      model,
+      provider,
+      message,
+      expectedInputTokens,
+      expectedOutputTokens,
+      expectedStopReason,
+    }) => {
+      const serialized = {
+        lc: 1,
+        type: 'constructor' as const,
+        id: serializedId,
+        kwargs: {},
+      }
+
+      handler.handleLLMStart(serialized, ['Test prompt'], runId, undefined, { invocation_params: {} }, undefined, {
+        ls_model_name: model,
+        ls_provider: provider,
+      })
+      const llmResult = {
+        generations: [
+          [
+            {
+              text: 'Test response',
+              message,
+            },
+          ],
         ],
-      ],
+      }
+      handler.handleLLMEnd(llmResult, runId)
+
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      expect(captureCall[0].properties['$ai_input_tokens']).toBe(expectedInputTokens)
+      expect(captureCall[0].properties['$ai_output_tokens']).toBe(expectedOutputTokens)
+      expect(captureCall[0].properties['$ai_stop_reason']).toBe(expectedStopReason)
     }
-    handler.handleLLMEnd(llmResult, runId)
-
-    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    expect(captureCall[0].properties['$ai_input_tokens']).toBe(12)
-    expect(captureCall[0].properties['$ai_output_tokens']).toBe(4)
-    expect(captureCall[0].properties['$ai_stop_reason']).toBe('stop')
-  })
-
-  it('should extract usage and stop reason from AIMessage response_metadata without llmOutput', () => {
-    const serialized = {
-      lc: 1,
-      type: 'constructor' as const,
-      id: ['langchain', 'chat_models', 'anthropic', 'ChatAnthropic'],
-      kwargs: {},
-    }
-    const runId = 'run_ai_message_response_metadata'
-
-    handler.handleLLMStart(serialized, ['Test prompt'], runId, undefined, { invocation_params: {} }, undefined, {
-      ls_model_name: 'claude-3',
-      ls_provider: 'anthropic',
-    })
-    const llmResult = {
-      generations: [
-        [
-          {
-            text: 'Test response',
-            message: new AIMessage({
-              content: 'Test response',
-              response_metadata: {
-                stop_reason: 'end_turn',
-                usage: {
-                  input_tokens: 15,
-                  output_tokens: 5,
-                },
-              },
-            }),
-          },
-        ],
-      ],
-    }
-    handler.handleLLMEnd(llmResult, runId)
-
-    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    expect(captureCall[0].properties['$ai_input_tokens']).toBe(15)
-    expect(captureCall[0].properties['$ai_output_tokens']).toBe(5)
-    expect(captureCall[0].properties['$ai_stop_reason']).toBe('end_turn')
-  })
+  )
 
   it('should convert AIMessage with tool calls to dict format', () => {
     const toolCalls = [

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -79,6 +79,85 @@ describe('LangChainCallbackHandler', () => {
     expect(captureCall[0].properties.$ai_provider).toBe('openai')
   })
 
+  it('should extract usage and stop reason from AIMessage metadata without llmOutput', () => {
+    const serialized = {
+      lc: 1,
+      type: 'constructor' as const,
+      id: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
+      kwargs: {},
+    }
+    const runId = 'run_ai_message_metadata'
+
+    handler.handleLLMStart(serialized, ['Test prompt'], runId, undefined, { invocation_params: {} }, undefined, {
+      ls_model_name: 'gpt-4',
+      ls_provider: 'openai',
+    })
+    const llmResult = {
+      generations: [
+        [
+          {
+            text: 'Test response',
+            message: new AIMessage({
+              content: 'Test response',
+              usage_metadata: {
+                input_tokens: 12,
+                output_tokens: 4,
+                total_tokens: 16,
+              },
+              response_metadata: { finish_reason: 'stop' },
+            }),
+          },
+        ],
+      ],
+    }
+    handler.handleLLMEnd(llmResult, runId)
+
+    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    expect(captureCall[0].properties['$ai_input_tokens']).toBe(12)
+    expect(captureCall[0].properties['$ai_output_tokens']).toBe(4)
+    expect(captureCall[0].properties['$ai_stop_reason']).toBe('stop')
+  })
+
+  it('should extract usage and stop reason from AIMessage response_metadata without llmOutput', () => {
+    const serialized = {
+      lc: 1,
+      type: 'constructor' as const,
+      id: ['langchain', 'chat_models', 'anthropic', 'ChatAnthropic'],
+      kwargs: {},
+    }
+    const runId = 'run_ai_message_response_metadata'
+
+    handler.handleLLMStart(serialized, ['Test prompt'], runId, undefined, { invocation_params: {} }, undefined, {
+      ls_model_name: 'claude-3',
+      ls_provider: 'anthropic',
+    })
+    const llmResult = {
+      generations: [
+        [
+          {
+            text: 'Test response',
+            message: new AIMessage({
+              content: 'Test response',
+              response_metadata: {
+                stop_reason: 'end_turn',
+                usage: {
+                  input_tokens: 15,
+                  output_tokens: 5,
+                },
+              },
+            }),
+          },
+        ],
+      ],
+    }
+    handler.handleLLMEnd(llmResult, runId)
+
+    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    expect(captureCall[0].properties['$ai_input_tokens']).toBe(15)
+    expect(captureCall[0].properties['$ai_output_tokens']).toBe(5)
+    expect(captureCall[0].properties['$ai_stop_reason']).toBe('end_turn')
+  })
+
   it('should convert AIMessage with tool calls to dict format', () => {
     const toolCalls = [
       {

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -86,15 +86,17 @@ describe('LangChainCallbackHandler', () => {
       runId: 'run_ai_message_metadata',
       model: 'gpt-4',
       provider: 'openai',
-      message: new AIMessage({
-        content: 'Test response',
-        usage_metadata: {
-          input_tokens: 12,
-          output_tokens: 4,
-          total_tokens: 16,
-        },
-        response_metadata: { finish_reason: 'stop' },
-      }),
+      generation: {
+        message: new AIMessage({
+          content: 'Test response',
+          usage_metadata: {
+            input_tokens: 12,
+            output_tokens: 4,
+            total_tokens: 16,
+          },
+          response_metadata: { finish_reason: 'stop' },
+        }),
+      },
       expectedInputTokens: 12,
       expectedOutputTokens: 4,
       expectedStopReason: 'stop',
@@ -105,18 +107,103 @@ describe('LangChainCallbackHandler', () => {
       runId: 'run_ai_message_response_metadata',
       model: 'claude-3',
       provider: 'anthropic',
-      message: new AIMessage({
-        content: 'Test response',
-        response_metadata: {
-          stop_reason: 'end_turn',
-          usage: {
-            input_tokens: 15,
-            output_tokens: 5,
+      generation: {
+        message: new AIMessage({
+          content: 'Test response',
+          response_metadata: {
+            stop_reason: 'end_turn',
+            usage: {
+              input_tokens: 15,
+              output_tokens: 5,
+            },
           },
-        },
-      }),
+        }),
+      },
       expectedInputTokens: 15,
       expectedOutputTokens: 5,
+      expectedStopReason: 'end_turn',
+    },
+    {
+      name: 'generationInfo usage_metadata and finish_reason',
+      serializedId: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
+      runId: 'run_generation_info_usage_metadata',
+      model: 'gpt-4',
+      provider: 'openai',
+      generation: {
+        generationInfo: {
+          usage_metadata: {
+            input_tokens: 18,
+            output_tokens: 6,
+          },
+          finish_reason: 'length',
+        },
+      },
+      expectedInputTokens: 18,
+      expectedOutputTokens: 6,
+      expectedStopReason: 'length',
+    },
+    {
+      name: 'generationInfo response_metadata usage and stop_reason',
+      serializedId: ['langchain', 'chat_models', 'anthropic', 'ChatAnthropic'],
+      runId: 'run_generation_info_response_metadata',
+      model: 'claude-3',
+      provider: 'anthropic',
+      generation: {
+        generationInfo: {
+          response_metadata: {
+            usage: {
+              input_tokens: 21,
+              output_tokens: 7,
+            },
+            stop_reason: 'end_turn',
+          },
+        },
+      },
+      expectedInputTokens: 21,
+      expectedOutputTokens: 7,
+      expectedStopReason: 'end_turn',
+    },
+    {
+      name: 'response_metadata Bedrock invocation metrics',
+      serializedId: ['langchain', 'chat_models', 'bedrock', 'ChatBedrock'],
+      runId: 'run_message_bedrock_invocation_metrics',
+      model: 'anthropic.claude-3',
+      provider: 'bedrock',
+      generation: {
+        message: new AIMessage({
+          content: 'Test response',
+          response_metadata: {
+            finish_reason: 'stop',
+            'amazon-bedrock-invocationMetrics': {
+              inputTokenCount: 24,
+              outputTokenCount: 8,
+            },
+          },
+        }),
+      },
+      expectedInputTokens: 24,
+      expectedOutputTokens: 8,
+      expectedStopReason: 'stop',
+    },
+    {
+      name: 'generationInfo response_metadata Bedrock invocation metrics',
+      serializedId: ['langchain', 'chat_models', 'bedrock', 'ChatBedrock'],
+      runId: 'run_generation_info_bedrock_invocation_metrics',
+      model: 'anthropic.claude-3',
+      provider: 'bedrock',
+      generation: {
+        generationInfo: {
+          response_metadata: {
+            stop_reason: 'end_turn',
+            'amazon-bedrock-invocationMetrics': {
+              inputTokenCount: 27,
+              outputTokenCount: 9,
+            },
+          },
+        },
+      },
+      expectedInputTokens: 27,
+      expectedOutputTokens: 9,
       expectedStopReason: 'end_turn',
     },
   ])(
@@ -126,7 +213,7 @@ describe('LangChainCallbackHandler', () => {
       runId,
       model,
       provider,
-      message,
+      generation,
       expectedInputTokens,
       expectedOutputTokens,
       expectedStopReason,
@@ -147,7 +234,7 @@ describe('LangChainCallbackHandler', () => {
           [
             {
               text: 'Test response',
-              message,
+              ...generation,
             },
           ],
         ],


### PR DESCRIPTION
## Problem

Current LangChain AIMessage objects report usage and stop metadata in fields that the callback integration did not read.

## Changes

- Read usage_metadata and response_metadata from current LangChain messages.
- Retain fallbacks for legacy LangChain generation metadata.
- Add regression coverage for token details and finish reasons.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently checked with Pi autoreview. The change was kept isolated in its own worktree and validated with the full `packages/ai` Jest suite, TypeScript, ESLint, and Rollup build. Human review is required before merge.
