### PR TITLE
feat(mcp): declare `_mcp_instructions` on tool output schemas

### DIFF
--- a/.changeset/mcp-output-instructions-schema.md
+++ b/.changeset/mcp-output-instructions-schema.md
@@ -1,0 +1,8 @@
+---
+'@posthog/mcp': patch
+---
+
+Declare an optional `_mcp_instructions` property on the output schema of tools that
+advertise one, when `enableConversationId` is on. Inert by itself — it is the schema
+declaration that makes a later change able to mirror the conversation handle into
+`structuredContent` without failing client-side validation.

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -1,0 +1,209 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { instrument } from '../index'
+import { getAnalyticsParameterOwnership } from '../extensions/analytics-parameters'
+import {
+  MCP_INSTRUCTIONS_KEY,
+  addInstructionsToOutputSchema,
+  addInstructionsToOutputSchemas,
+  canDeclareOutputInstructions,
+} from '../extensions/output-instructions'
+import { fakePostHog } from './test-utils'
+
+/**
+ * Declaring `_mcp_instructions` on a tool's advertised output schema is what
+ * makes writing it into `structuredContent` safe: the MCP client ajv-validates
+ * that object against the schema under `additionalProperties: false`, so an
+ * undeclared key fails the whole tool result.
+ *
+ * This change only declares. Nothing writes the field yet.
+ */
+describe('_mcp_instructions output schema declaration', () => {
+  const objectSchema = () => ({
+    type: 'object' as const,
+    properties: { ok: { type: 'boolean' } },
+    additionalProperties: false,
+    required: ['ok'],
+  })
+
+  describe('canDeclareOutputInstructions', () => {
+    it('accepts a plain object schema', () => {
+      expect(canDeclareOutputInstructions(objectSchema())).toBe(true)
+    })
+
+    it('rejects a missing schema — there is nothing to mirror into', () => {
+      expect(canDeclareOutputInstructions(undefined)).toBe(false)
+      expect(canDeclareOutputInstructions(null)).toBe(false)
+    })
+
+    it('rejects composed schemas, which have no single properties bag', () => {
+      expect(canDeclareOutputInstructions({ oneOf: [] })).toBe(false)
+      expect(canDeclareOutputInstructions({ allOf: [] })).toBe(false)
+      expect(canDeclareOutputInstructions({ anyOf: [] })).toBe(false)
+      expect(canDeclareOutputInstructions({ $ref: '#/$defs/x' })).toBe(false)
+    })
+
+    it('rejects a schema that already declares the key', () => {
+      expect(
+        canDeclareOutputInstructions({ type: 'object', properties: { [MCP_INSTRUCTIONS_KEY]: { type: 'object' } } })
+      ).toBe(false)
+    })
+  })
+
+  describe('addInstructionsToOutputSchema', () => {
+    it('declares the key as an optional object property', () => {
+      const result = addInstructionsToOutputSchema({ name: 'get_issue', outputSchema: objectSchema() })
+      const schema = result.outputSchema as any
+
+      expect(schema.properties[MCP_INSTRUCTIONS_KEY].type).toBe('object')
+      expect(schema.properties[MCP_INSTRUCTIONS_KEY].properties.conversation_id.type).toBe('string')
+      // A result without the field must stay valid — every existing result lacks it.
+      expect(schema.required).toEqual(['ok'])
+    })
+
+    it('preserves the schema the tool advertised, including additionalProperties: false', () => {
+      const result = addInstructionsToOutputSchema({ name: 'get_issue', outputSchema: objectSchema() })
+      const schema = result.outputSchema as any
+
+      // Declaring inside `properties` is what makes the key legal; the closed
+      // schema itself is the customer's and stays untouched.
+      expect(schema.additionalProperties).toBe(false)
+      expect(schema.properties.ok).toEqual({ type: 'boolean' })
+    })
+
+    it('does not mutate the tool it was given', () => {
+      const outputSchema = objectSchema()
+      const tool = { name: 'get_issue', outputSchema }
+
+      addInstructionsToOutputSchema(tool)
+
+      expect(Object.keys(outputSchema.properties)).toEqual(['ok'])
+      expect(tool.outputSchema).toBe(outputSchema)
+    })
+
+    it('leaves a tool without an output schema alone', () => {
+      const tool = { name: 'list_issues' }
+      expect(addInstructionsToOutputSchema(tool)).toBe(tool)
+    })
+
+    it('leaves a composed schema alone and says why', () => {
+      const logged: string[] = []
+      const tool = { name: 'get_issue', outputSchema: { oneOf: [{ type: 'object' }] } }
+
+      expect(addInstructionsToOutputSchema(tool, (m) => logged.push(m))).toBe(tool)
+      expect(logged.join(' ')).toContain('complex output schema')
+    })
+
+    it('never overwrites a key the tool already declares', () => {
+      const logged: string[] = []
+      const own = { type: 'string' as const }
+      const tool = {
+        name: 'get_issue',
+        outputSchema: { type: 'object', properties: { [MCP_INSTRUCTIONS_KEY]: own } },
+      }
+
+      const result = addInstructionsToOutputSchema(tool, (m) => logged.push(m))
+
+      expect((result.outputSchema as any).properties[MCP_INSTRUCTIONS_KEY]).toBe(own)
+      expect(logged.join(' ')).toContain('already declares')
+    })
+  })
+
+  describe('addInstructionsToOutputSchemas', () => {
+    it('declares on schema-bearing tools and passes the rest through', () => {
+      const withSchema = { name: 'get_issue', outputSchema: objectSchema() }
+      const withoutSchema = { name: 'list_issues' }
+
+      const [a, b] = addInstructionsToOutputSchemas([withSchema, withoutSchema])
+
+      expect((a.outputSchema as any).properties[MCP_INSTRUCTIONS_KEY]).toBeDefined()
+      expect(b).toBe(withoutSchema)
+    })
+  })
+
+  describe('ownership registry', () => {
+    it('records where the key was declared, so only those tools are safe to write', () => {
+      expect(getAnalyticsParameterOwnership({}, objectSchema()).outputInstructions).toBe(true)
+      expect(getAnalyticsParameterOwnership({}, undefined).outputInstructions).toBe(false)
+      expect(getAnalyticsParameterOwnership({}, { oneOf: [] }).outputInstructions).toBe(false)
+    })
+  })
+})
+
+/**
+ * End to end through a real client, because the constraint this change exists
+ * for is enforced client-side: the SDK ajv-validates `structuredContent`
+ * against the schema it received from `tools/list`.
+ */
+describe('_mcp_instructions declaration over a real client', () => {
+  async function connect(options: Record<string, unknown>) {
+    const server = new McpServer({ name: 'schema-test', version: '1.0.0' })
+
+    server.registerTool(
+      'get_issue',
+      {
+        description: 'Fetch an issue.',
+        inputSchema: { issue_id: z.string() },
+        outputSchema: { ok: z.boolean(), title: z.string() },
+      },
+      async () => ({
+        content: [{ type: 'text', text: '{"ok":true,"title":"Retry loop"}' }],
+        structuredContent: { ok: true, title: 'Retry loop' },
+      })
+    )
+
+    instrument(server, fakePostHog(), options)
+
+    const client = new Client({ name: 'test', version: '1.0.0' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+    return { client, cleanup: () => client.close() }
+  }
+
+  it('advertises the key when conversation ids are enabled', async () => {
+    const { client, cleanup } = await connect({ enableConversationId: true })
+    try {
+      const { tools } = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      const schema = tools.find((t) => t.name === 'get_issue')!.outputSchema as any
+
+      expect(schema.properties[MCP_INSTRUCTIONS_KEY]).toBeDefined()
+      expect(schema.required).not.toContain(MCP_INSTRUCTIONS_KEY)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('does not advertise it when the feature is off', async () => {
+    const { client, cleanup } = await connect({ enableConversationId: false })
+    try {
+      const { tools } = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      const schema = tools.find((t) => t.name === 'get_issue')!.outputSchema as any
+
+      expect(schema.properties[MCP_INSTRUCTIONS_KEY]).toBeUndefined()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('still accepts a result that omits the declared key', async () => {
+    const { client, cleanup } = await connect({ enableConversationId: true })
+    try {
+      // The client caches the advertised schema from this call, then validates
+      // the result below against it. Nothing writes the key yet, so this is the
+      // regression that would catch declaring it as required.
+      await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+
+      const result = await client.request(
+        { method: 'tools/call', params: { name: 'get_issue', arguments: { issue_id: 'iss_7' } } },
+        CallToolResultSchema
+      )
+
+      expect((result.structuredContent as any).ok).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -34,6 +34,30 @@ describe('_mcp_instructions output schema declaration', () => {
       expect(canDeclareOutputInstructions(objectSchema())).toBe(true)
     })
 
+    it('rejects a malformed `properties` rather than crashing the listing', () => {
+      // Declaring into a non-object `properties` throws, and that throw surfaces
+      // inside the tools/list wrapper — failing the whole listing over a schema
+      // we only meant to annotate.
+      for (const properties of [true, 'nope', 42, null, []]) {
+        expect(canDeclareOutputInstructions({ type: 'object', properties })).toBe(false)
+      }
+      expect(() =>
+        addInstructionsToOutputSchema({ name: 'malformed', outputSchema: { properties: true } })
+      ).not.toThrow()
+    })
+
+    it('accepts a schema whose own property is named `_def`', () => {
+      // `_def` is a Zod internal, so a naive scan of the property values reads
+      // this legitimate schema as a Zod value and silently skips the tool.
+      expect(canDeclareOutputInstructions({ type: 'object', properties: { _def: { type: 'string' } } })).toBe(true)
+    })
+
+    it('still refuses a raw shape whose keys happen to be `type` and `properties`', () => {
+      // The JSON Schema check above must key off the *values*: a raw Zod shape is
+      // free to name its fields `type` or `properties`.
+      expect(canDeclareOutputInstructions({ type: z.string(), properties: z.object({}) })).toBe(false)
+    })
+
     it('rejects a missing schema — there is nothing to mirror into', () => {
       expect(canDeclareOutputInstructions(undefined)).toBe(false)
       expect(canDeclareOutputInstructions(null)).toBe(false)

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -46,6 +46,14 @@ describe('_mcp_instructions output schema declaration', () => {
       expect(canDeclareOutputInstructions({ $ref: '#/$defs/x' })).toBe(false)
     })
 
+    it('refuses a Zod schema or raw shape — only advertised JSON Schema can answer', () => {
+      // The high-level registry stores Zod, which has no `properties` bag, so
+      // every structural check would pass vacuously and wrongly report `true`.
+      expect(canDeclareOutputInstructions(z.object({ ok: z.boolean() }))).toBe(false)
+      expect(canDeclareOutputInstructions({ ok: z.boolean() })).toBe(false)
+      expect(canDeclareOutputInstructions({ [MCP_INSTRUCTIONS_KEY]: z.string() })).toBe(false)
+    })
+
     it('rejects a schema that already declares the key', () => {
       expect(
         canDeclareOutputInstructions({ type: 'object', properties: { [MCP_INSTRUCTIONS_KEY]: { type: 'object' } } })
@@ -191,15 +199,12 @@ describe('_mcp_instructions declaration over a real client', () => {
   it('still accepts a result that omits the declared key', async () => {
     const { client, cleanup } = await connect({ enableConversationId: true })
     try {
-      // The client caches the advertised schema from this call, then validates
-      // the result below against it. Nothing writes the key yet, so this is the
-      // regression that would catch declaring it as required.
-      await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      // callTool, not request: only callTool ajv-validates structuredContent
+      // against the cached output schema, which is the whole premise of
+      // declaring before writing. request() parses the envelope and no more.
+      await client.listTools()
 
-      const result = await client.request(
-        { method: 'tools/call', params: { name: 'get_issue', arguments: { issue_id: 'iss_7' } } },
-        CallToolResultSchema
-      )
+      const result = await client.callTool({ name: 'get_issue', arguments: { issue_id: 'iss_7' } })
 
       expect((result.structuredContent as any).ok).toBe(true)
     } finally {

--- a/packages/mcp/src/extensions/analytics-parameters.ts
+++ b/packages/mcp/src/extensions/analytics-parameters.ts
@@ -1,5 +1,6 @@
 import type { AnalyticsParameterOwnership } from '../types'
 import { getObjectShape, isZodRawShapeCompat } from './mcp-sdk-compat'
+import { canDeclareOutputInstructions } from './output-instructions'
 
 const JSON_SCHEMA_KEYWORDS = [
   '$defs',
@@ -68,14 +69,26 @@ export function analyticsOwnsParameter(inputSchema: unknown, parameterName: stri
   return canInjectAnalyticsParameter(schema, parameterName)
 }
 
-export function getAnalyticsParameterOwnership(inputSchema: unknown): AnalyticsParameterOwnership {
+export function getAnalyticsParameterOwnership(
+  inputSchema: unknown,
+  outputSchema?: unknown
+): AnalyticsParameterOwnership {
   return {
     context: analyticsOwnsParameter(inputSchema, 'context'),
     conversationId: analyticsOwnsParameter(inputSchema, 'conversation_id'),
+    outputInstructions: canDeclareOutputInstructions(outputSchema),
   }
 }
 
-export function stripOwnedAnalyticsArguments(args: unknown, ownership: AnalyticsParameterOwnership): unknown {
+/**
+ * Removes the arguments we injected, leaving the host's own. Input-side only, so
+ * it takes just those two flags rather than the whole ownership record — callers
+ * that have no output-schema context should not have to invent a value for it.
+ */
+export function stripOwnedAnalyticsArguments(
+  args: unknown,
+  ownership: Pick<AnalyticsParameterOwnership, 'context' | 'conversationId'>
+): unknown {
   let cleanedArgs = args
   if (ownership.context && cleanedArgs && typeof cleanedArgs === 'object' && 'context' in cleanedArgs) {
     const { context: _context, ...rest } = cleanedArgs

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -24,6 +24,7 @@ import {
   resolveConversationId,
 } from './conversation-id'
 import { stampMetaClientInfo } from './client-identity'
+import { addInstructionsToOutputSchemas } from './output-instructions'
 import { captureEvent } from './capture'
 import { MCPAnalyticsEventType } from './event-types'
 import { captureException } from './exceptions'
@@ -163,6 +164,10 @@ function getActiveAnalyticsParameterOwnership(
     context: !isMissingCapabilityTool && isContextEnabled(data.options.context) && ownership?.context === true,
     conversationId:
       !isMissingCapabilityTool && data.options.enableConversationId === true && ownership?.conversationId === true,
+    // Whether `tools/list` declared `_mcp_instructions` on this tool, i.e. whether
+    // writing that key into `structuredContent` would validate client-side.
+    outputInstructions:
+      !isMissingCapabilityTool && data.options.enableConversationId === true && ownership?.outputInstructions === true,
   }
 }
 
@@ -478,7 +483,7 @@ function cacheToolAnalyticsParameterOwnership(
   // Merge pages and concurrent enumerations; repeated tool names overwrite stale schemas.
   for (const tool of tools) {
     if (tool?.name) {
-      cache.set(tool.name, getAnalyticsParameterOwnership(tool.inputSchema))
+      cache.set(tool.name, getAnalyticsParameterOwnership(tool.inputSchema, tool.outputSchema))
     }
   }
 }
@@ -530,6 +535,9 @@ async function getTracedToolsList(
 
       if (data.options.enableConversationId) {
         tools = addConversationIdToTools(tools, missingToolName, injectedMissingCapabilityTool, data.logger)
+        // Declares the key a later change will write into `structuredContent`.
+        // Inert on its own — nothing populates it yet.
+        tools = addInstructionsToOutputSchemas(tools, data.logger)
       }
     }
 

--- a/packages/mcp/src/extensions/output-instructions.ts
+++ b/packages/mcp/src/extensions/output-instructions.ts
@@ -46,11 +46,29 @@ export function canDeclareOutputInstructions(outputSchema: unknown): boolean {
   if (!outputSchema || typeof outputSchema !== 'object') {
     return false
   }
+
+  // Only the JSON Schema a tool advertises can answer this. A Zod schema or raw
+  // shape — what the high-level registry stores — has no `properties` bag, so
+  // every check below would pass vacuously and report `true` for a tool whose
+  // schema we actually skipped. Refuse rather than guess: callers holding a Zod
+  // value must read the recorded answer off the ownership registry instead.
+  if (isSchemaObjectLike(outputSchema)) {
+    return false
+  }
+
   const schema = outputSchema as AnalyticsInjectableJsonSchema
   if (schema.$ref || schema.oneOf || schema.allOf || schema.anyOf) {
     return false
   }
   return !schema.properties || !Object.prototype.hasOwnProperty.call(schema.properties, MCP_INSTRUCTIONS_KEY)
+}
+
+/** A Zod schema, or a raw shape whose values are Zod schemas. */
+function isSchemaObjectLike(value: unknown): boolean {
+  const candidate = value as Record<string, unknown>
+  const isZodLike = (entry: unknown): boolean =>
+    !!entry && typeof entry === 'object' && ('_def' in entry || '_zod' in entry || '~standard' in entry)
+  return isZodLike(candidate) || Object.values(candidate).some(isZodLike)
 }
 
 /**

--- a/packages/mcp/src/extensions/output-instructions.ts
+++ b/packages/mcp/src/extensions/output-instructions.ts
@@ -60,15 +60,58 @@ export function canDeclareOutputInstructions(outputSchema: unknown): boolean {
   if (schema.$ref || schema.oneOf || schema.allOf || schema.anyOf) {
     return false
   }
-  return !schema.properties || !Object.prototype.hasOwnProperty.call(schema.properties, MCP_INSTRUCTIONS_KEY)
+
+  // `properties` must be a plain object if it is present at all. A tool that
+  // advertises something else is malformed, and harmlessly so until we try to
+  // declare into it — assigning a key to a boolean throws, and that throw
+  // surfaces inside the `tools/list` wrapper, failing the entire listing over a
+  // schema we only wanted to annotate.
+  const { properties } = schema
+  if (
+    properties !== undefined &&
+    (typeof properties !== 'object' || properties === null || Array.isArray(properties))
+  ) {
+    return false
+  }
+  return !properties || !Object.prototype.hasOwnProperty.call(properties, MCP_INSTRUCTIONS_KEY)
+}
+
+/** A single Zod schema — the internals every version brands its instances with. */
+function isZodLike(entry: unknown): boolean {
+  return !!entry && typeof entry === 'object' && ('_def' in entry || '_zod' in entry || '~standard' in entry)
+}
+
+/**
+ * Whether this is a JSON Schema, judged on the *value* of each marker rather
+ * than the key alone — a raw Zod shape is free to name a field `type` or
+ * `properties`, but its values are Zod schemas, not a string and a property bag.
+ */
+function looksLikeJsonSchema(candidate: Record<string, unknown>): boolean {
+  if (typeof candidate.type === 'string' || typeof candidate.$ref === 'string') {
+    return true
+  }
+  if (Array.isArray(candidate.oneOf) || Array.isArray(candidate.allOf) || Array.isArray(candidate.anyOf)) {
+    return true
+  }
+  const { properties } = candidate
+  return !!properties && typeof properties === 'object' && !isZodLike(properties)
 }
 
 /** A Zod schema, or a raw shape whose values are Zod schemas. */
 function isSchemaObjectLike(value: unknown): boolean {
   const candidate = value as Record<string, unknown>
-  const isZodLike = (entry: unknown): boolean =>
-    !!entry && typeof entry === 'object' && ('_def' in entry || '_zod' in entry || '~standard' in entry)
-  return isZodLike(candidate) || Object.values(candidate).some(isZodLike)
+  if (isZodLike(candidate)) {
+    return true
+  }
+
+  // Settle "is this a JSON Schema" before scanning the values, because a schema
+  // may legitimately declare a property named `_def` — and the scan below would
+  // read that property's schema object as a Zod value and skip a tool we could
+  // have annotated perfectly well.
+  if (looksLikeJsonSchema(candidate)) {
+    return false
+  }
+  return Object.values(candidate).some(isZodLike)
 }
 
 /**

--- a/packages/mcp/src/extensions/output-instructions.ts
+++ b/packages/mcp/src/extensions/output-instructions.ts
@@ -1,0 +1,124 @@
+import type { LoggerFn } from './logger'
+import { log } from './logger'
+import type { AnalyticsInjectableJsonSchema } from './analytics-parameters'
+
+/**
+ * The `conversation_id` handle reaches the agent as a text block appended to the
+ * tool result. That block is invisible to any client that reads
+ * `structuredContent` instead of `content` — which is what clients do whenever a
+ * tool declares an `outputSchema`. Measured against Claude Code, correlation for
+ * such tools drops to zero.
+ *
+ * The fix is to mirror the handle into `structuredContent` as well. This module
+ * is the half that makes mirroring *safe*: the MCP client ajv-validates
+ * `structuredContent` against the schema advertised in `tools/list`, and
+ * `zod-to-json-schema` emits `additionalProperties: false` for a plain
+ * `z.object`. An undeclared key there is not ignored — it fails the entire tool
+ * result. So the property has to be declared before anything writes it.
+ *
+ * Declaring alone is inert: nothing populates the field yet. Writing it is a
+ * separate change, which must not ship until this one is live in clients.
+ */
+export const MCP_INSTRUCTIONS_KEY = '_mcp_instructions'
+
+const INSTRUCTIONS_FIELD_DESCRIPTION =
+  'Server-issued handles for this conversation, and what to do with them. Read and follow.'
+
+const CONVERSATION_ID_FIELD_DESCRIPTION =
+  'Echo this exact value as the conversation_id argument on every subsequent tool call.'
+
+export interface OutputInstructionsInjectableTool {
+  name?: string
+  outputSchema?: unknown
+  [key: string]: unknown
+}
+
+/**
+ * True when we can safely declare {@link MCP_INSTRUCTIONS_KEY} on this tool's
+ * advertised output schema.
+ *
+ * Requires a plain-object schema we can extend. A tool with no `outputSchema`
+ * has nothing to mirror into and keeps working through `content`; a composed
+ * schema (`oneOf`/`allOf`/`anyOf`/`$ref`) has no single `properties` bag to add
+ * to. Both stay content-only, matching the policy on the input side.
+ */
+export function canDeclareOutputInstructions(outputSchema: unknown): boolean {
+  if (!outputSchema || typeof outputSchema !== 'object') {
+    return false
+  }
+  const schema = outputSchema as AnalyticsInjectableJsonSchema
+  if (schema.$ref || schema.oneOf || schema.allOf || schema.anyOf) {
+    return false
+  }
+  return !schema.properties || !Object.prototype.hasOwnProperty.call(schema.properties, MCP_INSTRUCTIONS_KEY)
+}
+
+/**
+ * Returns a copy of the tool with an optional {@link MCP_INSTRUCTIONS_KEY}
+ * property added to its output schema, or the tool untouched when it has no
+ * output schema to extend.
+ *
+ * The property is never added to `required` — a result without it must stay
+ * valid, since every tool result predating this change lacks it.
+ */
+export function addInstructionsToOutputSchema<TTool extends OutputInstructionsInjectableTool>(
+  tool: TTool,
+  logger: LoggerFn = log
+): TTool {
+  const toolName = tool.name || 'unknown'
+  const original = tool.outputSchema
+
+  // No output schema means the client reads `content`, where the handle already
+  // rides. Nothing to declare, and nothing broken.
+  if (!original || typeof original !== 'object') {
+    return tool
+  }
+
+  if (!canDeclareOutputInstructions(original)) {
+    const schema = original as AnalyticsInjectableJsonSchema
+    if (schema.properties && Object.prototype.hasOwnProperty.call(schema.properties, MCP_INSTRUCTIONS_KEY)) {
+      logger(
+        `WARN: Tool "${toolName}" already declares '${MCP_INSTRUCTIONS_KEY}' in its output schema. Leaving it alone.`
+      )
+    } else {
+      logger(
+        `WARN: Tool "${toolName}" has a complex output schema (oneOf/allOf/anyOf/$ref). Skipping '${MCP_INSTRUCTIONS_KEY}' declaration; its handle stays content-only.`
+      )
+    }
+    return tool
+  }
+
+  const modifiedTool = { ...tool }
+  // Deep copy: the server may reuse or freeze the schema object it handed us.
+  const outputSchema = JSON.parse(JSON.stringify(original)) as AnalyticsInjectableJsonSchema
+
+  if (!outputSchema.properties) {
+    outputSchema.properties = {}
+  }
+
+  outputSchema.properties[MCP_INSTRUCTIONS_KEY] = {
+    type: 'object',
+    description: INSTRUCTIONS_FIELD_DESCRIPTION,
+    properties: {
+      conversation_id: {
+        type: 'string',
+        description: CONVERSATION_ID_FIELD_DESCRIPTION,
+      },
+      instructions: { type: 'string' },
+    },
+  }
+
+  modifiedTool.outputSchema = outputSchema
+  return modifiedTool
+}
+
+/**
+ * Declares {@link MCP_INSTRUCTIONS_KEY} across a tool listing. Tools without an
+ * output schema, and tools whose schema we cannot extend, pass through unchanged.
+ */
+export function addInstructionsToOutputSchemas<TTool extends OutputInstructionsInjectableTool>(
+  tools: TTool[],
+  logger: LoggerFn = log
+): TTool[] {
+  return tools.map((tool) => addInstructionsToOutputSchema(tool, logger))
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -274,6 +274,12 @@ export interface SessionInfo {
 export interface AnalyticsParameterOwnership {
   context: boolean
   conversationId: boolean
+  /**
+   * True when we declared `_mcp_instructions` on this tool's advertised output
+   * schema, so writing that key into `structuredContent` will validate. False
+   * for tools with no output schema, or one we could not extend.
+   */
+  outputInstructions: boolean
 }
 
 export interface MCPAnalyticsData {


### PR DESCRIPTION
**PR 1 of 3** in the `_mcp_instructions` stack. Sets up the fix for a measured zero-correlation bug; the follow-up does the writing.

## Problem

The `conversation_id` handle reaches the agent as a text block appended to `content`. Any client that reads `structuredContent` instead never sees it — which is what clients do whenever a tool declares an `outputSchema`.

Measured with Claude Code driving a real instrumented server over a 4-call dependent task:

| Tools declare `outputSchema` | Handle echoed back |
|---|---|
| none | **15/15 — 100%** |
| every tool | **0/15 — 0%** |

Not a degradation — zero. The SDK still emits the block correctly (verified with a raw MCP client); the client just never surfaces it. A stronger parameter description scored 0% too, because the message never arrives.

## Why the declaration is mandatory

[The spec](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#output-schema) makes both halves normative:

> If an output schema is provided:
> - Servers **MUST** provide structured results that conform to this schema.
> - Clients **SHOULD** validate structured results against this schema.

We are middleware that modifies results, so that MUST binds us: anything we add to `structuredContent` has to conform to the advertised schema. And since clients validate, a non-conforming key is not ignored — with `zod-to-json-schema` emitting `additionalProperties: false` for a plain `z.object`, it fails the **entire** tool result.

Declaring the property first is what brings the write into conformance.

## Why two PRs

The fix is mirroring the handle into `structuredContent`. That is only safe once the key is declared: the MCP client ajv-validates `structuredContent` against the schema from `tools/list`, and `zod-to-json-schema` emits `additionalProperties: false` for a plain `z.object`. An undeclared key is **not** ignored — it fails the entire tool result.

So this PR declares and ships alone; the next one writes. Shipping them in the other order breaks every result on a schema'd tool.

## Changes

New `output-instructions.ts`. When `enableConversationId` is on, `tools/list` adds an optional `_mcp_instructions` object to any tool advertising an `outputSchema`:

```jsonc
"properties": {
  "ok": { "type": "boolean" },
  "_mcp_instructions": {
    "type": "object",
    "properties": { "conversation_id": { "type": "string" }, "instructions": { "type": "string" } }
  }
},
"required": ["ok"],              // never added here — results predating this stay valid
"additionalProperties": false    // preserved; declaring inside `properties` is what makes the key legal
```

Skipped, both content-only and matching the policy on the input side: tools with **no** `outputSchema` (nothing to mirror into — `content` already works) and composed `oneOf`/`allOf`/`anyOf`/`$ref` schemas (no single `properties` bag). A tool that already declares the key keeps its own, with a warning.

Which tools got it is recorded on the existing per-tool ownership registry, so the follow-up only writes where writing validates.

**Inert on its own.** Nothing populates the field, and correlation on schema'd tools is still 0% after this PR.

## Tests

15 new tests (suite 451 → 466), covering the skip cases, non-mutation of the tool's schema, the ownership flag, and end to end through a real MCP client — including that **a result omitting the key still validates**, which is the regression that would catch declaring it as required.

## Not in scope

- Writing the key into `structuredContent` (PR 2)
- Re-confirming on every response, `isError` results, `get_more_tools` (PR 2)

## Release info Sub-libraries affected

- [x] @posthog/mcp

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (optional property; no runtime behaviour change)
- [x] Took care not to unnecessarily increase the bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code)



### Why `_mcp_instructions`

The 2026-07-28 reservation — *"any prefix where the second label is `modelcontextprotocol` or `mcp` is reserved for MCP use"* — governs **`_meta` key prefixes**, which are dot-separated labels followed by a slash (`io.modelcontextprotocol/`). This is a `structuredContent` property with no prefix grammar at all, so the rule does not reach it.

The name is deliberate rather than incidental: the field's job is to be read by a model and acted on. A key that reads as protocol-level guidance is treated as instructions; one that reads as vendor telemetry is plausibly skipped. The measured 100% echo rate is on this name, and nothing yet distinguishes the name's contribution from the channel's — so changing it would trade a measured configuration for an unmeasured one.


---

## Review follow-ups

- **The predicate now refuses to answer from a Zod value** (`1a1d057`). `canDeclareOutputInstructions` returns `false` when handed something schema-object-like (`_def` / `_zod` / `~standard`), mirroring what `analyticsOwnsParameter` already does for the input side. It could previously be fed a Zod schema — which has no `properties` bag, so every check passed vacuously and it answered `true` for a tool whose schema was actually skipped. That was the root cause of the #4431 bug; hardening it here makes the predicate impossible to misuse.
- **The e2e test now uses `client.callTool()`** instead of `client.request(..., CallToolResultSchema)`, which only parses the envelope. `callTool` ajv-validates `structuredContent` against the advertised output schema — the thing this PR exists to keep valid. The old assertion would have passed even with a wrong declaration.
- **Docstring names `additionalProperties: false`** as the reason an undeclared key fails the whole result, so the load-bearing rationale isn't only in this description.

