### PR TITLE
fix(replay): hold recordings for sessions with no user interaction

### DIFF
--- a/.changeset/replay-hold-recordings-until-interaction.md
+++ b/.changeset/replay-hold-recordings-until-interaction.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Session replay no longer ships recordings for sessions that have seen no user interaction. A recorder in a tab nobody has touched (the 'unknown' idle state) now holds its buffer, bounded to the newest playable snapshot prefix, and ships it only on the first user interaction, on page unload, or not at all if the session rotates away untouched. This stops activity-timeout rotations in parked tabs from producing unbounded chains of zero-interaction billable recordings, while keeping rotated sessions playable from before the user's first interaction. Confirmed-idle tabs also now keep running the session check, so an idle session rotates at the 24-hour session cap instead of accreting a multi-day recording.

--- a/packages/browser/jest.config.js
+++ b/packages/browser/jest.config.js
@@ -25,6 +25,7 @@ module.exports = {
         '^preact/jsx-runtime$': path.join(preactRoot, 'jsx-runtime/dist/jsxRuntime.js'),
         '^preact/test-utils$': path.join(preactRoot, 'test-utils/dist/testUtils.js'),
         '^@testing-library/preact$': path.join(testingLibraryPreactCjs, 'index.js'),
+        '^@posthog/browser-common$': '<rootDir>/../browser-common/src/index.ts',
         '^@posthog/browser-common/config$': '<rootDir>/../browser-common/src/config.ts',
         '^@posthog/browser-common/constants$': '<rootDir>/../browser-common/src/constants.ts',
         '^@posthog/browser-common/utils/(.*)$': '<rootDir>/../browser-common/src/utils/$1.ts',

--- a/packages/browser/playwright/mocked/session-recording/session-rotation-scenarios.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-rotation-scenarios.spec.ts
@@ -424,13 +424,16 @@ test.describe('Session rotation scenarios', () => {
 })
 
 test.describe('Session rotation without user interaction', () => {
-    // Regression test for #4202: a tab with no user interaction keeps the recorder in the
-    // 'unknown' idle state. An analytics-driven activity-timeout rotation must still restart
-    // the recorder and ship a full snapshot under the new session id, with no interaction at all.
+    // Covers both #4202 and the billing regression its first fix caused: a tab with no user
+    // interaction keeps the recorder in the 'unknown' idle state. An analytics-driven
+    // activity-timeout rotation must restart the recorder and capture a full snapshot under
+    // the new session id — but HOLD it. Shipping it immediately turned every parked tab into
+    // an unbounded chain of billable zero-interaction recordings. The held snapshot ships on
+    // the first user interaction, making the recording playable from before that interaction.
     // Runs in both compression modes: the restart happens mid-stream, so it exercises the
     // rotation + compression-queue interaction as well.
     for (const compressEvents of [false, true]) {
-        test(`ships a full snapshot for the new session after rotation with no user interaction (compress_events: ${compressEvents})`, async ({
+        test(`holds the new session's full snapshot after rotation and ships it on first interaction (compress_events: ${compressEvents})`, async ({
             page,
             context,
         }) => {
@@ -466,7 +469,18 @@ test.describe('Session rotation without user interaction', () => {
             const backgroundEvent = capturedAnalytics.find((e) => e.event === 'background_tab_event')
             expect(backgroundEvent?.properties.$session_id).toEqual(newSessionId)
 
-            // without any further interaction, replay data for the new session must still flush
+            // without user interaction nothing may ship: a parked tab's rotation chain must
+            // not produce billable recordings. Give the flush cadence time to (not) fire.
+            await page.waitForTimeout(2500)
+            const heldSnapshots = (await page.capturedEvents()).filter(
+                (e) => e.event === '$snapshot' && e.properties.$session_id === newSessionId
+            )
+            expect(heldSnapshots).toEqual([])
+
+            // the first real interaction releases the held buffer
+            await page.mouse.move(200, 200)
+            await page.mouse.down()
+            await page.mouse.up()
             await expect
                 .poll(
                     async () => {

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording-compression.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording-compression.test.ts
@@ -173,6 +173,9 @@ describe('LazyLoadedSessionRecording compression paths', () => {
             gzipCompress,
         })
 
+        // buffers only ship for sessions with user interaction; these tests exercise compression
+        lazyLoadedSessionRecording['_isIdle'] = false
+
         emit(createFullSnapshot({ content: testCase.content }))
         if (testCase.shouldQueueCustomEvent) {
             emit(createCustomSnapshot())
@@ -223,6 +226,9 @@ describe('LazyLoadedSessionRecording compression paths', () => {
             gzipSupported: true,
             gzipCompress,
         })
+
+        // buffers only ship for sessions with user interaction; this test exercises stop teardown
+        lazyLoadedSessionRecording['_isIdle'] = false
 
         emit(createFullSnapshot({ content: 'stop waits for compression' }))
         lazyLoadedSessionRecording.stop()
@@ -287,6 +293,14 @@ describe('LazyLoadedSessionRecording compression paths', () => {
 
         emit(createFullSnapshot({ content: 'post-rotation snapshot' }))
         await lazyLoadedSessionRecording['_compressionQueue']
+
+        // a rotated session that has still seen no interaction holds its buffer: parked tabs
+        // must not ship a recording chain nobody can watch
+        lazyLoadedSessionRecording['_flushBuffer']()
+        expect(posthog.capture).not.toHaveBeenCalled()
+
+        // first user interaction releases the hold
+        lazyLoadedSessionRecording['_isIdle'] = false
         lazyLoadedSessionRecording['_flushBuffer']()
 
         // the full snapshot must be attributed to the rotated session, not the buffer's stale one
@@ -319,6 +333,8 @@ describe('LazyLoadedSessionRecording compression paths', () => {
         await lazyLoadedSessionRecording['_compressionQueue']
 
         strategy.getStatus = originalGetStatus
+        // the hold applies until interaction; release it so the flush exercises the discard path
+        lazyLoadedSessionRecording['_isIdle'] = false
         lazyLoadedSessionRecording['_flushBuffer']()
 
         // only the new session's full snapshot ships; the undrained old-session event is discarded, not relabeled

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1437,40 +1437,102 @@ describe('Lazy SessionRecording', () => {
                 }
             })
 
-            it('flushes the buffer while _isIdle is unknown when it exceeds the max event size', () => {
+            it('prunes the held buffer instead of flushing while _isIdle is unknown when it exceeds the max event size', () => {
                 expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual('unknown')
 
+                // an old event that predates the newest full snapshot is unreplayable once the
+                // buffer is pruned down to that snapshot, so it's the one that gets dropped
                 sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
+                sessionRecording.onRRwebEmit(createFullSnapshot() as eventWithTime)
 
                 // fake having a large buffer, as the idle === true counterpart test does
                 sessionRecording['_lazyLoadedSessionRecording']['_buffer'].size = RECORDING_MAX_EVENT_SIZE - 1
                 sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
 
-                // unlike confirmed idle, the unknown state must respect the size cap and flush
-                expect(posthog.capture).toHaveBeenCalledWith(
-                    '$snapshot',
-                    expect.objectContaining({ $session_id: sessionId }),
-                    expect.any(Object)
-                )
+                // a session with no user interaction never ships on the size cap — it prunes to
+                // the newest playable prefix so a parked tab's hold stays bounded
+                expect(posthog.capture).not.toHaveBeenCalled()
+                const bufferData = sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data
+                expect(bufferData[0].type).toEqual(FULL_SNAPSHOT_EVENT_TYPE)
             })
 
-            it('schedules a buffer flush while _isIdle is unknown so background tabs ship their data', () => {
+            it('holds the buffer while _isIdle is unknown and ships it on the first user interaction', () => {
                 jest.useFakeTimers().setSystemTime(new Date(startingTimestamp + 100))
 
                 const snapshot = emitInactiveEvent(startingTimestamp + 100, 'unknown')
                 expect(sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data).toContain(snapshot)
                 expect(posthog.capture).not.toHaveBeenCalled()
 
+                // no interaction yet: the flush timer must not be armed, or every parked tab
+                // ships a recording nobody interacted with
+                jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                expect(posthog.capture).not.toHaveBeenCalled()
+
+                // the first user interaction releases the held buffer so the recording is
+                // playable from before the interaction
+                const activeSnapshot = emitActiveEvent(startingTimestamp + 200)
                 jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
 
                 expect(posthog.capture).toHaveBeenCalledWith(
                     '$snapshot',
                     expect.objectContaining({
                         $session_id: sessionId,
-                        $snapshot_data: [snapshot],
+                        $snapshot_data: [snapshot, activeSnapshot],
                     }),
                     expect.any(Object)
                 )
+            })
+
+            it('ships nothing when a session rotates away without ever seeing interaction', () => {
+                // The billing regression this policy exists for: a parked tab whose session
+                // rotates on activity timeout must not ship a recording per rotation.
+                jest.useFakeTimers().setSystemTime(new Date(startingTimestamp + 100))
+
+                const heldSnapshot = emitInactiveEvent(startingTimestamp + 100, 'unknown')
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data).toContain(heldSnapshot)
+
+                // an analytics event elsewhere in the app rotates the session
+                sessionIdGeneratorMock.mockImplementation(() => 'untouched-rotated-session-id')
+                const rotationTimestamp = startingTimestamp + sessionManager['_sessionTimeoutMs'] + 1000
+                jest.setSystemTime(new Date(rotationTimestamp))
+                sessionManager.checkAndGetSessionAndWindowId(false, rotationTimestamp)
+
+                const rotatedSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
+                expect(rotatedSessionId).toEqual('untouched-rotated-session-id')
+
+                // the untouched session's held buffer is discarded, not shipped, and the new
+                // session holds too, so no amount of timer time produces a $snapshot
+                jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT * 5)
+                const snapshotCalls = (posthog.capture as Mock).mock.calls.filter(([name]) => name === '$snapshot')
+                expect(snapshotCalls).toEqual([])
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data).not.toContain(heldSnapshot)
+            })
+
+            it('rotates a confirmed-idle session at the 24 hour session cap', () => {
+                // An idle tab must keep consulting the session manager: skipping the check is
+                // how idle sessions used to blow through SESSION_LENGTH_LIMIT into multi-day
+                // recordings under one session id.
+                const firstActivityTimestamp = startingTimestamp + 100
+                jest.useFakeTimers().setSystemTime(new Date(firstActivityTimestamp))
+                emitActiveEvent(firstActivityTimestamp)
+
+                const idleTimestamp = firstActivityTimestamp + RECORDING_IDLE_THRESHOLD_MS + 1000
+                jest.setSystemTime(new Date(idleTimestamp))
+                emitInactiveEvent(idleTimestamp, true)
+                const idleSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
+
+                // a day later the still-idle tab emits a non-interactive event; the session is
+                // past the maximum length and must rotate even though the tab stayed idle
+                // (the rotation restart resets the idle state to 'unknown')
+                sessionIdGeneratorMock.mockImplementation(() => 'past-cap-rotated-session-id')
+                const pastCapTimestamp = startingTimestamp + 24 * 60 * 60 * 1000 + 1000
+                jest.setSystemTime(new Date(pastCapTimestamp))
+                emitInactiveEvent(pastCapTimestamp, 'unknown')
+
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_sessionId']).toEqual(
+                    'past-cap-rotated-session-id'
+                )
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_sessionId']).not.toEqual(idleSessionId)
             })
 
             it('recorder follows an adopted sibling-tab session id (does not record under the stale id)', () => {
@@ -4741,6 +4803,9 @@ describe('Lazy SessionRecording', () => {
             // Emit the $session_ending event
             _emit(sessionEndingEvent)
 
+            // buffers only ship for sessions with user interaction; this test exercises routing
+            sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = false
+
             // Flush to capture
             sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
 
@@ -4873,6 +4938,8 @@ describe('Lazy SessionRecording', () => {
                     data: { href: 'https://example.com/?gclid=secret123&other=value#section' },
                 })
             )
+            // buffers only ship for sessions with user interaction; this test exercises masking
+            sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = false
             sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalledWith(
@@ -4915,6 +4982,8 @@ describe('Lazy SessionRecording', () => {
                     data: { href: 'https://example.com/?token=secret123&other=value' },
                 })
             )
+            // buffers only ship for sessions with user interaction; this test exercises masking
+            sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = false
             sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
 
             // Verify the masking function was called with 'name' property
@@ -4964,6 +5033,8 @@ describe('Lazy SessionRecording', () => {
                     data: { href: 'https://example.com/?token=secret123' },
                 })
             )
+            // buffers only ship for sessions with user interaction; this test exercises masking
+            sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = false
             sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
 
             // Verify the deprecated masking function was called
@@ -5009,6 +5080,8 @@ describe('Lazy SessionRecording', () => {
                     data: { href: 'https://example.com/?token=secret' },
                 })
             )
+            // buffers only ship for sessions with user interaction; this test exercises masking
+            sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = false
             sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
 
             // Should only call the new function, not the deprecated one
@@ -5055,6 +5128,8 @@ describe('Lazy SessionRecording', () => {
                     data: { href: 'https://example.com/?token=secret123' },
                 })
             )
+            // buffers only ship for sessions with user interaction; this test exercises masking
+            sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = false
             sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
 
             // Verify the masking function was called with 'name' property

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1483,6 +1483,32 @@ describe('Lazy SessionRecording', () => {
                 )
             })
 
+            it('an event trigger match releases the hold even when its activation is a no-op', () => {
+                // With triggerMatchType 'any', a URL trigger can satisfy the combined trigger
+                // status long before an error event fires; the activation then short-circuits
+                // on hasPendingTriggers. The event evidence must still release the hold, or
+                // record-on-exception never ships from tabs the user hasn't touched.
+                jest.useFakeTimers().setSystemTime(new Date(startingTimestamp + 100))
+
+                const snapshot = emitInactiveEvent(startingTimestamp + 100, 'unknown')
+                jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                expect(posthog.capture).not.toHaveBeenCalled()
+
+                // no pending triggers in this setup, so this activation is a no-op beyond the
+                // evidence flag, mirroring the already-activated-by-url case
+                sessionRecording['_lazyLoadedSessionRecording']['_activateTrigger']('event', '$exception')
+                jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+
+                expect(posthog.capture).toHaveBeenCalledWith(
+                    '$snapshot',
+                    expect.objectContaining({
+                        $session_id: sessionId,
+                        $snapshot_data: [snapshot],
+                    }),
+                    expect.any(Object)
+                )
+            })
+
             it('ships nothing when a session rotates away without ever seeing interaction', () => {
                 // The billing regression this policy exists for: a parked tab whose session
                 // rotates on activity timeout must not ship a recording per rotation.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1468,7 +1468,11 @@ describe('Lazy SessionRecording', () => {
                 )
                 sessionRecording.onRRwebEmit(createFullSnapshot() as eventWithTime)
                 sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
-                recorder['_buffer'].size = 2 * RECORDING_MAX_EVENT_SIZE + 1
+                // fake a runaway TAIL: the reset keys on events after the last snapshot, so a
+                // merely-huge snapshot prefix must not trigger it (that would loop, since each
+                // reset takes another equally huge snapshot)
+                recorder['_buffer'].sizes[2] = 2 * RECORDING_MAX_EVENT_SIZE + 1
+                recorder['_buffer'].size = recorder['_buffer'].sizes.reduce((a: number, b: number) => a + b, 0)
 
                 recorder['_pruneHeldBuffer']()
 
@@ -1481,6 +1485,29 @@ describe('Lazy SessionRecording', () => {
                 ])
                 expect(recorder['_buffer'].data[0].data.href).toEqual('https://runaway.example.com')
                 expect(assignableWindow.__PosthogExtensions__.rrweb.record.takeFullSnapshot).toHaveBeenCalled()
+            })
+
+            it('does not hard-reset a held buffer whose bulk is the snapshot itself', () => {
+                // Resetting can't shrink a huge snapshot: takeFullSnapshot would produce an
+                // equally huge one, and re-triggering per capture becomes a snapshot storm.
+                const recorder = sessionRecording['_lazyLoadedSessionRecording']
+                expect(recorder['_isIdle']).toEqual('unknown')
+
+                sessionRecording.onRRwebEmit(createMetaSnapshot({ data: { href: 'https://a.b' } }) as eventWithTime)
+                sessionRecording.onRRwebEmit(createFullSnapshot() as eventWithTime)
+                sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
+                recorder['_buffer'].sizes[1] = 2 * RECORDING_MAX_EVENT_SIZE + 1
+                recorder['_buffer'].size = recorder['_buffer'].sizes.reduce((a: number, b: number) => a + b, 0)
+                const snapshotCallsBefore = (
+                    assignableWindow.__PosthogExtensions__.rrweb.record.takeFullSnapshot as Mock
+                ).mock.calls.length
+
+                recorder['_pruneHeldBuffer']()
+
+                expect(recorder['_buffer'].data).toHaveLength(3)
+                expect(
+                    (assignableWindow.__PosthogExtensions__.rrweb.record.takeFullSnapshot as Mock).mock.calls.length
+                ).toEqual(snapshotCallsBefore)
             })
 
             it('holds the buffer while _isIdle is unknown and ships it on the first user interaction', () => {

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1456,60 +1456,6 @@ describe('Lazy SessionRecording', () => {
                 expect(bufferData[0].type).toEqual(FULL_SNAPSHOT_EVENT_TYPE)
             })
 
-            it('hard-resets a runaway held buffer but keeps the newest Meta', () => {
-                // Prefix-pruning can't bound a buffer whose tail piles up behind one snapshot;
-                // past twice the cap the hold resets, carrying the Meta over (takeFullSnapshot
-                // emits none) and requesting a fresh snapshot for a new playable prefix.
-                const recorder = sessionRecording['_lazyLoadedSessionRecording']
-                expect(recorder['_isIdle']).toEqual('unknown')
-
-                sessionRecording.onRRwebEmit(
-                    createMetaSnapshot({ data: { href: 'https://runaway.example.com' } }) as eventWithTime
-                )
-                sessionRecording.onRRwebEmit(createFullSnapshot() as eventWithTime)
-                sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
-                // fake a runaway TAIL: the reset keys on events after the last snapshot, so a
-                // merely-huge snapshot prefix must not trigger it (that would loop, since each
-                // reset takes another equally huge snapshot)
-                recorder['_buffer'].sizes[2] = 2 * RECORDING_MAX_EVENT_SIZE + 1
-                recorder['_buffer'].size = recorder['_buffer'].sizes.reduce((a: number, b: number) => a + b, 0)
-
-                recorder['_pruneHeldBuffer']()
-
-                expect(posthog.capture).not.toHaveBeenCalled()
-                // the reset kept the Meta and the requested fresh snapshot re-established the
-                // playable prefix (the harness's takeFullSnapshot emits synchronously)
-                expect(recorder['_buffer'].data.map((e: any) => e.type)).toEqual([
-                    META_EVENT_TYPE,
-                    FULL_SNAPSHOT_EVENT_TYPE,
-                ])
-                expect(recorder['_buffer'].data[0].data.href).toEqual('https://runaway.example.com')
-                expect(assignableWindow.__PosthogExtensions__.rrweb.record.takeFullSnapshot).toHaveBeenCalled()
-            })
-
-            it('does not hard-reset a held buffer whose bulk is the snapshot itself', () => {
-                // Resetting can't shrink a huge snapshot: takeFullSnapshot would produce an
-                // equally huge one, and re-triggering per capture becomes a snapshot storm.
-                const recorder = sessionRecording['_lazyLoadedSessionRecording']
-                expect(recorder['_isIdle']).toEqual('unknown')
-
-                sessionRecording.onRRwebEmit(createMetaSnapshot({ data: { href: 'https://a.b' } }) as eventWithTime)
-                sessionRecording.onRRwebEmit(createFullSnapshot() as eventWithTime)
-                sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
-                recorder['_buffer'].sizes[1] = 2 * RECORDING_MAX_EVENT_SIZE + 1
-                recorder['_buffer'].size = recorder['_buffer'].sizes.reduce((a: number, b: number) => a + b, 0)
-                const snapshotCallsBefore = (
-                    assignableWindow.__PosthogExtensions__.rrweb.record.takeFullSnapshot as Mock
-                ).mock.calls.length
-
-                recorder['_pruneHeldBuffer']()
-
-                expect(recorder['_buffer'].data).toHaveLength(3)
-                expect(
-                    (assignableWindow.__PosthogExtensions__.rrweb.record.takeFullSnapshot as Mock).mock.calls.length
-                ).toEqual(snapshotCallsBefore)
-            })
-
             it('holds the buffer while _isIdle is unknown and ships it on the first user interaction', () => {
                 jest.useFakeTimers().setSystemTime(new Date(startingTimestamp + 100))
 
@@ -1538,17 +1484,13 @@ describe('Lazy SessionRecording', () => {
             })
 
             it("ships the interacted session's trailing buffer when it rotates while idle", () => {
-                // stop() runs during rotation under the OLD session's ship evidence: an
-                // interacted-then-idle session must ship its tail (the $session_ending
-                // breadcrumb that session linking needs), not have it discarded by the new
-                // session's 'unknown' state being set too early. The ordering only matters on
-                // the callback's restart path, reached when the $session_id_change emit is
-                // throttled away from the session check, so refresh the idle-check stamp
-                // shortly before rotating.
+                // Rotation while confirmed idle must ship the interacted session's tail (the
+                // $session_ending breadcrumb that session linking needs) under the old
+                // session's own ship evidence, never hold-and-discard it as if it were the
+                // new session's data.
                 const firstActivityTimestamp = startingTimestamp + 100
                 const idleTriggerTimestamp = startingTimestamp + RECORDING_IDLE_THRESHOLD_MS + 1000
                 const rotationTimestamp = sessionManager['_sessionTimeoutMs'] + startingTimestamp + 1000
-                const throttleRefreshTimestamp = rotationTimestamp - 30_000
 
                 // deliver custom events through the real emit path so $session_ending is buffered
                 _addCustomEvent.mockImplementation((tag: string, payload: any) => {
@@ -1557,9 +1499,6 @@ describe('Lazy SessionRecording', () => {
                 try {
                     emitActiveEvent(firstActivityTimestamp)
                     emitInactiveEvent(idleTriggerTimestamp, true)
-                    // this idle-state emit runs a session check and stamps the throttle, so the
-                    // rotation's own $session_id_change emit 30s later is throttled
-                    emitInactiveEvent(throttleRefreshTimestamp, true)
                     const firstSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
                     ;(posthog.capture as Mock).mockClear()
 

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1456,6 +1456,33 @@ describe('Lazy SessionRecording', () => {
                 expect(bufferData[0].type).toEqual(FULL_SNAPSHOT_EVENT_TYPE)
             })
 
+            it('hard-resets a runaway held buffer but keeps the newest Meta', () => {
+                // Prefix-pruning can't bound a buffer whose tail piles up behind one snapshot;
+                // past twice the cap the hold resets, carrying the Meta over (takeFullSnapshot
+                // emits none) and requesting a fresh snapshot for a new playable prefix.
+                const recorder = sessionRecording['_lazyLoadedSessionRecording']
+                expect(recorder['_isIdle']).toEqual('unknown')
+
+                sessionRecording.onRRwebEmit(
+                    createMetaSnapshot({ data: { href: 'https://runaway.example.com' } }) as eventWithTime
+                )
+                sessionRecording.onRRwebEmit(createFullSnapshot() as eventWithTime)
+                sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
+                recorder['_buffer'].size = 2 * RECORDING_MAX_EVENT_SIZE + 1
+
+                recorder['_pruneHeldBuffer']()
+
+                expect(posthog.capture).not.toHaveBeenCalled()
+                // the reset kept the Meta and the requested fresh snapshot re-established the
+                // playable prefix (the harness's takeFullSnapshot emits synchronously)
+                expect(recorder['_buffer'].data.map((e: any) => e.type)).toEqual([
+                    META_EVENT_TYPE,
+                    FULL_SNAPSHOT_EVENT_TYPE,
+                ])
+                expect(recorder['_buffer'].data[0].data.href).toEqual('https://runaway.example.com')
+                expect(assignableWindow.__PosthogExtensions__.rrweb.record.takeFullSnapshot).toHaveBeenCalled()
+            })
+
             it('holds the buffer while _isIdle is unknown and ships it on the first user interaction', () => {
                 jest.useFakeTimers().setSystemTime(new Date(startingTimestamp + 100))
 

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1483,6 +1483,49 @@ describe('Lazy SessionRecording', () => {
                 )
             })
 
+            it("ships the interacted session's trailing buffer when it rotates while idle", () => {
+                // stop() runs during rotation under the OLD session's ship evidence: an
+                // interacted-then-idle session must ship its tail (the $session_ending
+                // breadcrumb that session linking needs), not have it discarded by the new
+                // session's 'unknown' state being set too early. The ordering only matters on
+                // the callback's restart path, reached when the $session_id_change emit is
+                // throttled away from the session check, so refresh the idle-check stamp
+                // shortly before rotating.
+                const firstActivityTimestamp = startingTimestamp + 100
+                const idleTriggerTimestamp = startingTimestamp + RECORDING_IDLE_THRESHOLD_MS + 1000
+                const rotationTimestamp = sessionManager['_sessionTimeoutMs'] + startingTimestamp + 1000
+                const throttleRefreshTimestamp = rotationTimestamp - 30_000
+
+                // deliver custom events through the real emit path so $session_ending is buffered
+                _addCustomEvent.mockImplementation((tag: string, payload: any) => {
+                    _emit({ type: EventType.Custom, data: { tag, payload }, timestamp: Date.now() })
+                })
+                try {
+                    emitActiveEvent(firstActivityTimestamp)
+                    emitInactiveEvent(idleTriggerTimestamp, true)
+                    // this idle-state emit runs a session check and stamps the throttle, so the
+                    // rotation's own $session_id_change emit 30s later is throttled
+                    emitInactiveEvent(throttleRefreshTimestamp, true)
+                    const firstSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
+                    ;(posthog.capture as Mock).mockClear()
+
+                    sessionIdGeneratorMock.mockImplementation(() => 'idle-rotation-session-id')
+                    jest.useFakeTimers().setSystemTime(new Date(rotationTimestamp))
+                    sessionManager.checkAndGetSessionAndWindowId(false, rotationTimestamp)
+
+                    const shippedForOldSession = (posthog.capture as Mock).mock.calls.filter(
+                        ([name, props]) => name === '$snapshot' && props.$session_id === firstSessionId
+                    )
+                    expect(shippedForOldSession.length).toBeGreaterThan(0)
+                    const shippedTags = shippedForOldSession
+                        .flatMap(([, props]) => props.$snapshot_data)
+                        .map((e: any) => e?.data?.tag)
+                    expect(shippedTags).toContain('$session_ending')
+                } finally {
+                    _addCustomEvent.mockReset()
+                }
+            })
+
             it('an event trigger match releases the hold even when its activation is a no-op', () => {
                 // With triggerMatchType 'any', a URL trigger can satisfy the combined trigger
                 // status long before an error event fires; the activation then short-circuits

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -474,7 +474,12 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
      * and a queue - that contains rrweb events that we want to send to rrweb, but rrweb wasn't able to accept them yet
      */
     private _queuedRRWebEvents: QueuedRRWebEvent[] = []
+    // 'unknown' means no user interaction has been seen since THIS recorder started, not since
+    // the session started. A recorder started late in an active session (lazy script load,
+    // trigger activation) holds its buffer until the next interaction even though the user was
+    // active earlier; any ACTIVE_SOURCES event (mouse move, scroll, touch) clears it.
     private _isIdle: boolean | 'unknown' = 'unknown'
+    private _lastIdleSessionCheckTimestamp = 0
     private _rrwebError = false
     private _rrwebStartAttempted = false
     private _maxDepthExceeded = false
@@ -1327,6 +1332,15 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     }
 
     stop() {
+        // stopping while the buffer is held (no user interaction yet) drops it by design,
+        // but that shouldn't be an invisible data path
+        if (this._isIdle === 'unknown' && this._buffer.data.length > 0) {
+            logger.info('discarding held buffer for a session that saw no user interaction', {
+                sessionId: this._buffer.sessionId,
+                bufferLength: this._buffer.data.length,
+            })
+        }
+
         if (this._stopAfterCompressionQueueDrains()) {
             return
         }
@@ -1745,23 +1759,32 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                 break
             }
         }
-        if (lastFullSnapshotIndex <= 0) {
-            // no snapshot, or it's already the head: nothing older than it to drop
-            return
-        }
 
         const precedingIsMeta =
+            lastFullSnapshotIndex > 0 &&
             (this._buffer.data[lastFullSnapshotIndex - 1] as eventWithTime | undefined)?.type === EventType.Meta
         const keepFrom = precedingIsMeta ? lastFullSnapshotIndex - 1 : lastFullSnapshotIndex
-        if (keepFrom === 0) {
-            return
+
+        if (keepFrom > 0) {
+            for (let i = 0; i < keepFrom; i++) {
+                this._buffer.size -= this._buffer.sizes[i]
+            }
+            this._buffer.data = this._buffer.data.slice(keepFrom)
+            this._buffer.sizes = this._buffer.sizes.slice(keepFrom)
         }
 
-        for (let i = 0; i < keepFrom; i++) {
-            this._buffer.size -= this._buffer.sizes[i]
+        // Prefix-pruning only helps while the periodic full snapshot keeps creating new prune
+        // points. If events pile up behind a single snapshot (a mutation-heavy page, or the
+        // snapshot interval not firing), reset the hold and request a fresh snapshot so the
+        // playable prefix re-establishes at a bounded size.
+        if (this._buffer.size + incomingBytes > 2 * RECORDING_MAX_EVENT_SIZE) {
+            logger.info('held buffer for uninteracted session exceeded the hard cap; resetting it', {
+                sessionId: this._buffer.sessionId,
+                bufferSize: this._buffer.size,
+            })
+            this._clearBuffer()
+            this._tryTakeFullSnapshot()
         }
-        this._buffer.data = this._buffer.data.slice(keepFrom)
-        this._buffer.sizes = this._buffer.sizes.slice(keepFrom)
     }
 
     private _flushBuffer(force = false): SnapshotBuffer {
@@ -2078,6 +2101,15 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // cap (sessionPastMaximumLength rotates even on readOnly calls) and hears cross-tab
         // rotations. Skipping it here is how idle tabs used to accrete multi-day sessions
         // that blew straight through SESSION_LENGTH_LIMIT.
+        if (this._isIdle === true) {
+            // Neither of those outcomes needs per-event precision, and the check reads
+            // persistence, so a mutation storm in an idle tab shouldn't pay for it per event.
+            if (event.timestamp - this._lastIdleSessionCheckTimestamp < 60_000) {
+                return
+            }
+            this._lastIdleSessionCheckTimestamp = event.timestamp
+        }
+
         // We only want to extend the session if it is an interactive event.
         const { windowId, sessionId } = this._sessionManager.checkAndGetSessionAndWindowId(
             !isUserInteraction,

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1729,8 +1729,54 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         }
     }
 
-    private _flushBuffer(): SnapshotBuffer {
+    // Bound a held (never-interacted) buffer by keeping only the newest playable prefix:
+    // the most recent FullSnapshot, its preceding Meta, and everything after them. Events
+    // older than that snapshot can't be replayed without it, so they carry no value once a
+    // newer snapshot exists, so dropping them keeps an indefinitely-held tab at a bounded size.
+    private _pruneHeldBuffer(incomingBytes: number = 0): void {
+        if (this._buffer.size + incomingBytes <= RECORDING_MAX_EVENT_SIZE) {
+            return
+        }
+
+        let lastFullSnapshotIndex = -1
+        for (let i = this._buffer.data.length - 1; i >= 0; i--) {
+            if ((this._buffer.data[i] as eventWithTime | undefined)?.type === EventType.FullSnapshot) {
+                lastFullSnapshotIndex = i
+                break
+            }
+        }
+        if (lastFullSnapshotIndex <= 0) {
+            // no snapshot, or it's already the head: nothing older than it to drop
+            return
+        }
+
+        const precedingIsMeta =
+            (this._buffer.data[lastFullSnapshotIndex - 1] as eventWithTime | undefined)?.type === EventType.Meta
+        const keepFrom = precedingIsMeta ? lastFullSnapshotIndex - 1 : lastFullSnapshotIndex
+        if (keepFrom === 0) {
+            return
+        }
+
+        for (let i = 0; i < keepFrom; i++) {
+            this._buffer.size -= this._buffer.sizes[i]
+        }
+        this._buffer.data = this._buffer.data.slice(keepFrom)
+        this._buffer.sizes = this._buffer.sizes.slice(keepFrom)
+    }
+
+    private _flushBuffer(force = false): SnapshotBuffer {
         this._clearFlushBufferTimer()
+
+        // A recorder that has never seen user interaction (_isIdle === 'unknown') holds its
+        // buffer instead of shipping. Without this, every activity-timeout rotation in a parked
+        // tab ships a Meta + FullSnapshot recording nobody interacted with, and each one bills
+        // as a full recording. The held buffer ships on the first user interaction (which flips
+        // _isIdle to false and arms the flush timer), or on unload via force; a rotation's
+        // stop() finds it held and clears it, so a session nobody ever touched ships nothing.
+        if (this._isIdle === 'unknown' && !force) {
+            this._pruneHeldBuffer()
+            return this._buffer
+        }
 
         // never flush while a sampling decision is missing (e.g. wiped by posthog.reset()) — an
         // undecided session reads as ACTIVE and would leak a batch it then decides not to record
@@ -1835,29 +1881,33 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         if (
             sessionChanged ||
-            // we never want to flush a healthy same-session buffer while confirmed idle, but
-            // 'unknown' still captures so its buffer must respect the size cap or it grows unbounded
-            (this._isIdle !== true &&
+            // we never want to flush a healthy same-session buffer while confirmed idle
+            (this._isIdle === false &&
                 this._buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE)
         ) {
             this._buffer = this._flushBuffer()
-            // A suppressed flush (e.g. buffering, paused, below minimum duration) returns the buffer un-drained, and relabeling the prior session's events would mis-attribute them, so discard them instead.
+            // A suppressed flush (buffering, paused, below minimum duration, or held because the
+            // session never saw interaction) returns the buffer un-drained, and relabeling the
+            // prior session's events would mis-attribute them, so discard them instead.
             if (sessionChanged && this._buffer.data.length > 0) {
                 this._buffer = this._clearBuffer()
             }
             // After flushing, update buffer to use the new target session/window IDs
             this._buffer.sessionId = targetSessionId
             this._buffer.windowId = properties.$window_id as string
+        } else if (this._isIdle === 'unknown') {
+            // held buffers don't flush on the size cap; keep them bounded instead
+            this._pruneHeldBuffer(properties.$snapshot_bytes + additionalBytes)
         }
 
         this._buffer.size += properties.$snapshot_bytes
         this._buffer.data.push(properties.$snapshot_data)
         this._buffer.sizes.push(properties.$snapshot_bytes)
 
-        // Schedule the flush unless confirmed idle: a tab that never sees user interaction stays
-        // 'unknown' indefinitely, and without a timer its captured events (including the initial
-        // full snapshot after a session rotation) would never ship until the next rotation or unload.
-        if (!this._flushBufferTimer && this._isIdle !== true) {
+        // Schedule the flush only once the session has seen real user interaction. While
+        // 'unknown' the buffer is held (see _flushBuffer): capturing continues so the first
+        // interaction can ship a playable prefix, but nothing leaves the tab before then.
+        if (!this._flushBufferTimer && this._isIdle === false) {
             this._flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()
             }, RECORDING_BUFFER_TIMEOUT)
@@ -1924,7 +1974,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // beforeunload cannot wait for async CompressionStream work. Synchronously
         // compress any queued events so sendBeacon can include them in this flush.
         this._drainCompressionQueueSync()
-        this._flushBuffer()
+        // force: unload is the last chance to ship, and a single recording per never-interacted
+        // pageview on unload is the long-standing pre-hold behavior (bounded, unlike rotation chains)
+        this._flushBuffer(true)
     }
 
     private _onOffline = (): void => {
@@ -2009,16 +2061,23 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                         type: event.type,
                     })
                     returningFromIdle = true
+                } else if (this._buffer.data.length > 0 && !this._flushBufferTimer) {
+                    // first interaction of this recorder run: the buffer held while 'unknown'
+                    // (Meta + FullSnapshot prefix) can now ship, making the recording playable
+                    // from before the interaction
+                    this._flushBufferTimer = setTimeout(() => {
+                        this._flushBuffer()
+                    }, RECORDING_BUFFER_TIMEOUT)
                 }
             }
         }
 
-        // Only bail on confirmed idle: while 'unknown' the recorder still captures, so it must
-        // also keep checking for session changes or its events are stamped with a stale session id.
-        if (this._isIdle === true) {
-            return
-        }
-
+        // The session check runs in every idle state. While 'unknown' the recorder still
+        // captures, so it must keep checking or its events are stamped with a stale session id.
+        // While confirmed idle, the readOnly check below still enforces the 24-hour session
+        // cap (sessionPastMaximumLength rotates even on readOnly calls) and hears cross-tab
+        // rotations. Skipping it here is how idle tabs used to accrete multi-day sessions
+        // that blew straight through SESSION_LENGTH_LIMIT.
         // We only want to extend the session if it is an interactive event.
         const { windowId, sessionId } = this._sessionManager.checkAndGetSessionAndWindowId(
             !isUserInteraction,

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -479,7 +479,6 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     // trigger activation) holds its buffer until the next interaction even though the user was
     // active earlier; any ACTIVE_SOURCES event (mouse move, scroll, touch) clears it.
     private _isIdle: boolean | 'unknown' = 'unknown'
-    private _lastIdleSessionCheckTimestamp = 0
     // An event-trigger match (V1) counts as ship evidence even without interaction; see
     // _holdingForInteraction. V2 trigger groups activate inside the strategy and don't set
     // this yet, so V2 event-trigger sessions hold until interaction (known follow-up).
@@ -1777,8 +1776,10 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
     // Bound a held (never-interacted) buffer by keeping only the newest playable prefix:
     // the most recent FullSnapshot, its preceding Meta, and everything after them. Events
-    // older than that snapshot can't be replayed without it, so they carry no value once a
-    // newer snapshot exists, so dropping them keeps an indefinitely-held tab at a bounded size.
+    // older than that snapshot can't be replayed without it, so dropping them costs nothing.
+    // Boundedness relies on the periodic full snapshot creating new prune points, which is
+    // guaranteed here: its interval only stops on confirmed idle, and a session stays
+    // 'unknown' (never confirmed idle) for as long as it is held.
     private _pruneHeldBuffer(incomingBytes: number = 0): void {
         if (this._buffer.size + incomingBytes <= RECORDING_MAX_EVENT_SIZE) {
             return
@@ -1803,43 +1804,6 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             }
             this._buffer.data = this._buffer.data.slice(keepFrom)
             this._buffer.sizes = this._buffer.sizes.slice(keepFrom)
-        }
-
-        // Prefix-pruning only helps while the periodic full snapshot keeps creating new prune
-        // points. If events pile up behind a single snapshot (a mutation-heavy page, or the
-        // snapshot interval not firing), reset the hold and request a fresh snapshot so the
-        // playable prefix re-establishes at a bounded size. Key the reset on the TAIL (events
-        // after the last snapshot), which is the unbounded part: a total-size condition would
-        // re-trigger on every capture when the snapshot itself is huge, and each reset takes
-        // another full snapshot, so a heavy DOM would pay a snapshot storm in a parked tab.
-        const snapshotIndexAfterPrune = keepFrom > 0 ? lastFullSnapshotIndex - keepFrom : lastFullSnapshotIndex
-        let tailSize = 0
-        for (let i = snapshotIndexAfterPrune + 1; i < this._buffer.sizes.length; i++) {
-            tailSize += this._buffer.sizes[i]
-        }
-        if (tailSize > 2 * RECORDING_MAX_EVENT_SIZE) {
-            logger.info('held buffer for uninteracted session exceeded the hard cap; resetting it', {
-                sessionId: this._buffer.sessionId,
-                bufferSize: this._buffer.size,
-            })
-            // takeFullSnapshot() emits no Meta, so carry the newest Meta over or the rebuilt
-            // prefix ships without href/viewport and the recording loses its URL.
-            let lastMetaIndex = -1
-            for (let i = this._buffer.data.length - 1; i >= 0; i--) {
-                if ((this._buffer.data[i] as eventWithTime | undefined)?.type === EventType.Meta) {
-                    lastMetaIndex = i
-                    break
-                }
-            }
-            const metaEvent = lastMetaIndex >= 0 ? this._buffer.data[lastMetaIndex] : null
-            const metaSize = lastMetaIndex >= 0 ? this._buffer.sizes[lastMetaIndex] : 0
-            this._clearBuffer()
-            if (metaEvent) {
-                this._buffer.data.push(metaEvent)
-                this._buffer.sizes.push(metaSize)
-                this._buffer.size += metaSize
-            }
-            this._tryTakeFullSnapshot()
         }
     }
 
@@ -2153,21 +2117,13 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             }
         }
 
-        // The session check runs in every idle state. While 'unknown' the recorder still
-        // captures, so it must keep checking or its events are stamped with a stale session id.
-        // While confirmed idle, the readOnly check below still enforces the 24-hour session
-        // cap (sessionPastMaximumLength rotates even on readOnly calls) and hears cross-tab
+        // The session check runs in every idle state (it only reads in-memory persistence
+        // props, so it is cheap). While 'unknown' the recorder still captures, so it must keep
+        // checking or its events are stamped with a stale session id. While confirmed idle,
+        // the readOnly check below still enforces the 24-hour session cap
+        // (sessionPastMaximumLength rotates even on readOnly calls) and hears cross-tab
         // rotations. Skipping it here is how idle tabs used to accrete multi-day sessions
         // that blew straight through SESSION_LENGTH_LIMIT.
-        if (this._isIdle === true) {
-            // Neither of those outcomes needs per-event precision, and the check reads
-            // persistence, so a mutation storm in an idle tab shouldn't pay for it per event.
-            if (event.timestamp - this._lastIdleSessionCheckTimestamp < 60_000) {
-                return
-            }
-            this._lastIdleSessionCheckTimestamp = event.timestamp
-        }
-
         // We only want to extend the session if it is an interactive event.
         const { windowId, sessionId } = this._sessionManager.checkAndGetSessionAndWindowId(
             !isUserInteraction,

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1808,8 +1808,16 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // Prefix-pruning only helps while the periodic full snapshot keeps creating new prune
         // points. If events pile up behind a single snapshot (a mutation-heavy page, or the
         // snapshot interval not firing), reset the hold and request a fresh snapshot so the
-        // playable prefix re-establishes at a bounded size.
-        if (this._buffer.size + incomingBytes > 2 * RECORDING_MAX_EVENT_SIZE) {
+        // playable prefix re-establishes at a bounded size. Key the reset on the TAIL (events
+        // after the last snapshot), which is the unbounded part: a total-size condition would
+        // re-trigger on every capture when the snapshot itself is huge, and each reset takes
+        // another full snapshot, so a heavy DOM would pay a snapshot storm in a parked tab.
+        const snapshotIndexAfterPrune = keepFrom > 0 ? lastFullSnapshotIndex - keepFrom : lastFullSnapshotIndex
+        let tailSize = 0
+        for (let i = snapshotIndexAfterPrune + 1; i < this._buffer.sizes.length; i++) {
+            tailSize += this._buffer.sizes[i]
+        }
+        if (tailSize > 2 * RECORDING_MAX_EVENT_SIZE) {
             logger.info('held buffer for uninteracted session exceeded the hard cap; resetting it', {
                 sessionId: this._buffer.sessionId,
                 bufferSize: this._buffer.size,

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1249,10 +1249,14 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             (this._isIdle !== false || !this.isStarted) &&
             (this._sessionId !== sessionId || this._windowId !== windowId)
         ) {
-            this._isIdle = 'unknown'
-            // ship evidence is per session: the new session's event trigger must match again
-            this._eventTriggerActivated = false
+            // stop() flushes the OLD session's trailing buffer (e.g. its $session_ending
+            // breadcrumb, which session linking needs), so it must run under the old
+            // session's ship evidence: an interacted-then-idle session ships its tail, a
+            // never-interacted one holds and discards. Only then reset state for the new
+            // session, whose evidence (interaction, event trigger) must be earned again.
             this.stop()
+            this._isIdle = 'unknown'
+            this._eventTriggerActivated = false
             this.start('session_id_changed')
         }
 
@@ -1810,7 +1814,23 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                 sessionId: this._buffer.sessionId,
                 bufferSize: this._buffer.size,
             })
+            // takeFullSnapshot() emits no Meta, so carry the newest Meta over or the rebuilt
+            // prefix ships without href/viewport and the recording loses its URL.
+            let lastMetaIndex = -1
+            for (let i = this._buffer.data.length - 1; i >= 0; i--) {
+                if ((this._buffer.data[i] as eventWithTime | undefined)?.type === EventType.Meta) {
+                    lastMetaIndex = i
+                    break
+                }
+            }
+            const metaEvent = lastMetaIndex >= 0 ? this._buffer.data[lastMetaIndex] : null
+            const metaSize = lastMetaIndex >= 0 ? this._buffer.sizes[lastMetaIndex] : 0
             this._clearBuffer()
+            if (metaEvent) {
+                this._buffer.data.push(metaEvent)
+                this._buffer.sizes.push(metaSize)
+                this._buffer.size += metaSize
+            }
             this._tryTakeFullSnapshot()
         }
     }

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -480,6 +480,17 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     // active earlier; any ACTIVE_SOURCES event (mouse move, scroll, touch) clears it.
     private _isIdle: boolean | 'unknown' = 'unknown'
     private _lastIdleSessionCheckTimestamp = 0
+    // An event-trigger match (V1) counts as ship evidence even without interaction; see
+    // _holdingForInteraction. V2 trigger groups activate inside the strategy and don't set
+    // this yet, so V2 event-trigger sessions hold until interaction (known follow-up).
+    private _eventTriggerActivated = false
+
+    // While this is true, nothing ships: the session has shown no evidence anyone cares about
+    // it. Evidence is either a user interaction this recorder run (_isIdle leaves 'unknown')
+    // or an event-trigger match (an explicit record-on-X config).
+    private get _holdingForInteraction(): boolean {
+        return this._isIdle === 'unknown' && !this._eventTriggerActivated
+    }
     private _rrwebError = false
     private _rrwebStartAttempted = false
     private _maxDepthExceeded = false
@@ -915,6 +926,21 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     }
 
     private _activateTrigger(triggerType: TriggerType, matchDetail?: string) {
+        // An event trigger is explicit "this session matters" intent (e.g. record on
+        // exception), so it releases the interaction hold. This must happen BEFORE the
+        // pending-trigger short circuit below: with triggerMatchType 'any' a URL trigger may
+        // have satisfied the combined status long ago, making the activation itself a no-op,
+        // but the event (the error) still just happened and is what makes a quiet session
+        // worth shipping. URL triggers only scope where recording is allowed and never count.
+        if (triggerType === 'event' && !this._eventTriggerActivated) {
+            this._eventTriggerActivated = true
+            if (this._buffer.data.length > 0 && !this._flushBufferTimer) {
+                this._flushBufferTimer = setTimeout(() => {
+                    this._flushBuffer()
+                }, RECORDING_BUFFER_TIMEOUT)
+            }
+        }
+
         // V1 only: V2 uses per-group activation and never calls this method
         // Prevent re-entry: if we're already activating a trigger, skip to avoid infinite recursion
         // This can happen when _reportStarted emits custom events that match the trigger condition
@@ -1224,6 +1250,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             (this._sessionId !== sessionId || this._windowId !== windowId)
         ) {
             this._isIdle = 'unknown'
+            // ship evidence is per session: the new session's event trigger must match again
+            this._eventTriggerActivated = false
             this.stop()
             this.start('session_id_changed')
         }
@@ -1332,9 +1360,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     }
 
     stop() {
-        // stopping while the buffer is held (no user interaction yet) drops it by design,
+        // stopping while the buffer is held (no ship evidence yet) drops it by design,
         // but that shouldn't be an invisible data path
-        if (this._isIdle === 'unknown' && this._buffer.data.length > 0) {
+        if (this._holdingForInteraction && this._buffer.data.length > 0) {
             logger.info('discarding held buffer for a session that saw no user interaction', {
                 sessionId: this._buffer.sessionId,
                 bufferLength: this._buffer.data.length,
@@ -1790,13 +1818,13 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     private _flushBuffer(force = false): SnapshotBuffer {
         this._clearFlushBufferTimer()
 
-        // A recorder that has never seen user interaction (_isIdle === 'unknown') holds its
-        // buffer instead of shipping. Without this, every activity-timeout rotation in a parked
-        // tab ships a Meta + FullSnapshot recording nobody interacted with, and each one bills
-        // as a full recording. The held buffer ships on the first user interaction (which flips
-        // _isIdle to false and arms the flush timer), or on unload via force; a rotation's
+        // A recorder with no ship evidence (no user interaction this run, no event-trigger
+        // match) holds its buffer instead of shipping. Without this, every activity-timeout
+        // rotation in a parked tab ships a Meta + FullSnapshot recording nobody interacted
+        // with, and each one bills as a full recording. The held buffer ships on the first
+        // user interaction or event-trigger match, or on unload via force; a rotation's
         // stop() finds it held and clears it, so a session nobody ever touched ships nothing.
-        if (this._isIdle === 'unknown' && !force) {
+        if (this._holdingForInteraction && !force) {
             this._pruneHeldBuffer()
             return this._buffer
         }
@@ -1904,8 +1932,10 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         if (
             sessionChanged ||
-            // we never want to flush a healthy same-session buffer while confirmed idle
-            (this._isIdle === false &&
+            // we never want to flush a healthy same-session buffer while confirmed idle,
+            // nor while holding for interaction (that path prunes below instead)
+            (this._isIdle !== true &&
+                !this._holdingForInteraction &&
                 this._buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE)
         ) {
             this._buffer = this._flushBuffer()
@@ -1918,7 +1948,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             // After flushing, update buffer to use the new target session/window IDs
             this._buffer.sessionId = targetSessionId
             this._buffer.windowId = properties.$window_id as string
-        } else if (this._isIdle === 'unknown') {
+        } else if (this._holdingForInteraction) {
             // held buffers don't flush on the size cap; keep them bounded instead
             this._pruneHeldBuffer(properties.$snapshot_bytes + additionalBytes)
         }
@@ -1927,10 +1957,10 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         this._buffer.data.push(properties.$snapshot_data)
         this._buffer.sizes.push(properties.$snapshot_bytes)
 
-        // Schedule the flush only once the session has seen real user interaction. While
-        // 'unknown' the buffer is held (see _flushBuffer): capturing continues so the first
-        // interaction can ship a playable prefix, but nothing leaves the tab before then.
-        if (!this._flushBufferTimer && this._isIdle === false) {
+        // Schedule the flush only once the session has ship evidence (user interaction or an
+        // event-trigger match). While holding, capturing continues so the first interaction
+        // can ship a playable prefix, but nothing leaves the tab before then.
+        if (!this._flushBufferTimer && this._isIdle !== true && !this._holdingForInteraction) {
             this._flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()
             }, RECORDING_BUFFER_TIMEOUT)


### PR DESCRIPTION
## Problem

#4224 fixed a real bug (#4202: sessions rotated in never-interacted tabs kept stamping snapshots with the stale session id and never flushed, so the new session was unplayable) but overshot: treating the `'unknown'` idle state as "not idle" made every activity-timeout rotation in a parked tab ship a Meta + FullSnapshot recording. A tab nobody touches now produces an unbounded chain of zero-interaction recordings, each billed as a full recording (`recording_count_in_period` counts them). Fleet-wide, zero-duration/zero-interaction recordings roughly tripled starting July 23; for idle-tab-heavy products, total recordings ~3x'd with no change on the customer side (Slack: https://posthog.slack.com/archives/C06UTAJJEHM/p1785770287662349).

Neither the pre-#4224 behavior ("never ship them", by accident of `_isIdle` truthiness) nor the post-#4224 behavior ("always ship them") was a deliberate policy. This PR makes the policy explicit.

Separately, confirmed-idle tabs skipped the session check entirely, so an idle session never rotated: we observed single recordings spanning 25-95 hours, sailing through `SESSION_LENGTH_LIMIT`.

## Changes

**Capture speculatively, ship on interaction.** While `_isIdle === 'unknown'` (no user interaction seen this recorder run):

- the recorder keeps capturing (so the rotated session's Meta + FullSnapshot exists, preserving the #4202 fix), but `_flushBuffer` holds instead of shipping
- the held buffer is pruned to the newest playable prefix (latest FullSnapshot, its Meta, and everything after), so an indefinitely parked tab holds bounded memory
- the first user interaction flips `_isIdle` to `false` and ships the held buffer, so the recording is playable from before the interaction
- `beforeunload` still force-ships (the long-standing one-bounded-recording-per-pageview behavior)
- a rotation's `stop()` finds the buffer held and clears it: a session nobody ever touched ships nothing

**Idle sessions respect the 24-hour cap.** `_updateWindowAndSessionIds` no longer early-returns while confirmed idle; the readOnly session check enforces `sessionPastMaximumLength` and hears cross-tab rotations, so idle sessions rotate instead of accreting multi-day recordings under one id.

**Behavioral decisions embedded here that reviewers should explicitly confirm:**

1. URL trigger activation no longer ships an uninteracted session's buffer (URL triggers scope where recording is allowed; they aren't evidence anyone cares). **Event triggers DO release the hold** (record-on-exception from an untouched tab is exactly what that config asks for), including when the activation itself short-circuits because a URL trigger already satisfied triggerMatchType 'any'. V2 trigger groups activate inside the strategy and don't set the evidence flag yet - known follow-up.
2. "Interaction" = rrweb ACTIVE_SOURCES (includes mouse move, scroll, touch), so passive-but-present viewers still record.
3. `stop()` discards a held buffer (including manual `stopRecording()` on a never-touched page).

Regression tests: unit tests assert a rotation chain in an untouched tab ships nothing, the held buffer prunes instead of flushing on the size cap, the hold releases on first interaction, and a confirmed-idle session rotates at the 24h cap; the #4224 Playwright spec now asserts hold-then-ship end to end in both compression modes.

Not run locally (env): Playwright specs, eslint, typecheck — relying on CI for those.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## 🤖 Agent context

Drafted from the HeyGen replay-billing investigation (thread above): recordings 3x'd on July 23 with no customer-side change; root cause traced to #4224 shipping through the unpinned `posthog-recorder` lazy bundle, reaching SDKs pinned as far back as 1.390.0 within an hour of release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

