### PR TITLE
fix(replay): make attribute masking options mutually exclusive

### DIFF
--- a/.changeset/replay-attribute-masking-exclusive.md
+++ b/.changeset/replay-attribute-masking-exclusive.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+Make the session replay attribute masking options mutually exclusive: when both `maskAllElementAttributes` and `maskAttributeFn` are set, the coarse option wins and the callback is ignored (with a console warning), so a callback can no longer accidentally unmask what `maskAllElementAttributes` hides.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -4619,9 +4619,8 @@ describe('Lazy SessionRecording', () => {
             )
         })
 
-        it('passes client-side maskAllElementAttributes and maskAttributeFn to rrweb', () => {
+        it('passes client-side maskAttributeFn to rrweb', () => {
             const maskAttributeFn = (_name: string, value: string) => value
-            posthog.config.session_recording.maskAllElementAttributes = true
             posthog.config.session_recording.maskAttributeFn = maskAttributeFn
 
             sessionRecording.onRemoteConfig(
@@ -4636,10 +4635,96 @@ describe('Lazy SessionRecording', () => {
 
             expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    maskAllElementAttributes: true,
+                    maskAllElementAttributes: false,
                     maskAttributeFn,
                 })
             )
+        })
+
+        describe('attribute masking options are mutually exclusive', () => {
+            let logSpy: jest.SpyInstance
+            let warnSpy: jest.SpyInstance
+
+            beforeEach(() => {
+                // the logger only emits to the console when debug mode is enabled
+                assignableWindow.POSTHOG_DEBUG = true
+                logSpy = jest.spyOn(window!.console, 'log').mockImplementation(() => {})
+                warnSpy = jest.spyOn(window!.console, 'warn').mockImplementation(() => {})
+            })
+
+            afterEach(() => {
+                logSpy.mockRestore()
+                warnSpy.mockRestore()
+                assignableWindow.POSTHOG_DEBUG = undefined
+            })
+
+            // the logger prepends a prefix arg, so the human-readable message is the second call arg
+            const exclusivityWarnings = () =>
+                warnSpy.mock.calls.filter(
+                    (call) => typeof call[1] === 'string' && call[1].includes('mutually exclusive')
+                )
+
+            it('drops maskAttributeFn and warns when maskAllElementAttributes is also set', () => {
+                posthog.config.session_recording.maskAllElementAttributes = true
+                posthog.config.session_recording.maskAttributeFn = (_name: string, value: string) => value
+
+                sessionRecording.onRemoteConfig(
+                    makeFlagsResponse({
+                        sessionRecording: {
+                            endpoint: '/s/',
+                        },
+                    })
+                )
+
+                sessionRecording['_onScriptLoaded']()
+
+                expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        maskAllElementAttributes: true,
+                        maskAttributeFn: undefined,
+                    })
+                )
+                expect(exclusivityWarnings()).toHaveLength(1)
+            })
+
+            it('drops maskAttributeFn and warns when the project setting enables maskAllElementAttributes', () => {
+                posthog.config.session_recording.maskAttributeFn = (_name: string, value: string) => value
+
+                sessionRecording.onRemoteConfig(
+                    makeFlagsResponse({
+                        sessionRecording: {
+                            endpoint: '/s/',
+                            masking: { maskAllElementAttributes: true },
+                        },
+                    })
+                )
+
+                sessionRecording['_onScriptLoaded']()
+
+                expect(assignableWindow.__PosthogExtensions__.rrweb.record).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        maskAllElementAttributes: true,
+                        maskAttributeFn: undefined,
+                    })
+                )
+                expect(exclusivityWarnings()).toHaveLength(1)
+            })
+
+            it('does not warn when only one option is set', () => {
+                posthog.config.session_recording.maskAllElementAttributes = true
+
+                sessionRecording.onRemoteConfig(
+                    makeFlagsResponse({
+                        sessionRecording: {
+                            endpoint: '/s/',
+                        },
+                    })
+                )
+
+                sessionRecording['_onScriptLoaded']()
+
+                expect(exclusivityWarnings()).toHaveLength(0)
+            })
         })
 
         describe('warns when client-side masking shadows the project setting', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -512,6 +512,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     private _slowestFullSnapshot: SnapshotCost | undefined
     // only warn once per recorder instance that client-side masking is shadowing the project setting
     private _hasWarnedClientMaskingOverride = false
+    // only warn once per recorder instance that maskAttributeFn is ignored
+    private _hasWarnedExclusiveAttributeMasking = false
     private _maskRegionsFnFailed = false
 
     private _linkedFlagMatching: LinkedFlagMatching
@@ -2384,6 +2386,20 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             sessionRecordingOptions.maskTextSelector = this._masking.maskTextSelector ?? undefined
             sessionRecordingOptions.blockSelector = this._masking.blockSelector ?? undefined
             sessionRecordingOptions.maskAllElementAttributes = this._masking.maskAllElementAttributes ?? false
+        }
+
+        if (sessionRecordingOptions.maskAllElementAttributes && sessionRecordingOptions.maskAttributeFn) {
+            // mutually exclusive, and the coarse option fails closed so a callback
+            // cannot accidentally unmask what it hides
+            sessionRecordingOptions.maskAttributeFn = undefined
+            if (!this._hasWarnedExclusiveAttributeMasking) {
+                this._hasWarnedExclusiveAttributeMasking = true
+                logger.warn(
+                    '`maskAllElementAttributes` and `maskAttributeFn` are mutually exclusive, and `maskAttributeFn` is being ignored. ' +
+                        'Remove one of the two. Note that `maskAllElementAttributes` can also come from your project\'s "Privacy and masking" settings. ' +
+                        'See https://posthog.com/docs/session-replay/privacy'
+                )
+            }
         }
 
         this._warnIfClientMaskingShadowsServer()

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -301,6 +301,7 @@
         "_hasUnobservableSurfaces",
         "_hasUsableMessage",
         "_hasWarnedClientMaskingOverride",
