### PR TITLE
feat(react-native-plugin): add the native push notification bridge

### DIFF
--- a/.changeset/tall-otters-arrive.md
+++ b/.changeset/tall-otters-arrive.md
@@ -1,0 +1,10 @@
+---
+"@posthog/react-native-plugin": minor
+---
+
+Add the native push notification bridge, so `posthog-react-native` can register device tokens and capture notification opens through the native PostHog SDKs.
+
+- Forwards the push config (`capturePushNotificationSubscriptions`, `capturePushNotificationOpened`) to posthog-ios and posthog-android at setup.
+- Bridges `registerPushNotificationToken`, `unregisterPushNotificationToken`, `capturePushNotificationOpened`, `setOptOut`, and `reset` for runtime control from JS.
+- Supports a JS `pushIdentityProvider` for projects that require identity-verified subscriptions.
+- Captures cold-start notification opens on Android by inspecting the launch Activity's intent at setup, which posthog-android's own lifecycle integration cannot observe in React Native apps.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,6 +85,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.54.0"
+  implementation "com.posthog:posthog-android:3.58.0"
 }
 

--- a/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
+++ b/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
@@ -1,6 +1,8 @@
 package com.posthogreactnativeplugin
 
+import android.content.Intent
 import android.util.Log
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -8,6 +10,7 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.JavascriptException
+import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.posthog.PostHog
 import com.posthog.PostHogConfig
 import com.posthog.android.PostHogAndroid
@@ -42,6 +45,7 @@ class PosthogReactNativePluginModule(
       decideReplayConfig = getMap(sessionReplayConfig, "decideReplayConfig"),
       nativeErrorTrackingAutocapture = getBoolean(errorTrackingConfig, "nativeAutocapture", false),
       exceptionStepsConfig = getMap(errorTrackingConfig, "exceptionSteps"),
+      pushConfig = getMap(pluginConfig, "push"),
       promise = promise,
     )
   }
@@ -63,6 +67,7 @@ class PosthogReactNativePluginModule(
       decideReplayConfig = decideReplayConfig,
       nativeErrorTrackingAutocapture = false,
       exceptionStepsConfig = null,
+      pushConfig = null,
       promise = promise,
     )
   }
