### PR TITLE
chore: update PostHog watcher action

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -39,7 +39,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@8b166434ccf42ce9da6ee1fda3f622268812aed5
+              uses: PostHog/posthog-watcher-action@46c2a53dd018bfc21435ff97360d7a1a04521db9
               with:
                   mode: enqueue
                   trigger-drain-workflow: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -45,7 +45,7 @@ jobs:
                   sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@8b166434ccf42ce9da6ee1fda3f622268812aed5
+              uses: PostHog/posthog-watcher-action@46c2a53dd018bfc21435ff97360d7a1a04521db9
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -51,7 +51,7 @@ jobs:
                   sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@8b166434ccf42ce9da6ee1fda3f622268812aed5
+              uses: PostHog/posthog-watcher-action@46c2a53dd018bfc21435ff97360d7a1a04521db9
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -88,7 +88,7 @@ jobs:
                   sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@8b166434ccf42ce9da6ee1fda3f622268812aed5
+              uses: PostHog/posthog-watcher-action@46c2a53dd018bfc21435ff97360d7a1a04521db9
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}


### PR DESCRIPTION
## Problem

The PostHog watcher workflows were pinned to an older commit of `PostHog/posthog-watcher-action` and need the latest upstream updates.

## Changes

- Bump all `PostHog/posthog-watcher-action` workflow references from `8b166434ccf42ce9da6ee1fda3f622268812aed5` to the latest upstream SHA, `46c2a53dd018bfc21435ff97360d7a1a04521db9`.
- Keep the enqueue, sweep, queue-drain, and issue-processing workflows on the same pinned SHA.
- Verification: watcher-reference `rg` checks, stale-SHA check, `git diff --check`, and autoreview.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent updated the workflow-only dependency in a dedicated worktree. The pinned SHA was resolved directly from the upstream repository, all references were kept consistent, and the committed diff passed the bundled autoreview with no actionable findings. No changeset or package tests are needed for this workflow-only update.
