### PR TITLE
fix: slim no-external extension bundle types

### DIFF
--- a/.changeset/fix-slim-no-external-extension-types.md
+++ b/.changeset/fix-slim-no-external-extension-types.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Share extension bundle types between the slim and slim no-external entrypoints.

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -418,6 +418,7 @@ const typeTargets = entrypoints
     .map((file) => {
         const source = `./lib/src/entrypoints/${file.replace('.ts', '.d.ts')}`
         const isExtensionBundles = file === 'extension-bundles.es.ts'
+        const isSlimModule = file === 'module.slim.es.ts'
         // customizations types must reference the main module for the PostHog class —
         // an inlined duplicate would be nominally incompatible with the consumer's
         // `posthog` instance (same private-fields problem as extension-bundles).
@@ -429,8 +430,12 @@ const typeTargets = entrypoints
             input: source,
             // extension-bundles types must reference module.slim rather than inlining
             // their own copies — classes with private fields are nominally typed, so
-            // duplicate declarations across .d.ts files are incompatible.
+            // duplicate declarations across .d.ts files are incompatible. For the same
+            // reason, module.slim must use a source-level re-export from
+            // module.slim.no-external and keep that module external here, so dts preserves
+            // the reference instead of inlining a second declaration graph.
             ...(isExtensionBundles ? { external: [/module\.slim/] } : {}),
+            ...(isSlimModule ? { external: [/module\.slim\.no-external/] } : {}),
             ...(isCustomizations ? { external: [/posthog-core$/] } : {}),
             output: [
                 {
@@ -444,14 +449,19 @@ const typeTargets = entrypoints
                     exclude: [],
                     ...(inlineExternalTypes ? { respectExternal: true } : {}),
                 }),
-                // dts preserves the tsc-era path (e.g. './module.slim.es') but the
-                // output has been renamed to module.slim.d.ts — fix the reference.
-                ...(isExtensionBundles
+                // dts preserves tsc-era paths ending in `.es`, but the output files
+                // omit that segment — fix references between the generated declarations.
+                ...(isExtensionBundles || isSlimModule
                     ? [
                           {
                               name: 'fix-dts-external-paths',
                               renderChunk(code) {
-                                  return code.replace(/\.\/module\.slim\.es(?=['"])/g, './module.slim')
+                                  return code
+                                      .replace(/\.\/module\.slim\.es(?=['"])/g, './module.slim')
+                                      .replace(
+                                          /\.\/module\.slim\.no-external\.es(?=['"])/g,
+                                          './module.slim.no-external'
+                                      )
                               },
                           },
                       ]

--- a/packages/browser/src/__tests__/entrypoints/module.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/module.test.ts
@@ -1,5 +1,7 @@
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
+import * as ts from 'typescript'
 // Sanity checks to check the built code does not contain any script loaders
 
 const arrayJs = fs.readFileSync(path.join(__dirname, '../../../dist/array.js'), 'utf-8')
@@ -14,6 +16,8 @@ const moduleFullNoExternalJs = fs.readFileSync(
     path.join(__dirname, '../../../dist/module.full.no-external.js'),
     'utf-8'
 )
+const moduleSlimDts = fs.readFileSync(path.join(__dirname, '../../../dist/module.slim.d.ts'), 'utf-8')
+const extensionBundlesDts = fs.readFileSync(path.join(__dirname, '../../../dist/extension-bundles.d.ts'), 'utf-8')
 
 describe('Array entrypoint', () => {
     it('should not contain any script loaders', () => {
@@ -31,6 +35,58 @@ describe('Module entrypoint', () => {
         expect(moduleFullJs).toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(moduleNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(moduleFullNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
+    })
+})
+
+describe('Slim module declarations', () => {
+    it('share nominal types between extension bundles and both slim entrypoints', () => {
+        expect(extensionBundlesDts).toContain("from './module.slim'")
+        expect(moduleSlimDts).toContain("from './module.slim.no-external'")
+        expect(moduleSlimDts).not.toContain('declare class PostHog')
+
+        const fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-slim-types-'))
+        const fixturePath = path.join(fixtureDirectory, 'index.ts')
+        const distPath = path.resolve(__dirname, '../../../dist').replaceAll('\\', '/')
+        fs.writeFileSync(
+            fixturePath,
+            `
+import { AnalyticsExtensions, ErrorTrackingExtensions, SessionReplayExtensions } from '${distPath}/extension-bundles'
+import posthog from '${distPath}/module.slim'
+import type { PostHog, PostHogConfig } from '${distPath}/module.slim.no-external'
+
+const instance: PostHog = posthog
+void instance
+
+const extensionClasses = {
+    ...SessionReplayExtensions,
+    ...AnalyticsExtensions,
+    ...ErrorTrackingExtensions,
+} satisfies NonNullable<PostHogConfig['__extensionClasses']>
+void extensionClasses
+`
+        )
+
+        try {
+            const program = ts.createProgram([fixturePath], {
+                exactOptionalPropertyTypes: true,
+                module: ts.ModuleKind.ESNext,
+                moduleResolution: ts.ModuleResolutionKind.Bundler,
+                noEmit: true,
+                skipLibCheck: true,
+                strict: true,
+                target: ts.ScriptTarget.ESNext,
+            })
+            const diagnostics = ts.getPreEmitDiagnostics(program)
+            expect(
+                ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+                    getCanonicalFileName: (fileName) => fileName,
+                    getCurrentDirectory: () => fixtureDirectory,
+                    getNewLine: () => '\n',
+                })
+            ).toBe('')
+        } finally {
+            fs.rmSync(fixtureDirectory, { recursive: true })
+        }
     })
 })
 

--- a/packages/browser/src/entrypoints/module.slim.es.ts
+++ b/packages/browser/src/entrypoints/module.slim.es.ts
@@ -1,4 +1,3 @@
 import './external-scripts-loader'
-import posthog from './module.slim.no-external.es'
 export * from './module.slim.no-external.es'
-export default posthog
+export { default } from './module.slim.no-external.es'


### PR DESCRIPTION
## Problem

[#4305](https://github.com/PostHog/posthog-js/pull/4305) fixed the runtime ABI between `module.slim.no-external.js` and `extension-bundles.js`, but the corresponding TypeScript declarations remain incompatible.

`extension-bundles.d.ts` references types from `module.slim.d.ts`, while `module.slim.no-external.d.ts` contains an independently emitted copy of the same classes. TypeScript treats classes with private members nominally, so extension constructors from `extension-bundles` cannot be assigned to `PostHogConfig['__extensionClasses']` from `module.slim.no-external`. Consumers see errors such as:

```text
ScrollManager types have separate declarations of private property '_instance'
```

## Changes

- Preserve `module.slim`'s declaration-level re-export from `module.slim.no-external` instead of allowing `rollup-plugin-dts` to inline a second declaration graph.
- Rewrite the preserved `.es` declaration path to the published `./module.slim.no-external` path.
- Express the default export as a source-level re-export so the generated declaration remains a reference rather than pulling the nominal types back into `module.slim.d.ts`.
- Add a regression test that compiles the built declarations and verifies both extension constructor compatibility and default-export compatibility across the two slim entrypoints.

The generated `module.slim.d.ts` is now a pure re-export:

```ts
export * from './module.slim.no-external';
export { default } from './module.slim.no-external';
```

The runtime bundle remains unchanged in behavior and retains the `external-scripts-loader` side effect.

Verification:

- `pnpm turbo run build --filter=posthog-js`
- `pnpm --filter posthog-js test:unit -- --runInBand` — 5,122 passed
- Focused declaration regression test — 5 passed
- `pnpm --filter posthog-js lint`
- Prettier and `git diff --check`
- A real Vue consumer using `module.slim.no-external` and `extension-bundles` passes `vue-tsc --noEmit` with its declaration workaround removed

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi Coding Agent with OpenAI GPT-5.6 implemented and tested this change under human direction. Claude Code with Opus 5 independently reviewed the code changes. The implementation keeps `module.slim.no-external` as the canonical declaration graph and makes `module.slim` reference it, preserving compatibility for consumers of either entrypoint without adding a new public artifact. No public session links are available.
