### PR TITLE
fix(replay): adopt stylesheets that arrive before the shadow root is attached

### DIFF
--- a/.changeset/replay-adopted-stylesheet-shadow-root-race.md
+++ b/.changeset/replay-adopted-stylesheet-shadow-root-race.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): stop dropping adopted stylesheets that arrive before the host's shadow root is attached. When the recorder's full snapshot races a web component's hydration, the AdoptedStyleSheet event can be recorded before the mutation that attaches the host's shadow root. The replayer silently dropped those styles for the rest of the page view, so components styled via `shadowRoot.adoptedStyleSheets` (Stencil, Lit) rendered completely unstyled. The replayer now constructs the stylesheet even when the shadow root does not exist yet and keeps retrying adoption until it is attached.

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -157,6 +157,10 @@ export class Replayer {
   // was attached, keyed by node id; adopted when the shadow root appears.
   private pendingAdoptedStyleSheets: Map<number, number[]> = new Map();
 
+  // Latest adoption per host, keyed by node id; a wall-clock retry armed by
+  // an older AdoptedStyleSheet event must not overwrite a newer one.
+  private adoptedStyleSheetTokens: Map<number, object> = new Map();
+
   // Used to track video & audio elements, and keep them in sync with general playback.
   private mediaManager: MediaManager;
 
@@ -380,6 +384,7 @@ export class Replayer {
       this.mirror.reset();
       this.styleMirror.reset();
       this.pendingAdoptedStyleSheets.clear();
+      this.adoptedStyleSheetTokens.clear();
       this.mediaManager.reset();
       this.lastScrollMap.clear();
     };
@@ -669,6 +674,7 @@ export class Replayer {
     this.mirror.reset();
     this.styleMirror.reset();
     this.pendingAdoptedStyleSheets.clear();
+    this.adoptedStyleSheetTokens.clear();
     this.mediaManager.reset();
     this.resetCache();
 
@@ -932,6 +938,7 @@ export class Replayer {
           this.mediaManager.reset();
           this.styleMirror.reset();
           this.pendingAdoptedStyleSheets.clear();
+          this.adoptedStyleSheetTokens.clear();
           this.rebuildFullSnapshot(event, isSync);
           // 'instant' so the offset is not animated when the page sets scroll-behavior: smooth
           this.iframe.contentWindow?.scrollTo({
@@ -2326,6 +2333,9 @@ export class Replayer {
   private applyAdoptedStyleSheet(data: adoptedStyleSheetData) {
     const targetHost = this.mirror.getNode(data.id);
     if (!targetHost) return;
+    // supersede retries still pending from an older event for this host
+    const token = {};
+    this.adoptedStyleSheetTokens.set(data.id, token);
     // Create StyleSheet objects which will be adopted after.
     data.styles?.forEach((style) => {
       let newStyleSheet: CSSStyleSheet | null = null;
@@ -2361,6 +2371,8 @@ export class Replayer {
     const MAX_RETRY_TIME = 10;
     let count = 0;
     const adoptStyleSheets = (targetHost: Node, styleIds: number[]) => {
+      // a newer AdoptedStyleSheet event for this host supersedes this one
+      if (this.adoptedStyleSheetTokens.get(data.id) !== token) return;
       const stylesToAdopt = styleIds
         .map((styleId) => this.styleMirror.getStyle(styleId))
         .filter((style) => style !== null) as CSSStyleSheet[];

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -153,6 +153,10 @@ export class Replayer {
   // Used to track StyleSheetObjects adopted on multiple document hosts.
   private styleMirror: StyleSheetMirror = new StyleSheetMirror();
 
+  // Hosts whose AdoptedStyleSheet event was applied before their shadow root
+  // was attached, keyed by node id; adopted when the shadow root appears.
+  private pendingAdoptedStyleSheets: Map<number, number[]> = new Map();
+
   // Used to track video & audio elements, and keep them in sync with general playback.
   private mediaManager: MediaManager;
 
@@ -320,6 +324,16 @@ export class Replayer {
           this.applyAdoptedStyleSheet(data);
         });
         this.adoptedStyleSheets = [];
+
+        // the virtual dom diff attaches shadow roots without going through
+        // applyMutation, so finish any adoptions that were pending
+        this.pendingAdoptedStyleSheets.forEach((styleIds, id) => {
+          this.applyAdoptedStyleSheet({
+            source: IncrementalSource.AdoptedStyleSheet,
+            id,
+            styleIds,
+          });
+        });
       }
 
       if (this.mousePos) {
@@ -365,6 +379,7 @@ export class Replayer {
       this.firstFullSnapshot = null;
       this.mirror.reset();
       this.styleMirror.reset();
+      this.pendingAdoptedStyleSheets.clear();
       this.mediaManager.reset();
       this.lastScrollMap.clear();
     };
@@ -653,6 +668,7 @@ export class Replayer {
     // Reset caches and mirrors
     this.mirror.reset();
     this.styleMirror.reset();
+    this.pendingAdoptedStyleSheets.clear();
     this.mediaManager.reset();
     this.resetCache();
 
@@ -915,6 +931,7 @@ export class Replayer {
           }
           this.mediaManager.reset();
           this.styleMirror.reset();
+          this.pendingAdoptedStyleSheets.clear();
           this.rebuildFullSnapshot(event, isSync);
           // 'instant' so the offset is not animated when the page sets scroll-behavior: smooth
           this.iframe.contentWindow?.scrollTo({
@@ -1738,6 +1755,17 @@ export class Replayer {
           (parent as Element | RRElement).attachShadow({ mode: 'open' });
           parent = (parent as Element | RRElement).shadowRoot! as Node | RRNode;
         } else parent = parent.shadowRoot as Node | RRNode;
+        // adopt stylesheets whose event arrived before this shadow root existed
+        const pendingStyleIds = this.pendingAdoptedStyleSheets.get(
+          mutation.parentId,
+        );
+        if (pendingStyleIds && !this.usingVirtualDom) {
+          this.applyAdoptedStyleSheet({
+            source: IncrementalSource.AdoptedStyleSheet,
+            id: mutation.parentId,
+            styleIds: pendingStyleIds,
+          });
+        }
       }
 
       let previous: Node | RRNode | null = null;
@@ -2346,6 +2374,11 @@ export class Replayer {
         (targetHost as Document).adoptedStyleSheets = stylesToAdopt;
         adopted = true;
       }
+      // remember hosts that can't adopt yet so applyMutation can finish the
+      // adoption when it attaches the shadow root, independent of the
+      // wall-clock retries below (which pause/buffering can outlast)
+      if (adopted) this.pendingAdoptedStyleSheets.delete(data.id);
+      else this.pendingAdoptedStyleSheets.set(data.id, styleIds);
 
       /**
        * In the live mode where events are transferred over network without strict order guarantee, some newer events are applied before some old events and adopted stylesheets may haven't been created.

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -2306,10 +2306,12 @@ export class Replayer {
        * The replayer has to get the correct host window to recreate a StyleSheetObject.
        */
       let hostWindow: IWindow | null = null;
-      if (hasShadowRoot(targetHost))
-        hostWindow = targetHost.ownerDocument?.defaultView || null;
-      else if (targetHost.nodeName === '#document')
+      if (targetHost.nodeName === '#document')
         hostWindow = (targetHost as Document).defaultView;
+      else
+        // don't require the host's shadow root to exist yet: the mutation
+        // attaching it may arrive after this event, and rules are only sent once
+        hostWindow = targetHost.ownerDocument?.defaultView || null;
 
       if (!hostWindow) return;
       try {
@@ -2334,18 +2336,26 @@ export class Replayer {
       const stylesToAdopt = styleIds
         .map((styleId) => this.styleMirror.getStyle(styleId))
         .filter((style) => style !== null) as CSSStyleSheet[];
-      if (hasShadowRoot(targetHost))
+      let adopted = false;
+      if (hasShadowRoot(targetHost)) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         (targetHost as HTMLElement).shadowRoot!.adoptedStyleSheets =
           stylesToAdopt;
-      else if (targetHost.nodeName === '#document')
+        adopted = true;
+      } else if (targetHost.nodeName === '#document') {
         (targetHost as Document).adoptedStyleSheets = stylesToAdopt;
+        adopted = true;
+      }
 
       /**
        * In the live mode where events are transferred over network without strict order guarantee, some newer events are applied before some old events and adopted stylesheets may haven't been created.
-       * This retry mechanism can help resolve this situation.
+       * The same applies to recorded streams when this event was emitted before the mutation that attaches the host's shadow root.
+       * This retry mechanism can help resolve these situations.
        */
-      if (stylesToAdopt.length !== styleIds.length && count < MAX_RETRY_TIME) {
+      if (
+        (!adopted || stylesToAdopt.length !== styleIds.length) &&
+        count < MAX_RETRY_TIME
+      ) {
         setTimeout(
           () => adoptStyleSheets(targetHost, styleIds),
           0 + 100 * count,

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -2401,7 +2401,8 @@ export class Replayer {
         (!adopted || stylesToAdopt.length !== styleIds.length) &&
         count < MAX_RETRY_TIME
       ) {
-        setTimeout(
+        // tracked so destroy() cancels retries still pending on teardown
+        this.addTimeout(
           () => adoptStyleSheets(targetHost, styleIds),
           0 + 100 * count,
         );

--- a/packages/rrweb/rrweb/test/events/adopted-style-sheet-before-shadow-root.ts
+++ b/packages/rrweb/rrweb/test/events/adopted-style-sheet-before-shadow-root.ts
@@ -54,7 +54,7 @@ const events: eventWithTime[] = [
                 childNodes: [
                   {
                     type: 2,
-                    tagName: 'shared-header',
+                    tagName: 'late-shadow-host',
                     attributes: {},
                     childNodes: [],
                     id: 6,
@@ -130,7 +130,7 @@ const events: eventWithTime[] = [
           nextId: null,
           node: {
             type: 3,
-            textContent: 'Products',
+            textContent: 'menu item',
             id: 9,
           },
         },

--- a/packages/rrweb/rrweb/test/events/adopted-style-sheet-before-shadow-root.ts
+++ b/packages/rrweb/rrweb/test/events/adopted-style-sheet-before-shadow-root.ts
@@ -1,0 +1,143 @@
+import { EventType, IncrementalSource } from '@posthog/rrweb-types';
+import type { eventWithTime } from '@posthog/rrweb-types';
+
+const now = Date.now();
+
+/**
+ * A web component host serialized into the full snapshot BEFORE its shadow
+ * root was attached (no isShadowHost, no shadow children). The
+ * AdoptedStyleSheet event for the host arrives before the mutation that
+ * attaches the shadow root, which happens when the recorder's full snapshot
+ * races the component's hydration (e.g. Stencil/Lit components styled via
+ * shadowRoot.adoptedStyleSheets).
+ */
+const events: eventWithTime[] = [
+  { type: EventType.DomContentLoaded, data: {}, timestamp: now },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'about:blank',
+      width: 1920,
+      height: 1080,
+    },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0,
+        childNodes: [
+          {
+            type: 1,
+            name: 'html',
+            publicId: '',
+            systemId: '',
+            id: 2,
+          },
+          {
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+                id: 4,
+              },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  {
+                    type: 2,
+                    tagName: 'shared-header',
+                    attributes: {},
+                    childNodes: [],
+                    id: 6,
+                  },
+                ],
+                id: 5,
+              },
+            ],
+            id: 3,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: {
+        left: 0,
+        top: 0,
+      },
+    },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.AdoptedStyleSheet,
+      id: 6,
+      styleIds: [1],
+      styles: [
+        {
+          rules: [
+            { rule: ':host { display: block; }' },
+            { rule: 'nav { display: flex; }' },
+            { rule: 'a { color: rgb(255, 0, 0); }' },
+          ],
+          styleId: 1,
+        },
+      ],
+    },
+    timestamp: now + 110,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [],
+      removes: [],
+      adds: [
+        {
+          parentId: 6,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'nav',
+            attributes: {},
+            childNodes: [],
+            id: 7,
+            isShadow: true,
+          },
+        },
+        {
+          parentId: 7,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'a',
+            attributes: { href: '#' },
+            childNodes: [],
+            id: 8,
+          },
+        },
+        {
+          parentId: 8,
+          nextId: null,
+          node: {
+            type: 3,
+            textContent: 'Products',
+            id: 9,
+          },
+        },
+      ],
+    },
+    timestamp: now + 120,
+  },
+];
+
+export default events;

--- a/packages/rrweb/rrweb/test/events/adopted-style-sheet-stale-retry.ts
+++ b/packages/rrweb/rrweb/test/events/adopted-style-sheet-stale-retry.ts
@@ -1,0 +1,161 @@
+import { EventType, IncrementalSource } from '@posthog/rrweb-types';
+import type { eventWithTime } from '@posthog/rrweb-types';
+
+const now = Date.now();
+
+/**
+ * Same shadow-root race as adopted-style-sheet-before-shadow-root, followed by
+ * a second AdoptedStyleSheet event for the same host after the shadow root is
+ * attached. The first event's wall-clock retries (armed at ~110ms, backoff
+ * fires at ~110/210/410/710/1110/1610ms) are still alive when the second event
+ * applies at 1450ms, so the ~1610ms retry would overwrite the newer stylesheet
+ * list with the stale one.
+ */
+const events: eventWithTime[] = [
+  { type: EventType.DomContentLoaded, data: {}, timestamp: now },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'about:blank',
+      width: 1920,
+      height: 1080,
+    },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0,
+        childNodes: [
+          {
+            type: 1,
+            name: 'html',
+            publicId: '',
+            systemId: '',
+            id: 2,
+          },
+          {
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+                id: 4,
+              },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  {
+                    type: 2,
+                    tagName: 'late-shadow-host',
+                    attributes: {},
+                    childNodes: [],
+                    id: 6,
+                  },
+                ],
+                id: 5,
+              },
+            ],
+            id: 3,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: {
+        left: 0,
+        top: 0,
+      },
+    },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.AdoptedStyleSheet,
+      id: 6,
+      styleIds: [1],
+      styles: [
+        {
+          rules: [
+            { rule: ':host { display: block; }' },
+            { rule: 'nav { display: flex; }' },
+            { rule: 'a { color: rgb(255, 0, 0); }' },
+          ],
+          styleId: 1,
+        },
+      ],
+    },
+    timestamp: now + 110,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [],
+      removes: [],
+      adds: [
+        {
+          parentId: 6,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'nav',
+            attributes: {},
+            childNodes: [],
+            id: 7,
+            isShadow: true,
+          },
+        },
+        {
+          parentId: 7,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'a',
+            attributes: { href: '#' },
+            childNodes: [],
+            id: 8,
+          },
+        },
+        {
+          parentId: 8,
+          nextId: null,
+          node: {
+            type: 3,
+            textContent: 'menu item',
+            id: 9,
+          },
+        },
+      ],
+    },
+    timestamp: now + 1250,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.AdoptedStyleSheet,
+      id: 6,
+      styleIds: [2],
+      styles: [
+        {
+          rules: [
+            { rule: ':host { display: block; }' },
+            { rule: 'a { color: rgb(0, 0, 255); }' },
+          ],
+          styleId: 2,
+        },
+      ],
+    },
+    timestamp: now + 1450,
+  },
+];
+
+export default events;

--- a/packages/rrweb/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/rrweb/test/replayer.test.ts
@@ -1070,6 +1070,30 @@ describe('replayer', function () {
     expect(state.anchorColor).toBe('rgb(255, 0, 0)');
   });
 
+  it('adopts stylesheets when playback pauses past the retry window before the shadow root attaches', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(adoptedStyleSheetBeforeShadowRoot)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events,{showDebug:true});
+      replayer.pause(115);
+    `);
+    // sit between the AdoptedStyleSheet event (offset 110) and the
+    // shadow-attaching mutation (offset 120) until the wall-clock retry
+    // budget (~4.5s) is exhausted
+    await page.waitForTimeout(5000);
+    await page.evaluate('replayer.play(115);');
+    await page.waitForTimeout(500);
+
+    const adoptedSheetCount = await page.evaluate(() => {
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      const host = iframe.contentDocument!.querySelector(
+        'late-shadow-host',
+      ) as HTMLElement;
+      return host.shadowRoot!.adoptedStyleSheets.length;
+    });
+    expect(adoptedSheetCount).toBe(1);
+  });
+
   it('can replay modification events for adoptedStyleSheet', async () => {
     await page.evaluate(`
     events = ${JSON.stringify(adoptedStyleSheetModification)};

--- a/packages/rrweb/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/rrweb/test/replayer.test.ts
@@ -1054,7 +1054,7 @@ describe('replayer', function () {
     const state = await page.evaluate(() => {
       const iframe = document.querySelector('iframe') as HTMLIFrameElement;
       const host = iframe.contentDocument!.querySelector(
-        'shared-header',
+        'late-shadow-host',
       ) as HTMLElement;
       const anchor = host.shadowRoot!.querySelector('a')!;
       return {

--- a/packages/rrweb/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/rrweb/test/replayer.test.ts
@@ -29,6 +29,7 @@ import StyleSheetTextMutation from './events/style-sheet-text-mutation';
 import canvasInIframe from './events/canvas-in-iframe';
 import adoptedStyleSheet from './events/adopted-style-sheet';
 import adoptedStyleSheetBeforeShadowRoot from './events/adopted-style-sheet-before-shadow-root';
+import adoptedStyleSheetStaleRetry from './events/adopted-style-sheet-stale-retry';
 import adoptedStyleSheetModification from './events/adopted-style-sheet-modification';
 import documentReplacementEvents from './events/document-replacement';
 import hoverInIframeShadowDom from './events/iframe-shadowdom-hover';
@@ -1092,6 +1093,36 @@ describe('replayer', function () {
       return host.shadowRoot!.adoptedStyleSheets.length;
     });
     expect(adoptedSheetCount).toBe(1);
+  });
+
+  it('does not let a stale adoption retry overwrite a newer stylesheet list', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(adoptedStyleSheetStaleRetry)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events,{showDebug:true});
+      replayer.play();
+    `);
+    // wait past the first event's last surviving retry (~1610ms), which
+    // without the token guard re-adopts the stale stylesheet list
+    await page.waitForTimeout(2500);
+
+    const state = await page.evaluate(() => {
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      const host = iframe.contentDocument!.querySelector(
+        'late-shadow-host',
+      ) as HTMLElement;
+      const anchor = host.shadowRoot!.querySelector('a')!;
+      return {
+        ruleCounts: host.shadowRoot!.adoptedStyleSheets.map(
+          (s) => s.cssRules.length,
+        ),
+        anchorColor: iframe.contentWindow!.getComputedStyle(anchor).color,
+      };
+    });
+    // the second AdoptedStyleSheet event (2 rules, blue anchor) must win over
+    // the first (3 rules, red anchor)
+    expect(state.ruleCounts).toEqual([2]);
+    expect(state.anchorColor).toBe('rgb(0, 0, 255)');
   });
 
   it('can replay modification events for adoptedStyleSheet', async () => {

--- a/packages/rrweb/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/rrweb/test/replayer.test.ts
@@ -28,6 +28,7 @@ import badStyleEvents from './events/bad-style';
 import StyleSheetTextMutation from './events/style-sheet-text-mutation';
 import canvasInIframe from './events/canvas-in-iframe';
 import adoptedStyleSheet from './events/adopted-style-sheet';
+import adoptedStyleSheetBeforeShadowRoot from './events/adopted-style-sheet-before-shadow-root';
 import adoptedStyleSheetModification from './events/adopted-style-sheet-modification';
 import documentReplacementEvents from './events/document-replacement';
 import hoverInIframeShadowDom from './events/iframe-shadowdom-hover';
@@ -1037,6 +1038,36 @@ describe('replayer', function () {
     await waitForRAF(page);
     await page.evaluate('replayer.pause(600);');
     await checkCorrectness();
+  });
+
+  it('can replay adopted stylesheet events that arrive before the shadow root is attached', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(adoptedStyleSheetBeforeShadowRoot)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events,{showDebug:true});
+      replayer.play();
+    `);
+    // the retry loop in applyAdoptedStyleSheet needs a few real timer ticks
+    // after the shadow-attaching mutation (at 20ms) has been applied
+    await page.waitForTimeout(1000);
+
+    const state = await page.evaluate(() => {
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      const host = iframe.contentDocument!.querySelector(
+        'shared-header',
+      ) as HTMLElement;
+      const anchor = host.shadowRoot!.querySelector('a')!;
+      return {
+        adoptedSheetCount: host.shadowRoot!.adoptedStyleSheets.length,
+        ruleCounts: host.shadowRoot!.adoptedStyleSheets.map(
+          (s) => s.cssRules.length,
+        ),
+        anchorColor: iframe.contentWindow!.getComputedStyle(anchor).color,
+      };
+    });
+    expect(state.adoptedSheetCount).toBe(1);
+    expect(state.ruleCounts).toEqual([3]);
+    expect(state.anchorColor).toBe('rgb(255, 0, 0)');
   });
 
   it('can replay modification events for adoptedStyleSheet', async () => {


### PR DESCRIPTION
## Problem

Reported through a customer support ticket: a Stencil web component styled exclusively via `shadowRoot.adoptedStyleSheets` renders completely unstyled ("mobile mode") in session replay, while users saw the correctly styled component.

The recording is fine: the `AdoptedStyleSheet` event is captured with all rules. The replayer drops it. When a full snapshot races the component's hydration, the host element is serialized before `attachShadow` runs, and the recorder emits the `AdoptedStyleSheet` event (via its intentional `setTimeout(0)` deferral) before the mutation that attaches the shadow children. On replay, `applyAdoptedStyleSheet` then:

1. skips constructing the `CSSStyleSheet` entirely, because `hostWindow` is only derived when the host already has a shadow root, and
2. never recovers, because the retry loop only retries adoption (a `styleMirror` lookup), never construction, and the recorder sends rules only once per `styleId`.

Result: shadow root present, `adoptedStyleSheets.length === 0`, all failures silent. This affects any site styling shadow DOM components with constructed stylesheets (Stencil, Lit). Upstream rrweb has the same bug.

## Changes

Three changes in `packages/rrweb/rrweb/src/replay/index.ts`:

- Derive the host window from `ownerDocument` for element hosts, so the stylesheet is constructed and registered in `styleMirror` even when the shadow root is not attached yet.
- Extend the retry condition so it also retries while adoption was impossible (element host without a shadow root), instead of only when sheets were missing from the mirror. The existing 10-retry backoff is unchanged.
- Track adoptions that could not happen yet in a `pendingAdoptedStyleSheets` map and complete them deterministically at the moment the shadow root is attached (in `applyMutation`, or after the virtual dom flush). This covers what the wall-clock retries cannot: a paused, buffering, or background-throttled player outlasting the ~4.5s retry budget, or the shadow-attaching mutation simply arriving later than that in replay time (raised by Greptile, and it fails in a real browser). The map is cleared wherever `styleMirror` is reset.

Two regression tests replay the exact stream shape from the affected recording (full snapshot with a non-shadow-host element, `AdoptedStyleSheet` at +10ms, shadow-attaching mutation at +20ms): one plays straight through, one pauses between the two events until the retry budget is exhausted and then resumes. Both fail without their respective fix (`adoptedStyleSheets.length` is 0) and pass with it; the existing adopted-stylesheet tests (which only exercise the mutation-first ordering, why this was never caught) still pass, as do `replayer.test.ts` and `fast-forward.test.ts` in full (62 tests).

Backwards compatible: no API changes; for streams where the shadow root exists when the event applies (every case that worked before), behavior is identical.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file (authored manually: `.changeset/replay-adopted-stylesheet-shadow-root-race.md`, versions only `posthog-js` per rrweb convention)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Root cause investigated and fixed with PostHog Code (Claude) starting from a customer support ticket. The mechanism was confirmed before fixing: a puppeteer repro of the recorded event ordering showed `adoptedStyleSheets.length === 0` with the UA default link color, while the identical stream with the two incremental events swapped adopted all rules, proving pure order sensitivity.
- Alternatives ruled out during investigation: sandboxed-iframe `CSSStyleSheet` construction failure, `styleMirror.reset` on rebuild, node id remapping across snapshots, CSS parse errors, virtual-dom queue loss (the PostHog player runs `useVirtualDom: false`), and a real media-query match.
- Considered also fixing the partial-adoption assignment (an incomplete retry overwrites previously adopted sheets) but left it: it is upstream behavior, semantically "set the full list", and not needed for this bug.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