@@ -76,6 +81,7 @@ class PosthogReactNativePluginModule(
     decideReplayConfig: ReadableMap?,
     nativeErrorTrackingAutocapture: Boolean,
     exceptionStepsConfig: ReadableMap?,
+    pushConfig: ReadableMap?,
     promise: Promise,
   ) {
     val initRunnable =
@@ -92,6 +98,9 @@ class PosthogReactNativePluginModule(
           val anonymousId = getString(sdkOptions, "anonymousId", "")
           val theSdkVersion = getString(sdkOptions, "sdkVersion", "")
           val theFlushAt = getInt(sdkOptions, "flushAt", DEFAULT_FLUSH_AT)
+          val theOptOut = getBoolean(sdkOptions, "optOut", false)
+          // Default true: an older JS layer that never sends this keeps native's own fetch.
+          val thePreloadFeatureFlags = getBoolean(sdkOptions, "preloadFeatureFlags", true)
 
           // Forward custom headers (e.g. Authorization for a reverse proxy) so the native SDK
           // attaches them to the requests it sends directly (session replay, crash uploads).
@@ -104,6 +113,8 @@ class PosthogReactNativePluginModule(
           val config =
             PostHogAndroidConfig(apiKey, host).apply {
               debug = debugValue
+              optOut = theOptOut
+              preloadFeatureFlags = thePreloadFeatureFlags
               captureDeepLinks = false
               captureApplicationLifecycleEvents = false
               captureScreenViews = false
@@ -153,6 +164,25 @@ class PosthogReactNativePluginModule(
                 snapshotEndpoint = endpoint
               }
 
+              // Only set when present: the legacy start() path predates push, and there the
+              // native defaults (both true) must win, matching posthog-android on its own.
+              if (hasKey(pushConfig, "capturePushNotificationSubscriptions")) {
+                capturePushNotificationSubscriptions =
+                  getBoolean(pushConfig, "capturePushNotificationSubscriptions", true)
+              }
+              if (hasKey(pushConfig, "capturePushNotificationOpened")) {
+                capturePushNotificationOpened = getBoolean(pushConfig, "capturePushNotificationOpened", true)
+              }
+
+              // Installed only when JS asked for it: an uninvited bridging provider would
+              // change how the native SDK handles a 401 on the subscription call.
+              if (getBoolean(pushConfig, "pushIdentityProviderEnabled", false)) {
+                pushModule = this@PosthogReactNativePluginModule
+                pushIdentityProvider = { distinctId, appId, completion ->
+                  requestPushIdentityToken(distinctId, appId, completion)
+                }
+              }
+
               if (theSdkVersion.isNotEmpty()) {
                 sdkName = "posthog-react-native"
                 sdkVersion = theSdkVersion
@@ -161,6 +191,8 @@ class PosthogReactNativePluginModule(
           PostHogAndroid.setup(context, config)
 
           setIdentify(config.cachePreferences, distinctId, anonymousId)
+
+          captureColdStartPushOpenIfNeeded(config)
         } catch (e: Throwable) {
           logError(method, e)
         } finally {
@@ -223,6 +255,50 @@ class PosthogReactNativePluginModule(
       setIdentify(PostHog.getConfig<PostHogConfig>()?.cachePreferences, distinctId, anonymousId)
     } catch (e: Throwable) {
       logError("identify", e)
+    } finally {
+      promise.resolve(null)
+    }
+  }
+
+  // Calls the native SDK rather than writing preferences like identify() does: reset() is what
+  // unregisters the logged-out user's push subscription and re-registers under the new identity.
+  @ReactMethod
+  fun reset(
+    distinctId: String,
+    anonymousId: String,
+    promise: Promise,
+  ) {
+    try {
+      PostHog.reset()
+      // Native reset() mints its own anonymous id; overwrite it with the JS one so the two
+      // SDKs stay on the same identity. Must run after reset(), which needs the pre-reset
+      // distinctId to know which subscription to unregister. Known gap (as on iOS): native's
+      // async push re-registration can read the identity before this write lands and register
+      // under a throwaway id; retryPending() converges it on the next flush.
+      setIdentify(PostHog.getConfig<PostHogConfig>()?.cachePreferences, distinctId, anonymousId)
+    } catch (e: Throwable) {
+      logError("reset", e)
+    } finally {
+      promise.resolve(null)
+    }
+  }
+
+  // Runtime consent changes must reach native: it persists its own opt-out flag and only reads
+  // the JS value at setup(), so a refreshed FCM token could otherwise auto-register after the
+  // user opted out. optIn() also resumes deferred push work on the next flush.
+  @ReactMethod
+  fun setOptOut(
+    optOut: Boolean,
+    promise: Promise,
+  ) {
+    try {
+      if (optOut) {
+        PostHog.optOut()
+      } else {
+        PostHog.optIn()
+      }
+    } catch (e: Throwable) {
+      logError("setOptOut", e)
     } finally {
       promise.resolve(null)
     }
@@ -333,9 +409,147 @@ class PosthogReactNativePluginModule(
     Log.println(Log.ERROR, POSTHOG_TAG, "Method $method, error: $error")
   }
 
+  // These reject instead of this module's usual swallow-and-resolve convention: a failed
+  // registration is a distinct signal, not a silent success. The JS layer's public methods
+  // never throw, so the rejection is what gives it something to log.
+  @ReactMethod
+  fun registerPushNotificationToken(
+    deviceToken: String?,
+    appId: String?,
+    promise: Promise,
+  ) {
+    try {
+      if (deviceToken.isNullOrBlank()) {
+        // A blank token is dropped silently by the native SDK, so surface it here
+        // instead of reporting false success.
+        promise.reject(
+          PUSH_ERROR_CODE,
+          "registerPushNotificationToken: deviceToken is blank; token not registered.",
+        )
+        return
+      }
+      val resolvedAppId = appId?.trim()?.takeIf { it.isNotEmpty() } ?: firebaseProjectId
+      if (resolvedAppId.isNullOrEmpty()) {
+        val message =
+          "registerPushNotificationToken: no appId provided and no Firebase project id " +
+            "could be resolved, skipping. Pass appId explicitly if this app does not use Firebase."
+        Log.w(POSTHOG_TAG, message)
+        promise.reject(PUSH_ERROR_CODE, message)
+        return
+      }
+      PostHog.registerPushNotificationToken(deviceToken, resolvedAppId)
+      promise.resolve(null)
+    } catch (e: Throwable) {
+      logError("registerPushNotificationToken", e)
+      promise.reject(PUSH_ERROR_CODE, e)
+    }
+  }
+
+  @ReactMethod
+  fun unregisterPushNotificationToken(promise: Promise) {
+    try {
+      PostHog.unregisterPushNotificationToken()
+      promise.resolve(null)
+    } catch (e: Throwable) {
+      logError("unregisterPushNotificationToken", e)
+      promise.reject(PUSH_ERROR_CODE, e)
+    }
+  }
+
+  @ReactMethod
+  fun capturePushNotificationOpened(
+    properties: ReadableMap,
+    promise: Promise,
+  ) {
+    try {
+      // subtitle is iOS-only; posthog-android's capturePushNotificationOpened has no
+      // subtitle parameter, so JS's value is dropped here.
+      val title = if (hasKey(properties, "title")) properties.getString("title") else null
+      val body = if (hasKey(properties, "body")) properties.getString("body") else null
+      val payload = if (hasKey(properties, "payload")) properties.getMap("payload")?.toHashMap() else null
+      val action = if (hasKey(properties, "action")) properties.getString("action") else null
+      PostHog.capturePushNotificationOpened(title, body, payload, action)
+      promise.resolve(null)
+    } catch (e: Throwable) {
+      logError("capturePushNotificationOpened", e)
+      promise.reject(PUSH_ERROR_CODE, e)
+    }
+  }
+
+  // posthog-android's open-capture integration registers ActivityLifecycleCallbacks during
+  // setup(), which the bridge reaches only after the launch Activity was created — so the
+  // cold-start tray tap it exists for is the one creation it can never observe here. Read
+  // the launch intent directly, then strip the marker so the integration (or a re-run)
+  // can't capture the same tap again from this intent object.
+  private fun captureColdStartPushOpenIfNeeded(config: PostHogAndroidConfig) {
+    if (!config.capturePushNotificationOpened) {
+      return
+    }
+    val intent = currentActivity?.intent ?: return
+    // A relaunch from recents redelivers the original tray intent to a fresh activity;
+    // capturing it would count a days-old tap as a new open.
+    if (intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0) {
+      return
+    }
+    try {
+      intent.getStringExtra(GOOGLE_MESSAGE_ID) ?: return
+      // Unmarshalling extras throws BadParcelableException on a Parcelable class this
+      // classloader lacks; read before stripping the marker so a failed read leaves the
+      // intent as the native integration expects it.
+      val payload =
+        intent.extras?.let { bundle ->
+          bundle.keySet().associateWith { key ->
+            @Suppress("DEPRECATION")
+            bundle.get(key)
+          }
+        }
+      intent.removeExtra(GOOGLE_MESSAGE_ID)
+      PostHog.capturePushNotificationOpened(null, null, payload, null)
+    } catch (e: Throwable) {
+      logError("capturePushNotificationOpened", e)
+    }
+  }
+
+  @ReactMethod
+  fun providePushIdentityToken(
+    requestId: String?,
+    token: String?,
+    promise: Promise,
+  ) {
+    try {
+      if (requestId != null) {
+        pushIdentityCompletions.remove(requestId)?.invoke(token)
+      }
+    } catch (e: Throwable) {
+      logError("providePushIdentityToken", e)
+    } finally {
+      promise.resolve(null)
+    }
+  }
+
+  // Required by NativeEventEmitter on the old architecture; events are broadcast via
+  // RCTDeviceEventEmitter, so there is nothing to do here.
+  @ReactMethod
+  fun addListener(eventName: String?) = Unit
+
+  @ReactMethod
+  fun removeListeners(count: Int) = Unit
+
+  override fun invalidate() {
+    if (pushModule === this) {
+      // Decline mints fast after teardown instead of stalling the native 10s watchdog.
+      pushModule = null
+    }
+    super.invalidate()
+  }
+
   companion object {
     const val NAME = "PosthogReactNativePlugin"
     const val POSTHOG_TAG = "PostHog"
+
+    // FCM stamps this extra on the tray-tap launch intent; mirrors posthog-android's
+    // PostHogActivityLifecycleCallbackIntegration.
+    private const val GOOGLE_MESSAGE_ID = "google.message_id"
 
     // Default session replay configuration values
     const val DEFAULT_MASK_ALL_TEXT_INPUTS = true
@@ -343,5 +557,80 @@ class PosthogReactNativePluginModule(
     const val DEFAULT_CAPTURE_LOG = true
     const val DEFAULT_FLUSH_AT = 20
     const val DEFAULT_THROTTLE_DELAY_MS = 1000
+
+    private const val PUSH_ERROR_CODE = "PosthogReactNativePluginError"
+    private const val PUSH_IDENTITY_EVENT = "PostHogPushIdentityRequest"
+    private const val PUSH_IDENTITY_REPLY_TTL_MS = 15_000L
+
+    // Modules die on every bridge reload, so the provider closure resolves the live
+    // module through this static reference at call time, not a captured setup-time one.
+    @Volatile
+    private var pushModule: PosthogReactNativePluginModule? = null
+
+    private val pushIdentityCompletions = java.util.concurrent.ConcurrentHashMap<String, (String?) -> Unit>()
+
+    private fun requestPushIdentityToken(
+      distinctId: String,
+      appId: String,
+      completion: (String?) -> Unit,
+    ) {
+      val module = pushModule
+      val context = module?.reactApplicationContext
+      if (module == null || context == null || !context.hasActiveReactInstance()) {
+        declinePushIdentity(completion, "no React instance attached")
+        return
+      }
+      val requestId = UUID.randomUUID().toString()
+      pushIdentityCompletions[requestId] = completion
+      try {
+        val params =
+          Arguments.createMap().apply {
+            putString("requestId", requestId)
+            putString("distinctId", distinctId)
+            putString("appId", appId)
+          }
+        context
+          .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+          .emit(PUSH_IDENTITY_EVENT, params)
+      } catch (e: Throwable) {
+        pushIdentityCompletions.remove(requestId)
+        declinePushIdentity(completion, "failed to reach JS: ${e.message}")
+        return
+      }
+      // The native SDK's own 10s mint watchdog handles the fallback; this only drops the
+      // entry so a late JS reply is ignored and the completion doesn't leak.
+      UiThreadUtil.runOnUiThread({ pushIdentityCompletions.remove(requestId) }, PUSH_IDENTITY_REPLY_TTL_MS)
+    }
+
+    // A null identity token sends the request unauthenticated, which a project requiring
+    // identity verification rejects server-side. Log the reason so that failure is
+    // greppable and distinct from a host that deliberately returned null.
+    private fun declinePushIdentity(
+      completion: (String?) -> Unit,
+      reason: String,
+    ) {
+      Log.w(POSTHOG_TAG, "Push subscription will be sent unauthenticated: $reason")
+      completion(null)
+    }
+
+    @Volatile private var cachedFirebaseProjectId: String? = null
+
+    // No Firebase dependency here, so the project id is looked up reflectively and any
+    // failure (class missing, Firebase not initialized) is swallowed. Only a successful lookup
+    // is cached: getInstance() throws until Firebase initializes, so memoizing the null would
+    // strand every later token-refresh call with no resolvable appId for the process lifetime.
+    private val firebaseProjectId: String?
+      get() =
+        cachedFirebaseProjectId
+          ?: try {
+            val firebaseAppClass = Class.forName("com.google.firebase.FirebaseApp")
+            val firebaseApp = firebaseAppClass.getMethod("getInstance").invoke(null)
+            val options = firebaseAppClass.getMethod("getOptions").invoke(firebaseApp)
+            (options?.javaClass?.getMethod("getProjectId")?.invoke(options) as? String)?.also {
+              cachedFirebaseProjectId = it
+            }
+          } catch (e: Throwable) {
+            null
+          }
   }
 }

--- a/packages/react-native-plugin/ios/PosthogReactNativePlugin-Bridging-Header.h
+++ b/packages/react-native-plugin/ios/PosthogReactNativePlugin-Bridging-Header.h
@@ -1,2 +1,3 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTViewManager.h>
+#import <React/RCTEventEmitter.h>

--- a/packages/react-native-plugin/ios/PosthogReactNativePlugin.mm
+++ b/packages/react-native-plugin/ios/PosthogReactNativePlugin.mm
@@ -1,6 +1,7 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RCT_EXTERN_MODULE(PosthogReactNativePlugin, NSObject)
+@interface RCT_EXTERN_MODULE(PosthogReactNativePlugin, RCTEventEmitter)
 
 RCT_EXTERN_METHOD(setup:(NSString)sessionId
                  withSdkOptions:(NSDictionary)sdkOptions
@@ -39,6 +40,32 @@ RCT_EXTERN_METHOD(stopRecording:(RCTPromiseResolveBlock)resolve
 
 RCT_EXTERN_METHOD(addExceptionStep:(NSString)message
                  withProperties:(NSDictionary)properties
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(reset:(NSString)distinctId
+                 withAnonymousId:(NSString)anonymousId
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(registerPushNotificationToken:(NSString)deviceToken
+                 withAppId:(NSString)appId
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(unregisterPushNotificationToken:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(setOptOut:(BOOL)optOut
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(capturePushNotificationOpened:(NSDictionary)properties
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(providePushIdentityToken:(NSString)requestId
+                 withToken:(NSString)token
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 

--- a/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
+++ b/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
@@ -46,9 +46,39 @@ private func isReactNativeFatalJsError(_ event: PostHogEvent) -> Bool {
     }
 }
 
+// A nil identity token sends the request unauthenticated, which a project requiring
+// identity verification rejects server-side. Log the reason so that failure is greppable
+// and distinct from a host that deliberately returned nil.
+private func declinePushIdentity(_ completion: (String?) -> Void, _ reason: String) {
+    hedgeLog("Push subscription will be sent unauthenticated: \(reason)")
+    completion(nil)
+}
+
 @objc(PosthogReactNativePlugin)
-class PosthogReactNativePlugin: NSObject {
+class PosthogReactNativePlugin: RCTEventEmitter {
     private var config: PostHogConfig?
+
+    private static let pushIdentityEvent = "PostHogPushIdentityRequest"
+
+    // This module dies on every bridge reload, so the provider closure resolves the live
+    // module through this static weak reference at call time, not a captured setup-time one.
+    private static weak var pushInstance: PosthogReactNativePlugin?
+
+    // Main-thread confined, like the rest of the identity-request bookkeeping below.
+    private var hasPushListeners = false
+    private var pushIdentityCompletions: [String: (String?) -> Void] = [:]
+
+    override func supportedEvents() -> [String]! {
+        [PosthogReactNativePlugin.pushIdentityEvent]
+    }
+
+    override func startObserving() {
+        DispatchQueue.main.async { self.hasPushListeners = true }
+    }
+
+    override func stopObserving() {
+        DispatchQueue.main.async { self.hasPushListeners = false }
+    }
 
     @objc(setup:withSdkOptions:withPluginConfig:withResolver:withRejecter:)
     func setup(
@@ -68,6 +98,7 @@ class PosthogReactNativePlugin: NSObject {
             decideReplayConfig: sessionReplayConfig["decideReplayConfig"] as? [String: Any] ?? [:],
             nativeErrorTrackingAutocapture: errorTrackingConfig["nativeAutocapture"] as? Bool ?? false,
             exceptionStepsConfig: exceptionStepsConfig,
+            pushConfig: pluginConfig["push"] as? [String: Any] ?? [:],
             resolve: resolve
         )
     }
@@ -87,6 +118,7 @@ class PosthogReactNativePlugin: NSObject {
             decideReplayConfig: decideReplayConfig,
             nativeErrorTrackingAutocapture: false,
             exceptionStepsConfig: [:],
+            pushConfig: [:],
             resolve: resolve
         )
     }
@@ -100,6 +132,7 @@ class PosthogReactNativePlugin: NSObject {
         decideReplayConfig: [String: Any],
         nativeErrorTrackingAutocapture: Bool,
         exceptionStepsConfig: [String: Any],
+        pushConfig: [String: Any],
         resolve: RCTPromiseResolveBlock
     ) {
         if sessionId.isEmpty {
@@ -193,6 +226,11 @@ class PosthogReactNativePlugin: NSObject {
         let flushAt = sdkOptions["flushAt"] as? Int ?? 20
         config.flushAt = flushAt
 
+        config.optOut = sdkOptions["optOut"] as? Bool ?? false
+        // JS owns flags; it tells us when the native preload would be a duplicate. posthog-ios
+        // has no remoteConfig switch to mirror — it deprecated the option and always loads.
+        config.preloadFeatureFlags = sdkOptions["preloadFeatureFlags"] as? Bool ?? true
+
         // Forward custom headers (e.g. Authorization for a reverse proxy) so the native SDK
         // attaches them to the requests it sends directly (session replay, crash uploads).
         // Keep only string values so a stray non-string doesn't drop every header (matches Android).
@@ -203,6 +241,40 @@ class PosthogReactNativePlugin: NSObject {
         if !sdkVersion.isEmpty {
             postHogSdkName = "posthog-react-native"
             postHogVersion = sdkVersion
+        }
+
+        // Only set when present: the legacy start() path predates push, and there the
+        // native defaults (both true) must win, matching posthog-ios on its own.
+        if let capturePushSubscriptions = pushConfig["capturePushNotificationSubscriptions"] as? Bool {
+            config.capturePushNotificationSubscriptions = capturePushSubscriptions
+        }
+        if let capturePushOpened = pushConfig["capturePushNotificationOpened"] as? Bool {
+            config.capturePushNotificationOpened = capturePushOpened
+        }
+
+        // Installed only when JS asked for it: an uninvited bridging provider would change
+        // how the native SDK handles a 401 on the subscription call.
+        if pushConfig["pushIdentityProviderEnabled"] as? Bool == true {
+            PosthogReactNativePlugin.pushInstance = self
+            config.pushIdentityProvider = { distinctId, appId, completion in
+                DispatchQueue.main.async {
+                    guard let instance = PosthogReactNativePlugin.pushInstance, instance.hasPushListeners else {
+                        declinePushIdentity(completion, "no JS listener attached")
+                        return
+                    }
+                    let requestId = UUID().uuidString
+                    instance.pushIdentityCompletions[requestId] = completion
+                    instance.sendEvent(
+                        withName: PosthogReactNativePlugin.pushIdentityEvent,
+                        body: ["requestId": requestId, "distinctId": distinctId, "appId": appId]
+                    )
+                    // The native SDK's own 10s mint watchdog handles the fallback; this only
+                    // drops the entry so a late JS reply is ignored and the closure doesn't leak.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 15) { [weak instance] in
+                        instance?.pushIdentityCompletions.removeValue(forKey: requestId)
+                    }
+                }
+            }
         }
 
         PostHogSDK.shared.setup(config)
@@ -265,6 +337,23 @@ class PosthogReactNativePlugin: NSObject {
         resolve(nil)
     }
 
+    // Calls the native SDK rather than writing storage like identify() does: reset() is what
+    // unregisters the logged-out user's push subscription and re-registers under the new identity.
+    @objc(reset:withAnonymousId:withResolver:withRejecter:)
+    func reset(
+        distinctId: String, anonymousId: String, resolve: RCTPromiseResolveBlock,
+        reject _: RCTPromiseRejectBlock
+    ) {
+        PostHogSDK.shared.reset()
+        // Native reset() mints its own anonymous id; overwrite it with the JS one so the two SDKs
+        // stay on the same identity. Must run after reset(), which needs the pre-reset distinctId
+        // to know which subscription to unregister.
+        if let storageManager = config?.storageManager {
+            setIdentify(storageManager, distinctId: distinctId, anonymousId: anonymousId)
+        }
+        resolve(nil)
+    }
+
     private func setIdentify(
         _ storageManager: PostHogStorageManager, distinctId: String, anonymousId: String
     ) {
@@ -274,6 +363,21 @@ class PosthogReactNativePlugin: NSObject {
         if !distinctId.isEmpty {
             storageManager.setDistinctId(distinctId)
         }
+    }
+
+    // Runtime consent changes must reach native: it persists its own opt-out flag and only
+    // reads the JS value at setup(), so a refreshed APNs token could otherwise auto-register
+    // after the user opted out. optIn() also reinstalls the integrations opt-out removed.
+    @objc(setOptOut:withResolver:withRejecter:)
+    func setOptOut(
+        optOut: Bool, resolve: RCTPromiseResolveBlock, reject _: RCTPromiseRejectBlock
+    ) {
+        if optOut {
+            PostHogSDK.shared.optOut()
+        } else {
+            PostHogSDK.shared.optIn()
+        }
+        resolve(nil)
     }
 
     @objc(startRecording:withResolver:withRejecter:)
@@ -304,6 +408,66 @@ class PosthogReactNativePlugin: NSObject {
         reject _: RCTPromiseRejectBlock
     ) {
         PostHogSDK.shared.addExceptionStep(message, properties: properties)
+        resolve(nil)
+    }
+
+    @objc(registerPushNotificationToken:withAppId:withResolver:withRejecter:)
+    func registerPushNotificationToken(
+        deviceToken: String, appId: String?, resolve: RCTPromiseResolveBlock,
+        reject: RCTPromiseRejectBlock
+    ) {
+        #if os(iOS)
+            // A blank token is dropped silently by the native SDK, so surface it here
+            // instead of reporting false success.
+            if deviceToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                reject("PosthogReactNativePluginError", "registerPushNotificationToken: deviceToken is blank; token not registered.", nil)
+                return
+            }
+            PostHogSDK.shared.registerPushNotificationToken(deviceToken, appId: appId)
+            resolve(nil)
+        #else
+            // posthog-ios push registration is iOS-only (the backend rejects the macos platform).
+            _ = reject
+            hedgeLog("registerPushNotificationToken is not supported on macOS; token not registered.")
+            resolve(nil)
+        #endif
+    }
+
+    @objc(unregisterPushNotificationToken:withRejecter:)
+    func unregisterPushNotificationToken(resolve: RCTPromiseResolveBlock, reject _: RCTPromiseRejectBlock) {
+        #if os(iOS)
+            PostHogSDK.shared.unregisterPushNotificationToken()
+        #else
+            hedgeLog("unregisterPushNotificationToken is not supported on macOS; nothing to unregister.")
+        #endif
+        resolve(nil)
+    }
+
+    @objc(capturePushNotificationOpened:withResolver:withRejecter:)
+    func capturePushNotificationOpened(
+        properties: [String: Any], resolve: RCTPromiseResolveBlock, reject _: RCTPromiseRejectBlock
+    ) {
+        PostHogSDK.shared.capturePushNotificationOpened(
+            title: properties["title"] as? String,
+            subtitle: properties["subtitle"] as? String,
+            body: properties["body"] as? String,
+            payload: properties["payload"] as? [String: Any],
+            action: properties["action"] as? String
+        )
+        resolve(nil)
+    }
+
+    @objc(providePushIdentityToken:withToken:withResolver:withRejecter:)
+    func providePushIdentityToken(
+        requestId: String, token: String?, resolve: RCTPromiseResolveBlock,
+        reject _: RCTPromiseRejectBlock
+    ) {
+        DispatchQueue.main.async { [weak self] in
+            guard let completion = self?.pushIdentityCompletions.removeValue(forKey: requestId) else {
+                return
+            }
+            completion(token)
+        }
         resolve(nil)
     }
 }

--- a/packages/react-native-plugin/package.json
+++ b/packages/react-native-plugin/package.json
@@ -80,7 +80,6 @@
     "react-native": "*"
   },
   "jest": {
-    "preset": "react-native",
     "modulePathIgnorePatterns": [
       "<rootDir>/lib/"
     ],

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.69.1'
+posthog_ios_version = '3.69.2'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.69.0'
+posthog_ios_version = '3.69.1'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"

--- a/packages/react-native-plugin/src/__tests__/push-identity.test.ts
+++ b/packages/react-native-plugin/src/__tests__/push-identity.test.ts
@@ -1,0 +1,100 @@
+/* eslint-disable compat/compat */
+// All mock state lives inside the factory: the mocked module is required while this
+// file's imports hoist, before any module-scope const here would initialize.
+jest.mock('react-native', () => {
+  const listeners: { [event: string]: (payload: any) => void | Promise<void> } = {}
+  const removed: string[] = []
+  const nativeModule = {
+    providePushIdentityToken: jest.fn(() => Promise.resolve()),
+  }
+  return {
+    __pushMock: { listeners, removed, nativeModule },
+    NativeModules: { PosthogReactNativePlugin: nativeModule },
+    NativeEventEmitter: class {
+      addListener(event: string, handler: (payload: any) => void) {
+        listeners[event] = handler
+        return {
+          remove: () => {
+            removed.push(event)
+            delete listeners[event]
+          },
+        }
+      }
+    },
+    Platform: { OS: 'ios', select: (obj: any) => obj.ios ?? obj.default },
+  }
+})
+
+import { setPushIdentityProvider } from '../index'
+
+const { listeners, removed, nativeModule } = (jest.requireMock('react-native') as any).__pushMock as {
+  listeners: { [event: string]: (payload: any) => void | Promise<void> }
+  removed: string[]
+  nativeModule: { providePushIdentityToken: jest.Mock }
+}
+
+const emitRequest = async (requestId = 'req-1'): Promise<void> => {
+  const handler = listeners.PostHogPushIdentityRequest
+  if (!handler) {
+    throw new Error('no PostHogPushIdentityRequest listener installed')
+  }
+  await handler({ requestId, distinctId: 'user-1', appId: 'my-project' })
+  // providePushIdentityToken is awaited inside the handler; flush the microtask queue.
+  await Promise.resolve()
+}
+
+describe('setPushIdentityProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    nativeModule.providePushIdentityToken.mockImplementation(() => Promise.resolve())
+    removed.length = 0
+  })
+
+  it('replies with the minted token, keyed by request id', async () => {
+    const provider = jest.fn(async (distinctId: string, appId: string) => `token-${distinctId}-${appId}`)
+    setPushIdentityProvider(provider)
+
+    await emitRequest()
+
+    expect(provider).toHaveBeenCalledWith('user-1', 'my-project')
+    expect(nativeModule.providePushIdentityToken).toHaveBeenCalledWith('req-1', 'token-user-1-my-project')
+  })
+
+  it('a throwing provider degrades to a null token', async () => {
+    setPushIdentityProvider(jest.fn(async () => Promise.reject(new Error('mint failed'))))
+
+    await emitRequest()
+
+    expect(nativeModule.providePushIdentityToken).toHaveBeenCalledWith('req-1', null)
+  })
+
+  it('a non-string reply degrades to a null token', async () => {
+    setPushIdentityProvider(jest.fn(async () => 42 as any))
+
+    await emitRequest()
+
+    expect(nativeModule.providePushIdentityToken).toHaveBeenCalledWith('req-1', null)
+  })
+
+  it('installing a new provider replaces the previous listener', async () => {
+    setPushIdentityProvider(jest.fn(async () => 'old'))
+    // The module-level subscription persists across tests; only count removals
+    // caused by the replacement below.
+    removed.length = 0
+    const replacement = jest.fn(async () => 'new')
+    setPushIdentityProvider(replacement)
+
+    await emitRequest()
+
+    expect(removed).toEqual(['PostHogPushIdentityRequest'])
+    expect(replacement).toHaveBeenCalled()
+    expect(nativeModule.providePushIdentityToken).toHaveBeenCalledWith('req-1', 'new')
+  })
+
+  it('a failing native reply does not throw into the emitter', async () => {
+    nativeModule.providePushIdentityToken.mockImplementation(() => Promise.reject(new Error('bridge gone')))
+    setPushIdentityProvider(jest.fn(async () => 'token'))
+
+    await expect(emitRequest()).resolves.toBeUndefined()
+  })
+})

--- a/packages/react-native-plugin/src/index.tsx
+++ b/packages/react-native-plugin/src/index.tsx
@@ -1,4 +1,5 @@
-import { NativeModules, Platform } from 'react-native'
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native'
+import type { EmitterSubscription } from 'react-native'
 
 const LINKING_ERROR =
   `The package '@posthog/react-native-plugin' doesn't seem to be linked. Make sure: \n\n` +
@@ -35,9 +36,22 @@ export interface PostHogReactNativePluginErrorTrackingConfig {
   exceptionSteps?: PostHogReactNativePluginExceptionStepsConfig
 }
 
+export interface PostHogReactNativePluginPushConfig {
+  capturePushNotificationSubscriptions?: boolean
+  capturePushNotificationOpened?: boolean
+  /**
+   * A provider callback can't cross the bridge, so this only tells native whether to
+   * install the bridging provider at all — installing one the host didn't ask for
+   * would change how the native SDK handles a 401 on the subscription call.
+   * Pair with {@link setPushIdentityProvider} before calling setup().
+   */
+  pushIdentityProviderEnabled?: boolean
+}
+
 export interface PostHogReactNativePluginConfig {
   sessionReplay?: PostHogReactNativePluginSessionReplayConfig
   errorTracking?: PostHogReactNativePluginErrorTrackingConfig
+  push?: PostHogReactNativePluginPushConfig
 }
 
 export function setup(
@@ -73,6 +87,15 @@ export function identify(distinctId: string, anonymousId: string): Promise<void>
   return PosthogReactNativePlugin.identify(distinctId, anonymousId)
 }
 
+/**
+ * Resets the native SDK's identity on logout. Unlike {@link identify}, this calls the native
+ * SDK's own `reset()`, which unregisters the logged-out user's push subscription and
+ * re-registers it under the new anonymous id.
+ */
+export function reset(distinctId: string, anonymousId: string): Promise<void> {
+  return PosthogReactNativePlugin.reset(distinctId, anonymousId)
+}
+
 export function startRecording(resumeCurrent: boolean): Promise<void> {
   return PosthogReactNativePlugin.startRecording(resumeCurrent)
 }
@@ -83,6 +106,71 @@ export function stopRecording(): Promise<void> {
 
 export function addExceptionStep(message: string, properties?: PostHogReactNativePluginMap): Promise<void> {
   return PosthogReactNativePlugin.addExceptionStep(message, properties ?? {})
+}
+
+export function registerPushNotificationToken(deviceToken: string, appId: string | null): Promise<void> {
+  return PosthogReactNativePlugin.registerPushNotificationToken(deviceToken, appId)
+}
+
+export function unregisterPushNotificationToken(): Promise<void> {
+  return PosthogReactNativePlugin.unregisterPushNotificationToken()
+}
+
+/**
+ * Propagates a runtime consent change to the native SDK, which otherwise only reads the JS
+ * opt-out flag at setup() and could auto-register a refreshed push token after optOut().
+ */
+export function setOptOut(optOut: boolean): Promise<void> {
+  return PosthogReactNativePlugin.setOptOut(optOut)
+}
+
+export function capturePushNotificationOpened(properties: PostHogReactNativePluginMap): Promise<void> {
+  return PosthogReactNativePlugin.capturePushNotificationOpened(properties)
+}
+
+/**
+ * Mints a signed identity-verification token for a push subscription request.
+ * Return null to send the request without an identity token.
+ */
+export type PostHogPushIdentityProvider = (distinctId: string, appId: string) => Promise<string | null>
+
+const PUSH_IDENTITY_EVENT = 'PostHogPushIdentityRequest'
+
+let pushIdentitySubscription: EmitterSubscription | undefined
+
+/**
+ * Installs the JS side of the push identity-provider bridge. The native SDK asks for a
+ * token via a `PostHogPushIdentityRequest` event; the reply is routed back with
+ * `providePushIdentityToken`, keyed by the request id so late replies are ignored.
+ *
+ * Install before setup() with `push.pushIdentityProviderEnabled` set, so the native
+ * config gets its bridging provider at SDK initialization. Any provider failure
+ * degrades to a null token — an unauthenticated request — never a stalled mint.
+ */
+export function setPushIdentityProvider(provider: PostHogPushIdentityProvider): void {
+  pushIdentitySubscription?.remove()
+  // Via the proxy, not raw NativeModules: an unlinked module would build an emitter over
+  // undefined and throw a generic RN error inside the SDK's init try, taking replay down with it.
+  const emitter = new NativeEventEmitter(PosthogReactNativePlugin)
+  pushIdentitySubscription = emitter.addListener(
+    PUSH_IDENTITY_EVENT,
+    async (request: { requestId: string; distinctId: string; appId: string }) => {
+      let token: string | null = null
+      try {
+        const minted = await provider(request.distinctId, request.appId)
+        token = typeof minted === 'string' ? minted : null
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn(`[PostHog] pushIdentityProvider threw: ${e}. Push subscription will be sent unauthenticated.`)
+      }
+      try {
+        await PosthogReactNativePlugin.providePushIdentityToken(request.requestId, token)
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn(`[PostHog] Failed to deliver push identity token to native: ${e}`)
+      }
+    }
+  )
 }
 
 export interface PostHogReactNativePluginModule {
@@ -110,11 +198,23 @@ export interface PostHogReactNativePluginModule {
 
   identify: (distinctId: string, anonymousId: string) => Promise<void>
 
+  reset: (distinctId: string, anonymousId: string) => Promise<void>
+
   startRecording: (resumeCurrent: boolean) => Promise<void>
 
   stopRecording: () => Promise<void>
 
   addExceptionStep: (message: string, properties?: PostHogReactNativePluginMap) => Promise<void>
+
+  registerPushNotificationToken: (deviceToken: string, appId: string | null) => Promise<void>
+
+  unregisterPushNotificationToken: () => Promise<void>
+
+  setOptOut: (optOut: boolean) => Promise<void>
+
+  capturePushNotificationOpened: (properties: PostHogReactNativePluginMap) => Promise<void>
+
+  setPushIdentityProvider: (provider: PostHogPushIdentityProvider) => void
 }
 
 const PostHogReactNativePlugin: PostHogReactNativePluginModule = {
@@ -124,9 +224,15 @@ const PostHogReactNativePlugin: PostHogReactNativePluginModule = {
   endSession,
   isEnabled,
   identify,
+  reset,
   startRecording,
   stopRecording,
   addExceptionStep,
+  registerPushNotificationToken,
+  unregisterPushNotificationToken,
+  setOptOut,
+  capturePushNotificationOpened,
+  setPushIdentityProvider,
 }
 
 export default PostHogReactNativePlugin

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -3935,6 +3935,10 @@
           "name": "identify"
         },
         {
+          "type": "(distinctId: string, anonymousId: string) => Promise<void>",
+          "name": "reset"
+        },
+        {
           "type": "((resumeCurrent: boolean) => Promise<void>) & ((resumeCurrent: boolean) => Promise<void>)",
           "name": "startRecording"
         },
@@ -3945,6 +3949,26 @@
         {
           "type": "((message: string, properties?: PostHogReactNativePluginMap) => Promise<void>) & ((message: string, properties?: { [key: string]: any; }) => Promise<void>)",
           "name": "addExceptionStep"
+        },
+        {
+          "type": "(deviceToken: string, appId: string | null) => Promise<void>",
+          "name": "registerPushNotificationToken"
+        },
+        {
+          "type": "() => Promise<void>",
+          "name": "unregisterPushNotificationToken"
+        },
+        {
+          "type": "(optOut: boolean) => Promise<void>",
+          "name": "setOptOut"
+        },
+        {
+          "type": "(properties: PostHogReactNativePluginMap) => Promise<void>",
+          "name": "capturePushNotificationOpened"
+        },
+        {
+          "type": "(provider: PostHogPushIdentityProvider) => void",
+          "name": "setPushIdentityProvider"
         }
       ],
       "path": "dist/optional/OptionalPlugin.d.ts"


### PR DESCRIPTION
## Problem

PostHog Workflows can't target React Native apps: the native SDKs (posthog-ios 3.69.x, posthog-android 3.58.0) ship push subscription support, but the React Native plugin has no bridge to reach it.

This is the plugin half of #4415, split out so `@posthog/react-native-plugin` 2.3.0 can release before `posthog-react-native` declares it as the peer floor. Releasing them from one PR risked a partial-publish state where the SDK's floor points at a plugin version that doesn't exist (raised in [#4415's review](https://github.com/PostHog/posthog-js/pull/4415#discussion_r3720376729)); with this ordering the floor target always exists first.

## Changes

Extracted verbatim from #4415, no new code:

- Forwards the push config (`capturePushNotificationSubscriptions`, `capturePushNotificationOpened`) from `setup()` into the native SDK configs.
- Bridges `registerPushNotificationToken`, `unregisterPushNotificationToken`, `capturePushNotificationOpened`, `setOptOut`, and `reset` so the JS layer can drive registration, consent, and identity transitions at runtime.
- Supports a JS `pushIdentityProvider` round-trip over the event emitter for projects requiring identity-verified subscriptions.
- Captures cold-start notification opens on Android by reading the launch Activity's intent right after `PostHogAndroid.setup()`: posthog-android's lifecycle integration registers its callbacks at setup, which the bridge reaches only after the launch Activity exists, so it can never see the cold-start tap itself. Guarded against recents redelivery (`FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY`) and double capture (the `google.message_id` marker is stripped after reading).
- Bumps the posthog-ios pin to 3.69.2 and requires posthog-android 3.58.0 for the push APIs.

Note on CI: the CocoaPods example jobs fail on Xcode 16.2 because posthog-ios 3.69.1's module-interface-verification skip doesn't take effect there. PostHog/posthog-ios#747 fixes that and the pin here targets 3.69.2, which carries it, so these jobs stay red until that version reaches the CocoaPods CDN. I validated both the iOS and macOS example builds locally against the fix branch: clean builds, no verification tasks scheduled.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)

