### PR TITLE
fix: publish declarations for browser entrypoints

### DIFF
--- a/.changeset/browser-entrypoint-declarations.md
+++ b/.changeset/browser-entrypoint-declarations.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Publish TypeScript declarations for browser extension entrypoints under their public `dist` paths.

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -411,9 +411,25 @@ const entrypointTargets = entrypoints.map((file) => {
 // consumers don't need a runtime dep on the re-exported package to resolve them.
 const inlineExternalTypesEntries = new Set([
     'extension-bundles.es.ts',
+    'posthog-recorder.ts',
+    'recorder.ts',
     'rrweb.es.ts',
     'rrweb-types.es.ts',
     'rrweb-plugin-console-record.es.ts',
+])
+
+// Entries whose declarations use PostHog must reference the canonical class in
+// module.d.ts instead of inlining a nominally incompatible copy.
+const mainModuleTypesEntries = new Set([
+    'conversations.ts',
+    'customizations.es.ts',
+    'dead-clicks-autocapture.ts',
+    'main.cjs.ts',
+    'product-tours-preview.es.ts',
+    'product-tours.ts',
+    'surveys-preview.es.ts',
+    'surveys.ts',
+    'tracing-headers.ts',
 ])
 
 // rrdom's dts drops the local `RRNodeType` alias declaration; the renderChunk
@@ -421,15 +437,12 @@ const inlineExternalTypesEntries = new Set([
 const rewriteRrdomNodeTypeAlias = (file) => file === 'rrweb.es.ts'
 
 const typeTargets = entrypoints
-    .filter((file) => file.endsWith('.es.ts'))
+    .filter((file) => file.endsWith('.ts'))
     .map((file) => {
         const source = `./lib/src/entrypoints/${file.replace('.ts', '.d.ts')}`
         const isExtensionBundles = file === 'extension-bundles.es.ts'
         const isSlimModule = file === 'module.slim.es.ts'
-        // customizations types must reference the main module for the PostHog class —
-        // an inlined duplicate would be nominally incompatible with the consumer's
-        // `posthog` instance (same private-fields problem as extension-bundles).
-        const isCustomizations = file === 'customizations.es.ts'
+        const referencesMainModuleTypes = mainModuleTypesEntries.has(file)
         const inlineExternalTypes = inlineExternalTypesEntries.has(file)
         const rewriteRrdomAlias = rewriteRrdomNodeTypeAlias(file)
         /** @type {import('rollup').RollupOptions} */
@@ -443,11 +456,11 @@ const typeTargets = entrypoints
             // the reference instead of inlining a second declaration graph.
             ...(isExtensionBundles ? { external: [/module\.slim/] } : {}),
             ...(isSlimModule ? { external: [/module\.slim\.no-external/] } : {}),
-            ...(isCustomizations ? { external: [/posthog-core$/] } : {}),
+            ...(referencesMainModuleTypes ? { external: [/posthog-core$/] } : {}),
             output: [
                 {
                     dir: path.resolve('./dist'),
-                    entryFileNames: file.replace('.es.ts', '.d.ts'),
+                    entryFileNames: file.replace(/(?:\.(?:cjs|es|iife))?\.ts$/, '.d.ts'),
                 },
             ],
             plugins: [
@@ -473,13 +486,13 @@ const typeTargets = entrypoints
                           },
                       ]
                     : []),
-                ...(isCustomizations
+                ...(referencesMainModuleTypes
                     ? [
                           {
-                              name: 'fix-customizations-dts-external-paths',
+                              name: 'fix-main-module-dts-external-paths',
                               renderChunk(code) {
-                                  // the external posthog-core import keeps its source-relative
-                                  // path; point it at dist/module.d.ts instead
+                                  // The external posthog-core import keeps its source-relative
+                                  // path; point it at the canonical PostHog in dist/module.d.ts.
                                   return code.replace(/['"](?:\.\.\/)+posthog-core['"]/g, "'./module'")
                               },
                           },

--- a/packages/browser/src/__tests__/entrypoints/module.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/module.test.ts
@@ -90,6 +90,126 @@ void extensionClasses
     })
 })
 
+describe('Published entrypoint declarations', () => {
+    it('includes declarations for every source entrypoint', () => {
+        const distDirectory = path.resolve(__dirname, '../../../dist')
+        const sourceDirectory = path.resolve(__dirname, '../../entrypoints')
+        const declarations = fs
+            .readdirSync(sourceDirectory)
+            .filter((file) => file.endsWith('.ts'))
+            .map((file) => file.replace(/(?:\.(?:cjs|es|iife))?\.ts$/, '.d.ts'))
+
+        for (const declaration of declarations) {
+            expect(fs.existsSync(path.join(distDirectory, declaration))).toBe(true)
+        }
+    })
+
+    it('resolves extension declarations from their public package paths', () => {
+        const fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-extension-types-'))
+        const fixturePath = path.join(fixtureDirectory, 'index.ts')
+        const distPath = path.resolve(__dirname, '../../../dist').replaceAll('\\', '/')
+        const entrypointImports = fs
+            .readdirSync(path.resolve(__dirname, '../../entrypoints'))
+            .filter((file) => file.endsWith('.ts'))
+            .map((file) => file.replace(/(?:\.(?:cjs|es|iife))?\.ts$/, ''))
+            .map((entrypoint) => `import 'posthog-js/dist/${entrypoint}'`)
+            .join('\n')
+        fs.writeFileSync(
+            fixturePath,
+            `
+${entrypointImports}
+
+import posthog from 'posthog-js/dist/module'
+import recorder from 'posthog-js/dist/posthog-recorder'
+import exceptionAutocapture from 'posthog-js/dist/exception-autocapture'
+import webVitals from 'posthog-js/dist/web-vitals'
+import DeadClicksAutocapture from 'posthog-js/dist/dead-clicks-autocapture'
+import initConversations from 'posthog-js/dist/conversations'
+import generateProductTours from 'posthog-js/dist/product-tours'
+import generateSurveys from 'posthog-js/dist/surveys'
+
+new DeadClicksAutocapture(posthog)
+initConversations({} as any, posthog)
+generateProductTours(posthog, true)
+generateSurveys(posthog, true)
+void recorder
+void exceptionAutocapture
+void webVitals
+`
+        )
+
+        try {
+            const program = ts.createProgram([fixturePath], {
+                baseUrl: fixtureDirectory,
+                module: ts.ModuleKind.ESNext,
+                moduleResolution: ts.ModuleResolutionKind.Bundler,
+                noEmit: true,
+                paths: { 'posthog-js/dist/*': [`${distPath}/*`] },
+                strict: true,
+                target: ts.ScriptTarget.ESNext,
+                types: [],
+            })
+            const diagnostics = ts.getPreEmitDiagnostics(program)
+            expect(
+                ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+                    getCanonicalFileName: (fileName) => fileName,
+                    getCurrentDirectory: () => fixtureDirectory,
+                    getNewLine: () => '\n',
+                })
+            ).toBe('')
+        } finally {
+            fs.rmSync(fixtureDirectory, { recursive: true })
+        }
+    })
+
+    it('only declares PostHog in canonical module entrypoints', () => {
+        const sourceDirectory = path.resolve(__dirname, '../../entrypoints')
+        const declarations = fs
+            .readdirSync(sourceDirectory)
+            .filter((file) => file.endsWith('.ts'))
+            .map((file) => file.replace(/(?:\.(?:cjs|es|iife))?\.ts$/, '.d.ts'))
+            .filter((file) => !file.startsWith('module'))
+
+        for (const declarationFile of declarations) {
+            const declaration = fs.readFileSync(path.resolve(__dirname, `../../../dist/${declarationFile}`), 'utf-8')
+            expect(declaration).not.toMatch(/declare class PostHog\s/)
+        }
+    })
+
+    it('inlines recorder types that are not production dependencies', () => {
+        const fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-recorder-types-'))
+        const packageDistDirectory = path.join(fixtureDirectory, 'node_modules/posthog-js/dist')
+        const fixturePath = path.join(fixtureDirectory, 'index.ts')
+        fs.mkdirSync(packageDistDirectory, { recursive: true })
+        fs.copyFileSync(
+            path.resolve(__dirname, '../../../dist/posthog-recorder.d.ts'),
+            path.join(packageDistDirectory, 'posthog-recorder.d.ts')
+        )
+        fs.writeFileSync(fixturePath, "import recorder from 'posthog-js/dist/posthog-recorder'\nvoid recorder\n")
+
+        try {
+            const program = ts.createProgram([fixturePath], {
+                module: ts.ModuleKind.ESNext,
+                moduleResolution: ts.ModuleResolutionKind.Bundler,
+                noEmit: true,
+                strict: true,
+                target: ts.ScriptTarget.ESNext,
+                types: [],
+            })
+            const diagnostics = ts.getPreEmitDiagnostics(program)
+            expect(
+                ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+                    getCanonicalFileName: (fileName) => fileName,
+                    getCurrentDirectory: () => fixtureDirectory,
+                    getNewLine: () => '\n',
+                })
+            ).toBe('')
+        } finally {
+            fs.rmSync(fixtureDirectory, { recursive: true })
+        }
+    })
+})
+
 describe('Full no-external bundles', () => {
     it.each([
         ['array', arrayFullNoExternalJs, arrayNoExternalJs],

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -128,7 +128,7 @@ const SURVEY_TARGETING_FLAG_PREFIX = 'survey-targeting-'
 export class SurveyManager {
     private _posthog: PostHog
     private _surveyInFocus: string | null
-    private _surveyTimeouts: Map<string, NodeJS.Timeout> = new Map()
+    private _surveyTimeouts: Map<string, ReturnType<Window['setTimeout']>> = new Map()
     private _widgetSelectorListeners: Map<string, { element: Element; listener: EventListener; survey: Survey }> =
         new Map()
     private _prefillHandledSurveys: Set<string> = new Set()
@@ -242,7 +242,7 @@ export class SurveyManager {
         if (delaySeconds <= 0) {
             return render(<SurveyPopup {...surveyPopupProps} />, shadow)
         }
-        const timeoutId = setTimeout(() => {
+        const timeoutId = window.setTimeout(() => {
             // remove survey to keep `_surveyTimeouts` as a true list of "pending" surveys
             this._surveyTimeouts.delete(survey.id)
 


### PR DESCRIPTION
## Problem

`posthog-js` publishes JavaScript entrypoints such as `dist/posthog-recorder.js`, `dist/exception-autocapture.js`, and `dist/web-vitals.js`, but it does not publish matching declarations at those public paths. Although TypeScript already emits declarations for their source entrypoints under `lib/src/entrypoints`, Rollup only moves declarations for `.es.ts` entrypoints into `dist`.

As a result, consumers get a missing declaration error for valid imports such as:

```ts
await import('posthog-js/dist/posthog-recorder')
```

and need to suppress it with `@ts-expect-error`.

## Changes

- Generate a root declaration for every TypeScript entrypoint that has a published JavaScript output in `dist`.
- Normalize format-specific source names so, for example, `module.es.ts` still produces `module.d.ts` and `main.cjs.ts` produces `main.d.ts`.
- Add a package-output regression test deriving the expected declarations from `src/entrypoints`, avoiding stale or code-split files in `dist`.
- Inline recorder types so the declarations do not require the development-only `@posthog/rrweb-record` package.
- Reference the canonical `PostHog` declaration from extension entrypoints instead of inlining nominally incompatible copies.
- Reduce total published declaration output by approximately 155 KB uncompressed (33 KB compressed) by deduplicating the canonical `PostHog` type; runtime JavaScript bundles are unaffected.
- Add TypeScript fixtures that resolve every generated entrypoint without ambient Node types, test the recorder in isolation, and compose extension APIs with the main `posthog` instance.
- Avoid leaking the `NodeJS.Timeout` type through the public surveys declaration.

### Alternatives and follow-ups

Adding a package `exports` map was considered as a way to distinguish supported imports from files that only need to be present for CDN or internal loading. However, introducing one would require defining every supported subpath and could break existing deep imports, so it would be better handled as a separate compatibility-focused change.

Because declarations are generated for every shipped entrypoint, this also covers paths that consumers probably do not need to import directly, such as array variants, `main`, and `external-scripts-loader`. There is currently no canonical list separating public extension entrypoints from these files, while `package.json` publishes all of `dist/*`. This PR therefore follows the mechanically enforceable rule that every published JavaScript entrypoint receives a declaration rather than introducing another allowlist.

Most side-effect-only entrypoints already produce 13-byte `export {}` declarations, while larger declarations now reference the canonical `PostHog` type rather than inlining the main declaration graph. Maintaining a narrower set of typed entrypoints or generating lightweight declarations that forward to the existing `lib` declaration tree was also considered, but those approaches add maintenance or declaration-graph compatibility concerns while the overall declaration output already decreases.

Consumers that currently suppress the missing-declaration diagnostic with `@ts-expect-error` will need to remove that directive after upgrading, because TypeScript can report it as unused once the declaration is available.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with OpenAI ChatGPT 5.6 using Pi Coding Agent. The scope and alternatives were reviewed with human direction, including how to handle the package's existing deep-import surface and whether declarations should preserve entrypoint exports or only provide module-resolution shims.