+        "_hasWarnedExclusiveAttributeMasking",
         "_heldBufferOverflowed",
         "_heldEpochShipsOnUnload",
         "_holdFlushUntilInteraction",

--- a/packages/rrweb/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb/rrweb-snapshot/src/utils.ts
@@ -367,15 +367,16 @@ export function maskAttributeValue({
   if (!value) {
     return value;
   }
-  // A custom callback takes precedence so callers can choose a stable mask.
+  // The options are mutually exclusive and the coarse one fails closed: when
+  // both are set the callback is never consulted, so it cannot silently
+  // unmask values the coarse option would have hidden.
+  if (maskAllElementAttributes) {
+    return isGenerated && RENDERING_METADATA_ATTRIBUTES.has(toLowerCase(name))
+      ? value
+      : '*'.repeat(value.length);
+  }
   if (maskAttributeFn) {
     return maskAttributeFn(name, value, element);
-  }
-  if (
-    maskAllElementAttributes &&
-    !(isGenerated && RENDERING_METADATA_ATTRIBUTES.has(toLowerCase(name)))
-  ) {
-    return '*'.repeat(value.length);
   }
   return value;
 }

--- a/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
@@ -415,7 +415,7 @@ describe('attribute masking', () => {
     },
   );
 
-  it('maskAttributeFn takes precedence over maskAllElementAttributes', () => {
+  it('ignores maskAttributeFn when maskAllElementAttributes is set', () => {
     const maskAttributeFn = vi.fn((name: string, value: string) =>
       name === 'aria-label' ? 'REDACTED' : value,
     );
@@ -424,13 +424,11 @@ describe('attribute masking', () => {
       'div',
       { maskAllElementAttributes: true, maskAttributeFn },
     );
-    expect(sn.attributes['aria-label']).toBe('REDACTED');
-    expect(sn.attributes.title).toBe('visible');
-    expect(maskAttributeFn).toHaveBeenCalledWith(
-      'title',
-      'visible',
-      expect.any(Element),
-    );
+    // the options are mutually exclusive and the coarse one fails closed, so
+    // the callback cannot unmask what maskAllElementAttributes hides
+    expect(sn.attributes['aria-label']).toMatch(/^\*+$/);
+    expect(sn.attributes.title).toMatch(/^\*+$/);
+    expect(maskAttributeFn).not.toHaveBeenCalled();
   });
 
   it('passes SVG and namespaced attributes with an Element to the callback', () => {

--- a/packages/rrweb/rrweb/test/record/stylesheet-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/stylesheet-manager.test.ts
@@ -71,4 +71,16 @@ describe('StylesheetManager.inlineDeferredLinkElement()', () => {
       linkEl,
     );
   });
+
+  it('ignores maskAttributeFn when maskAllElementAttributes is set', () => {
+    const maskAttributeFn = vi.fn(() => '[CSS-MASKED]');
+
+    makeManager({
+      maskAllElementAttributes: true,
+      maskAttributeFn,
+    }).inlineDeferredLinkElement(linkEl, LINK_ID);
+
+    expect(emittedCssText()).toMatch(/^\*+$/);
+    expect(maskAttributeFn).not.toHaveBeenCalled();
+  });
 });

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -633,8 +633,8 @@ export interface SessionRecordingOptions {
      * Derived from `rrweb.record` options. Masks every string-valued source DOM attribute,
      * including rendering attributes such as `class`, `id`, `style`, `src`, `href`, and
      * synthesized form values. Only rrweb-generated layout metadata is retained, so this
-     * option intentionally reduces replay fidelity. `maskAttributeFn` takes precedence when
-     * both options are set.
+     * option intentionally reduces replay fidelity. Mutually exclusive with
+     * `maskAttributeFn`: when both are set this option wins and the callback is ignored.
      * @see https://github.com/rrweb-io/rrweb/blob/master/guide.md
      * @default false
      */
@@ -643,8 +643,9 @@ export interface SessionRecordingOptions {
     /**
      * Derived from `rrweb.record` options. Called with `(name, value, element)` for every
      * non-empty string-valued attribute in the final serialized representation so you can mask
-     * specific attributes. Returning the original value leaves it visible. This callback
-     * takes precedence over `maskAllElementAttributes` when both options are set.
+     * specific attributes. Returning the original value leaves it visible. Mutually exclusive
+     * with `maskAllElementAttributes`: when both are set that option wins and this callback
+     * is ignored, so a callback cannot accidentally unmask what the coarse option hides.
      * @see https://github.com/rrweb-io/rrweb/blob/master/guide.md
      */
     maskAttributeFn?: ((name: string, value: string, element?: Element) => string) | null


### PR DESCRIPTION
## Problem

#4376 added `maskAllElementAttributes` and `maskAttributeFn` with callback-takes-precedence semantics. That precedence is a footgun in the dangerous direction: a project enables `maskAllElementAttributes` (client config or the project "Privacy and masking" setting), someone later adds a `maskAttributeFn` for an unrelated tweak, and the coarse mask is silently disabled entirely, so attributes the project intended to hide ship raw into recordings.

Note on timing: #4376 shipped in 1.413.0 while this PR was in flight, so the callback-takes-precedence semantics are technically released (hours old). The change still fails closed: anyone setting both options gets more masking rather than less, plus a console warning pointing at the fix.

## Changes

- The options are now mutually exclusive, failing closed: in `maskAttributeValue` (the single choke point used by the full-snapshot loop, the mutation path, the inline-image callback, and deferred stylesheet inlining), `maskAllElementAttributes` wins and the callback is never consulted when both are set.
- posthog-js drops `maskAttributeFn` and logs a one-time warning when both are configured, including when `maskAllElementAttributes` comes from the project masking settings rather than client config.
- Updated the `SessionRecordingOptions` docs for both fields and flipped the precedence regression tests to exclusivity tests (callback not called, values masked).

No API surface changes: same two options, so this is backwards compatible with everything released. "Mask everything except X" remains expressible with `maskAttributeFn` alone.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

