### PR TITLE
fix(conversations): keep widget list markers under host CSS resets

### DIFF
--- a/.changeset/widget-list-markers.md
+++ b/.changeset/widget-list-markers.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Conversations widget: bullet and numbered lists in a support reply now keep their markers on host pages with an aggressive CSS reset (for example Tailwind preflight's `ol, ul { list-style: none }`). The widget renders into the host page's DOM, so the list style is now set inline on `<ul>`, `<ol>`, and `<li>` rather than left to the page's own styles.

--- a/packages/browser/src/__tests__/extensions/conversations/rich-content.test.tsx
+++ b/packages/browser/src/__tests__/extensions/conversations/rich-content.test.tsx
@@ -715,7 +715,9 @@ describe('RichContent', () => {
 
             const { container } = render(<RichContent {...defaultProps} richContent={doc} />)
 
-            expect(container.querySelector('ul')).not.toBeNull()
+            const ul = container.querySelector('ul')
+            expect(ul).not.toBeNull()
+            expect(ul?.style.listStyleType).toBe('disc')
             expect(container.querySelectorAll('li')).toHaveLength(2)
         })
 
@@ -741,7 +743,9 @@ describe('RichContent', () => {
 
             const { container } = render(<RichContent {...defaultProps} richContent={doc} />)
 
-            expect(container.querySelector('ol')).not.toBeNull()
+            const ol = container.querySelector('ol')
+            expect(ol).not.toBeNull()
+            expect(ol?.style.listStyleType).toBe('decimal')
             expect(container.querySelectorAll('li')).toHaveLength(2)
         })
 

--- a/packages/browser/src/extensions/conversations/external/components/RichContent.tsx
+++ b/packages/browser/src/extensions/conversations/external/components/RichContent.tsx
@@ -251,21 +251,37 @@ function renderNode(
 
         case 'bulletList':
             return (
-                <ul key={key} style={{ margin: '8px 0', paddingLeft: '24px' }}>
+                <ul
+                    key={key}
+                    style={{
+                        margin: '8px 0',
+                        paddingLeft: '24px',
+                        listStyleType: 'disc',
+                        listStylePosition: 'outside',
+                    }}
+                >
                     {children}
                 </ul>
             )
 
         case 'orderedList':
             return (
-                <ol key={key} style={{ margin: '8px 0', paddingLeft: '24px' }}>
+                <ol
+                    key={key}
+                    style={{
+                        margin: '8px 0',
+                        paddingLeft: '24px',
+                        listStyleType: 'decimal',
+                        listStylePosition: 'outside',
+                    }}
+                >
                     {children}
                 </ol>
             )
 
         case 'listItem':
             return (
-                <li key={key} style={{ margin: '4px 0' }}>
+                <li key={key} style={{ margin: '4px 0', listStyleType: 'inherit' }}>
                     {children}
                 </li>
             )


### PR DESCRIPTION
## Problem

Bullet and numbered lists sent from PostHog Conversations render in the support widget without their markers: the `<ul>`/`<ol>`/`<li>` structure is intact, but no bullets or numbers show, so list items read as plain indented lines.

The widget renders into the host page's DOM (no shadow DOM) and relies on inline styles to resist host CSS. The list elements in `RichContent.tsx` only inline `margin` and `padding-left`, so any host page with an aggressive CSS reset (for example Tailwind preflight's `ol, ul { list-style: none }`) strips the markers. This was latent since list rendering was added in #3000 and became visible once PostHog/posthog#73165 started delivering `bulletList`/`orderedList` nodes in `rich_content`.

## Changes

- Inline `listStyleType: 'disc'` / `'decimal'` and `listStylePosition: 'outside'` on the widget's `<ul>`/`<ol>`, so the markers survive host page resets that target `ol, ul`.
- Inline `listStyleType: 'inherit'` on `<li>` so resets that target `li` directly can't strip the marker either.
- Extended the existing bullet and ordered list tests to assert the inline `list-style-type` is present, which guards against this exact regression.

Verified with `pnpm jest src/__tests__/extensions/conversations/rich-content.test.tsx` in `packages/browser` (148 passed). Written and tested without a live widget embed; the DOM-level root cause was confirmed against a Tailwind host page in devtools before the change.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code)
