### PR TITLE
fix(node): apply feature flag timeout to response body

### DIFF
--- a/.changeset/feature-flag-definition-body-timeout.md
+++ b/.changeset/feature-flag-definition-body-timeout.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+Apply the feature flag definition request timeout while consuming the response body.

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -6186,29 +6186,54 @@ describe('feature flag definition request timeout', () => {
     jest.useFakeTimers()
   })
 
-  it('aborts a hanging definitions request and lets reload and evaluation settle', async () => {
+  const successfulFlagDefinitions = {
+    flags: [
+      {
+        id: 1,
+        key: 'body-timeout-flag',
+        active: true,
+        filters: { groups: [{ properties: [], rollout_percentage: 100 }] },
+      },
+    ],
+    group_type_mapping: {},
+    cohorts: {},
+  }
+
+  it('aborts a stalled 200 response body without pinning reload, local evaluation, or polling', async () => {
     const signals: AbortSignal[] = []
-    const hangingFetch = jest.fn((_url: string, options: { signal?: AbortSignal }) => {
+    const fetchDefinitions = jest.fn((_url: string, options: { signal?: AbortSignal }) => {
       const signal = options.signal
       if (!signal) {
         throw new Error('Expected feature flag definition request to include an AbortSignal')
       }
       signals.push(signal)
 
-      return new Promise<Response>((_resolve, reject) => {
-        signal.addEventListener('abort', () => {
-          const error = new Error('The operation was aborted')
-          error.name = 'AbortError'
-          reject(error)
-        })
+      return Promise.resolve({
+        status: 200,
+        headers: { get: () => null },
+        text: () => Promise.resolve(''),
+        json: () => {
+          if (signals.length === 3) {
+            return Promise.resolve(successfulFlagDefinitions)
+          }
+
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => {
+              const error = new Error('The operation was aborted')
+              error.name = 'AbortError'
+              reject(error)
+            })
+          })
+        },
       })
     })
 
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
-      fetch: hangingFetch as any,
+      fetch: fetchDefinitions as any,
       requestTimeout: 10,
+      featureFlagsPollingInterval: 100,
       ...posthogImmediateResolveOptions,
     })
 
@@ -6220,7 +6245,7 @@ describe('feature flag definition request timeout', () => {
     expect(signals[0].aborted).toBe(true)
     await expect(reloadPromise).resolves.toBeUndefined()
 
-    const evaluationPromise = posthog.getFeatureFlag('missing-flag', 'distinct-id', {
+    const evaluationPromise = posthog.getFeatureFlag('body-timeout-flag', 'distinct-id', {
       onlyEvaluateLocally: true,
       sendFeatureFlagEvents: false,
     })
@@ -6230,6 +6255,131 @@ describe('feature flag definition request timeout', () => {
 
     expect(signals[1].aborted).toBe(true)
     await expect(evaluationPromise).resolves.toBeUndefined()
+
+    await jest.advanceTimersByTimeAsync(90)
+
+    expect(fetchDefinitions).toHaveBeenCalledTimes(3)
+    await expect(
+      posthog.getFeatureFlag('body-timeout-flag', 'distinct-id', {
+        onlyEvaluateLocally: true,
+        sendFeatureFlagEvents: false,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('allows a slow 200 response body to complete before the deadline and clears its timer', async () => {
+    let signal: AbortSignal | undefined
+    const fetchDefinitions = jest.fn((_url: string, options: { signal?: AbortSignal }) => {
+      signal = options.signal
+      if (!signal) {
+        throw new Error('Expected feature flag definition request to include an AbortSignal')
+      }
+
+      return Promise.resolve({
+        status: 200,
+        headers: { get: () => null },
+        text: () => Promise.resolve(''),
+        json: () =>
+          new Promise((resolve, reject) => {
+            const bodyTimer = setTimeout(() => resolve(successfulFlagDefinitions), 5)
+            signal?.addEventListener('abort', () => {
+              clearTimeout(bodyTimer)
+              const error = new Error('The operation was aborted')
+              error.name = 'AbortError'
+              reject(error)
+            })
+          }),
+      })
+    })
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      fetch: fetchDefinitions as any,
+      requestTimeout: 10,
+      featureFlagsPollingInterval: 60000,
+      ...posthogImmediateResolveOptions,
+    })
+
+    const reloadPromise = posthog.reloadFeatureFlags()
+    await jest.advanceTimersByTimeAsync(5)
+
+    await expect(reloadPromise).resolves.toBeUndefined()
+    expect(signal?.aborted).toBe(false)
+    await expect(
+      posthog.getFeatureFlag('body-timeout-flag', 'distinct-id', {
+        onlyEvaluateLocally: true,
+        sendFeatureFlagEvents: false,
+      })
+    ).resolves.toBe(true)
+
+    await jest.advanceTimersByTimeAsync(5)
+
+    expect(signal?.aborted).toBe(false)
+  })
+
+  it('clears the request timer after consuming a 200 response as text and preserves its body', async () => {
+    const signals: AbortSignal[] = []
+    const body = { cancel: jest.fn() } as unknown as ReadableStream<Uint8Array>
+    const fetchDefinitions = jest.fn((_url: string, options: { signal?: AbortSignal }) => {
+      if (!options.signal) {
+        throw new Error('Expected feature flag definition request to include an AbortSignal')
+      }
+      signals.push(options.signal)
+      return Promise.resolve({
+        status: 200,
+        headers: { get: () => null },
+        body,
+        text: () => Promise.resolve('response body'),
+        json: () => Promise.resolve(successfulFlagDefinitions),
+      })
+    })
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      fetch: fetchDefinitions as any,
+      requestTimeout: 10,
+      featureFlagsPollingInterval: 60000,
+      ...posthogImmediateResolveOptions,
+    })
+
+    const response = await (posthog as any).featureFlagsPoller._requestFeatureFlagDefinitions()
+
+    expect(response.body).toBe(body)
+    await expect(response.text()).resolves.toBe('response body')
+    await jest.advanceTimersByTimeAsync(10)
+
+    expect(signals[0].aborted).toBe(false)
+  })
+
+  it.each([304, 500])('clears the request timer for a %i response without consuming its body', async (status) => {
+    let signal: AbortSignal | undefined
+    const json = jest.fn()
+    const fetchDefinitions = jest.fn((_url: string, options: { signal?: AbortSignal }) => {
+      signal = options.signal
+      return Promise.resolve({
+        status,
+        headers: { get: () => (status === 304 ? 'etag' : null) },
+        text: () => Promise.resolve(''),
+        json,
+      })
+    })
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+      fetch: fetchDefinitions as any,
+      requestTimeout: 10,
+      featureFlagsPollingInterval: 60000,
+      ...posthogImmediateResolveOptions,
+    })
+
+    await posthog.reloadFeatureFlags()
+    await jest.advanceTimersByTimeAsync(10)
+
+    expect(json).not.toHaveBeenCalled()
+    expect(signal?.aborted).toBe(false)
   })
 })
 

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -1013,13 +1013,41 @@ class FeatureFlagsPoller {
       options.signal = controller.signal
     }
 
+    const clearAbortTimeout = () => clearTimeout(abortTimeout)
+
     try {
       // Unbind fetch from `this` to avoid potential issues in edge environments, e.g., Cloudflare Workers:
       // https://developers.cloudflare.com/workers/observability/errors/#illegal-invocation-errors
       const fetch = this.fetch
-      return await fetch(url, options)
-    } finally {
-      clearTimeout(abortTimeout)
+      const res = await fetch(url, options)
+
+      if (res.status !== 200) {
+        clearAbortTimeout()
+        return res
+      }
+
+      return {
+        status: res.status,
+        headers: res.headers,
+        body: res.body,
+        text: async () => {
+          try {
+            return await res.text()
+          } finally {
+            clearAbortTimeout()
+          }
+        },
+        json: async () => {
+          try {
+            return await res.json()
+          } finally {
+            clearAbortTimeout()
+          }
+        },
+      }
+    } catch (err) {
+      clearAbortTimeout()
+      throw err
     }
   }
 


### PR DESCRIPTION
## Problem

The feature flag definitions request timeout currently ends once `fetch()` resolves. A successful response whose body stalls during `json()` consumption can therefore keep `loadingPromise` pending, block local evaluation reloads, and stop subsequent polling.

This is a stacked follow-up to #4349 and should be retargeted to `main` after that PR merges.

## Changes

- Keep the definitions request abort timeout active while a successful response body is consumed through `json()` or `text()`.
- Clear the timer after body success/failure, fetch failure, and non-200 responses.
- Preserve status, headers, and the original response body.
- Add regression coverage for stalled and slow bodies, reload/local-evaluation settlement, poller recovery, text consumption, and non-200 cleanup.
- Add a patch changeset for `posthog-node`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A reviewer identified the body-consumption timeout gap on #4349. A Pi coding agent implemented the isolated follow-up, added regression coverage, and ran focused tests, lint, build, and bundle-driven autoreview. The implementation keeps the existing response contract while extending timer cleanup to every supported consumption path.
