### PR TITLE
fix(browser): clear register_for_session properties on session rotation

### DIFF
--- a/.changeset/session-persistence-clear-on-rotation.md
+++ b/.changeset/session-persistence-clear-on-rotation.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Clear `register_for_session` properties when the `$session_id` rotates, matching the documented behavior that session super properties are cleared when the session ends.

--- a/packages/browser/src/__tests__/posthog-core.session-persistence-reset.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.session-persistence-reset.test.ts
@@ -1,0 +1,70 @@
+import { createPosthogInstance } from './helpers/posthog-instance'
+import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
+
+// register_for_session/unregister_for_session are documented as being cleared when the
+// session ends (see the `sessionPersistence` docstring in posthog-core.ts). Verifies that
+// a real $session_id rotation actually clears them, and that the baseline-recording +
+// shared-instance guards in _clearSessionPersistenceOnNewSession behave correctly.
+describe('session-scoped persistence is cleared on session id rotation', () => {
+    it('clears register_for_session properties when the session id rotates', async () => {
+        const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage+cookie' })
+
+        // establish the initial session (as page load normally would, e.g. via the first capture)
+        // before registering session-scoped properties
+        posthog.sessionManager!.checkAndGetSessionAndWindowId()
+
+        posthog.register_for_session({ current_flow: 'checkout' })
+        expect(posthog.sessionPersistence!.props.current_flow).toBe('checkout')
+
+        // Force a real session id rotation via the same mechanism used for
+        // activity-timeout/max-length rotations, then let the change propagate
+        // through onSessionId handlers (including our new one).
+        posthog.sessionManager!.resetSessionId()
+        posthog.sessionManager!.checkAndGetSessionAndWindowId()
+
+        expect(posthog.sessionPersistence!.props.current_flow).toBeUndefined()
+    })
+
+    it('does not clear when register_for_session is called within the same session', async () => {
+        const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage+cookie' })
+
+        // establish the current session id as the tracked baseline
+        posthog.sessionManager!.checkAndGetSessionAndWindowId()
+
+        posthog.register_for_session({ current_flow: 'checkout' })
+        expect(posthog.sessionPersistence!.props.current_flow).toBe('checkout')
+
+        // re-checking without any rotation trigger should not touch session persistence
+        posthog.sessionManager!.checkAndGetSessionAndWindowId()
+
+        expect(posthog.sessionPersistence!.props.current_flow).toBe('checkout')
+    })
+
+    it('does not clear properties registered before the very first rotation', async () => {
+        const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage+cookie' })
+
+        // onSessionId fires immediately on subscription with the current session id,
+        // which must only record a baseline — not clear anything already registered.
+        posthog.register_for_session({ current_flow: 'checkout' })
+
+        expect(posthog.sessionPersistence!.props.current_flow).toBe('checkout')
+    })
+
+    it('does not wipe unrelated persistence when sessionPersistence and persistence share an instance', async () => {
+        const posthog = await createPosthogInstance(uuidv7(), { persistence: 'memory' })
+
+        expect(posthog.sessionPersistence).toBe(posthog.persistence)
+
+        posthog.sessionManager!.checkAndGetSessionAndWindowId()
+
+        posthog.register({ some_super_property: 'keep-me' } as unknown as Record<string, unknown>)
+        posthog.register_for_session({ current_flow: 'checkout' })
+
+        posthog.sessionManager!.resetSessionId()
+        posthog.sessionManager!.checkAndGetSessionAndWindowId()
+
+        // In shared-instance mode we deliberately skip the clear, since it would also
+        // wipe distinct_id, super properties, feature flags, etc.
+        expect(posthog.persistence!.props.some_super_property).toBe('keep-me')
+    })
+})

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -422,6 +422,7 @@ export class PostHog implements PostHogInterface {
     sessionPersistence?: PostHogPersistence
     sessionManager?: SessionIdManager
     sessionPropsManager?: SessionPropsManager
+    _sessionPersistenceLastSessionId?: string
     requestRouter: RequestRouter
     siteApps?: SiteApps
     autocapture?: Autocapture
@@ -716,6 +717,7 @@ export class PostHog implements PostHogInterface {
         if (!startInCookielessMode) {
             this.sessionManager = new SessionIdManager(this)
             this.sessionPropsManager = new SessionPropsManager(this, this.sessionManager, this.persistence)
+            this.sessionManager.onSessionId(this._clearSessionPersistenceOnNewSession)
         }
 
         // Conditionally defer extension initialization based on config
@@ -1930,6 +1932,26 @@ export class PostHog implements PostHogInterface {
      */
     unregister_for_session(property: string): void {
         this.sessionPersistence?.unregister(property)
+    }
+
+    // Session-scoped properties (register_for_session, campaign/referrer info) are documented as
+    // cleared when the session ends. onSessionId fires immediately on subscription with the current
+    // id, so the first call only records a baseline instead of clearing — otherwise props registered
+    // before this handler is wired up (or across a page load within the same session) would be wiped.
+    // When sessionPersistence and persistence are the same instance (persistence: 'sessionStorage' or
+    // 'memory'), clearing would wipe unrelated state like distinct_id and feature flags, so skip it.
+    _clearSessionPersistenceOnNewSession = (sessionId: string): void => {
+        if (isUndefined(this._sessionPersistenceLastSessionId)) {
+            this._sessionPersistenceLastSessionId = sessionId
+            return
+        }
+        if (this._sessionPersistenceLastSessionId === sessionId) {
+            return
+        }
+        this._sessionPersistenceLastSessionId = sessionId
+        if (this.sessionPersistence && this.sessionPersistence !== this.persistence) {
+            this.sessionPersistence.clear()
+        }
     }
 
     _register_single(prop: string, value: Property) {
@@ -3975,6 +3997,8 @@ export class PostHog implements PostHogInterface {
             if (this.persistence) {
                 this.sessionPropsManager = new SessionPropsManager(this, this.sessionManager, this.persistence)
             }
+            this._sessionPersistenceLastSessionId = undefined
+            this.sessionManager.onSessionId(this._clearSessionPersistenceOnNewSession)
             const SessionRecordingClass =
                 this.config.__extensionClasses?.sessionRecording ?? PostHog.__defaultExtensionClasses?.sessionRecording
             if (SessionRecordingClass) {


### PR DESCRIPTION
Closes #3573

## Problem

`register_for_session`'s docstring states these properties are "cleared when the session ends," but nothing actually cleared `sessionPersistence` when `$session_id` rotates (activity timeout, max session length, etc.). Properties persisted in `sessionStorage` as long as the browser tab stayed open, requiring `unregister_for_session` as a manual workaround.

The gap was even anticipated in a comment in `sessionid.ts`, describing "session-scoped props" as a consumer that should react to session id changes but never did.

## Fix

Hooks into the existing `SessionIdManager.onSessionId` mechanism — the same pattern `SessionPropsManager` already uses for `$client_session_props`. A new handler, `_clearSessionPersistenceOnNewSession`, subscribes and clears `sessionPersistence` only on a genuine session id change.

Two edge cases handled:
- `onSessionId` fires immediately on subscription with the *current* session id. The handler treats its first call as a baseline recording rather than a clear, so properties registered before the handler is wired up (or across a page load within the same session) aren't wiped.
- When `config.persistence` is `'sessionStorage'` or `'memory'`, `sessionPersistence` and `persistence` are the same instance. Clearing in that case would wipe unrelated state (distinct_id, super properties, feature flags), so it's skipped.

## Testing

Added `posthog-core.session-persistence-reset.test.ts` covering:
- properties clear on a real session id rotation (via `resetSessionId()` + `checkAndGetSessionAndWindowId()`)
- properties are *not* cleared within the same session
- properties registered before the very first rotation aren't wiped
- shared-instance mode (`persistence: 'memory'`) doesn't wipe unrelated persisted state