### PR TITLE
fix(ai): capture reasoning text of assistant turns in Vercel AI SDK input

### DIFF
--- a/.changeset/vercel-reasoning-input-text.md
+++ b/.changeset/vercel-reasoning-input-text.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Capture the reasoning text of assistant turns replayed in a Vercel AI SDK prompt. The input mapper read a non-existent `reasoning` field instead of the spec's `text`, so `$ai_input` reasoning parts arrived empty for multi-step agentic loops.

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -128,7 +128,7 @@ const mapVercelPrompt = (messages: LanguageModelPrompt): PostHogInput[] => {
           } else if (c.type === 'reasoning') {
             return {
               type: 'reasoning',
-              text: truncate(c.reasoning),
+              text: truncate(c.text),
             }
           } else if (c.type === 'tool-call') {
             return {

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -1540,6 +1540,39 @@ describe('Vercel AI SDK - Dual Version Support', () => {
       ])
       expect(captureCall[0].properties.$ai_reasoning_tokens).toBe(5)
     })
+
+    // Agentic loops replay the previous assistant turn — reasoning included — as the
+    // next step's prompt, so the input mapper has to carry the thinking text too.
+    it.each(['v2', 'v3'] as const)(
+      'should map the reasoning text of an assistant turn in %s input',
+      async (version) => {
+        const baseModel = version === 'v3' ? createMockV3Model('test-model') : createMockV2Model('test-model')
+        const model = withTracing(baseModel, mockPostHogClient, { posthogDistinctId: 'test-user' })
+
+        await model.doGenerate({
+          prompt: [
+            { role: 'user', content: [{ type: 'text', text: 'What is 9 + 10?' }] },
+            {
+              role: 'assistant',
+              content: [
+                { type: 'reasoning', text: 'The user wants a sum: 9 + 10 = 19.' },
+                { type: 'text', text: '19' },
+              ],
+            },
+            { role: 'user', content: [{ type: 'text', text: 'And plus one?' }] },
+          ],
+        } as any)
+
+        const properties = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
+        expect(properties.$ai_input[1]).toEqual({
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'The user wants a sum: 9 + 10 = 19.' },
+            { type: 'text', text: '19' },
+          ],
+        })
+      }
+    )
   })
 
   describe('Prototype getter preservation', () => {


### PR DESCRIPTION
## Problem

Every reasoning block in `$ai_input` from the Vercel AI SDK arrives **empty** — the UI renders an `assistant (thinking)` bubble with no content. The input mapper reads a field that isn't on the spec.

Reported by a customer on `@posthog/ai@7.20.5` (AI SDK spec v3); confirmed present at that tag. Introduced in #2191; #2199 fixed the same mistake on the *output* side an hour later but never the input, and no test covered reasoning-in-input.

## Changes

Do not drop these blocks. Covered by tests.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file


## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code. Established the correct field from the `@ai-sdk/provider` types, ruled out a frontend rendering bug via the normalizer recipes, and bisected history to the origin. Confirmed with a throwaway repro before writing the fix, then validated red/green.

Note for reviewers: the version in the original report ("Vercel AI SDK 7.20.5") is actually `@posthog/ai@7.20.5` — our own package; `ai@7.20.5` doesn't exist. Chasing that confusion is what surfaced the v4 gap above.
