### PR TITLE
chore: assign client libraries as default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,34 +1,37 @@
+# Default owner for the repository
+* @PostHog/team-client-libraries
+
 # the recorder file can have unexpected impact on users' sites
-packages/browser/src/entrypoints/recorder.ts           @PostHog/team-replay
+packages/browser/src/entrypoints/recorder.ts           @PostHog/team-client-libraries @PostHog/team-replay
 
 # Network recorder
 packages/browser/src/extensions/replay/external/network-plugin.ts @PostHog/team-client-libraries
 
 # Surveys
-packages/browser/src/extensions/surveys/               @PostHog/team-surveys
-packages/browser/src/extensions/surveys.tsx            @PostHog/team-surveys
-packages/browser/src/entrypoints/surveys.ts            @PostHog/team-surveys
-packages/browser/src/entrypoints/surveys-preview.es.ts @PostHog/team-surveys
-packages/browser/src/posthog-surveys-types.ts          @PostHog/team-surveys
-packages/browser/src/posthog-surveys.ts                @PostHog/team-surveys
-packages/browser/src/utils/survey-event-receiver.ts    @PostHog/team-surveys
-packages/browser/src/utils/survey-utils.ts             @PostHog/team-surveys
+packages/browser/src/extensions/surveys/               @PostHog/team-client-libraries @PostHog/team-surveys
+packages/browser/src/extensions/surveys.tsx            @PostHog/team-client-libraries @PostHog/team-surveys
+packages/browser/src/entrypoints/surveys.ts            @PostHog/team-client-libraries @PostHog/team-surveys
+packages/browser/src/entrypoints/surveys-preview.es.ts @PostHog/team-client-libraries @PostHog/team-surveys
+packages/browser/src/posthog-surveys-types.ts          @PostHog/team-client-libraries @PostHog/team-surveys
+packages/browser/src/posthog-surveys.ts                @PostHog/team-client-libraries @PostHog/team-surveys
+packages/browser/src/utils/survey-event-receiver.ts    @PostHog/team-client-libraries @PostHog/team-surveys
+packages/browser/src/utils/survey-utils.ts             @PostHog/team-client-libraries @PostHog/team-surveys
 
 # Mobile
 packages/react-native/                                 @PostHog/team-client-libraries
 
 # AI
-/packages/ai/package.json                              @PostHog/team-llm-analytics
+/packages/ai/package.json                              @PostHog/team-client-libraries @PostHog/team-llm-analytics
 
 # Web Analytics
-packages/browser/src/page-view.ts                      @PostHog/team-web-analytics
-packages/browser/src/sessionid.ts                      @PostHog/team-web-analytics
-packages/browser/src/session-props.ts                  @PostHog/team-web-analytics
-packages/browser/src/utils/blocked-uas.ts              @PostHog/team-web-analytics
-packages/browser/src/consent.ts                        @PostHog/team-web-analytics
+packages/browser/src/page-view.ts                      @PostHog/team-client-libraries @PostHog/team-web-analytics
+packages/browser/src/sessionid.ts                      @PostHog/team-client-libraries @PostHog/team-web-analytics
+packages/browser/src/session-props.ts                  @PostHog/team-client-libraries @PostHog/team-web-analytics
+packages/browser/src/utils/blocked-uas.ts              @PostHog/team-client-libraries @PostHog/team-web-analytics
+packages/browser/src/consent.ts                        @PostHog/team-client-libraries @PostHog/team-web-analytics
 
 # Error tracking
-packages/rollup-plugin/                                @PostHog/team-error-tracking
-packages/nuxt/                                         @PostHog/team-error-tracking
-packages/nextjs-config/                                @PostHog/team-error-tracking
-packages/core/src/process/                             @PostHog/team-error-tracking
+packages/rollup-plugin/                                @PostHog/team-client-libraries @PostHog/team-error-tracking
+packages/nuxt/                                         @PostHog/team-client-libraries @PostHog/team-error-tracking
+packages/nextjs-config/                                @PostHog/team-client-libraries @PostHog/team-error-tracking
+packages/core/src/process/                             @PostHog/team-client-libraries @PostHog/team-error-tracking


### PR DESCRIPTION
## Problem

Pull requests that do not touch an existing path-specific CODEOWNERS entry are not automatically routed to the Client Libraries team. Path-specific entries also replace the repository default, so they need to retain Client Libraries explicitly.

## Changes

- Add `@PostHog/team-client-libraries` as the default owner for the repository.
- Keep Client Libraries alongside every specialist team in path-specific rules so all changes continue to request the team.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and reviewed using Pi's isolated autoreview skill. The change keeps the existing specialist ownership while making Client Libraries the repository-wide default. No runtime tests or changeset are needed for this CODEOWNERS-only change.
