### PR TITLE
ci: skip changeset hygiene for fork PRs

### DIFF
--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   check:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@836a5e06cdf40ed2a46b16f131b0a9b03c1ffea1
     with:
       script-ref: 836a5e06cdf40ed2a46b16f131b0a9b03c1ffea1


### PR DESCRIPTION
## Problem

The changeset hygiene check failed on fork PR #4283 because its read-only GitHub token could not create the informational PR comment.

## Changes

Guard the reusable changeset hygiene job using the repository's existing fork check pattern. The workflow continues to run for branches in `PostHog/posthog-js` and is skipped for fork PRs, where comment permissions are unavailable.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi after inspecting the failing GitHub Actions log and matching the fork guard already used by another reusable workflow caller in this repository. Pi autoreview found no actionable issues in the final branch diff.
