### PR TITLE
fix(replay): advance timers in V2 trigger hold-release tests

### DIFF
--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1699,6 +1699,8 @@ describe('Lazy SessionRecording', () => {
                         expect(sessionRecording['_lazyLoadedSessionRecording']['_holdFlushUntilInteraction']).toEqual(
                             false
                         )
+                        // the release clears the hold synchronously but ships on the normal flush cadence
+                        jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
                         expect(posthog.capture).toHaveBeenCalledWith(
                             '$snapshot',
                             expect.objectContaining({
@@ -1790,6 +1792,8 @@ describe('Lazy SessionRecording', () => {
                         simpleEventEmitter.emit('eventCaptured', { event: '$exception', properties: {} })
 
                         expect(lazyRecorder['_holdFlushUntilInteraction']).toEqual(false)
+                        // the release clears the hold synchronously but ships on the normal flush cadence
+                        jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
                         expect(posthog.capture).toHaveBeenCalledWith(
                             '$snapshot',
                             expect.objectContaining({


### PR DESCRIPTION
## Problem

Unit tests on `main` have been red since Aug 4. #4410 added two tests ("an event trigger match releases the hold and ships under the rotated session id" and "releases a hold that begins after the initial-flush unhook optimization") that assert `posthog.capture` synchronously after a hold release. #4412 merged 14 minutes later and deliberately changed `_releaseHoldAndFlush` to schedule the flush on the normal cadence (`_scheduleFlushBuffer`) instead of flushing synchronously. Under fake timers the scheduled flush never fires, so both tests fail on every branch, and unrelated PRs (for example #4376) fail CI on them.

## Changes

Advance fake timers by `RECORDING_BUFFER_TIMEOUT` after the release in both tests, mirroring the sibling hold tests that #4412 already updated. The assertions still verify the release itself is synchronous (`_holdFlushUntilInteraction` flips to `false` immediately) and that the held snapshot ships under the rotated session id afterwards.

Test-only change, no runtime behavior touched: `packages/browser` unit suite passes 307/307 locally with this fix, and fails 2/307 on `main` without it.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)

None, test-only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
