### PR TITLE
fix(ci): sign the commits these workflows create

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -22,7 +22,10 @@ jobs:
       # the signed-commits ruleset on this repo rejects. continue-on-error keeps the
       # job alive through that rejected push; the changeset file it wrote is still in
       # the workspace, and the next step commits it through the GitHub API instead.
+      # The guard below makes sure this only tolerates the rejected push, not a real
+      # failure of the action.
       - name: Generate changeset
+        id: generate
         continue-on-error: true
         uses: the-guild-org/changesets-dependencies-action@f11b16181c79e07d62b112c2f32c9db534a9df09 # v1.2.2
         env:
@@ -42,8 +45,17 @@ jobs:
 
       - name: Check for a generated changeset
         id: changes
+        env:
+          GENERATE_OUTCOME: ${{ steps.generate.outcome }}
         run: |
           if [ -z "$(git status --porcelain -- .changeset)" ]; then
+            # The only failure we tolerate is the rejected push, which still leaves the
+            # changeset behind. Nothing to commit plus a failed step means the action
+            # itself broke, so surface it instead of passing a job that did nothing.
+            if [ "$GENERATE_OUTCOME" = "failure" ]; then
+              echo "::error::changesets-dependencies-action failed without writing a changeset"
+              exit 1
+            fi
             echo "No changeset generated"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -18,8 +18,34 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+      # The action writes the changeset and then commits it with plain `git`, which
+      # the signed-commits ruleset on this repo rejects. continue-on-error keeps the
+      # job alive through that rejected push; the changeset file it wrote is still in
+      # the workspace, and the next step commits it through the GitHub API instead.
       - name: Generate changeset
+        continue-on-error: true
         uses: the-guild-org/changesets-dependencies-action@f11b16181c79e07d62b112c2f32c9db534a9df09 # v1.2.2
         env:
           # this commits to the branch so we can't use the default GITHUB_TOKEN, otherwise Actions won't trigger
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Check for a generated changeset
+        id: changes
+        run: |
+          if [ -z "$(git status --porcelain -- .changeset)" ]; then
+            echo "No changeset generated"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit changeset
+        if: steps.changes.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: 'chore(deps): add changeset'
+          repo: ${{ github.repository }}
+          branch: ${{ github.event.pull_request.head.ref }}
+          file_pattern: .changeset
+        env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -32,16 +32,43 @@ jobs:
           # this commits to the branch so we can't use the default GITHUB_TOKEN, otherwise Actions won't trigger
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      # The action leaves a local commit behind that it could not push. ghcommit
-      # sends `git rev-parse HEAD` as the mutation's expectedHeadOid, so HEAD has
-      # to be rewound onto the remote branch tip or the commit below is rejected.
-      # --mixed keeps the generated changeset file in the working tree.
+      # The action leaves a local commit behind that it could not push. ghcommit sends
+      # `git rev-parse HEAD` as the mutation's expectedHeadOid, so HEAD has to be
+      # rewound off that commit or the commit below is rejected. --mixed keeps the
+      # generated changeset in the working tree.
+      #
+      # Rewinding decouples HEAD from the working tree, which defeats the
+      # expectedHeadOid guard, so the invariants of the one tolerated failure are
+      # checked first: exactly one local commit, sitting on the current remote tip,
+      # touching nothing outside `.changeset/`. Without that, a partial write that
+      # never committed, or a branch that advanced mid-run, would be replayed onto the
+      # new tip — resurrecting changesets the branch has since deleted.
+      #
+      # The reset targets HEAD^ rather than the fetched ref so the retained working
+      # tree is exactly that commit's diff by construction.
       - name: Rewind the failed local commit
+        if: steps.generate.outcome == 'failure'
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
+          set -euo pipefail
           git fetch origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git reset --mixed "refs/remotes/origin/$HEAD_REF"
+          remote=$(git rev-parse "refs/remotes/origin/$HEAD_REF")
+
+          if [ "$(git rev-parse HEAD)" = "$remote" ]; then
+            echo "::error::generation failed without committing; refusing to commit a partial result"
+            exit 1
+          fi
+          if [ "$(git rev-parse HEAD^)" != "$remote" ]; then
+            echo "::error::$HEAD_REF advanced during generation; rerun against the new branch state"
+            exit 1
+          fi
+          if git diff --name-only HEAD^ HEAD | grep -qv '^\.changeset/'; then
+            echo "::error::the generated commit touches files outside .changeset/"
+            exit 1
+          fi
+
+          git reset --mixed HEAD^
 
       - name: Check for a generated changeset
         id: changes

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -29,6 +29,17 @@ jobs:
           # this commits to the branch so we can't use the default GITHUB_TOKEN, otherwise Actions won't trigger
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # The action leaves a local commit behind that it could not push. ghcommit
+      # sends `git rev-parse HEAD` as the mutation's expectedHeadOid, so HEAD has
+      # to be rewound onto the remote branch tip or the commit below is rejected.
+      # --mixed keeps the generated changeset file in the working tree.
+      - name: Rewind the failed local commit
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git fetch origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git reset --mixed "refs/remotes/origin/$HEAD_REF"
+
       - name: Check for a generated changeset
         id: changes
         run: |

--- a/.github/workflows/generate-references.yml
+++ b/.github/workflows/generate-references.yml
@@ -65,8 +65,15 @@ jobs:
             echo "No new latest references generated for $PACKAGE_NAME"
           fi
           
-      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+      # Commits through the GitHub API so it carries GitHub's signature, which the
+      # signed-commits ruleset on this repo requires. git-auto-commit-action pushes
+      # with plain git and has no API mode, so it is rejected.
+      - uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         if: steps.changes.outputs.changed == 'true'
         with:
           commit_message: "Update generated references"
+          repo: ${{ github.repository }}
+          branch: ${{ github.ref_name }}
           file_pattern: "packages/*/references/*-references-latest.json"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Makes the workflows that commit in this repo produce **signed** commits.

Commits created with plain `git` are unsigned. PostHog is rolling the org-wide "Require signed commits" ruleset out to every repo, and this workflow would be rejected with `GH013` once it applies here. Routing the commit through the GitHub API instead means GitHub signs it with its own key, so it lands verified.

Found while inventorying which workflows across the org still create unsigned commits. `planetscale/ghcommit-action` is the pattern already in use in `posthog-js`, `posthog-roblox`, `brand`, `charts` and the SDK release fleet.

## Changes

`dependabot-changeset.yml` and `generate-references.yml` both commit through the API.

## Testing

**`dependabot-changeset.yml` is confirmed broken today**, not a precaution: run [30843671203](https://github.com/PostHog/posthog-js/actions/runs/30843671203) failed with `GH013: Commits must have verified signatures`. Of its last 100 runs, 98 were skipped and the single run that actually executed is that failure, so dependabot PRs have silently not been getting changesets. `changesets-dependencies-action` commits with plain git internally and has no API mode, so the fix lets its push fail via `continue-on-error` and commits the changeset it left in the workspace through the API. `generate-references.yml` is the latent case: `workflow_dispatch`-only, last ran 2025-12-20 before this repo was onboarded to the ruleset, so it has no failing run yet but would fail on the next dispatch.
