### PR TITLE
ci: parse compatibility results without jq

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -140,26 +140,38 @@ jobs:
             exit 0
           fi
 
-          if ! jq -e '(.stats.unexpected | type == "number") and (.errors | type == "array")' compat-results.json > /dev/null; then
+          if ! node -e '
+            const results = require("./compat-results.json")
+            if (!Number.isInteger(results.stats?.unexpected) || !Array.isArray(results.errors)) process.exit(1)
+          '; then
             report_failures "- Compatibility test results could not be parsed. Check the test step logs."
             exit 0
           fi
 
-          UNEXPECTED=$(jq -r '.stats.unexpected' compat-results.json)
-          RUNNER_ERRORS=$(jq -r '.errors | length' compat-results.json)
+          UNEXPECTED=$(node -p 'require("./compat-results.json").stats.unexpected')
+          RUNNER_ERRORS=$(node -p 'require("./compat-results.json").errors.length')
           if [ "$COMPAT_TEST_OUTCOME" = "success" ] && [ "$UNEXPECTED" -eq 0 ] && [ "$RUNNER_ERRORS" -eq 0 ]; then
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          FAILED_TESTS=$(jq -r '
-            [
-              .. | objects |
-              select(.tests? and (.tests | type == "array")) |
-              select(any(.tests[]?; .status == "unexpected")) |
-              "- `\(.title)`"
-            ] | unique[]?
-          ' compat-results.json)
+          FAILED_TESTS=$(node -e '
+            const results = require("./compat-results.json")
+            const failures = new Set()
+            const visit = (value) => {
+              if (!value || typeof value !== "object") return
+              if (
+                Array.isArray(value.tests) &&
+                value.tests.some((test) => test?.status === "unexpected") &&
+                typeof value.title === "string"
+              ) {
+                failures.add("- `" + value.title + "`")
+              }
+              Object.values(value).forEach(visit)
+            }
+            visit(results)
+            process.stdout.write([...failures].join("\n"))
+          ')
 
           if [ "$RUNNER_ERRORS" -gt 0 ]; then
             RUNNER_FAILURES="- $RUNNER_ERRORS Playwright runner error(s) were reported. Check the test step logs for details."


### PR DESCRIPTION
## Problem

Browser-affected pull requests receive a misleading backward-compatibility warning even when all compatibility tests pass. The Playwright container does not include `jq`, so the result-processing step reports valid JSON as unparseable after the test suite completes successfully.

## Changes

- Parse and validate Playwright compatibility results with Node.js, which the workflow setup already guarantees.
- Preserve failed-test deduplication, runner-error reporting, and the existing PR comment format.
- Avoid adding an `apt-get` package installation and its extra network dependency to the test job.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with the Pi coding agent and GitHub CLI. The failing PR logs showed 377 passing tests followed by `jq: not found`; Node-based parsing was chosen over restoring an OS package installation because Node is already guaranteed by the workflow setup. The final commit was checked with focused result-processing fixtures and the isolated autoreview skill.
