### PR TITLE
fix(browser): persist re-registered object mutations

### DIFF
--- a/.changeset/persist-reregistered-mutations.md
+++ b/.changeset/persist-reregistered-mutations.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Persist in-place object and array mutations when properties are re-registered.

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -159,6 +159,28 @@ describe('persistence', () => {
             saveMock.mockClear()
         })
 
+        it('persists nested object mutations when re-registering the same reference', () => {
+            const value = { nested: { status: 'initial' } }
+            library.register({ value })
+
+            value.nested.status = 'updated'
+            library.register({ value })
+
+            const reloaded = new PostHogPersistence(makePostHogConfig('test', persistenceMode))
+            expect(reloaded.props.value).toEqual({ nested: { status: 'updated' } })
+        })
+
+        it('persists array mutations when re-registering the same reference', () => {
+            const value = ['initial']
+            library.register({ value })
+
+            value.push('updated')
+            library.register({ value })
+
+            const reloaded = new PostHogPersistence(makePostHogConfig('test', persistenceMode))
+            expect(reloaded.props.value).toEqual(['initial', 'updated'])
+        })
+
         it('should rebuild storage when cookie_persisted_properties changes via update_config', () => {
             const encode = (props: any) => encodeURIComponent(JSON.stringify(props))
             const expectedProps = () => ({

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -31,7 +31,7 @@ const GROUP_FRESHNESS_KEY: Partial<Record<PersistenceStorageGroup, string>> = {
     surveys: SURVEYS_LOADED_AT,
 }
 
-import { isNumber, isUndefined } from '@posthog/core'
+import { isArray, isNumber, isUndefined } from '@posthog/core'
 import {
     getCampaignParams,
     getInitialPersonPropsFromInfo,
@@ -689,7 +689,7 @@ export class PostHogPersistence {
             let hasChanges = false
 
             each(props, (val, prop) => {
-                if (props.hasOwnProperty(prop) && this.props[prop] !== val) {
+                if (props.hasOwnProperty(prop) && (this.props[prop] !== val || isObject(val) || isArray(val))) {
                     this._setProp(prop, val)
                     hasChanges = true
                 }


### PR DESCRIPTION
## Problem

`PostHogPersistence.register()` uses top-level reference equality to skip unchanged properties. If an object or array is mutated in place and then explicitly re-registered with the same reference, persistence does not mark it dirty and the nested change can be lost after reload.

[Feature flags contain an existing production example](https://github.com/PostHog/posthog-js/blob/990ee9ba3a41dba871c1e880902dfa1574aac2d7/packages/browser/src/posthog-featureflags.ts#L873-L895): `getFeatureFlagResult()` mutates the nested array in `FLAG_CALL_REPORTED` and re-registers the same parent object. The current guard can skip that update.

## Changes

- Treat explicitly re-registered object and array values as potentially changed while retaining the equality optimization for primitives.
- Keep the fix deliberately small rather than adding deep comparison, cloning, fingerprints, or generalized change tracking. Existing save fingerprinting still rejects structurally unchanged durable writes.
- Add regression coverage showing same-reference nested object and array mutations survive reload across cookie, localStorage, and localStorage+cookie persistence.

### Validation

- Focused `posthog-persistence` suite: 419 tests passed.
- ESLint, Prettier, and `git diff --check`: passed.
- Fast `array.js` comparison against `origin/main`: +0.01% minified, +0.01% gzip, +0.10% Brotli.
- Fresh read-only review found no blockers.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and a delegated writer subagent, then checked by a fresh read-only reviewer subagent. The implementation intentionally favors a direct object/array guard over broader change-detection machinery because this code ships in the browser bundle.
