### PR TITLE
fix(mcp): deliver the session handle on errors and capability gaps

### DIFF
--- a/.changeset/mcp-conversation-id-edge-cases.md
+++ b/.changeset/mcp-conversation-id-edge-cases.md
@@ -1,0 +1,8 @@
+---
+'@posthog/mcp': patch
+---
+
+Deliver the `conversation_id` session handle on errored tool results, and inject it into
+the virtual `get_more_tools` tool. A first call that fails no longer sends the agent's
+retry into a different conversation, and a reported capability gap now groups with the
+work that hit it.

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -564,3 +564,50 @@ describe('conversation_id edge cases', () => {
     })
   })
 })
+
+describe('enableConversationId and reportMissing are independent', () => {
+  let server: HighLevelMCPServerLike
+  let client: any
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  /** [enableConversationId, reportMissing] → [handle on a real tool, virtual tool exists] */
+  const matrix: [boolean, boolean, boolean, boolean][] = [
+    [false, false, false, false],
+    [false, true, false, true],
+    [true, false, true, false],
+    [true, true, true, true],
+  ]
+
+  it.each(matrix)(
+    'enableConversationId=%s reportMissing=%s → handle=%s virtualTool=%s',
+    async (enableConversationId, reportMissing, expectHandle, expectVirtual) => {
+      instrument(server, fakePostHog(), { enableConversationId, reportMissing })
+
+      const { tools } = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      const realTool = tools.find((t: any) => t.name === 'add_todo')
+      const virtual = tools.find((t: any) => t.name === 'get_more_tools')
+
+      // One option decides stitching, the other decides whether the tool exists.
+      expect(!!(realTool.inputSchema as any).properties.conversation_id).toBe(expectHandle)
+      expect(!!virtual).toBe(expectVirtual)
+
+      // When both are on they compose: the virtual tool stitches like any other.
+      if (expectVirtual) {
+        expect(!!(virtual.inputSchema as any).properties.conversation_id).toBe(expectHandle)
+        expect((virtual.inputSchema as any).properties.context).toBeDefined()
+      }
+    }
+  )
+})

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -124,13 +124,15 @@ describe('conversation-id', () => {
   })
 
   describe('addConversationIdToTools', () => {
-    it('skips the get_more_tools tool', () => {
+    it('injects into get_more_tools too, so capability gaps join their session', () => {
       const tools = [
         { name: 'get_more_tools', description: 'report missing' },
         { name: 'other_tool', description: 'fine' },
       ]
       const result = addConversationIdToTools(tools)
-      expect(result[0]).toBe(tools[0])
+      expect(
+        (result[0].inputSchema as { properties?: Record<string, unknown> }).properties?.conversation_id
+      ).toBeDefined()
       expect(
         (
           result[1].inputSchema as {
@@ -182,12 +184,14 @@ describe('conversation-id', () => {
       expect(content[1].text).toContain('conversation_id=conv-123')
     })
 
-    it('does not inject when result.isError is true', () => {
+    it('injects into an errored result — the retry must land in the same conversation', () => {
       const original = {
         isError: true,
         content: [{ type: 'text', text: 'oops' }],
       }
-      expect(injectConversationIdPromptBack(original, 'conv-123')).toBe(original)
+      const result = injectConversationIdPromptBack(original, 'conv-123') as { content: { text: string }[] }
+      expect(result.content).toHaveLength(2)
+      expect(result.content[1].text).toContain('conv-123')
     })
 
     it('does not inject when content is missing or not an array', () => {
@@ -213,6 +217,7 @@ describe('conversation-id', () => {
 })
 import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { instrument } from '../index'
+import { MCPAnalyticsEventType } from '../extensions/event-types'
 import type { HighLevelMCPServerLike } from '../types'
 import { EventCapture, fakePostHog } from './test-utils'
 import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
@@ -354,7 +359,7 @@ describe('conversation_id tool parameter', () => {
       await capture.stop()
     })
 
-    it('does not inject the prompt-back into error results', async () => {
+    it('injects the prompt-back into error results too', async () => {
       instrument(server, fakePostHog(), { enableConversationId: true })
 
       const result = await client.request(
@@ -368,13 +373,15 @@ describe('conversation_id tool parameter', () => {
         CallToolResultSchema
       )
 
+      // A tool that fails on the first call is exactly when the agent needs the
+      // session handle, or its retry starts a different conversation.
       const hasPromptBack = (result.content ?? []).some(
         (c) => c.type === 'text' && typeof c.text === 'string' && c.text.includes('conversation_id=')
       )
-      expect(hasPromptBack).toBe(false)
+      expect(hasPromptBack).toBe(true)
     })
 
-    it('clears event.conversationId on error when we minted it (agent never received it)', async () => {
+    it('keeps event.conversationId on error, since the prompt-back now reaches the agent', async () => {
       const capture = new EventCapture()
       await capture.start()
       instrument(server, fakePostHog(), { enableConversationId: true })
@@ -393,7 +400,7 @@ describe('conversation_id tool parameter', () => {
       await new Promise((r) => setTimeout(r, 50))
       const toolCall = capture.getEvents().find((e) => e.resourceName === 'complete_todo')
       expect(toolCall).toBeDefined()
-      expect(toolCall?.conversationId).toBeUndefined()
+      expect(toolCall?.conversationId).toBeDefined()
       await capture.stop()
     })
 
@@ -421,5 +428,76 @@ describe('conversation_id tool parameter', () => {
       expect(toolCall?.conversationId).toBe('agent-supplied-on-error')
       await capture.stop()
     })
+  })
+})
+
+describe('conversation_id edge cases', () => {
+  let server: HighLevelMCPServerLike
+  let client: any
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('puts a capability gap in the same session as the calls around it', async () => {
+    const capture = new EventCapture()
+    await capture.start()
+    instrument(server, fakePostHog(), { enableConversationId: true, reportMissing: true })
+
+    await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+
+    // A real call mints the handle, then the agent echoes it while reporting the gap.
+    const first = await client.request(
+      { method: 'tools/call', params: { name: 'add_todo', arguments: { text: 'first' } } },
+      CallToolResultSchema
+    )
+    const handle = (first.content ?? [])
+      .map((c: any) => String(c.text ?? '').match(/conversation_id=([\w-]+)/)?.[1])
+      .find(Boolean)
+    expect(handle).toBeDefined()
+
+    await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'get_more_tools',
+          arguments: {
+            context: 'Needed a tool to delete todos, which this server does not expose.',
+            conversation_id: handle,
+          },
+        },
+      },
+      CallToolResultSchema
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    const events = capture.getEvents()
+    const toolCall = events.find((e) => e.resourceName === 'add_todo')
+    const missing = events.find((e) => e.eventType === MCPAnalyticsEventType.mcpMissingCapability)
+
+    expect(missing?.conversationId).toBe(handle)
+    // The point: the gap report and the work that hit it group together.
+    expect(missing?.sessionId).toBe(toolCall?.sessionId)
+    await capture.stop()
+  })
+
+  it('advertises conversation_id on the virtual get_more_tools tool', async () => {
+    instrument(server, fakePostHog(), { enableConversationId: true, reportMissing: true })
+
+    const { tools } = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+    const virtual = tools.find((t: any) => t.name === 'get_more_tools')
+
+    expect((virtual.inputSchema as any).properties.conversation_id).toBeDefined()
+    // Its own bespoke `context` parameter is untouched.
+    expect((virtual.inputSchema as any).properties.context).toBeDefined()
   })
 })

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -218,7 +218,7 @@ describe('conversation-id', () => {
 import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { instrument } from '../index'
 import { MCPAnalyticsEventType } from '../extensions/event-types'
-import type { HighLevelMCPServerLike } from '../types'
+import type { HighLevelMCPServerLike, MCPServerLike } from '../types'
 import { EventCapture, fakePostHog } from './test-utils'
 import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
 
@@ -381,6 +381,37 @@ describe('conversation_id tool parameter', () => {
       expect(hasPromptBack).toBe(true)
     })
 
+    it('clears event.conversationId when a minted handle reaches no channel at all', async () => {
+      // The `minted && !delivered` cell. Both delivery channels have to miss:
+      // no declared output schema means no mirror, and a result carrying no
+      // `content` array means no prompt-back. The handle then exists only in our
+      // event, describing a conversation the agent was never told about — so it
+      // is cleared rather than reported as one.
+      const capture = new EventCapture()
+      await capture.start()
+
+      // Replace the underlying handler *before* instrumenting, so our wrapper
+      // still runs and simply sees a result with no content array — bypassing the
+      // SDK's result normalisation, which would add one.
+      const lowLevel = server.server as unknown as MCPServerLike
+      lowLevel._requestHandlers.set('tools/call', async () => ({ structuredContent: { ok: true } }))
+      instrument(server, fakePostHog(), { enableConversationId: true })
+
+      const handler = lowLevel._requestHandlers.get('tools/call')!
+      const result = (await handler(
+        { method: 'tools/call', params: { name: 'add_todo', arguments: { text: 'x' } } },
+        {} as never
+      )) as { content?: unknown }
+
+      await new Promise((r) => setTimeout(r, 50))
+      const toolCall = capture.getEvents().find((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+      // The event must exist, or this asserts nothing.
+      expect(toolCall).toBeDefined()
+      expect(result.content).toBeUndefined()
+      expect(toolCall?.conversationId).toBeUndefined()
+      await capture.stop()
+    })
+
     it('keeps event.conversationId on error, since the prompt-back now reaches the agent', async () => {
       const capture = new EventCapture()
       await capture.start()
@@ -503,7 +534,8 @@ describe('conversation_id edge cases', () => {
     // Same connection, so anything falling back to the transport or in-memory
     // session would report one id for both. Only the handle can separate them.
     // Both are shaped like handles the SDK would have minted, which is what a
-    // real agent echoes — an arbitrary string is treated as no handle at all.
+    // real agent echoes. On this branch any non-empty string would do; #4428
+    // adds the shape check that makes the distinction matter.
     const one = '019fd2b0-aaaa-7aaa-8aaa-aaaaaaaaaaaa'
     const two = '019fd2b0-bbbb-7bbb-8bbb-bbbbbbbbbbbb'
     for (const [handle, text] of [

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -502,9 +502,13 @@ describe('conversation_id edge cases', () => {
 
     // Same connection, so anything falling back to the transport or in-memory
     // session would report one id for both. Only the handle can separate them.
+    // Both are shaped like handles the SDK would have minted, which is what a
+    // real agent echoes — an arbitrary string is treated as no handle at all.
+    const one = '019fd2b0-aaaa-7aaa-8aaa-aaaaaaaaaaaa'
+    const two = '019fd2b0-bbbb-7bbb-8bbb-bbbbbbbbbbbb'
     for (const [handle, text] of [
-      ['conversation-one', 'Needed a delete tool.'],
-      ['conversation-two', 'Needed an export tool.'],
+      [one, 'Needed a delete tool.'],
+      [two, 'Needed an export tool.'],
     ]) {
       await client.request(
         {
@@ -517,7 +521,7 @@ describe('conversation_id edge cases', () => {
 
     await new Promise((r) => setTimeout(r, 50))
     const gaps = capture.getEvents().filter((e) => e.eventType === MCPAnalyticsEventType.mcpMissingCapability)
-    expect(gaps.map((g) => g.conversationId)).toEqual(['conversation-one', 'conversation-two'])
+    expect(gaps.map((g) => g.conversationId)).toEqual([one, two])
     await capture.stop()
   })
 

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -484,9 +484,40 @@ describe('conversation_id edge cases', () => {
     const toolCall = events.find((e) => e.resourceName === 'add_todo')
     const missing = events.find((e) => e.eventType === MCPAnalyticsEventType.mcpMissingCapability)
 
+    // This is what this PR controls: the gap report carries the same handle.
     expect(missing?.conversationId).toBe(handle)
-    // The point: the gap report and the work that hit it group together.
+    // Forward guard only. On one server instance over InMemoryTransport both
+    // events fall back to the same in-memory session id anyway, so this cannot
+    // tell "grouped by the handle" from "nothing rotated" until the handle
+    // drives $session_id. The distinguishing assertion is the next test.
     expect(missing?.sessionId).toBe(toolCall?.sessionId)
+    await capture.stop()
+  })
+
+  it('gives two different handles two different conversations', async () => {
+    const capture = new EventCapture()
+    await capture.start()
+    instrument(server, fakePostHog(), { enableConversationId: true, reportMissing: true })
+    await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+
+    // Same connection, so anything falling back to the transport or in-memory
+    // session would report one id for both. Only the handle can separate them.
+    for (const [handle, text] of [
+      ['conversation-one', 'Needed a delete tool.'],
+      ['conversation-two', 'Needed an export tool.'],
+    ]) {
+      await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'get_more_tools', arguments: { context: text, conversation_id: handle } },
+        },
+        CallToolResultSchema
+      )
+    }
+
+    await new Promise((r) => setTimeout(r, 50))
+    const gaps = capture.getEvents().filter((e) => e.eventType === MCPAnalyticsEventType.mcpMissingCapability)
+    expect(gaps.map((g) => g.conversationId)).toEqual(['conversation-one', 'conversation-two'])
     await capture.stop()
   })
 

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -500,4 +500,67 @@ describe('conversation_id edge cases', () => {
     // Its own bespoke `context` parameter is untouched.
     expect((virtual.inputSchema as any).properties.context).toBeDefined()
   })
+
+  describe('with enableConversationId off', () => {
+    it('leaves errored results alone', async () => {
+      instrument(server, fakePostHog(), { enableConversationId: false })
+
+      const result = await client.request(
+        { method: 'tools/call', params: { name: 'complete_todo', arguments: { id: 'does-not-exist' } } },
+        CallToolResultSchema
+      )
+
+      const hasPromptBack = (result.content ?? []).some((c: any) => String(c.text ?? '').includes('conversation_id='))
+      expect(hasPromptBack).toBe(false)
+    })
+
+    it('leaves get_more_tools alone', async () => {
+      instrument(server, fakePostHog(), { enableConversationId: false, reportMissing: true })
+
+      const { tools } = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      const virtual = tools.find((t: any) => t.name === 'get_more_tools')
+
+      expect((virtual.inputSchema as any).properties.conversation_id).toBeUndefined()
+      // Its own parameter still there — we removed nothing.
+      expect((virtual.inputSchema as any).properties.context).toBeDefined()
+    })
+
+    it('publishes a capability gap with no conversation id', async () => {
+      const capture = new EventCapture()
+      await capture.start()
+      instrument(server, fakePostHog(), { enableConversationId: false, reportMissing: true })
+
+      await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      await client.request(
+        { method: 'tools/call', params: { name: 'get_more_tools', arguments: { context: 'Needed a delete tool.' } } },
+        CallToolResultSchema
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      const missing = capture.getEvents().find((e) => e.eventType === MCPAnalyticsEventType.mcpMissingCapability)
+      expect(missing).toBeDefined()
+      expect(missing?.conversationId).toBeUndefined()
+      await capture.stop()
+    })
+
+    it('ignores a conversation_id an agent sends anyway', async () => {
+      const capture = new EventCapture()
+      await capture.start()
+      instrument(server, fakePostHog(), { enableConversationId: false })
+
+      // With injection off the argument is the host's, not ours — never read.
+      await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'add_todo', arguments: { text: 'x', conversation_id: 'agent-made-up' } },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      const toolCall = capture.getEvents().find((e) => e.resourceName === 'add_todo')
+      expect(toolCall?.conversationId).toBeUndefined()
+      await capture.stop()
+    })
+  })
 })

--- a/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
+++ b/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
@@ -263,8 +263,9 @@ describe('Low-level Server reportMissing ownership (e2e)', () => {
 
       expect(first.tools.filter((tool) => tool.name === 'get_more_tools')).toHaveLength(1)
       expect(second.tools.filter((tool) => tool.name === 'get_more_tools')).toHaveLength(1)
-      expect((firstVirtual as any)?.inputSchema?.properties?.conversation_id).toBeUndefined()
-      expect((secondVirtual as any)?.inputSchema?.properties?.conversation_id).toBeUndefined()
+      // get_more_tools now carries the parameter like any other tool.
+      expect((firstVirtual as any)?.inputSchema?.properties?.conversation_id).toBeDefined()
+      expect((secondVirtual as any)?.inputSchema?.properties?.conversation_id).toBeDefined()
       expect(frozenTools.some((tool) => tool.name === 'get_more_tools')).toBe(false)
     } finally {
       await cleanup()

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -346,7 +346,8 @@ describe('mirroring over a real client', () => {
     try {
       await client.request({ method: 'tools/list' }, ListToolsResultSchema)
       // Shaped like a handle the SDK would have minted, which is what a real
-      // agent echoes — an arbitrary string is treated as no handle at all.
+      // agent echoes. On this branch any non-empty string would do; #4428 adds
+      // the shape check that makes the distinction matter.
       const echoed = '019fd2b0-1111-7111-8111-111111111111'
       const second = await call(client, echoed)
 

--- a/packages/mcp/src/extensions/conversation-id.ts
+++ b/packages/mcp/src/extensions/conversation-id.ts
@@ -11,7 +11,6 @@ import {
 } from './analytics-parameters'
 import { DEFAULT_CONVERSATION_ID_DESCRIPTION } from './constants'
 import { log, type LoggerFn } from './logger'
-import { GET_MORE_TOOLS_NAME } from './tools'
 
 export const CONVERSATION_ID_PARAM_NAME = 'conversation_id'
 
@@ -70,18 +69,17 @@ export function addConversationIdToTool<TTool extends ConversationIdInjectableTo
   return modifiedTool
 }
 
+/**
+ * Injects `conversation_id` across a tool listing, including the virtual
+ * `get_more_tools` tool. Its calls publish `$mcp_missing_capability`, and a
+ * capability gap is only meaningful next to the work that hit it — so it belongs
+ * in the same session as the surrounding tool calls.
+ */
 export function addConversationIdToTools<TTool extends ConversationIdInjectableTool>(
   tools: TTool[],
-  missingCapabilityToolName: string = GET_MORE_TOOLS_NAME,
-  skipMissingCapabilityTool = true,
   logger: LoggerFn = log
 ): TTool[] {
-  return tools.map((tool) => {
-    if (skipMissingCapabilityTool && tool.name === missingCapabilityToolName) {
-      return tool
-    }
-    return addConversationIdToTool(tool, logger)
-  })
+  return tools.map((tool) => addConversationIdToTool(tool, logger))
 }
 
 export type ConversationIdResolution =
@@ -90,17 +88,12 @@ export type ConversationIdResolution =
 
 /**
  * Decides which conversation_id to use for a tool call:
- *   - disabled or get_more_tools → none
+ *   - disabled → none
  *   - agent supplied a value → use it
  *   - agent omitted → mint a UUID
  */
-export function resolveConversationId(
-  enabled: boolean,
-  args: unknown,
-  toolName: string | undefined,
-  missingCapabilityToolName: string = GET_MORE_TOOLS_NAME
-): ConversationIdResolution {
-  if (!enabled || toolName === missingCapabilityToolName) {
+export function resolveConversationId(enabled: boolean, args: unknown): ConversationIdResolution {
+  if (!enabled) {
     return { minted: false, conversationId: undefined }
   }
   const supplied = extractConversationId(args)
@@ -111,19 +104,19 @@ export function resolveConversationId(
 }
 
 /**
- * Predicate matching the same eligibility checks injectConversationIdPromptBack uses,
- * exposed so callers can pre-decide whether the prompt-back will actually land
- * (and clear event.conversationId if not, to avoid orphan ids in analytics).
+ * Whether the prompt-back can ride this result's `content`. The only requirement
+ * is an array to append to.
+ *
+ * Errored results included on purpose. A tool that fails on the first call of a
+ * conversation is exactly when the agent needs the session handle: without it the
+ * retry starts a fresh conversation, so the failure and its fix land in different
+ * sessions.
  */
 export function canInjectConversationIdPromptBack(result: unknown): boolean {
   if (!(result && typeof result === 'object')) {
     return false
   }
-  const resultObj = result as { content?: unknown; isError?: unknown }
-  if (resultObj.isError === true) {
-    return false
-  }
-  return Array.isArray(resultObj.content)
+  return Array.isArray((result as { content?: unknown }).content)
 }
 
 export function extractConversationId(args: unknown): string | undefined {

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -107,14 +107,7 @@ export async function captureToolCall(params: TraceToolCallParams): Promise<unkn
     parameterOwnership,
     resolvedEventType === MCPAnalyticsEventType.mcpMissingCapability
   )
-  const conversation = resolveConversationId(
-    ownership.conversationId,
-    request.params?.arguments,
-    request.params?.name,
-    resolvedEventType === MCPAnalyticsEventType.mcpMissingCapability
-      ? resolveMissingCapabilityToolName(data.options)
-      : ''
-  )
+  const conversation = resolveConversationId(ownership.conversationId, request.params?.arguments)
   const downstreamRequest = cloneRequestWithoutOwnedAnalyticsArguments(request, ownership)
 
   // Prepare the event in isolation: if identity/metadata/intent resolution
@@ -163,8 +156,7 @@ function getActiveAnalyticsParameterOwnership(
   const ownership = override ?? listed
   return {
     context: !isMissingCapabilityTool && isContextEnabled(data.options.context) && ownership?.context === true,
-    conversationId:
-      !isMissingCapabilityTool && data.options.enableConversationId === true && ownership?.conversationId === true,
+    conversationId: data.options.enableConversationId === true && ownership?.conversationId === true,
     // Deliberately read off `listed`, never the override. This asks whether
     // `tools/list` actually declared `_mcp_instructions`, and only the advertised
     // JSON Schema can answer it — an override is built from the live registry,
@@ -181,8 +173,7 @@ function getActiveAnalyticsParameterOwnership(
     // so guessing costs the caller their result, while not guessing costs us one
     // delivery channel. The fix is a process-scoped ownership cache, so a listing
     // served by any instance answers for the rest — not a per-call guess.
-    outputInstructions:
-      !isMissingCapabilityTool && data.options.enableConversationId === true && listed?.outputInstructions === true,
+    outputInstructions: data.options.enableConversationId === true && listed?.outputInstructions === true,
   }
 }
 
@@ -561,7 +552,6 @@ async function getTracedToolsList(
 
     if (data) {
       const missingToolName = resolveMissingCapabilityToolName(data.options)
-      let injectedMissingCapabilityTool = false
       if (data.options.reportMissing) {
         const alreadyPresent = tools.some((tool) => tool?.name === missingToolName)
         if (alreadyPresent) {
@@ -569,15 +559,16 @@ async function getTracedToolsList(
             `Warning: Cannot inject missing-capability tool "${missingToolName}" because a real tool already uses that name. The real tool will not be intercepted.`
           )
         } else {
-          tools.push(getReportMissingToolDescriptor(missingToolName))
-          injectedMissingCapabilityTool = true
+          const virtualTool = getReportMissingToolDescriptor(missingToolName)
+          tools.push(virtualTool)
+          // Cached separately because the virtual tool is added after the listing
+          // was cached, and its calls need ownership like any other tool's.
+          cacheToolAnalyticsParameterOwnership(data.toolAnalyticsParameterOwnership, [virtualTool])
         }
       }
 
       if (data.options.enableConversationId) {
-        tools = addConversationIdToTools(tools, missingToolName, injectedMissingCapabilityTool, data.logger)
-        // Declares the key a later change will write into `structuredContent`.
-        // Inert on its own — nothing populates it yet.
+        tools = addConversationIdToTools(tools, data.logger)
         tools = addInstructionsToOutputSchemas(tools, data.logger)
       }
     }


### PR DESCRIPTION
**PR 3 of 3** in the `_mcp_instructions` stack. Stacked on #4431. Two narrow cases where the session handle was withheld, both splitting one conversation across sessions.

Context: [MCP 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/changelog) removed protocol-level sessions, so correlation depends entirely on the agent receiving and echoing an explicit handle. Anywhere we withhold it, the conversation fragments.

## 1. Errored results

The prompt-back was suppressed when `isError` was true:

```ts
if (resultObj.isError === true) return false   // removed
```

A tool that fails on the *first* call is exactly when the agent needs the handle — without it the retry starts a fresh conversation, so the failure and its fix land in different sessions. The only requirement for the text block is an array to append to.

## 2. `get_more_tools`

The virtual `reportMissing` tool was excluded from injection, so `$mcp_missing_capability` carried no handle and fell back to the transport session:

```
$mcp_tool_call            session=ses_4ee7c718…   ← the work
$mcp_missing_capability   session=ses_019fd1ec…   ← the gap it hit, orphaned
```

A capability gap only means something next to the work that hit it. Now both share a session. Its bespoke `context` argument is untouched.

One supporting fix: the virtual tool is pushed *after* the listing is cached, so it had no ownership entry at all — its calls silently resolved no handle. Now cached alongside the push. `injectedMissingCapabilityTool` became dead once the skip flag went away and is removed.

## 3. The two options are now independent

`resolveConversationId` used to take the missing-capability tool name and return no handle for it, which made *stitching* behaviour depend on *which tool* was called. It is now `resolveConversationId(enabled, args)`.

| `enableConversationId` | `reportMissing` | handle on tools | `get_more_tools` exists |
|---|---|:--:|:--:|
| false | false | ✗ | ✗ |
| false | true | ✗ | ✓ |
| true | false | ✓ | ✗ |
| true | true | ✓ | ✓ |

`enableConversationId` owns session stitching; `reportMissing` owns whether the virtual tool exists. When both are on they compose — the virtual tool stitches like any other.

`isMissingCapabilityTool` survives in one place only, and it is not about sessions: it stops us stripping `get_more_tools`' own `context` argument, which has different semantics from the injected one.

## Tests

475 → **485**. Two behaviour tests, four asserting the off state (errored results, `get_more_tools`, capability-gap events, and an agent-supplied `conversation_id` being ignored), and a four-row independence matrix.

Verified they bite: removing the `enableConversationId` gate fails **5 of 485**.

Five existing tests asserted the old behaviour and were updated — they encode the decisions being reversed here, so the diff is the point rather than incidental churn.

## Release info Sub-libraries affected

- [x] @posthog/mcp

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility
- [x] Took care not to unnecessarily increase the bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Review follow-ups

- **The session assertion is labelled as a forward guard**, since on this branch alone both events share the in-memory session id whether or not the handle is wired — it only becomes load-bearing once #4428 lands.
- **Added a test that does bite here**: two different handles in one connection produce two different conversations. Anything falling back to the transport or in-memory session reports one id for both, so only the handle can separate them.
- The `products/mcp_analytics` note — sessions filter to `event = '$mcp_tool_call'`, so capability gaps still won't show alongside calls — is recorded as a backend follow-up.
