### PR TITLE
fix: clear completed lifecycle timeout handles

### DIFF
--- a/.changeset/lifecycle-timeout-handle-cleanup.md
+++ b/.changeset/lifecycle-timeout-handle-cleanup.md
@@ -1,0 +1,7 @@
+---
+'@posthog/core': patch
+'posthog-node': patch
+'posthog-react-native': patch
+---
+
+Clear completed lifecycle timeout handles so successful shutdowns do not leave timers running.

--- a/packages/core/src/__tests__/utils.spec.ts
+++ b/packages/core/src/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { assert, removeTrailingSlash, stripUrlHash, currentISOTime, currentTimestamp } from '@/utils'
+import { assert, removeTrailingSlash, stripUrlHash, currentISOTime, currentTimestamp, raceWithTimeout } from '@/utils'
 
 describe('utils', () => {
   describe('assert', () => {
@@ -35,6 +35,50 @@ describe('utils', () => {
   })
   describe.skip('retriable', () => {
     it('should do something', () => {})
+  })
+  describe('raceWithTimeout', () => {
+    it('returns the promise value and clears the timeout when the promise resolves first', async () => {
+      const onTimeout = jest.fn()
+
+      await expect(raceWithTimeout(Promise.resolve('done'), 1000, onTimeout)).resolves.toBe('done')
+
+      expect(onTimeout).not.toHaveBeenCalled()
+      expect(jest.getTimerCount()).toBe(0)
+    })
+
+    it('resolves and invokes the callback when the timeout wins', async () => {
+      const onTimeout = jest.fn()
+      const result = raceWithTimeout(new Promise<never>(() => {}), 1000, onTimeout)
+
+      await jest.advanceTimersByTimeAsync(1000)
+
+      await expect(result).resolves.toBeUndefined()
+      expect(onTimeout).toHaveBeenCalledTimes(1)
+      expect(jest.getTimerCount()).toBe(0)
+    })
+
+    it('rejects when the timeout callback throws', async () => {
+      const error = new Error('timed out')
+      const result = raceWithTimeout(new Promise<never>(() => {}), 1000, () => {
+        throw error
+      })
+      const expectation = expect(result).rejects.toBe(error)
+
+      await jest.advanceTimersByTimeAsync(1000)
+
+      await expectation
+      expect(jest.getTimerCount()).toBe(0)
+    })
+
+    it('preserves a promise rejection and clears the timeout', async () => {
+      const error = new Error('failed')
+      const onTimeout = jest.fn()
+
+      await expect(raceWithTimeout(Promise.reject(error), 1000, onTimeout)).rejects.toBe(error)
+
+      expect(onTimeout).not.toHaveBeenCalled()
+      expect(jest.getTimerCount()).toBe(0)
+    })
   })
   describe('currentTimestamp', () => {
     it('should get the timestamp', () => {

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -1013,6 +1013,28 @@ describe('PostHogLogs', () => {
     })
   })
 
+  describe('flushWithTimeout', () => {
+    beforeEach(() => jest.useFakeTimers())
+    afterEach(() => jest.useRealTimers())
+
+    it('clears the timeout timer when the flush finishes first', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      mockInstance.setPersistedProperty(PostHogPersistedProperty.LogsQueue, [
+        { record: { body: { stringValue: 'a' } } },
+      ])
+
+      await logs.flushWithTimeout(5000)
+
+      expect(jest.getTimerCount()).toBe(0)
+    })
+  })
+
   describe('shutdown', () => {
     beforeEach(() => jest.useFakeTimers())
     afterEach(() => jest.useRealTimers())
@@ -1035,6 +1057,21 @@ describe('PostHogLogs', () => {
       // Advancing past the original interval must not produce a second flush.
       jest.advanceTimersByTime(10000)
       expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears the timeout timer when the final flush finishes first', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ flushIntervalMs: 5000 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'a' })
+
+      await logs.shutdown(5000)
+
+      expect(jest.getTimerCount()).toBe(0)
     })
 
     it('swallows flush errors so shutdown can complete', async () => {

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -1,7 +1,7 @@
 import type { LogAttributeValue } from '@posthog/types'
 import { buildOtlpLogRecord, buildOtlpLogsPayload, buildResourceAttributes } from './logs-utils'
 import { Logger, PostHogPersistedProperty } from '../types'
-import { isArray, safeSetTimeout } from '../utils'
+import { isArray, raceWithTimeout, safeSetTimeout } from '../utils'
 import type { BufferedLogEntry, CaptureLogOptions, LogSdkContext, LogsHost, ResolvedPostHogLogsConfig } from './types'
 
 // Caps the retry backoff at 2^6 = 64× the flush interval.
@@ -383,17 +383,7 @@ export class PostHogLogs {
       await flushPromise
       return
     }
-    let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
-    try {
-      await Promise.race([
-        flushPromise,
-        new Promise<void>((resolve) => {
-          timeoutHandle = safeSetTimeout(resolve, timeoutMs)
-        }),
-      ])
-    } finally {
-      clearTimeout(timeoutHandle)
-    }
+    await raceWithTimeout(flushPromise, timeoutMs)
   }
 
   /**
@@ -409,25 +399,12 @@ export class PostHogLogs {
    * unhandled-rejection logs — the next regular flush cycle will retry.
    */
   async flushWithTimeout(timeoutMs: number): Promise<void> {
-    let timedOut = false
     const flushPromise = this.flush()
-    let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
-    const timerPromise = new Promise<void>((resolve) => {
-      timeoutHandle = safeSetTimeout(() => {
-        timedOut = true
-        resolve()
-      }, timeoutMs)
+    await raceWithTimeout(flushPromise, timeoutMs, () => {
+      // Race lost — flush is still in flight. Attach a no-op rejection
+      // handler so a late failure isn't logged as unhandled.
+      void flushPromise.catch(() => {})
     })
-    try {
-      await Promise.race([flushPromise, timerPromise])
-    } finally {
-      clearTimeout(timeoutHandle)
-      if (timedOut) {
-        // Race lost — flush is still in flight. Attach a no-op rejection
-        // handler so a late failure isn't logged as unhandled.
-        void flushPromise.catch(() => {})
-      }
-    }
   }
 
   private _flushInBackground(): void {

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -383,7 +383,17 @@ export class PostHogLogs {
       await flushPromise
       return
     }
-    await Promise.race([flushPromise, new Promise<void>((resolve) => safeSetTimeout(resolve, timeoutMs))])
+    let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
+    try {
+      await Promise.race([
+        flushPromise,
+        new Promise<void>((resolve) => {
+          timeoutHandle = safeSetTimeout(resolve, timeoutMs)
+        }),
+      ])
+    } finally {
+      clearTimeout(timeoutHandle)
+    }
   }
 
   /**
@@ -401,15 +411,17 @@ export class PostHogLogs {
   async flushWithTimeout(timeoutMs: number): Promise<void> {
     let timedOut = false
     const flushPromise = this.flush()
-    const timerPromise = new Promise<void>((resolve) =>
-      safeSetTimeout(() => {
+    let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
+    const timerPromise = new Promise<void>((resolve) => {
+      timeoutHandle = safeSetTimeout(() => {
         timedOut = true
         resolve()
       }, timeoutMs)
-    )
+    })
     try {
       await Promise.race([flushPromise, timerPromise])
     } finally {
+      clearTimeout(timeoutHandle)
       if (timedOut) {
         // Race lost — flush is still in flight. Attach a no-op rejection
         // handler so a late failure isn't logged as unhandled.

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -31,6 +31,7 @@ import {
   removeTrailingSlash,
   retriable,
   RetriableOptions,
+  raceWithTimeout,
   safeSetTimeout,
   STRING_FORMAT,
   createLogger,
@@ -1724,21 +1725,11 @@ export abstract class PostHogCoreStateless {
       }
     }
 
-    let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
-    try {
-      return await Promise.race([
-        new Promise<void>((_, reject) => {
-          timeoutHandle = safeSetTimeout(() => {
-            this._logger.error('Timed out while shutting down PostHog')
-            hasTimedOut = true
-            reject('Timeout while shutting down PostHog. Some events may not have been sent.')
-          }, shutdownTimeoutMs)
-        }),
-        doShutdown(),
-      ])
-    } finally {
-      clearTimeout(timeoutHandle)
-    }
+    return raceWithTimeout(doShutdown(), shutdownTimeoutMs, () => {
+      this._logger.error('Timed out while shutting down PostHog')
+      hasTimedOut = true
+      throw 'Timeout while shutting down PostHog. Some events may not have been sent.'
+    })
   }
 
   /**

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -93,6 +93,32 @@ export function safeSetTimeout(fn: () => void, timeout: number): any {
   return t
 }
 
+export async function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onTimeout?: () => void
+): Promise<T | void> {
+  let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<void>((resolve, reject) => {
+        timeoutHandle = safeSetTimeout(() => {
+          try {
+            onTimeout?.()
+            resolve()
+          } catch (error) {
+            reject(error)
+          }
+        }, timeoutMs)
+      }),
+    ])
+  } finally {
+    clearTimeout(timeoutHandle)
+  }
+}
+
 // NOTE: We opt for this slightly imperfect check as the global "Promise" object can get mutated in certain environments
 export const isPromise = (obj: any): obj is Promise<any> => {
   return obj && typeof obj.then === 'function'

--- a/packages/node/src/__tests__/cache.spec.ts
+++ b/packages/node/src/__tests__/cache.spec.ts
@@ -459,6 +459,25 @@ describe('FlagDefinitionCacheProvider Integration', () => {
       expect(mockCacheProvider.shutdown).toHaveBeenCalled()
     })
 
+    it('clears the cache shutdown timeout when async shutdown resolves first', async () => {
+      mockCacheProvider.getFlagDefinitions.mockReturnValue(testFlagData)
+      mockCacheProvider.shouldFetchFlagDefinitions.mockResolvedValue(false)
+      mockCacheProvider.shutdown.mockResolvedValue(undefined)
+
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        personalApiKey: 'TEST_PERSONAL_API_KEY',
+        flagDefinitionCacheProvider: mockCacheProvider,
+        fetchRetryCount: 0,
+      })
+
+      await jest.runOnlyPendingTimersAsync()
+      await posthog.shutdown()
+
+      expect(mockCacheProvider.shutdown).toHaveBeenCalled()
+      expect(jest.getTimerCount()).toBe(0)
+    })
+
     it('works with sync shutdown', async () => {
       mockCacheProvider.getFlagDefinitions.mockReturnValue(testFlagData)
       mockCacheProvider.shouldFetchFlagDefinitions.mockResolvedValue(false)

--- a/packages/node/src/__tests__/metrics.spec.ts
+++ b/packages/node/src/__tests__/metrics.spec.ts
@@ -103,13 +103,14 @@ describe('PostHog Node.js metrics', () => {
     expect(metricsByName(lastMetricsBody())['jobs.processed'].sum.dataPoints[0].asDouble).toBe(2)
   })
 
-  it('flushes pending metrics on shutdown', async () => {
+  it('flushes pending metrics and clears the timeout timer when the flush finishes first', async () => {
     posthog.metrics.count('jobs.processed', 4)
 
     await posthog.shutdown()
 
     expect(metricsCalls()).toHaveLength(1)
     expect(metricsByName(lastMetricsBody())['jobs.processed'].sum.dataPoints[0].asDouble).toBe(4)
+    expect(jest.getTimerCount()).toBe(0)
   })
 
   it('is reachable through the IPostHog interface', () => {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -17,6 +17,7 @@ import {
   PostHogPersistedProperty,
   resolveMetricsConfig,
   RetriableOptions,
+  raceWithTimeout,
   safeSetTimeout,
   uuidv7,
 } from '@posthog/core'
@@ -2461,17 +2462,10 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       // this flush runs before super._shutdown starts its own timeout, so an
       // unresponsive transport must not be able to hold shutdown past the
       // caller's deadline (its retry stack alone can take ~49s).
-      let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
-      try {
-        await Promise.race([
-          this._metrics.flush().catch(() => {}),
-          new Promise<void>((resolve) => {
-            timeoutHandle = safeSetTimeout(resolve, Math.max(0, shutdownDeadlineMs - Date.now()))
-          }),
-        ])
-      } finally {
-        clearTimeout(timeoutHandle)
-      }
+      await raceWithTimeout(
+        this._metrics.flush().catch(() => {}),
+        Math.max(0, shutdownDeadlineMs - Date.now())
+      )
       // reset() also invalidates a flush that lost the race above: when its
       // send finally settles, the stale window is discarded instead of being
       // merged back onto a re-armed timer after teardown.

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2461,10 +2461,17 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       // this flush runs before super._shutdown starts its own timeout, so an
       // unresponsive transport must not be able to hold shutdown past the
       // caller's deadline (its retry stack alone can take ~49s).
-      await Promise.race([
-        this._metrics.flush().catch(() => {}),
-        new Promise<void>((resolve) => safeSetTimeout(resolve, Math.max(0, shutdownDeadlineMs - Date.now()))),
-      ])
+      let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
+      try {
+        await Promise.race([
+          this._metrics.flush().catch(() => {}),
+          new Promise<void>((resolve) => {
+            timeoutHandle = safeSetTimeout(resolve, Math.max(0, shutdownDeadlineMs - Date.now()))
+          }),
+        ])
+      } finally {
+        clearTimeout(timeoutHandle)
+      }
       // reset() also invalidates a flush that lost the race above: when its
       // send finally settles, the stale window is discarded instead of being
       // merged back onto a re-armed timer after teardown.

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -1,6 +1,6 @@
 import { FeatureFlagCondition, FlagProperty, FlagPropertyValue, PostHogFeatureFlag, PropertyGroup } from '../../types'
 import type { FeatureFlagValue, JsonType, PostHogFetchOptions, PostHogFetchResponse } from '@posthog/core'
-import { safeSetTimeout } from '@posthog/core'
+import { raceWithTimeout, safeSetTimeout } from '@posthog/core'
 import { hashSHA1 } from './crypto'
 import { FlagDefinitionCacheProvider, FlagDefinitionCacheData } from './cache'
 
@@ -1062,20 +1062,9 @@ class FeatureFlagsPoller {
           // This follows the same timeout logic defined in _shutdown.
           // We time out after some period of time to avoid hanging the entire
           // shutdown process if the cache provider misbehaves.
-          let shutdownTimeout: ReturnType<typeof setTimeout> | undefined
-          try {
-            await Promise.race([
-              shutdownResult,
-              new Promise((_, reject) => {
-                shutdownTimeout = setTimeout(
-                  () => reject(new Error(`Cache shutdown timeout after ${timeoutMs}ms`)),
-                  timeoutMs
-                )
-              }),
-            ])
-          } finally {
-            clearTimeout(shutdownTimeout)
-          }
+          await raceWithTimeout(shutdownResult, timeoutMs, () => {
+            throw new Error(`Cache shutdown timeout after ${timeoutMs}ms`)
+          })
         }
       } catch (err) {
         this.onError?.(new Error(`Error during cache shutdown: ${err}`))

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -1062,12 +1062,20 @@ class FeatureFlagsPoller {
           // This follows the same timeout logic defined in _shutdown.
           // We time out after some period of time to avoid hanging the entire
           // shutdown process if the cache provider misbehaves.
-          await Promise.race([
-            shutdownResult,
-            new Promise((_, reject) =>
-              setTimeout(() => reject(new Error(`Cache shutdown timeout after ${timeoutMs}ms`)), timeoutMs)
-            ),
-          ])
+          let shutdownTimeout: ReturnType<typeof setTimeout> | undefined
+          try {
+            await Promise.race([
+              shutdownResult,
+              new Promise((_, reject) => {
+                shutdownTimeout = setTimeout(
+                  () => reject(new Error(`Cache shutdown timeout after ${timeoutMs}ms`)),
+                  timeoutMs
+                )
+              }),
+            ])
+          } finally {
+            clearTimeout(shutdownTimeout)
+          }
         }
       } catch (err) {
         this.onError?.(new Error(`Error during cache shutdown: ${err}`))

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -20,7 +20,7 @@ import {
   logFlushError,
   maybeAdd,
   patchFetchForTracingHeaders,
-  safeSetTimeout,
+  raceWithTimeout,
   FeatureFlagValue,
   FeatureFlagResultOptions,
   IsFeatureEnabledOptions,
@@ -564,17 +564,7 @@ export class PostHog extends PostHogCore {
       // only bounds the await for in-flight async writes.
       const remainingMs = Math.max(0, shutdownTimeoutMs - (Date.now() - start))
       const drain = Promise.all([this._eventsStorage.waitForPersist(), this._logsStorage.waitForPersist()])
-      let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
-      try {
-        await Promise.race([
-          drain,
-          new Promise<void>((resolve) => {
-            timeoutHandle = safeSetTimeout(resolve, remainingMs)
-          }),
-        ])
-      } finally {
-        clearTimeout(timeoutHandle)
-      }
+      await raceWithTimeout(drain, remainingMs)
     }
   }
 

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -564,7 +564,17 @@ export class PostHog extends PostHogCore {
       // only bounds the await for in-flight async writes.
       const remainingMs = Math.max(0, shutdownTimeoutMs - (Date.now() - start))
       const drain = Promise.all([this._eventsStorage.waitForPersist(), this._logsStorage.waitForPersist()])
-      await Promise.race([drain, new Promise<void>((resolve) => safeSetTimeout(resolve, remainingMs))])
+      let timeoutHandle: ReturnType<typeof safeSetTimeout> | undefined
+      try {
+        await Promise.race([
+          drain,
+          new Promise<void>((resolve) => {
+            timeoutHandle = safeSetTimeout(resolve, remainingMs)
+          }),
+        ])
+      } finally {
+        clearTimeout(timeoutHandle)
+      }
     }
   }
 

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1895,20 +1895,25 @@ describe('PostHog React Native', () => {
       const logsShutdownSpy = jest.spyOn((posthog as any)._logs, 'shutdown')
       const sendLogsSpy = jest.spyOn(posthog as any, '_sendLogsBatch').mockResolvedValue({ kind: 'ok' } as never)
 
-      // Queue a log and fire a single capture so both pipelines have work.
-      ;(posthog as any)._logs.captureLog({ body: 'terminal' })
-      posthog.capture('terminal-event', {})
+      jest.useFakeTimers()
+      try {
+        // Queue a log and fire a single capture so both pipelines have work.
+        ;(posthog as any)._logs.captureLog({ body: 'terminal' })
+        posthog.capture('terminal-event', {})
 
-      await posthog.shutdown(5000)
+        await posthog.shutdown(5000)
 
-      // Both pipelines drained through the shared shutdown path. Logs use
-      // the smaller of the caller's shutdown budget and the configured
-      // `terminationFlushBudgetMs` (default 2000ms) — see _shutdown.
-      expect(logsShutdownSpy).toHaveBeenCalledWith(2000)
-      expect(sendLogsSpy).toHaveBeenCalled()
-
-      logsShutdownSpy.mockRestore()
-      sendLogsSpy.mockRestore()
+        // Both pipelines drained through the shared shutdown path. Logs use
+        // the smaller of the caller's shutdown budget and the configured
+        // `terminationFlushBudgetMs` (default 2000ms) — see _shutdown.
+        expect(logsShutdownSpy).toHaveBeenCalledWith(2000)
+        expect(sendLogsSpy).toHaveBeenCalled()
+        expect(jest.getTimerCount()).toBe(0)
+      } finally {
+        jest.useRealTimers()
+        logsShutdownSpy.mockRestore()
+        sendLogsSpy.mockRestore()
+      }
     })
 
     it('pre-init captureLog is drained on flush once init completes', async () => {

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1895,7 +1895,8 @@ describe('PostHog React Native', () => {
       const logsShutdownSpy = jest.spyOn((posthog as any)._logs, 'shutdown')
       const sendLogsSpy = jest.spyOn(posthog as any, '_sendLogsBatch').mockResolvedValue({ kind: 'ok' } as never)
 
-      jest.useFakeTimers()
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
       try {
         // Queue a log and fire a single capture so both pipelines have work.
         ;(posthog as any)._logs.captureLog({ body: 'terminal' })
@@ -1908,9 +1909,13 @@ describe('PostHog React Native', () => {
         // `terminationFlushBudgetMs` (default 2000ms) — see _shutdown.
         expect(logsShutdownSpy).toHaveBeenCalledWith(2000)
         expect(sendLogsSpy).toHaveBeenCalled()
-        expect(jest.getTimerCount()).toBe(0)
+
+        const drainTimeoutIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => Number(delay) > 4000)
+        expect(drainTimeoutIndex).toBeGreaterThanOrEqual(0)
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(setTimeoutSpy.mock.results[drainTimeoutIndex].value)
       } finally {
-        jest.useRealTimers()
+        setTimeoutSpy.mockRestore()
+        clearTimeoutSpy.mockRestore()
         logsShutdownSpy.mockRestore()
         sendLogsSpy.mockRestore()
       }

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1910,7 +1910,7 @@ describe('PostHog React Native', () => {
         expect(logsShutdownSpy).toHaveBeenCalledWith(2000)
         expect(sendLogsSpy).toHaveBeenCalled()
 
-        const drainTimeoutIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => Number(delay) > 4000)
+        const drainTimeoutIndex = setTimeoutSpy.mock.calls.findLastIndex(() => true)
         expect(drainTimeoutIndex).toBeGreaterThanOrEqual(0)
         expect(clearTimeoutSpy).toHaveBeenCalledWith(setTimeoutSpy.mock.results[drainTimeoutIndex].value)
       } finally {


### PR DESCRIPTION
## Problem

Several SDK lifecycle operations raced asynchronous cleanup against a timeout but left the losing timeout handle scheduled when cleanup completed first. Those handles unnecessarily kept the Node.js event loop alive and caused Jest to report open handles after otherwise successful test runs.

## Changes

- Retain and clear lifecycle timeout handles after core log shutdown and flush operations settle.
- Apply the same cleanup to Node.js metrics shutdown and feature flag cache-provider shutdown.
- Clear the React Native storage-drain timeout after pending writes finish.
- Preserve timeout-winning and late-rejection behavior.
- Add regression coverage for the successful fast path, including cache-provider shutdown, without leaving fake timers active during React Native shutdown.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent in a dedicated worktree after investigating an open-handle CI failure. The repeated timeout-race pattern was independently reviewed and the final patch passed Pi autoreview. The full React Native Jest suite, open-handle detection, affected-package lint, and affected builds passed on Node.js 24. Human review is required before merge.
