### PR TITLE
feat(mcp): mirror the session handle into `structuredContent`

### DIFF
--- a/.changeset/mcp-mirror-structured-instructions.md
+++ b/.changeset/mcp-mirror-structured-instructions.md
@@ -1,0 +1,7 @@
+---
+'@posthog/mcp': patch
+---
+
+Mirror the `conversation_id` session handle into `structuredContent` for tools whose
+output schema declares `_mcp_instructions`. Clients that read structured results never
+saw the handle in `content`, so correlation for those tools was zero.

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -221,6 +221,25 @@ describe('_mcp_instructions declaration over a real client', () => {
     }
   })
 
+  it('mirrors a key that validates against the real advertised schema', async () => {
+    // The claim this whole two-PR split exists to satisfy: the key we write is
+    // one the client's cached schema accepts. Only `callTool` ajv-validates
+    // `structuredContent`, so asserting the mirrored key anywhere else proves
+    // the write happened but not that it survives validation.
+    const { client, cleanup } = await connect({ enableConversationId: true })
+    try {
+      await client.listTools()
+
+      const result = await client.callTool({ name: 'get_issue', arguments: { issue_id: 'iss_7' } })
+
+      const mirrored = (result.structuredContent as Record<string, any>)[MCP_INSTRUCTIONS_KEY]
+      expect(mirrored?.conversation_id).toEqual(expect.any(String))
+      expect((result.structuredContent as any).ok).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+
   it('still accepts a result that omits the declared key', async () => {
     const { client, cleanup } = await connect({ enableConversationId: true })
     try {

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -326,12 +326,15 @@ describe('mirroring over a real client', () => {
     const { client, cleanup } = await connectStructured({ enableConversationId: true })
     try {
       await client.request({ method: 'tools/list' }, ListToolsResultSchema)
-      const second = await call(client, 'conv-supplied')
+      // Shaped like a handle the SDK would have minted, which is what a real
+      // agent echoes — an arbitrary string is treated as no handle at all.
+      const echoed = '019fd2b0-1111-7111-8111-111111111111'
+      const second = await call(client, echoed)
 
       // The text block is mint-only; the structured copy rides every response.
       const hasText = (second.content ?? []).some((c: any) => String(c.text).includes('conversation_id='))
       expect(hasText).toBe(false)
-      expect((second.structuredContent as any)[MCP_INSTRUCTIONS_KEY].conversation_id).toBe('conv-supplied')
+      expect((second.structuredContent as any)[MCP_INSTRUCTIONS_KEY].conversation_id).toBe(echoed)
     } finally {
       await cleanup()
     }

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -10,6 +10,7 @@ import {
   addInstructionsToOutputSchema,
   addInstructionsToOutputSchemas,
   canDeclareOutputInstructions,
+  mirrorInstructionsIntoStructuredContent,
 } from '../extensions/output-instructions'
 import { fakePostHog } from './test-utils'
 
@@ -231,6 +232,117 @@ describe('_mcp_instructions declaration over a real client', () => {
       const result = await client.callTool({ name: 'get_issue', arguments: { issue_id: 'iss_7' } })
 
       expect((result.structuredContent as any).ok).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
+describe('mirroring the session handle into structuredContent', () => {
+  const withStructured = (extra = {}) => ({
+    content: [{ type: 'text', text: '{"ok":true}' }],
+    structuredContent: { ok: true, ...extra },
+  })
+
+  it('adds the key alongside the tool’s own fields', () => {
+    const result = mirrorInstructionsIntoStructuredContent(withStructured(), 'conv-1') as any
+
+    expect(result.structuredContent[MCP_INSTRUCTIONS_KEY].conversation_id).toBe('conv-1')
+    expect(result.structuredContent[MCP_INSTRUCTIONS_KEY].instructions).toEqual(expect.any(String))
+    expect(result.structuredContent.ok).toBe(true)
+  })
+
+  it('does not mutate the result it was given', () => {
+    const original = withStructured()
+    mirrorInstructionsIntoStructuredContent(original, 'conv-1')
+    expect(Object.keys(original.structuredContent)).toEqual(['ok'])
+  })
+
+  it('leaves a result with no structuredContent alone', () => {
+    const original = { content: [{ type: 'text', text: 'plain' }] }
+    expect(mirrorInstructionsIntoStructuredContent(original, 'conv-1')).toBe(original)
+  })
+
+  it('leaves a non-object structuredContent alone', () => {
+    for (const structuredContent of [[1, 2], 'text', 42, null]) {
+      const original = { structuredContent }
+      expect(mirrorInstructionsIntoStructuredContent(original, 'conv-1')).toBe(original)
+    }
+  })
+
+  it('never overwrites a key the tool produced itself', () => {
+    const own = { mine: true }
+    const original = withStructured({ [MCP_INSTRUCTIONS_KEY]: own })
+    expect(mirrorInstructionsIntoStructuredContent(original, 'conv-1')).toBe(original)
+  })
+
+  it('leaves non-object results alone', () => {
+    expect(mirrorInstructionsIntoStructuredContent(null, 'conv-1')).toBeNull()
+    expect(mirrorInstructionsIntoStructuredContent('text', 'conv-1')).toBe('text')
+  })
+})
+
+describe('mirroring over a real client', () => {
+  /** A server whose tool declares an outputSchema and returns structuredContent. */
+  async function connectStructured(options: Record<string, unknown>) {
+    const server = new McpServer({ name: 'mirror-test', version: '1.0.0' })
+    server.registerTool(
+      'with_schema',
+      { description: 'Structured.', inputSchema: {}, outputSchema: { ok: z.boolean() } },
+      async () => ({ content: [{ type: 'text', text: '{"ok":true}' }], structuredContent: { ok: true } })
+    )
+    instrument(server, fakePostHog(), options)
+
+    const client = new Client({ name: 'test', version: '1.0.0' })
+    const [c, s] = InMemoryTransport.createLinkedPair()
+    await Promise.all([client.connect(c), server.connect(s)])
+    return { client, cleanup: () => client.close() }
+  }
+
+  async function call(client: any, conversationId?: string) {
+    return client.request(
+      {
+        method: 'tools/call',
+        params: { name: 'with_schema', arguments: conversationId ? { conversation_id: conversationId } : {} },
+      },
+      CallToolResultSchema
+    )
+  }
+
+  it('delivers the session handle where a structured-only client will see it', async () => {
+    const { client, cleanup } = await connectStructured({ enableConversationId: true })
+    try {
+      await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      const result = await call(client)
+
+      // The whole point: this survives a client that ignores `content`.
+      expect((result.structuredContent as any)[MCP_INSTRUCTIONS_KEY].conversation_id).toEqual(expect.any(String))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('re-sends it on later calls, so an agent that dropped it can recover', async () => {
+    const { client, cleanup } = await connectStructured({ enableConversationId: true })
+    try {
+      await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      const second = await call(client, 'conv-supplied')
+
+      // The text block is mint-only; the structured copy rides every response.
+      const hasText = (second.content ?? []).some((c: any) => String(c.text).includes('conversation_id='))
+      expect(hasText).toBe(false)
+      expect((second.structuredContent as any)[MCP_INSTRUCTIONS_KEY].conversation_id).toBe('conv-supplied')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('writes nothing when the feature is off', async () => {
+    const { client, cleanup } = await connectStructured({ enableConversationId: false })
+    try {
+      await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      const result = await call(client)
+      expect((result.structuredContent as any)[MCP_INSTRUCTIONS_KEY]).toBeUndefined()
     } finally {
       await cleanup()
     }

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -238,6 +238,22 @@ describe('_mcp_instructions declaration over a real client', () => {
   })
 })
 
+/** A server whose tool declares an outputSchema and returns structuredContent. */
+async function connectStructured(options: Record<string, unknown>) {
+  const server = new McpServer({ name: 'mirror-test', version: '1.0.0' })
+  server.registerTool(
+    'with_schema',
+    { description: 'Structured.', inputSchema: {}, outputSchema: { ok: z.boolean() } },
+    async () => ({ content: [{ type: 'text', text: '{"ok":true}' }], structuredContent: { ok: true } })
+  )
+  instrument(server, fakePostHog(), options)
+
+  const client = new Client({ name: 'test', version: '1.0.0' })
+  const [c, s] = InMemoryTransport.createLinkedPair()
+  await Promise.all([client.connect(c), server.connect(s)])
+  return { client, cleanup: () => client.close() }
+}
+
 describe('mirroring the session handle into structuredContent', () => {
   const withStructured = (extra = {}) => ({
     content: [{ type: 'text', text: '{"ok":true}' }],
@@ -283,22 +299,6 @@ describe('mirroring the session handle into structuredContent', () => {
 })
 
 describe('mirroring over a real client', () => {
-  /** A server whose tool declares an outputSchema and returns structuredContent. */
-  async function connectStructured(options: Record<string, unknown>) {
-    const server = new McpServer({ name: 'mirror-test', version: '1.0.0' })
-    server.registerTool(
-      'with_schema',
-      { description: 'Structured.', inputSchema: {}, outputSchema: { ok: z.boolean() } },
-      async () => ({ content: [{ type: 'text', text: '{"ok":true}' }], structuredContent: { ok: true } })
-    )
-    instrument(server, fakePostHog(), options)
-
-    const client = new Client({ name: 'test', version: '1.0.0' })
-    const [c, s] = InMemoryTransport.createLinkedPair()
-    await Promise.all([client.connect(c), server.connect(s)])
-    return { client, cleanup: () => client.close() }
-  }
-
   async function call(client: any, conversationId?: string) {
     return client.request(
       {
@@ -342,6 +342,56 @@ describe('mirroring over a real client', () => {
     try {
       await client.request({ method: 'tools/list' }, ListToolsResultSchema)
       const result = await call(client)
+      expect((result.structuredContent as any)[MCP_INSTRUCTIONS_KEY]).toBeUndefined()
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
+describe('the write is gated on what tools/list actually declared', () => {
+  /** A tool that declares `_mcp_instructions` itself, so we must not write it. */
+  async function connectOwningTheKey() {
+    const server = new McpServer({ name: 'own-key', version: '1.0.0' })
+    server.registerTool(
+      'own_key',
+      {
+        description: 'Owns the key.',
+        inputSchema: {},
+        outputSchema: { ok: z.boolean(), [MCP_INSTRUCTIONS_KEY]: z.string() },
+      },
+      async () => ({
+        content: [{ type: 'text', text: '{"ok":true}' }],
+        structuredContent: { ok: true, [MCP_INSTRUCTIONS_KEY]: 'mine' },
+      })
+    )
+    instrument(server, fakePostHog(), { enableConversationId: true })
+
+    const client = new Client({ name: 'test', version: '1.0.0' })
+    const [c, s] = InMemoryTransport.createLinkedPair()
+    await Promise.all([client.connect(c), server.connect(s)])
+    return { client, cleanup: () => client.close() }
+  }
+
+  it('never overwrites a key the tool declares and produces itself', async () => {
+    const { client, cleanup } = await connectOwningTheKey()
+    try {
+      await client.listTools()
+      const result = await client.callTool({ name: 'own_key', arguments: {} })
+
+      // tools/list skips the declaration for this tool, so the write must skip too.
+      expect((result.structuredContent as any)[MCP_INSTRUCTIONS_KEY]).toBe('mine')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('writes nothing when the tool was never listed', async () => {
+    const { client, cleanup } = await connectStructured({ enableConversationId: true })
+    try {
+      // No tools/list first: we cannot know what the client's cached schema
+      // declares, so writing would risk failing its validation.
+      const result = await client.callTool({ name: 'with_schema', arguments: {} })
       expect((result.structuredContent as any)[MCP_INSTRUCTIONS_KEY]).toBeUndefined()
     } finally {
       await cleanup()

--- a/packages/mcp/src/extensions/instrument-highlevel.ts
+++ b/packages/mcp/src/extensions/instrument-highlevel.ts
@@ -262,7 +262,9 @@ async function handleToolCallRequest(
     request,
     extra,
     execute: (downstreamRequest) => originalCallToolHandler(downstreamRequest as MCPRequest, extra),
-    parameterOwnership: registeredTool ? getAnalyticsParameterOwnership(registeredTool.inputSchema) : undefined,
+    parameterOwnership: registeredTool
+      ? getAnalyticsParameterOwnership(registeredTool.inputSchema, registeredTool.outputSchema)
+      : undefined,
     takeCapturedError: () => {
       const captured = extra?.__mcp_analytics_error
       if (extra) {

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -159,15 +159,20 @@ function getActiveAnalyticsParameterOwnership(
   override: AnalyticsParameterOwnership | undefined,
   isMissingCapabilityTool: boolean
 ): AnalyticsParameterOwnership {
-  const ownership = override ?? (toolName ? data.toolAnalyticsParameterOwnership.get(toolName) : undefined)
+  const listed = toolName ? data.toolAnalyticsParameterOwnership.get(toolName) : undefined
+  const ownership = override ?? listed
   return {
     context: !isMissingCapabilityTool && isContextEnabled(data.options.context) && ownership?.context === true,
     conversationId:
       !isMissingCapabilityTool && data.options.enableConversationId === true && ownership?.conversationId === true,
-    // Whether `tools/list` declared `_mcp_instructions` on this tool, i.e. whether
-    // writing that key into `structuredContent` would validate client-side.
+    // Deliberately read off `listed`, never the override. This asks whether
+    // `tools/list` actually declared `_mcp_instructions`, and only the advertised
+    // JSON Schema can answer it — an override is built from the live registry,
+    // which on the high-level path holds Zod. A tool whose listing skipped the
+    // declaration, or that was called before any `tools/list`, has no entry here,
+    // so nothing is written.
     outputInstructions:
-      !isMissingCapabilityTool && data.options.enableConversationId === true && ownership?.outputInstructions === true,
+      !isMissingCapabilityTool && data.options.enableConversationId === true && listed?.outputInstructions === true,
   }
 }
 

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -168,9 +168,19 @@ function getActiveAnalyticsParameterOwnership(
     // Deliberately read off `listed`, never the override. This asks whether
     // `tools/list` actually declared `_mcp_instructions`, and only the advertised
     // JSON Schema can answer it — an override is built from the live registry,
-    // which on the high-level path holds Zod. A tool whose listing skipped the
-    // declaration, or that was called before any `tools/list`, has no entry here,
-    // so nothing is written.
+    // which on the high-level path holds Zod.
+    //
+    // The cache is per-instance, so this is not merely "before the first
+    // `tools/list`": an instance that never serves a listing never writes the
+    // mirror at all. That is the per-request server pattern — `tools/list` lands
+    // on one instance, `tools/call` on a cold one — where the handle falls back
+    // to the `content` block and a structuredContent-only client misses it.
+    //
+    // Failing closed is deliberate. Writing a key the advertised schema did not
+    // declare fails the *entire* tool result under `additionalProperties: false`,
+    // so guessing costs the caller their result, while not guessing costs us one
+    // delivery channel. The fix is a process-scoped ownership cache, so a listing
+    // served by any instance answers for the rest — not a per-call guess.
     outputInstructions:
       !isMissingCapabilityTool && data.options.enableConversationId === true && listed?.outputInstructions === true,
   }

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -24,7 +24,7 @@ import {
   resolveConversationId,
 } from './conversation-id'
 import { stampMetaClientInfo } from './client-identity'
-import { addInstructionsToOutputSchemas } from './output-instructions'
+import { addInstructionsToOutputSchemas, mirrorInstructionsIntoStructuredContent } from './output-instructions'
 import { captureEvent } from './capture'
 import { MCPAnalyticsEventType } from './event-types'
 import { captureException } from './exceptions'
@@ -143,7 +143,7 @@ export async function captureToolCall(params: TraceToolCallParams): Promise<unkn
     throw error
   }
 
-  const finalResult = applyConversationPromptBack(preparedEvent?.event ?? null, result, conversation)
+  const finalResult = applyConversationInstructions(preparedEvent?.event ?? null, result, conversation, ownership)
   publishSuccessfulToolEvent(server, preparedEvent, finalResult, startTime, data.logger, takeCapturedError)
   return finalResult
 }
@@ -236,25 +236,51 @@ async function prepareToolCallEvent(
 }
 
 /**
- * When we minted a conversation id, append the prompt-back so the agent echoes
- * it on subsequent calls. If the result can't carry it, clear the id off the
- * event so analytics doesn't show an orphan the agent never received.
+ * Delivers the conversation session handle back to the agent, over both channels a tool
+ * result has:
+ *
+ * - `structuredContent`, on *every* response for a tool whose output schema we
+ *   declared the key on. Clients that read structured results never see the text
+ *   block, and re-sending it each time lets an agent that dropped the session handle read
+ *   it back.
+ * - `content`, as a text block, only on the response that minted the session handle.
+ *   Repeating it every call would put a `[SERVER]:` line in front of the user on
+ *   every single tool result.
+ *
+ * If neither channel could carry a session handle we minted, the agent never received it,
+ * so clear it off the event rather than showing analytics an id nobody has.
  */
-function applyConversationPromptBack(
+function applyConversationInstructions(
   event: McpEvent | null,
   result: unknown,
-  conversation: ConversationIdResolution
+  conversation: ConversationIdResolution,
+  ownership: AnalyticsParameterOwnership
 ): unknown {
-  if (!conversation.minted) {
+  const conversationId = conversation.conversationId
+  if (!conversationId) {
     return result
   }
-  if (canInjectConversationIdPromptBack(result)) {
-    return injectConversationIdPromptBack(result, conversation.conversationId)
+
+  let updated = result
+  let delivered = false
+
+  if (ownership.outputInstructions) {
+    const mirrored = mirrorInstructionsIntoStructuredContent(updated, conversationId)
+    delivered = mirrored !== updated
+    updated = mirrored
   }
-  if (event) {
+
+  if (conversation.minted && canInjectConversationIdPromptBack(updated)) {
+    updated = injectConversationIdPromptBack(updated, conversationId)
+    delivered = true
+  }
+
+  // Only a minted session handle can be lost this way — one the agent supplied, it has.
+  if (!delivered && conversation.minted && event) {
     event.conversationId = undefined
   }
-  return result
+
+  return updated
 }
 
 function publishSuccessfulToolEvent(

--- a/packages/mcp/src/extensions/output-instructions.ts
+++ b/packages/mcp/src/extensions/output-instructions.ts
@@ -3,21 +3,23 @@ import { log } from './logger'
 import type { AnalyticsInjectableJsonSchema } from './analytics-parameters'
 
 /**
- * The `conversation_id` handle reaches the agent as a text block appended to the
+ * The `conversation_id` session handle reaches the agent as a text block appended to the
  * tool result. That block is invisible to any client that reads
  * `structuredContent` instead of `content` — which is what clients do whenever a
  * tool declares an `outputSchema`. Measured against Claude Code, correlation for
  * such tools drops to zero.
  *
- * The fix is to mirror the handle into `structuredContent` as well. This module
- * is the half that makes mirroring *safe*: the MCP client ajv-validates
- * `structuredContent` against the schema advertised in `tools/list`, and
- * `zod-to-json-schema` emits `additionalProperties: false` for a plain
- * `z.object`. An undeclared key there is not ignored — it fails the entire tool
- * result. So the property has to be declared before anything writes it.
+ * The fix is to mirror the session handle into `structuredContent` as well, which this
+ * module does in two halves that must stay in that order:
  *
- * Declaring alone is inert: nothing populates the field yet. Writing it is a
- * separate change, which must not ship until this one is live in clients.
+ *   1. declare `_mcp_instructions` on the tool's advertised `outputSchema`
+ *   2. write it into the result's `structuredContent`
+ *
+ * The declaration is what makes the write safe. The MCP client ajv-validates
+ * `structuredContent` against the schema from `tools/list`, and
+ * `zod-to-json-schema` emits `additionalProperties: false` for a plain
+ * `z.object`, so an undeclared key is not ignored — it fails the entire tool
+ * result. Only tools that got the declaration are ever written to.
  */
 export const MCP_INSTRUCTIONS_KEY = '_mcp_instructions'
 
@@ -129,7 +131,7 @@ export function addInstructionsToOutputSchema<TTool extends OutputInstructionsIn
   const toolName = tool.name || 'unknown'
   const original = tool.outputSchema
 
-  // No output schema means the client reads `content`, where the handle already
+  // No output schema means the client reads `content`, where the session handle already
   // rides. Nothing to declare, and nothing broken.
   if (!original || typeof original !== 'object') {
     return tool
@@ -143,7 +145,7 @@ export function addInstructionsToOutputSchema<TTool extends OutputInstructionsIn
       )
     } else {
       logger(
-        `WARN: Tool "${toolName}" has a complex output schema (oneOf/allOf/anyOf/$ref). Skipping '${MCP_INSTRUCTIONS_KEY}' declaration; its handle stays content-only.`
+        `WARN: Tool "${toolName}" has a complex output schema (oneOf/allOf/anyOf/$ref). Skipping '${MCP_INSTRUCTIONS_KEY}' declaration; its session handle stays content-only.`
       )
     }
     return tool
@@ -182,4 +184,48 @@ export function addInstructionsToOutputSchemas<TTool extends OutputInstructionsI
   logger: LoggerFn = log
 ): TTool[] {
   return tools.map((tool) => addInstructionsToOutputSchema(tool, logger))
+}
+
+export interface ConversationInstructions {
+  conversation_id: string
+  instructions: string
+}
+
+const ECHO_INSTRUCTION = 'Send this conversation_id as an argument on every subsequent tool call in this conversation.'
+
+/** The payload mirrored into `structuredContent` for a tool we declared the key on. */
+export function buildConversationInstructions(conversationId: string): ConversationInstructions {
+  return { conversation_id: conversationId, instructions: ECHO_INSTRUCTION }
+}
+
+/**
+ * Adds {@link MCP_INSTRUCTIONS_KEY} to a result's `structuredContent`, which is
+ * where clients look once a tool declares an `outputSchema` — the `content` text
+ * block carrying the session handle is invisible to them.
+ *
+ * Unlike the text block, this rides *every* response rather than only the one
+ * that minted the session handle, so an agent that drops it can read it back.
+ *
+ * Returns the result untouched when there is no plain-object `structuredContent`
+ * to extend, or when the tool already produced its own key — customer data wins.
+ * Never mutates the input.
+ */
+export function mirrorInstructionsIntoStructuredContent(result: unknown, conversationId: string): unknown {
+  if (!result || typeof result !== 'object') {
+    return result
+  }
+  const structuredContent = (result as { structuredContent?: unknown }).structuredContent
+  if (!structuredContent || typeof structuredContent !== 'object' || Array.isArray(structuredContent)) {
+    return result
+  }
+  if (Object.prototype.hasOwnProperty.call(structuredContent, MCP_INSTRUCTIONS_KEY)) {
+    return result
+  }
+  return {
+    ...result,
+    structuredContent: {
+      ...structuredContent,
+      [MCP_INSTRUCTIONS_KEY]: buildConversationInstructions(conversationId),
+    },
+  }
 }

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -123,6 +123,8 @@ export type RegisteredTool = {
   /** MCP tool `_meta` block (spec-allowed arbitrary metadata, e.g. `category`). */
   _meta?: Record<string, unknown>
   inputSchema?: unknown
+  /** Present when the tool was registered with a declared output schema. */
+  outputSchema?: unknown
   update?: (...args: unknown[]) => unknown
 } & ({ callback: ToolCallback; handler?: never } | { handler: ToolCallback; callback?: never })
 


### PR DESCRIPTION
**PR 2 of 3** in the `_mcp_instructions` stack. Stacked on #4430 — review that first; this diff shows only the top commit once it merges.

## Problem

[MCP 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/changelog) removes protocol-level sessions. Servers correlate calls via an explicit handle the agent threads back — for us, `conversation_id`.

That handle reaches the agent as a text block on `content`. But clients read `structuredContent` whenever a tool declares an `outputSchema`, and never see it:

| Tools declare `outputSchema` | Handle echoed back |
|---|---|
| none | 15/15 — 100% |
| every tool | **0/15 — 0%** |

Measured with Claude Code against a real instrumented server. The SDK emitted the block correctly the whole time; the client just never surfaced it.

## Why `structuredContent`, per the spec

[Stateful Tools](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#stateful-tools) prescribes this exact pattern:

> MCP has no protocol-level session, so a server cannot rely on implicit per-connection state to relate one tool call to the next. Servers that need to maintain state across calls … should do so by **returning an explicit handle from a creation tool and accepting that handle as an argument on subsequent calls**.

and its worked example returns that handle in `structuredContent`:

```jsonc
// ← result
{
  "content": [{ "type": "text", "text": "Created basket bsk_a1b2c3" }],
  "structuredContent": { "basket_id": "bsk_a1b2c3" }
}
```

Two more rules make both channels necessary rather than either/or:

> Clients **SHOULD** validate structured results against this schema.

> For backwards compatibility, a tool that returns structured content **SHOULD** also return the serialized JSON in a TextContent block.

So the handle belongs in `structuredContent` where a structured-reading client will find it, while `content` stays the compatibility path. We were only doing the second.

## Change

Write the handle into `structuredContent` for tools whose schema #4430 declared `_mcp_instructions` on.

**Before** — handle present, agent never sees it:
```jsonc
{
  "content": [
    { "type": "text", "text": "{\"metric\":\"signups\",\"value\":4210}" },
    { "type": "text", "text": "[SERVER]: Reuse conversation_id=019fd23a-…" }   // ← dropped by the client
  ],
  "structuredContent": { "metric": "signups", "value": 4210 }                  // ← what it actually reads
}
```

**After**:
```jsonc
{
  "structuredContent": {
    "metric": "signups",
    "value": 4210,
    "_mcp_instructions": {
      "conversation_id": "019fd23a-363b-7c25-b26d-0565f728712a",
      "instructions": "Send this conversation_id as an argument on every subsequent tool call in this conversation."
    }
  }
}
```

Same measurement now: **15/15 — 100%**, each run on a single `$session_id`.

The structured copy rides **every** response, unlike the text block, so an agent that dropped the handle can read it back. The text block stays mint-only — repeating it would put a `[SERVER]:` line in front of the user on every tool result.

Never written where it wouldn't validate: only declared tools, only a plain-object `structuredContent`, never over a key the tool produced itself.

## Tests

9 new (suite 466 → 475), covering the skip cases, non-mutation, and end to end through a real MCP client. **No existing tests changed.**

## Not in scope

Both now in #4433, stacked on this:

- Prompt-back on `isError` results — separate channel, separate justification
- Including `get_more_tools`

## Release info Sub-libraries affected

- [x] @posthog/mcp

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (optional field; only where declared)
- [x] Took care not to unnecessarily increase the bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code)





---

## Review follow-ups

- **The `structuredContent` write is now gated on the listing** (`25100c8`). `outputInstructions` reads from `listed`, never from the override:

  ```ts
  const listed = toolName ? data.toolAnalyticsParameterOwnership.get(toolName) : undefined
  const ownership = override ?? listed
  // ...
  outputInstructions: data.options.enableConversationId === true && listed?.outputInstructions === true,
  ```

  Only the advertised JSON Schema can answer whether `tools/list` declared the key. The high-level override is built from the live registry, which holds Zod — so it answered `true` unconditionally, and we wrote an undeclared key into a tool that owned `_mcp_instructions` itself, failing the entire result with `-32602`. A tool never listed at all is now also left alone.
- **The reviewer's repro is now a regression test** — a tool declaring its own `_mcp_instructions`, asserting we skip the write.
- **The e2e tests use `client.callTool()`**, which ajv-validates the result. That's why a green suite missed this.
- The paired hardening (predicate refuses Zod values) is in #4430, where the predicate lives.
