### PR TITLE
feat(mcp): anchor $session_id to the agent's conversation_id

### DIFF
--- a/.changeset/mcp-conversation-session-id.md
+++ b/.changeset/mcp-conversation-session-id.md
@@ -1,0 +1,7 @@
+---
+'@posthog/mcp': patch
+---
+
+Use an agent-supplied `conversation_id` as the session anchor, so tool calls in one
+conversation share a `$session_id` across reconnects, restarts, and per-request server
+instances.

--- a/.changeset/mcp-conversation-session-id.md
+++ b/.changeset/mcp-conversation-session-id.md
@@ -4,4 +4,6 @@
 
 Use an agent-supplied `conversation_id` as the session anchor, so tool calls in one
 conversation share a `$session_id` across reconnects, restarts, and per-request server
-instances.
+instances. Only a handle the SDK could have minted is accepted; a value the agent invented
+is replaced with a fresh one, so two callers cannot land in the same session by sending the
+same string.

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -195,6 +195,14 @@ describe('conversation-id', () => {
       })
     })
 
+    it('canonicalises an uppercased echo, so it hashes to the minting session', () => {
+      // The shape test is case-insensitive; the hash behind `$session_id` is not.
+      // A host that normalises uuids to uppercase must not be split off from the
+      // call that minted the handle.
+      const { conversationId } = resolve({ conversation_id: AGENT_ECHOED.toUpperCase() })
+      expect(conversationId).toBe(AGENT_ECHOED)
+    })
+
     it('rejects a uuid that is not v7', () => {
       // v4 in the version nibble. Nothing we mint looks like this, so it is a
       // value the agent brought from somewhere else.

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -6,8 +6,16 @@ import {
   CONVERSATION_ID_PARAM_NAME,
   extractConversationId,
   injectConversationIdPromptBack,
+  resolveConversationId,
   stripConversationId,
 } from '../extensions/conversation-id'
+
+/**
+ * Handles shaped like ones we would have minted — `resolveConversationId` only
+ * echoes a value that could have come from us, and mints over anything else.
+ */
+const AGENT_ECHOED = '019fd2b0-1111-7111-8111-111111111111'
+const AGENT_ECHOED_ON_ERROR = '019fd2b0-2222-7222-8222-222222222222'
 
 describe('conversation-id', () => {
   describe('addConversationIdToTool', () => {
@@ -158,6 +166,50 @@ describe('conversation-id', () => {
     })
   })
 
+  describe('resolveConversationId', () => {
+    const resolve = (args: unknown) => resolveConversationId(true, args, 'a_tool')
+
+    it('echoes a handle shaped like one we minted', () => {
+      expect(resolve({ conversation_id: AGENT_ECHOED })).toEqual({
+        minted: false,
+        conversationId: AGENT_ECHOED,
+      })
+    })
+
+    it('mints instead of trusting a value the agent invented', () => {
+      // The reason this branch exists: the value becomes $session_id via a
+      // deterministic hash, so two unrelated callers both sending `conv-1` would
+      // otherwise be merged into a single session — across users and pods.
+      for (const invented of ['conv-1', '1', 'session', 'chat_abc', 'not-a-uuid']) {
+        const result = resolve({ conversation_id: invented })
+        expect(result.minted).toBe(true)
+        expect(result.conversationId).not.toBe(invented)
+      }
+    })
+
+    it('mints a value that would itself be echoed back', () => {
+      const { conversationId } = resolve({})
+      expect(resolve({ conversation_id: conversationId })).toEqual({
+        minted: false,
+        conversationId,
+      })
+    })
+
+    it('rejects a uuid that is not v7', () => {
+      // v4 in the version nibble. Nothing we mint looks like this, so it is a
+      // value the agent brought from somewhere else.
+      const v4 = '019fd2b0-1111-4111-8111-111111111111'
+      expect(resolve({ conversation_id: v4 }).minted).toBe(true)
+    })
+
+    it('returns nothing when the feature is off', () => {
+      expect(resolveConversationId(false, { conversation_id: AGENT_ECHOED }, 'a_tool')).toEqual({
+        minted: false,
+        conversationId: undefined,
+      })
+    })
+  })
+
   describe('stripConversationId', () => {
     it('returns args without conversation_id and leaves other keys intact', () => {
       const result = stripConversationId({
@@ -276,7 +328,7 @@ describe('conversation_id tool parameter', () => {
       await capture.start()
       instrument(server, fakePostHog(), { enableConversationId: true })
 
-      const agentConversationId = 'conversation-abc-1'
+      const agentConversationId = '019fd2b0-5555-7555-8555-555555555555'
       await client.request(
         {
           method: 'tools/call',
@@ -347,7 +399,7 @@ describe('conversation_id tool parameter', () => {
           method: 'tools/call',
           params: {
             name: 'add_todo',
-            arguments: { text: 'x', conversation_id: 'agent-supplied-1' },
+            arguments: { text: 'x', conversation_id: AGENT_ECHOED },
           },
         },
         CallToolResultSchema
@@ -355,7 +407,7 @@ describe('conversation_id tool parameter', () => {
 
       await new Promise((r) => setTimeout(r, 50))
       const toolCall = capture.getEvents().find((e) => e.resourceName === 'add_todo')
-      expect(toolCall?.conversationId).toBe('agent-supplied-1')
+      expect(toolCall?.conversationId).toBe(AGENT_ECHOED)
       await capture.stop()
     })
 
@@ -447,7 +499,7 @@ describe('conversation_id tool parameter', () => {
             name: 'complete_todo',
             arguments: {
               id: 'does-not-exist',
-              conversation_id: 'agent-supplied-on-error',
+              conversation_id: AGENT_ECHOED_ON_ERROR,
             },
           },
         },
@@ -456,7 +508,7 @@ describe('conversation_id tool parameter', () => {
 
       await new Promise((r) => setTimeout(r, 50))
       const toolCall = capture.getEvents().find((e) => e.resourceName === 'complete_todo')
-      expect(toolCall?.conversationId).toBe('agent-supplied-on-error')
+      expect(toolCall?.conversationId).toBe(AGENT_ECHOED_ON_ERROR)
       await capture.stop()
     })
   })

--- a/packages/mcp/src/__tests__/conversation-session-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-session-id.test.ts
@@ -144,6 +144,44 @@ describe('conversation_id as the session anchor', () => {
     })
   })
 
+  describe('client identity', () => {
+    it('still reads the token client identity when a handle wins the session', async () => {
+      // A stateless instance that never processed `initialize`: the client replays
+      // our token and the agent echoes a handle. The handle must decide the
+      // session *without* costing us the only client attribution the request
+      // carries — otherwise every tool call and $identify on that deployment goes
+      // out unattributed.
+      instrument(server, fakePostHog(), { enableConversationId: true })
+      const lowLevel = server.server as MCPServerLike
+      const data = getServerTrackingData(lowLevel)!
+      data.sessionInfo.clientName = undefined
+      data.sessionInfo.clientVersion = undefined
+      data.sessionInfo.protocolVersion = undefined
+
+      const extra = {
+        requestInfo: {
+          headers: {
+            [MCP_SESSION_HEADER]: encodeSessionId({
+              sessionId: 'ses_from_token',
+              clientName: 'acme-client',
+              clientVersion: '9.9.9',
+              protocolVersion: '2025-11-25',
+            }),
+          },
+        },
+      } as never
+
+      const derived = getSessionId(lowLevel, extra, CONVERSATION_HANDLE)
+
+      expect(derived).toBe(deterministicPrefixedId('ses', CONVERSATION_HANDLE))
+      expect(data.sessionInfo.clientName).toBe('acme-client')
+      expect(data.sessionInfo.clientVersion).toBe('9.9.9')
+      expect(data.sessionInfo.protocolVersion).toBe('2025-11-25')
+      // The token's own session id is per-chat, so the handle branch must not adopt it.
+      expect(derived).not.toBe('ses_from_token')
+    })
+  })
+
   describe('across server instances', () => {
     it('produces the same session id from the same handle with no shared state', async () => {
       instrument(server, fakePostHog())

--- a/packages/mcp/src/__tests__/conversation-session-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-session-id.test.ts
@@ -14,6 +14,9 @@ import { resetTodos, setupTestServerAndClient } from './test-utils/client-server
  * This is what lets calls correlate across reconnects, restarts, and the
  * per-request server instances the MCP 2026-07-28 revision introduces.
  */
+/** Shaped like a handle we would have minted, so it is echoed rather than replaced. */
+const CONVERSATION_HANDLE = '019fd2b0-4444-7444-8444-444444444444'
+
 describe('conversation_id as the session anchor', () => {
   let server: HighLevelMCPServerLike
   let client: any
@@ -129,7 +132,7 @@ describe('conversation_id as the session anchor', () => {
         },
       }
 
-      for (const handle of ['conversation-a', 'conversation-b']) {
+      for (const handle of ['019fd2b0-aaaa-7aaa-8aaa-aaaaaaaaaaaa', '019fd2b0-bbbb-7bbb-8bbb-bbbbbbbbbbbb']) {
         await callHandler(
           { method: 'tools/call', params: { name: 'add_todo', arguments: { text: 't', conversation_id: handle } } },
           extra
@@ -158,18 +161,49 @@ describe('conversation_id as the session anchor', () => {
         await other.cleanup()
       }
     })
+
+    it('does not merge two callers that invent the same conversation_id', async () => {
+      // The flip side of the property above. Agreement across pods is the whole
+      // point, so it cannot be weakened here — the guard is upstream, in
+      // resolveConversationId, which refuses to anchor on a handle it could not
+      // have minted. Without it, two unrelated users both sending `conv-1` share
+      // a session, and the data looks fine while being wrong.
+      instrument(server, fakePostHog(), { enableConversationId: true })
+
+      const other = await setupTestServerAndClient()
+      instrument(other.server, fakePostHog(), { enableConversationId: true })
+
+      try {
+        const invented = 'conv-1'
+        await callTool('from a', invented)
+        await other.client.request(
+          {
+            method: 'tools/call',
+            params: { name: 'add_todo', arguments: { text: 'from b', conversation_id: invented } },
+          },
+          CallToolResultSchema
+        )
+        await new Promise((r) => setTimeout(r, 60))
+
+        const sessions = new Set(capture.getCaptures().map((c: any) => c.properties.$session_id))
+        expect(sessions.size).toBe(2)
+        expect(sessions).not.toContain(deterministicPrefixedId('ses', invented))
+      } finally {
+        await other.cleanup()
+      }
+    })
   })
 
   describe('tool calls', () => {
     it('groups calls sharing a conversation id into one session', async () => {
       instrument(server, fakePostHog(), { enableConversationId: true })
 
-      await callTool('first', 'conversation-xyz')
-      await callTool('second', 'conversation-xyz')
+      await callTool('first', CONVERSATION_HANDLE)
+      await callTool('second', CONVERSATION_HANDLE)
 
       // Assert the derived value, not just that the two agree — they would also
       // agree on the transport session id if the handle were ignored entirely.
-      const expected = deterministicPrefixedId('ses', 'conversation-xyz')
+      const expected = deterministicPrefixedId('ses', CONVERSATION_HANDLE)
       expect(toolCallSessionIds()).toEqual([expected, expected])
     })
 
@@ -186,11 +220,11 @@ describe('conversation_id as the session anchor', () => {
     it('stamps both $session_id and $mcp_conversation_id on the payload', async () => {
       instrument(server, fakePostHog(), { enableConversationId: true })
 
-      await callTool('first', 'conversation-xyz')
+      await callTool('first', CONVERSATION_HANDLE)
 
       const [payload] = capture.findCapturesByEvent('$mcp_tool_call')
-      expect(payload.properties.$session_id).toBe(deterministicPrefixedId('ses', 'conversation-xyz'))
-      expect(payload.properties.$mcp_conversation_id).toBe('conversation-xyz')
+      expect(payload.properties.$session_id).toBe(deterministicPrefixedId('ses', CONVERSATION_HANDLE))
+      expect(payload.properties.$mcp_conversation_id).toBe(CONVERSATION_HANDLE)
       // Deliberately distinct values: one is the grouping key, the other the raw handle.
       expect(payload.properties.$session_id).not.toBe(payload.properties.$mcp_conversation_id)
     })
@@ -200,7 +234,7 @@ describe('conversation_id as the session anchor', () => {
       const data = getServerTrackingData(server.server as MCPServerLike)!
 
       // The argument is the host's own, not ours, when injection is disabled.
-      await callTool('first', 'conversation-xyz')
+      await callTool('first', CONVERSATION_HANDLE)
 
       expect(toolCallSessionIds()[0]).toBe(data.sessionId)
     })

--- a/packages/mcp/src/__tests__/conversation-session-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-session-id.test.ts
@@ -1,0 +1,189 @@
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { instrument } from '../index'
+import { deterministicPrefixedId } from '../extensions/ids'
+import { getServerTrackingData } from '../extensions/internal'
+import { getSessionId } from '../extensions/session'
+import type { HighLevelMCPServerLike, MCPServerLike } from '../types'
+import { EventCapture, fakePostHog } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+/**
+ * The conversation handle as the session anchor: when a tool call carries a
+ * `conversation_id`, `$session_id` derives from it instead of from the transport.
+ * This is what lets calls correlate across reconnects, restarts, and the
+ * per-request server instances the MCP 2026-07-28 revision introduces.
+ */
+describe('conversation_id as the session anchor', () => {
+  let server: HighLevelMCPServerLike
+  let client: any
+  let cleanup: () => Promise<void>
+  let capture: EventCapture
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+    capture = new EventCapture()
+    await capture.start()
+  })
+
+  afterEach(async () => {
+    await capture.stop()
+    await cleanup()
+  })
+
+  /** Runs a tool call, optionally carrying a conversation handle. */
+  async function callTool(text: string, conversationId?: string): Promise<void> {
+    await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'add_todo',
+          arguments: conversationId === undefined ? { text } : { text, conversation_id: conversationId },
+        },
+      },
+      CallToolResultSchema
+    )
+    // The capture pipeline runs after the handler returns.
+    await new Promise((r) => setTimeout(r, 50))
+  }
+
+  function toolCallSessionIds(): string[] {
+    return capture
+      .getEvents()
+      .filter((e) => e.resourceName === 'add_todo')
+      .map((e) => e.sessionId)
+  }
+
+  describe('getSessionId', () => {
+    it('derives the session id from the conversation id when one is supplied', () => {
+      instrument(server, fakePostHog())
+      const lowLevel = server.server as MCPServerLike
+
+      const derived = getSessionId(lowLevel, undefined, 'conversation-abc')
+
+      expect(derived).toMatch(/^ses_/)
+      expect(derived).not.toBe(getSessionId(lowLevel, undefined))
+    })
+
+    it('is deterministic — the same handle always yields the same session id', () => {
+      instrument(server, fakePostHog())
+      const lowLevel = server.server as MCPServerLike
+
+      expect(getSessionId(lowLevel, undefined, 'conversation-abc')).toBe(
+        getSessionId(lowLevel, undefined, 'conversation-abc')
+      )
+    })
+
+    it('maps different handles to different session ids', () => {
+      instrument(server, fakePostHog())
+      const lowLevel = server.server as MCPServerLike
+
+      expect(getSessionId(lowLevel, undefined, 'conversation-a')).not.toBe(
+        getSessionId(lowLevel, undefined, 'conversation-b')
+      )
+    })
+
+    it('leaves the in-memory session untouched, so a handle cannot leak across chats', () => {
+      instrument(server, fakePostHog())
+      const lowLevel = server.server as MCPServerLike
+      const data = getServerTrackingData(lowLevel)!
+      const before = data.sessionId
+
+      getSessionId(lowLevel, undefined, 'conversation-abc')
+
+      // A concurrent request with no handle must still see the original session.
+      expect(data.sessionId).toBe(before)
+      expect(getSessionId(lowLevel, undefined)).toBe(before)
+    })
+
+    it('falls back to the existing resolution when no handle is supplied', () => {
+      instrument(server, fakePostHog())
+      const lowLevel = server.server as MCPServerLike
+      const data = getServerTrackingData(lowLevel)!
+
+      expect(getSessionId(lowLevel, undefined, undefined)).toBe(data.sessionId)
+    })
+  })
+
+  describe('across server instances', () => {
+    it('produces the same session id from the same handle with no shared state', async () => {
+      instrument(server, fakePostHog())
+
+      const other = await setupTestServerAndClient()
+      instrument(other.server, fakePostHog())
+
+      try {
+        const fromA = getSessionId(server.server as MCPServerLike, undefined, 'shared-conversation')
+        const fromB = getSessionId(other.server.server as MCPServerLike, undefined, 'shared-conversation')
+
+        // The cross-pod property: two processes that never met agree on the session.
+        expect(fromA).toBe(fromB)
+      } finally {
+        await other.cleanup()
+      }
+    })
+  })
+
+  describe('tool calls', () => {
+    it('groups calls sharing a conversation id into one session', async () => {
+      instrument(server, fakePostHog(), { enableConversationId: true })
+
+      await callTool('first', 'conversation-xyz')
+      await callTool('second', 'conversation-xyz')
+
+      // Assert the derived value, not just that the two agree — they would also
+      // agree on the transport session id if the handle were ignored entirely.
+      const expected = deterministicPrefixedId('ses', 'conversation-xyz')
+      expect(toolCallSessionIds()).toEqual([expected, expected])
+    })
+
+    it('separates calls carrying different conversation ids', async () => {
+      instrument(server, fakePostHog(), { enableConversationId: true })
+
+      await callTool('first', 'conversation-one')
+      await callTool('second', 'conversation-two')
+
+      const [first, second] = toolCallSessionIds()
+      expect(first).not.toBe(second)
+    })
+
+    it('stamps both $session_id and $mcp_conversation_id on the payload', async () => {
+      instrument(server, fakePostHog(), { enableConversationId: true })
+
+      await callTool('first', 'conversation-xyz')
+
+      const [payload] = capture.findCapturesByEvent('$mcp_tool_call')
+      expect(payload.properties.$session_id).toBe(deterministicPrefixedId('ses', 'conversation-xyz'))
+      expect(payload.properties.$mcp_conversation_id).toBe('conversation-xyz')
+      // Deliberately distinct values: one is the grouping key, the other the raw handle.
+      expect(payload.properties.$session_id).not.toBe(payload.properties.$mcp_conversation_id)
+    })
+
+    it('keeps the transport session when the feature is off', async () => {
+      instrument(server, fakePostHog(), { enableConversationId: false })
+      const data = getServerTrackingData(server.server as MCPServerLike)!
+
+      // The argument is the host's own, not ours, when injection is disabled.
+      await callTool('first', 'conversation-xyz')
+
+      expect(toolCallSessionIds()[0]).toBe(data.sessionId)
+    })
+
+    it('reuses the minted handle across calls once the agent echoes it back', async () => {
+      instrument(server, fakePostHog(), { enableConversationId: true })
+
+      // First call omits the handle, so the SDK mints one and prompts for it.
+      await callTool('first')
+      const minted = capture.getEvents().find((e) => e.resourceName === 'add_todo')?.conversationId
+      expect(minted).toBeDefined()
+
+      await callTool('second', minted)
+
+      const expected = deterministicPrefixedId('ses', minted!)
+      expect(toolCallSessionIds()).toEqual([expected, expected])
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/conversation-session-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-session-id.test.ts
@@ -1,10 +1,9 @@
 import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { instrument } from '../index'
 import { MCPAnalyticsEventType } from '../extensions/event-types'
-import { deterministicPrefixedId } from '../extensions/ids'
 import { MCP_SESSION_HEADER, encodeSessionId } from '../extensions/session-token'
 import { getServerTrackingData } from '../extensions/internal'
-import { getSessionId } from '../extensions/session'
+import { deriveSessionIdFromConversation, getSessionId } from '../extensions/session'
 import type { HighLevelMCPServerLike, MCPServerLike } from '../types'
 import { EventCapture, fakePostHog } from './test-utils'
 import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
@@ -178,7 +177,7 @@ describe('conversation_id as the session anchor', () => {
 
       const derived = getSessionId(lowLevel, extra, CONVERSATION_HANDLE)
 
-      expect(derived).toBe(deterministicPrefixedId('ses', CONVERSATION_HANDLE))
+      expect(derived).toBe(deriveSessionIdFromConversation(CONVERSATION_HANDLE))
       expect(data.sessionInfo.clientName).toBe('acme-client')
       expect(data.sessionInfo.clientVersion).toBe('9.9.9')
       expect(data.sessionInfo.protocolVersion).toBe('2025-11-25')
@@ -230,7 +229,7 @@ describe('conversation_id as the session anchor', () => {
 
         const sessions = new Set(capture.getCaptures().map((c: any) => c.properties.$session_id))
         expect(sessions.size).toBe(2)
-        expect(sessions).not.toContain(deterministicPrefixedId('ses', invented))
+        expect(sessions).not.toContain(deriveSessionIdFromConversation(invented))
       } finally {
         await other.cleanup()
       }
@@ -246,7 +245,7 @@ describe('conversation_id as the session anchor', () => {
 
       // Assert the derived value, not just that the two agree — they would also
       // agree on the transport session id if the handle were ignored entirely.
-      const expected = deterministicPrefixedId('ses', CONVERSATION_HANDLE)
+      const expected = deriveSessionIdFromConversation(CONVERSATION_HANDLE)
       expect(toolCallSessionIds()).toEqual([expected, expected])
     })
 
@@ -262,7 +261,7 @@ describe('conversation_id as the session anchor', () => {
       await callTool('first', a)
       await callTool('second', b)
 
-      expect(toolCallSessionIds()).toEqual([deterministicPrefixedId('ses', a), deterministicPrefixedId('ses', b)])
+      expect(toolCallSessionIds()).toEqual([deriveSessionIdFromConversation(a), deriveSessionIdFromConversation(b)])
     })
 
     it('stamps both $session_id and $mcp_conversation_id on the payload', async () => {
@@ -271,7 +270,7 @@ describe('conversation_id as the session anchor', () => {
       await callTool('first', CONVERSATION_HANDLE)
 
       const [payload] = capture.findCapturesByEvent('$mcp_tool_call')
-      expect(payload.properties.$session_id).toBe(deterministicPrefixedId('ses', CONVERSATION_HANDLE))
+      expect(payload.properties.$session_id).toBe(deriveSessionIdFromConversation(CONVERSATION_HANDLE))
       expect(payload.properties.$mcp_conversation_id).toBe(CONVERSATION_HANDLE)
       // Deliberately distinct values: one is the grouping key, the other the raw handle.
       expect(payload.properties.$session_id).not.toBe(payload.properties.$mcp_conversation_id)
@@ -330,7 +329,7 @@ describe('conversation_id as the session anchor', () => {
 
       await callTool('second', minted)
 
-      const expected = deterministicPrefixedId('ses', minted!)
+      const expected = deriveSessionIdFromConversation(minted!)
       expect(toolCallSessionIds()).toEqual([expected, expected])
     })
   })

--- a/packages/mcp/src/__tests__/conversation-session-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-session-id.test.ts
@@ -1,6 +1,7 @@
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { instrument } from '../index'
 import { deterministicPrefixedId } from '../extensions/ids'
+import { MCP_SESSION_HEADER, encodeSessionId } from '../extensions/session-token'
 import { getServerTrackingData } from '../extensions/internal'
 import { getSessionId } from '../extensions/session'
 import type { HighLevelMCPServerLike, MCPServerLike } from '../types'
@@ -105,6 +106,38 @@ describe('conversation_id as the session anchor', () => {
       const data = getServerTrackingData(lowLevel)!
 
       expect(getSessionId(lowLevel, undefined, undefined)).toBe(data.sessionId)
+    })
+  })
+
+  describe('identity', () => {
+    it('still announces $identify for a handle-anchored session on a token deployment', async () => {
+      instrument(server, fakePostHog(), {
+        enableConversationId: true,
+        identify: async () => ({ distinctId: 'user-1' }),
+      })
+
+      // A replayed token leaves data.sessionSource === 'token', which is what
+      // suppresses a second $identify. A handle-anchored session is a brand new
+      // session nobody announced, so suppressing it would lose the event entirely
+      // on exactly the stateless deployments this feature targets.
+      const lowLevel = server.server as MCPServerLike
+      getServerTrackingData(lowLevel)!.sessionSource = 'token'
+      const callHandler = lowLevel._requestHandlers.get('tools/call')!
+      const extra: any = {
+        requestInfo: {
+          headers: { [MCP_SESSION_HEADER]: encodeSessionId({ sessionId: 'ses_from_token', clientName: 'c' }) },
+        },
+      }
+
+      for (const handle of ['conversation-a', 'conversation-b']) {
+        await callHandler(
+          { method: 'tools/call', params: { name: 'add_todo', arguments: { text: 't', conversation_id: handle } } },
+          extra
+        )
+      }
+      await new Promise((r) => setTimeout(r, 60))
+
+      expect(capture.findCapturesByEvent('$identify')).toHaveLength(2)
     })
   })
 

--- a/packages/mcp/src/__tests__/conversation-session-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-session-id.test.ts
@@ -210,11 +210,16 @@ describe('conversation_id as the session anchor', () => {
     it('separates calls carrying different conversation ids', async () => {
       instrument(server, fakePostHog(), { enableConversationId: true })
 
-      await callTool('first', 'conversation-one')
-      await callTool('second', 'conversation-two')
+      // Both handles must be minted-shaped, or the shape check replaces them and
+      // the two sessions differ because *minting* produced two ids — not because
+      // the two supplied handles did. Assert the derived values for the same
+      // reason as the test above: `not.toBe` alone cannot tell those apart.
+      const a = '019fd2b0-1111-7111-8111-111111111111'
+      const b = '019fd2b0-2222-7222-8222-222222222222'
+      await callTool('first', a)
+      await callTool('second', b)
 
-      const [first, second] = toolCallSessionIds()
-      expect(first).not.toBe(second)
+      expect(toolCallSessionIds()).toEqual([deterministicPrefixedId('ses', a), deterministicPrefixedId('ses', b)])
     })
 
     it('stamps both $session_id and $mcp_conversation_id on the payload', async () => {

--- a/packages/mcp/src/__tests__/conversation-session-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-session-id.test.ts
@@ -1,5 +1,6 @@
-import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { instrument } from '../index'
+import { MCPAnalyticsEventType } from '../extensions/event-types'
 import { deterministicPrefixedId } from '../extensions/ids'
 import { MCP_SESSION_HEADER, encodeSessionId } from '../extensions/session-token'
 import { getServerTrackingData } from '../extensions/internal'
@@ -55,10 +56,14 @@ describe('conversation_id as the session anchor', () => {
   }
 
   function toolCallSessionIds(): string[] {
-    return capture
-      .getEvents()
-      .filter((e) => e.resourceName === 'add_todo')
-      .map((e) => e.sessionId)
+    return (
+      capture
+        .getEvents()
+        // `resourceName` alone is not enough: a `$identify` published during a tool
+        // call carries the same resource name, so it would be counted as a call.
+        .filter((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'add_todo')
+        .map((e) => e.sessionId)
+    )
   }
 
   describe('getSessionId', () => {
@@ -280,6 +285,39 @@ describe('conversation_id as the session anchor', () => {
       await callTool('first', CONVERSATION_HANDLE)
 
       expect(toolCallSessionIds()[0]).toBe(data.sessionId)
+    })
+
+    it('changes nothing at all when the feature is off', async () => {
+      // The no-regression contract. `enableConversationId` is the switch for the
+      // whole 2026-07-28 mechanism, so a server that never opts in must see the
+      // SDK behave exactly as it did before — including one that happens to send
+      // a handle-shaped argument of its own.
+      instrument(server, fakePostHog(), { enableConversationId: false, identify: async () => ({ distinctId: 'u1' }) })
+      const data = getServerTrackingData(server.server as MCPServerLike)!
+
+      const { tools } = (await client.request({ method: 'tools/list' }, ListToolsResultSchema)) as {
+        tools: Array<{ inputSchema?: { properties?: Record<string, unknown> } }>
+      }
+      await callTool('first', CONVERSATION_HANDLE)
+      await callTool('second')
+      await callTool('third')
+
+      // Nothing advertised.
+      for (const tool of tools) {
+        expect(tool.inputSchema?.properties?.conversation_id).toBeUndefined()
+      }
+      // Nothing anchored: every call resolves to this instance's session, even the
+      // one that carried a handle-shaped argument.
+      expect(toolCallSessionIds()).toEqual([data.sessionId, data.sessionId, data.sessionId])
+      // Nothing captured: the handle never reaches the event.
+      expect(
+        capture
+          .getEvents()
+          .map((e) => e.conversationId)
+          .filter(Boolean)
+      ).toEqual([])
+      // Nothing amplified: one session means one $identify, not one per call.
+      expect(capture.findCapturesByEvent('$identify')).toHaveLength(1)
     })
 
     it('reuses the minted handle across calls once the agent echoes it back', async () => {

--- a/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
+++ b/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
@@ -113,6 +113,9 @@ async function setupLowLevelServer(realToolName?: string) {
   }
 }
 
+/** Shaped like a handle we would have minted, so it is echoed rather than replaced. */
+const ANALYTICS_CONVERSATION = '019fd2b0-3333-7333-8333-333333333333'
+
 describe('Low-level Server reportMissing ownership (e2e)', () => {
   let eventCapture: EventCapture
 
@@ -527,7 +530,7 @@ describe('Low-level Server tracing (e2e)', () => {
           method: 'tools/call',
           params: {
             name: 'echo',
-            arguments: { context: 'analytics intent', conversation_id: 'analytics conversation', text: 'hi' },
+            arguments: { context: 'analytics intent', conversation_id: ANALYTICS_CONVERSATION, text: 'hi' },
           },
         },
         CallToolResultSchema
@@ -537,7 +540,7 @@ describe('Low-level Server tracing (e2e)', () => {
       await new Promise((resolve) => setTimeout(resolve, 50))
       const event = eventCapture.getEvents().find((candidate) => candidate.resourceName === 'echo')
       expect(event?.userIntent).toBe('analytics intent')
-      expect(event?.conversationId).toBe('analytics conversation')
+      expect(event?.conversationId).toBe(ANALYTICS_CONVERSATION)
     } finally {
       await cleanup()
     }
@@ -621,7 +624,7 @@ describe('Low-level Server tracing (e2e)', () => {
           method: 'tools/call',
           params: {
             name: 'page_one_analytics',
-            arguments: { context: 'analytics context', conversation_id: 'analytics conversation', value: 'kept' },
+            arguments: { context: 'analytics context', conversation_id: ANALYTICS_CONVERSATION, value: 'kept' },
           },
         },
         CallToolResultSchema
@@ -647,7 +650,7 @@ describe('Low-level Server tracing (e2e)', () => {
       await new Promise((resolve) => setTimeout(resolve, 50))
       const analyticsEvent = eventCapture.getEvents().find((event) => event.resourceName === 'page_one_analytics')
       expect(analyticsEvent?.userIntent).toBe('analytics context')
-      expect(analyticsEvent?.conversationId).toBe('analytics conversation')
+      expect(analyticsEvent?.conversationId).toBe(ANALYTICS_CONVERSATION)
       const ownedEvent = eventCapture.getEvents().find((event) => event.resourceName === 'page_two_owned')
       expect(ownedEvent?.userIntent).toBeUndefined()
       expect(ownedEvent?.conversationId).toBeUndefined()

--- a/packages/mcp/src/__tests__/reserved-arguments.test.ts
+++ b/packages/mcp/src/__tests__/reserved-arguments.test.ts
@@ -21,6 +21,9 @@ async function connect(server: McpServer) {
   }
 }
 
+/** Shaped like a handle we would have minted, so it is echoed rather than replaced. */
+const ANALYTICS_CONVERSATION = '019fd2b0-3333-7333-8333-333333333333'
+
 describe('high-level reserved analytics arguments', () => {
   it('passes legitimate context and conversation_id fields to the callback when both features are disabled', async () => {
     const server = new McpServer({ name: 'disabled-reserved-arguments', version: '1.0.0' })
@@ -89,7 +92,7 @@ describe('high-level reserved analytics arguments', () => {
           method: 'tools/call',
           params: {
             name: 'record_schema',
-            arguments: { context: 'analytics context', conversation_id: 'analytics conversation', value: 'kept' },
+            arguments: { context: 'analytics context', conversation_id: ANALYTICS_CONVERSATION, value: 'kept' },
           },
         },
         CallToolResultSchema
@@ -121,7 +124,7 @@ describe('high-level reserved analytics arguments', () => {
           method: 'tools/call',
           params: {
             name: 'strict_schema',
-            arguments: { context: 'analytics context', conversation_id: 'analytics conversation', value: 'kept' },
+            arguments: { context: 'analytics context', conversation_id: ANALYTICS_CONVERSATION, value: 'kept' },
           },
         },
         CallToolResultSchema
@@ -132,7 +135,7 @@ describe('high-level reserved analytics arguments', () => {
       await new Promise((resolve) => setTimeout(resolve, 50))
       const event = capture.getEvents().find((candidate) => candidate.resourceName === 'strict_schema')
       expect(event?.userIntent).toBe('analytics context')
-      expect(event?.conversationId).toBe('analytics conversation')
+      expect(event?.conversationId).toBe(ANALYTICS_CONVERSATION)
     } finally {
       await capture.stop()
       await cleanup()

--- a/packages/mcp/src/extensions/conversation-id.ts
+++ b/packages/mcp/src/extensions/conversation-id.ts
@@ -82,6 +82,12 @@ export function addConversationIdToTools<TTool extends ConversationIdInjectableT
   return tools.map((tool) => addConversationIdToTool(tool, logger))
 }
 
+/**
+ * The shape of every id we mint: a uuidv7. Used to tell an echo of our own handle
+ * from a value the agent made up.
+ */
+const MINTED_CONVERSATION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
 export type ConversationIdResolution =
   | { minted: false; conversationId: string | undefined }
   | { minted: true; conversationId: string }
@@ -89,15 +95,26 @@ export type ConversationIdResolution =
 /**
  * Decides which conversation_id to use for a tool call:
  *   - disabled → none
- *   - agent supplied a value → use it
- *   - agent omitted → mint a UUID
+ *   - agent echoed a handle we could have minted → use it
+ *   - anything else → mint a fresh one
+ *
+ * The shape check matters because this value becomes `$session_id`, and the
+ * derivation is deterministic so that two pods agree — which also means two
+ * *callers* sending the same string land in the same session. The strings agents
+ * invent are not random (`conv-1`, `1`, `session`), so trusting them verbatim
+ * would silently merge unrelated conversations, potentially across users.
+ *
+ * A compliant agent echoes the uuidv7 we minted and is unaffected. Anything else
+ * is treated exactly as if the handle were absent: mint, and prompt back. Shape
+ * rather than a registry of issued ids, because a per-request server has no
+ * memory of what it minted.
  */
 export function resolveConversationId(enabled: boolean, args: unknown): ConversationIdResolution {
   if (!enabled) {
     return { minted: false, conversationId: undefined }
   }
   const supplied = extractConversationId(args)
-  if (supplied) {
+  if (supplied && MINTED_CONVERSATION_ID.test(supplied)) {
     return { minted: false, conversationId: supplied }
   }
   return { minted: true, conversationId: uuidv7() }

--- a/packages/mcp/src/extensions/conversation-id.ts
+++ b/packages/mcp/src/extensions/conversation-id.ts
@@ -123,7 +123,11 @@ export function resolveConversationId(enabled: boolean, args: unknown): Conversa
   }
   const supplied = extractConversationId(args)
   if (supplied && MINTED_CONVERSATION_ID.test(supplied)) {
-    return { minted: false, conversationId: supplied }
+    // Lowercased because the shape test is case-insensitive but the hash behind
+    // `$session_id` is not. Some hosts normalise uuids to uppercase, and an
+    // uppercased echo of our own handle would otherwise clear the gate and then
+    // land in a different session than the call that minted it.
+    return { minted: false, conversationId: supplied.toLowerCase() }
   }
   return { minted: true, conversationId: uuidv7() }
 }

--- a/packages/mcp/src/extensions/conversation-id.ts
+++ b/packages/mcp/src/extensions/conversation-id.ts
@@ -108,6 +108,14 @@ export type ConversationIdResolution =
  * is treated exactly as if the handle were absent: mint, and prompt back. Shape
  * rather than a registry of issued ids, because a per-request server has no
  * memory of what it minted.
+ *
+ * This narrows the problem, it does not prove provenance: a caller supplying a
+ * well-formed uuidv7 is trusted, so two that pick the *same* one still merge. That
+ * residue is far smaller than the case it replaces — an agent ignoring the
+ * parameter description reaches for `conv-1` or `1`, not a conforming uuidv7 — and
+ * closing it needs a signed handle, i.e. a secret shared by every pod. Worth doing
+ * if this ever anchors something security-bearing; `$session_id` is an analytics
+ * grouping key, so it does not today.
  */
 export function resolveConversationId(enabled: boolean, args: unknown): ConversationIdResolution {
   if (!enabled) {

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -207,7 +207,7 @@ async function prepareToolCallEvent(
   eventType: MCPAnalyticsEventType
 ): Promise<PreparedToolEvent | null> {
   try {
-    const sessionId = getSessionId(server, extra)
+    const sessionId = getSessionId(server, extra, conversation.conversationId)
     // Snapshot token/client/protocol metadata synchronously, before identify or
     // metadata callbacks can yield and let another request replace shared state.
     const sessionInfo = getSessionInfo(server, data, sessionId)

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -211,7 +211,15 @@ async function prepareToolCallEvent(
     // Snapshot token/client/protocol metadata synchronously, before identify or
     // metadata callbacks can yield and let another request replace shared state.
     const sessionInfo = getSessionInfo(server, data, sessionId)
-    const identity = await handleIdentify(server, data, sessionId, request, sessionInfo, extra)
+    const identity = await handleIdentify(
+      server,
+      data,
+      sessionId,
+      request,
+      sessionInfo,
+      extra,
+      !!conversation.conversationId
+    )
     const requestAttribution = withIdentity(sessionInfo, identity)
 
     const toolName = request.params?.name

--- a/packages/mcp/src/extensions/internal.ts
+++ b/packages/mcp/src/extensions/internal.ts
@@ -130,7 +130,14 @@ export async function handleIdentify(
   sessionId: string,
   request: MCPRequestLike,
   requestAttribution: SessionInfo,
-  extra?: CompatibleRequestHandlerExtra
+  extra?: CompatibleRequestHandlerExtra,
+  /**
+   * True when this session id came from an agent-carried `conversation_id`
+   * rather than the transport. Such a session is brand new and was never
+   * announced at `initialize`, whatever `data.sessionSource` still says about
+   * the connection.
+   */
+  sessionFromConversation = false
 ): Promise<UserIdentity | undefined> {
   const identityBeforeRequest = data.identifiedSessions.get(sessionId)
   const sessionSourceBeforeIdentify = data.sessionSource
@@ -166,7 +173,8 @@ export async function handleIdentify(
       // announced); revisit with the stateless-by-default rework.
       const changed = previousIdentity !== undefined && !areIdentitiesEqual(previousIdentity, mergedIdentity)
       const firstSeen = previousIdentity === undefined
-      const announcedAtInitialize = sessionSourceBeforeIdentify === 'token' && request.method !== 'initialize'
+      const announcedAtInitialize =
+        !sessionFromConversation && sessionSourceBeforeIdentify === 'token' && request.method !== 'initialize'
       const shouldPublish = changed || (firstSeen && !announcedAtInitialize)
 
       data.identifiedSessions.set(sessionId, mergedIdentity)

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -15,6 +15,7 @@ import { INACTIVITY_TIMEOUT_IN_MINUTES } from './constants'
 import { deterministicPrefixedId, newPrefixedId } from './ids'
 import { getServerTrackingData, setServerTrackingData } from './internal'
 import { decodeSessionId, readMcpSessionHeader } from './session-token'
+import type { SessionTokenPayload } from './session-token'
 
 export function newSessionId(): string {
   return newPrefixedId('ses')
@@ -65,6 +66,13 @@ export function getSessionId(
   // and a later call carrying no handle rotates it. That is the honest reading:
   // the fallback session really has been idle for that whole time.
   if (conversationId) {
+    // The handle decides the *session*, but the request may still carry our token,
+    // and on a stateless instance that never processed `initialize` its payload is
+    // the only place client identity exists. Restore that before returning: the
+    // early return is about not persisting a session, not about ignoring what the
+    // request told us about the client. Without this, tool calls and `$identify`
+    // go out unattributed on exactly the deployments this branch exists for.
+    applyTokenClientIdentity(data, extra)
     return deterministicPrefixedId('ses', conversationId)
   }
 
@@ -83,6 +91,32 @@ export function getSessionId(
 }
 
 /**
+ * Restores the client name/version and protocol version baked into our token at
+ * mint time, and hands the decoded token back so the caller can also take the
+ * session id from it.
+ *
+ * Split out from step 2 because the two halves of the token have different
+ * scopes. The session id it carries is per-chat, so a conversation-anchored
+ * request must not adopt it. The client identity is per-connection — the same
+ * client for every request on it — so a conversation-anchored request should,
+ * and on a stateless instance that never saw `initialize` this is the only
+ * source of it.
+ */
+function applyTokenClientIdentity(
+  data: MCPAnalyticsData,
+  extra?: CompatibleRequestHandlerExtra
+): SessionTokenPayload | undefined {
+  const token = decodeSessionId(readMcpSessionHeader(extra?.requestInfo?.headers))
+  if (!token) {
+    return undefined
+  }
+  data.sessionInfo.clientName = token.clientName
+  data.sessionInfo.clientVersion = token.clientVersion
+  data.sessionInfo.protocolVersion = token.protocolVersion
+  return token
+}
+
+/**
  * 2. The session id a request carried. Two sources, tried in order: our own token
  * on the `mcp-session-id` header, then the raw session id a stateful transport
  * issued. Returns undefined when the request carried neither, which is what
@@ -95,15 +129,10 @@ export function getSessionId(
 function readSessionIdFromRequest(data: MCPAnalyticsData, extra?: CompatibleRequestHandlerExtra): string | undefined {
   // 2a. A token we minted at `initialize` and the client replayed. It rides the
   // `mcp-session-id` header, which stateless transports don't surface as
-  // extra.sessionId, so read the header ourselves. Decoding it also restores the
-  // client name/version and protocol version baked in at mint time.
-  const sessionHeader = readMcpSessionHeader(extra?.requestInfo?.headers)
-  const token = decodeSessionId(sessionHeader)
+  // extra.sessionId, so read the header ourselves.
+  const token = applyTokenClientIdentity(data, extra)
   if (token) {
     data.sessionSource = 'token'
-    data.sessionInfo.clientName = token.clientName
-    data.sessionInfo.clientVersion = token.clientVersion
-    data.sessionInfo.protocolVersion = token.protocolVersion
     return token.sessionId
   }
 

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -59,6 +59,11 @@ export function getSessionId(
   // This returns instead of falling through to the shared-state writes at the
   // end: the handle belongs to this one request, and persisting it would leak
   // one chat's session onto a concurrent chat's `tools/list`.
+  //
+  // `lastActivity` therefore does not advance either, so a conversation that
+  // always echoes lets the in-memory fallback age past the inactivity timeout —
+  // and a later call carrying no handle rotates it. That is the honest reading:
+  // the fallback session really has been idle for that whole time.
   if (conversationId) {
     return deterministicPrefixedId('ses', conversationId)
   }

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -30,6 +30,23 @@ export function deriveSessionIdFromMCPSession(mcpSessionId: string): string {
 }
 
 /**
+ * Derives the SDK session id from the agent's conversation handle. Deterministic
+ * and unsalted on purpose: two pods that never met must agree on the session, and
+ * the 2026-07-28 revision leaves them no shared state to agree through.
+ *
+ * Hashed rather than used verbatim so an MCP session can never collide with a
+ * Session Replay id — a bare uuidv7 would render a "View recording" button that
+ * resolves to nothing.
+ *
+ * Exported because this *is* the cross-SDK contract: posthog-python has to
+ * reproduce it byte for byte or the same conversation splits into two sessions
+ * depending on which SDK served the call.
+ */
+export function deriveSessionIdFromConversation(conversationId: string): string {
+  return deterministicPrefixedId('ses', conversationId)
+}
+
+/**
  * Resolves the session id for a request. Three steps, first match wins:
  *
  *   1. the agent carried a `conversation_id` tool argument   — 2026-07-28
@@ -73,7 +90,7 @@ export function getSessionId(
     // request told us about the client. Without this, tool calls and `$identify`
     // go out unattributed on exactly the deployments this branch exists for.
     applyTokenClientIdentity(data, extra)
-    return deterministicPrefixedId('ses', conversationId)
+    return deriveSessionIdFromConversation(conversationId)
   }
 
   // 2. A session id the request itself carried (undefined if it carried none).

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -29,39 +29,48 @@ export function deriveSessionIdFromMCPSession(mcpSessionId: string): string {
 }
 
 /**
- * Resolves the session id for a request: from the replayed session token, from
- * the transport's MCP session id, or — when the request carries nothing — from
- * this instance's memory. Also saves the token's client name/version so events
- * built later in the request can use them (see getSessionInfo).
+ * Resolves the session id for a request. Three steps, first match wins:
+ *
+ *   1. the agent carried a `conversation_id` tool argument   — 2026-07-28
+ *   2. the request carried a session id                      — 2025-11-25
+ *   3. nothing was carried, so reuse this instance's own id  — stdio
+ *
+ * The split mirrors the two protocol revisions. 2026-07-28 removed protocol-level
+ * sessions, so the only thing that can carry a session across calls is the agent
+ * itself (1). 2025-11-25 kept the session on the connection, so the request
+ * carries it (2). 3 is for stdio, where neither applies — there is no
+ * HTTP request to carry anything, and no agent handle unless the host opted in.
  */
-export function getSessionId(server: MCPServerLike, extra?: CompatibleRequestHandlerExtra): string {
+export function getSessionId(
+  server: MCPServerLike,
+  extra?: CompatibleRequestHandlerExtra,
+  conversationId?: string
+): string {
   const data = getServerTrackingData(server)
   if (!data) {
     throw new Error('Server tracking data not found')
   }
 
-  // Our token rides the `mcp-session-id` request header, which stateless
-  // transports ignore — so read it ourselves.
-  const sessionHeader = readMcpSessionHeader(extra?.requestInfo?.headers)
-  const token = decodeSessionId(sessionHeader)
-
-  let sessionId: string
-  if (token) {
-    // Token we minted at `initialize` (see session-token.ts).
-    data.sessionSource = 'token'
-    data.sessionInfo.clientName = token.clientName
-    data.sessionInfo.clientVersion = token.clientVersion
-    data.sessionInfo.protocolVersion = token.protocolVersion
-    sessionId = token.sessionId
-  } else if (extra?.sessionId) {
-    // Session id issued by a stateful transport: hash it so the same MCP
-    // session maps to the same SDK session across restarts.
-    data.sessionSource = 'mcp'
-    sessionId = deriveSessionIdFromMCPSession(extra.sessionId)
-  } else {
-    sessionId = getSessionIdFromMemory(data)
+  // 1. The agent's conversation handle. It outranks both steps below because it
+  // is the only id that survives reconnects, restarts, and the per-request
+  // server instances the 2026-07-28 revision introduces. Hashed rather than used
+  // verbatim so it can never collide with Session Replay ids.
+  //
+  // This returns instead of falling through to the shared-state writes at the
+  // end: the handle belongs to this one request, and persisting it would leak
+  // one chat's session onto a concurrent chat's `tools/list`.
+  if (conversationId) {
+    return deterministicPrefixedId('ses', conversationId)
   }
 
+  // 2. A session id the request itself carried (undefined if it carried none).
+  const carriedByRequest = readSessionIdFromRequest(data, extra)
+
+  // 3. Nothing carried, so fall back to the id this instance already holds.
+  const sessionId = carriedByRequest ?? getSessionIdFromMemory(data)
+
+  // 2 and 3 are connection-scoped, so their result is remembered for the
+  // next request on this instance. 1 never reaches here.
   data.sessionId = sessionId
   data.lastActivity = new Date()
   setServerTrackingData(server, data)
@@ -69,9 +78,51 @@ export function getSessionId(server: MCPServerLike, extra?: CompatibleRequestHan
 }
 
 /**
- * Nothing replayed on this request: keep the id we already have. Only
- * generated sessions roll over on inactivity — token/MCP ids live as long as
- * the client replays them, and regenerating one would split the session.
+ * 2. The session id a request carried. Two sources, tried in order: our own token
+ * on the `mcp-session-id` header, then the raw session id a stateful transport
+ * issued. Returns undefined when the request carried neither, which is what
+ * sends the caller on to 3.
+ *
+ * Both are 2025-11-25 mechanisms. The 2026-07-28 revision removed that header
+ * outright — servers MUST NOT mint or echo it — so this entire step becomes
+ * legacy-only once era detection lands.
+ */
+function readSessionIdFromRequest(
+  data: MCPAnalyticsData,
+  extra?: CompatibleRequestHandlerExtra
+): string | undefined {
+  // 2a. A token we minted at `initialize` and the client replayed. It rides the
+  // `mcp-session-id` header, which stateless transports don't surface as
+  // extra.sessionId, so read the header ourselves. Decoding it also restores the
+  // client name/version and protocol version baked in at mint time.
+  const sessionHeader = readMcpSessionHeader(extra?.requestInfo?.headers)
+  const token = decodeSessionId(sessionHeader)
+  if (token) {
+    data.sessionSource = 'token'
+    data.sessionInfo.clientName = token.clientName
+    data.sessionInfo.clientVersion = token.clientVersion
+    data.sessionInfo.protocolVersion = token.protocolVersion
+    return token.sessionId
+  }
+
+  // 2b. No token, but a stateful transport issued its own session id. Hash it so
+  // the same MCP session maps to the same SDK session across restarts.
+  if (extra?.sessionId) {
+    data.sessionSource = 'mcp'
+    return deriveSessionIdFromMCPSession(extra.sessionId)
+  }
+
+  return undefined
+}
+
+/**
+ * 3. The request carried nothing, so keep the id this instance already holds —
+ * minted once at `instrument()`. This is what groups a stdio server's calls,
+ * where there is no header and no transport session to read.
+ *
+ * Only self-generated ids roll over on inactivity. Token and transport ids live
+ * as long as the client replays them, so regenerating one would split a session
+ * that is still very much alive.
  */
 function getSessionIdFromMemory(data: MCPAnalyticsData): string {
   const timeoutMs = INACTIVITY_TIMEOUT_IN_MINUTES * 60 * 1000

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -87,10 +87,7 @@ export function getSessionId(
  * outright — servers MUST NOT mint or echo it — so this entire step becomes
  * legacy-only once era detection lands.
  */
-function readSessionIdFromRequest(
-  data: MCPAnalyticsData,
-  extra?: CompatibleRequestHandlerExtra
-): string | undefined {
+function readSessionIdFromRequest(data: MCPAnalyticsData, extra?: CompatibleRequestHandlerExtra): string | undefined {
   // 2a. A token we minted at `initialize` and the client replayed. It rides the
   // `mcp-session-id` header, which stateless transports don't surface as
   // extra.sessionId, so read the header ourselves. Decoding it also restores the

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -57,7 +57,21 @@ export interface MCPAnalyticsOptions {
    * detected under the same name.
    */
   missingCapabilityToolName?: string
-  /** Enables the `conversation_id` tool parameter + prompt-back loop. */
+  /**
+   * Opt in to session correlation for the MCP **2026-07-28** revision, which removed
+   * protocol-level sessions: no `initialize`, no `mcp-session-id` header, and a fresh
+   * server instance per HTTP request. With none of those left to anchor on, the only
+   * thing that can carry a session across calls is the agent itself.
+   *
+   * Turning this on injects a `conversation_id` parameter into every tool, mints one
+   * on the first call, asks the agent to echo it back, and derives `$session_id` from
+   * that handle — so calls correlate across reconnects, restarts, and per-request
+   * instances.
+   *
+   * Off by default, and fully inert when off: no parameter is injected, no schema is
+   * touched, no prompt-back is appended, and `$session_id` resolves exactly as it did
+   * before (the request's own session id, else this instance's).
+   */
   enableConversationId?: boolean
   /**
    * Emit a `$exception` event alongside any failed tool call. Defaults to `true`.


### PR DESCRIPTION
## Problem

The MCP **2026-07-28** revision removes protocol-level sessions — no `initialize`, no `Mcp-Session-Id`. Every session id `@posthog/mcp` can currently produce comes from the transport, and all of them die on reconnect, restart, or a per-request server instance.

This is not only a future problem: stateless and serverless HTTP servers fragment **today**, which is what the self-encoded `Mcp-Session-Id` token exists to work around. `products/mcp_analytics` already detects it — `earlyDataChecklist` flags `sessionsDegenerate` when distinct sessions ≈ total calls.

The SDK has had the replacement built but inert since `enableConversationId` shipped: the agent carries a `conversation_id` and echoes it back. This wires that handle to `$session_id`.

## The spec prescribes exactly this

[Stateful Tools](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#stateful-tools):

> MCP has no protocol-level session, so a server cannot rely on implicit per-connection state to relate one tool call to the next. Servers that need to maintain state across calls … should do so by **returning an explicit handle from a creation tool and accepting that handle as an argument on subsequent calls.**

`conversation_id` is that handle. This PR makes it the thing `$session_id` is derived from.

Its handle-design guidance also backs the hashing choice below — *"Handles that encode internal structure invite parsing or guessing; opaque identifiers do not."*

## Changes

`getSessionId` now resolves in three steps, first match wins:

| | Source | Revision |
|---|---|---|
| 1 | the agent carried a `conversation_id` tool argument | 2026-07-28 |
| 2 | the request carried a session id (our token, else the transport's) | 2025-11-25 |
| 3 | this instance's in-memory id | stdio / fallback |

Steps 2 and 3 are the existing logic, extracted into `readSessionIdFromRequest` so the precedence reads top to bottom. **No behaviour changes without a handle.**

Two deliberate details:

- **Hashed, not verbatim.** `deterministicPrefixedId('ses', conversationId)` keeps MCP sessions out of the Session Replay namespace — a bare UUIDv7 would create a `raw_sessions` row and render a "View recording" button that resolves to nothing. `$mcp_conversation_id` still carries the raw handle for joining.
- **Never persisted.** Step 1 returns before the shared-state writes. The handle belongs to one request; storing it would leak one chat's session onto a concurrent chat's `tools/list`.
- **Only a handle we could have minted.** `resolveConversationId` accepts the supplied value only if it is shaped like a uuidv7; anything else is treated as an absent handle — mint a fresh one and prompt it back. The derivation is deterministic so two pods agree on a session, which means two *callers* sending the same string agree too. Agents that ignore the parameter description don't invent random strings, they invent `conv-1`; trusting those merges unrelated conversations across users. A compliant agent echoes what we gave it and is unaffected.

## Verification

Measured with Claude Code driving a real instrumented MCP server over a 4-call dependent task ([harness](https://github.com/PostHog/posthog-js), `~/mcp-playground/conversation-echo-test`):

| Tools declare `outputSchema` | Echoed |
|---|---|
| none | **15/15 — 100%** |
| every tool | **0/15 — 0%** |

The echo loop works; the first call correctly omits the handle in 18/18 runs, and across 38 subsequent calls the agent never invented a value.

**The 0% row is a known follow-up, not a regression here.** When a tool declares an `outputSchema`, clients read `structuredContent` and drop `content`, so the prompt-back carrying the handle is never seen. The SDK still emits it correctly — verified with a raw MCP client. Fix is mirroring the handle into `structuredContent`, which needs its own schema declaration and ships as two follow-up PRs.

Also confirmed end to end against a live PostHog project: calls in one chat now share a `$session_id` instead of each landing on the transport id.

## Tests

Suite 451 → 469. Checked each part actually bites by reverting it:

- revert the wiring in `instrumentation.ts` → 4 fail
- revert the resolution branch in `session.ts` → 7 fail
- revert the shape check in `conversation-id.ts` → 3 fail, including `does not merge two callers that invent the same conversation_id`

That last test sits directly under the one asserting the *opposite* property — same handle across two servers must agree — so the pair documents why the derivation is deterministic and where that has to stop.

Existing fixtures that passed arbitrary strings (`'analytics conversation'`) now pass minted-shaped ones, which is what a real agent sends.

## Not in scope

- `$mcp_initialize` / `$mcp_tools_list` still get the transport id — the handle only rides `tools/call` arguments
- `enableConversationId` stays opt-in
- Era detection and legacy-gating the token are separate follow-ups
- No new event property for minted-vs-echoed. Worth having to measure the echo rate in production, but it is a separate change.

## Release info Sub-libraries affected

- [x] @posthog/mcp

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (no behaviour change without a handle)
- [x] Took care not to unnecessarily increase the bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code)




