### PR TITLE
chore(ci): add replay incident risk registry and advisory PR check

### DIFF
--- a/.agents/skills/replay-incident-risk/INCIDENTS.md
+++ b/.agents/skills/replay-incident-risk/INCIDENTS.md
@@ -1,0 +1,112 @@
+# Replay and SDK incident pattern registry
+
+A catalog of past incidents caused by changes to posthog-js and the rrweb fork, organized by the code-level pattern that caused them. Used by the `replay-incident-risk` skill and the `Replay incident risk` CI check to flag diffs that resemble a past incident.
+
+Each entry describes the mechanism, not the blast radius. Internal impact numbers, customer names, and postmortem contents are deliberately omitted; PostHog employees can find the detail through the linked incident channels and the internal post-mortems repo.
+
+---
+
+## Class 1: Version skew across the lazy-load boundary
+
+**The single most repeated cause.** The recorder, surveys, web-vitals, and tracing-headers extensions are lazy-loaded from the CDN. With `strict_script_versioning: false` (the default for most teams), the `?v=` query param is only a cache-buster: the CDN serves the **latest published bundle to every SDK version, including npm-pinned ones** (`external-scripts-loader.ts`). Publishing an extension change is a fleet-wide deploy with no rollout control.
+
+The canonical failure: new extension code assumes something only newer cores provide (a function, a config field, a persisted value), or changes a cross-boundary function signature. Old cores load the new bundle and break.
+
+Known incidents in this class:
+
+- **Recorder rejected persisted config from old cores (Mar 2026, INC-749).** The new recorder added a staleness check on persisted remote config keyed on a `cache_timestamp` field old cores never wrote. `timestamp ?? 0` made every saved config infinitely stale, so the recorder deleted it and never started. Only reproduced when the recorder started from persisted config before the live config fetch returned, a race that instant-mock CI never hit. Millions of recordings were lost over a weekend, unrecoverably. Reverted in [#3213](https://github.com/PostHog/posthog-js/pull/3213) (v1.360.0); introduced by [#3191](https://github.com/PostHog/posthog-js/pull/3191).
+- **Surveys stopped rendering for all older cores (Jul 2025).** A change added a second argument to `generateSurveys()`; old cores loading the new unversioned `surveys.js` passed `undefined`, treated as `false`. Fixed in [#2074](https://github.com/PostHog/posthog-js/pull/2074) by treating `undefined` as the old behavior.
+- **Surveys code called a function old cores don't install (Oct 2025).** Produced identical exceptions captured at very high volume in customer apps, inflating their error-tracking usage. Reverted, patched in v1.270.1 ([#2355](https://github.com/PostHog/posthog-js/pull/2355) was the trigger). Public postmortem: [post-mortems repo](https://github.com/PostHog/post-mortems).
+- **Web vitals capture broke for six days (Jan 2026, INC-695).** A non-backward-compatible release broke `$web_vitals` capture fleet-wide; no per-event-type volume alerting existed, so it ran for six days. Fixed in [#2973](https://github.com/PostHog/posthog-js/pull/2973).
+
+**Review questions for any diff touching `entrypoints/` bundles or `extensions/`:**
+
+1. Does this change a function signature, argument list, or return shape that is called across the core/extension boundary?
+2. Does new extension code call anything that might not exist in a core released a year ago?
+3. Does new code read persisted state (localStorage, cookies, persistence keys) that old cores wrote in a different shape? Absent fields must be treated as neutral, never as fatal or stale.
+4. Does the compat test suite (old core + new lazy bundles, added in [#3003](https://github.com/PostHog/posthog-js/pull/3003)) cover this path, including a cold start from persisted config with a slow remote-config response?
+
+## Class 2: Session rotation, idle handling, and flush semantics
+
+Changing when sessions rotate, how idle state is tracked, or when buffers flush directly changes **how many recordings ship**, and every shipped recording bills. There is a long history of session-rotation changes being painful in exactly this way.
+
+- **Idle-tab over-recording (Jul-Aug 2026, INC-975).** [#4224](https://github.com/PostHog/posthog-js/pull/4224) flipped the "unknown" idle state to "not idle" to fix a playability bug. Side effect: every activity-timeout rotation in a parked background tab shipped a billed Meta+FullSnapshot recording, an unbounded chain per idle tab. Fleet-wide zero-interaction recordings surged for 11 days before a customer bill complaint surfaced it. It also produced multi-day-long recordings from idle buffers flushed late. Fixed by [#4407](https://github.com/PostHog/posthog-js/pull/4407) (hold rotation-born sessions in a buffer until real user interaction, cap recording age), plus [#4410](https://github.com/PostHog/posthog-js/pull/4410) and [#4412](https://github.com/PostHog/posthog-js/pull/4412).
+
+**Review questions:**
+
+1. Walk through an idle background tab over 24+ hours: how many recordings does this change cause to ship? Each rotation that ships a snapshot is a billed recording.
+2. Do URL triggers (which match `window.location.href` without any user interaction) or `recordCrossOriginIframes` amplify the change?
+3. What is the oldest event a flushed buffer can contain after this change?
+4. If recording volume moves fleet-wide, the week-over-week recordings anomaly alert should catch it within a day. Watch it after release.
+
+## Class 3: Network primitive wrappers (fetch and XHR patching)
+
+The highest-severity class: bugs here **break the customer's own site**, not just telemetry, and spread instantly to all SDK versions via the unversioned recorder bundle. Three separate incidents have come from the fetch wrappers. Standing policy from those incidents: no AI-generated PRs in the wrappers, and every change lands with a failing real-browser test first.
+
+- **FormData bodies broken (Jan 2026).** A fetch-wrapper "improvement" broke processing of `FormData` request bodies; customer sites failed to submit POST requests (checkouts, file uploads, logins) until the change was rolled back. Most customers were unaffected, which made it slow to detect; it was found through customer reports, not monitoring. Public postmortem: [replay SDK fetch wrapper incident](https://github.com/PostHog/post-mortems/blob/main/2026-01-17-replay-sdk-fetch-wrapper-incident.md). Follow-up compat tests: [#2935](https://github.com/PostHog/posthog-js/pull/2935).
+- **Safari string-body POSTs threw NotSupportedError (May 2026).** Both wrappers rebuilt `fetch(url, init)` as `new Request(url, init)`. Per the Fetch spec a string body becomes a `ReadableStream`; when a downstream fetch wrapper forwarded `request.body`, Safari (which doesn't support ReadableStream upload) threw on every POST with a string body. Fixed in [#3706](https://github.com/PostHog/posthog-js/pull/3706) (v1.378.1) with a WebKit Playwright regression test simulating an inner wrapper. Related hardening in [#3711](https://github.com/PostHog/posthog-js/pull/3711): spreading a `RequestInit` drops non-enumerable and accessor-backed fields (`body`, `signal`, `duplex`), because it is a WebIDL dictionary, not a plain object.
+- An earlier fetch-wrapper regression predates both of these.
+
+**Review questions:**
+
+1. Does the change preserve every body type: string, `FormData`, `Blob`, `ArrayBuffer`, `URLSearchParams`, `ReadableStream`?
+2. Is there a real-browser (including WebKit) test that exercises the change with **another fetch wrapper on the page** forwarding the Request? Many customer sites wrap fetch too.
+3. Never rebuild the caller's arguments into a `Request` you then hand downstream unless the caller passed a `Request`.
+4. Never spread `RequestInit` or `Request` into a plain object.
+
+## Class 4: rrweb serialization and snapshot correctness
+
+Serializer bugs corrupt replay **silently**: no exception, no volume change, just wrong or missing content discovered later by whoever watches the recording.
+
+- **CSS custom-properties emptied layout styles (May 2026).** Per the CSS spec, a shorthand set to `var()` with one longhand overridden by another `var()` stores the shorthand's longhands as empty token lists. rrweb serialized styles via `cssText`, emitting empty declarations (`padding-top: ;`), so layout silently vanished for sites using Chakra v3 / Panda CSS patterns. Fixed in [#3542](https://github.com/PostHog/posthog-js/pull/3542) (v1.372.10), tracked upstream as [rrweb#1667](https://github.com/rrweb-io/rrweb/issues/1667). Known remaining gap: stylesheets built via `insertRule()` before the first full snapshot (Emotion "speedy" mode).
+
+**Review questions:**
+
+1. If this touches style serialization (`cssText`, `adoptedStyleSheets`, stylesheet mirroring), test against framework-generated CSS: Chakra/Panda, Emotion (speedy mode), Tailwind, CSS custom properties, shorthand/longhand mixes.
+2. Failures here have no error signal. What would make this bug visible if it shipped? Add a real-browser snapshot assertion, not a unit test on mocked DOM.
+
+## Class 5: Replay reconstruction and player security
+
+Recorded page content is **untrusted input**. rrweb's replay sandbox (script-disabled iframe) protects rebuilt page DOM, but anything the replayer or plugins place in the top-level document sits outside it and must be sanitized independently.
+
+- **Canvas replay copied `onerror` onto a live img (Jul 2026).** The canvas plugin reconstructed recorded canvases as `<img>` elements in the top-level replay document and copied every recorded attribute across, including inline event handlers. A crafted `onerror` attribute plus a failing image source meant stored XSS in the viewer's dashboard session. Fixed in [posthog#68918](https://github.com/PostHog/posthog/pull/68918) by skipping `on*`, `src`, and `srcset`. Related guard: a test forbids rrweb's `UNSAFE_replayCanvas` option, which would add `allow-scripts` to the sandbox iframe.
+
+**Review questions:**
+
+1. Does replay-side code copy recorded attributes, HTML, or URLs into the live document? Allowlist what you copy; never copy `on*` handlers, `src`/`srcset`/`href` you don't construct yourself, or `style` containing `url()` you haven't checked.
+2. Does anything weaken the iframe sandbox (`allow-scripts`, `UNSAFE_replayCanvas`)?
+
+## Class 6: Recording start conditions and remote config semantics
+
+Changes to when recording is allowed to start (trigger evaluation, authorized domains, sampling, remote config fetch) fail silently in the suppress direction: recordings just stop, and nobody gets an error.
+
+- **New /flags endpoint disagreed with /decide on authorized domains (Jun 2025, INC-422).** A behavioral mismatch between the two implementations meant the newest posthog-js received a recording-disabled config for teams that had never set authorized domains. Recording silently stopped for days for those on the new endpoint.
+- **Remote config depended on a query param customer proxies dropped (Aug 2025, INC-489).** The /decide-to-/flags migration made recording config conditional on `?config=true`; customer reverse proxies that forward only the path dropped it, so the SDK never received recording config. Fixed server-side by returning a sensible default response.
+- Note the legacy authorized-domains check matches `Origin`/`Referer` headers server-side, not the page URL, so same-origin proxies and strict referrer policies silently disable it. It is deprecated for this reason.
+
+**Review questions:**
+
+1. When a trigger/config check cannot be evaluated (missing field, unreachable endpoint, stripped header or query param), does recording fail open or closed, and is that deliberate?
+2. Will this behave behind a customer reverse proxy that strips query strings, headers, or referrers?
+3. Endpoint or protocol migrations: does the old response shape and the new one both start recording correctly on old and new cores?
+
+## Class 7: Release and delivery channel integrity
+
+Bugs and attacks in how the SDK reaches browsers, rather than in SDK logic.
+
+- **Managed reverse proxy CORS misconfiguration (May 2026, INC-874).** A Cloudflare worker change to `/static/` routing served `array.js` without `Access-Control-Allow-Origin`, so browsers silently refused to load the SDK for all managed-proxy customers for several hours: no events, recordings, or client-side flags.
+- **npm supply-chain compromise (Nov 2025, INC-612).** An attacker exploited a `pull_request_target` workflow that checked out PR-author code, stole a bot PAT, exfiltrated the org npm token, and published trojanized versions of several packages including posthog-js and `@posthog/rrweb*`. Detected by a human noticing a publish with no matching commits. Countermeasures now standing: npm Trusted Publishing (OIDC), pnpm with lifecycle scripts disabled and a minimum release age, no `pull_request_target`, per-repo secrets, release-to-CI correlation monitoring. Public postmortem: [Nov 24 attack post-mortem](https://posthog.com/blog/nov-24-shai-hulud-attack-post-mortem).
+
+**Review questions:**
+
+1. Workflow changes: never reintroduce `pull_request_target` with a checkout of PR code; keep `.github` under CODEOWNERS; don't add lifecycle scripts (`preinstall`/`postinstall`) to any package.
+2. Anything touching how bundles are served (CDN paths, CORS, cache headers) is a fleet-wide single point of failure; verify cross-origin loading from a real page, not curl.
+
+---
+
+## Cross-cutting lessons
+
+- **npm pinning does not protect customers.** Until extension scripts are strictly versioned everywhere, treat every publish of a lazy-loaded bundle as an immediate fleet-wide deploy to all SDK versions ever released.
+- **Detection lag is the norm, not the exception.** These incidents were found by customers, bills, and support tickets days later, not by alerts. If a change could move recording volume, event volume, or error volume, decide before merging how you would notice within a day.
+- **Both directions bill.** Over-recording inflates PostHog bills; exception floods inflate customers' error-tracking usage; suppression destroys unrecoverable data. There is no cheap direction to be wrong in.
+- **Test with old cores and real browsers.** The compat suite exists because mocked-instant, latest-only CI missed the two biggest recorder incidents. New cross-boundary behavior needs a test against a genuinely old pinned core and real network latency.

--- a/.agents/skills/replay-incident-risk/INCIDENTS.md
+++ b/.agents/skills/replay-incident-risk/INCIDENTS.md
@@ -39,6 +39,12 @@ Changing when sessions rotate, how idle state is tracked, or when buffers flush 
 3. What is the oldest event a flushed buffer can contain after this change?
 4. If recording volume moves fleet-wide, the week-over-week recordings anomaly alert should catch it within a day. Watch it after release.
 
+**Volume invariants.** These must hold after any change in this class. The scenario tests in `lazy-sessionrecording.test.ts` (`recording volume invariants` block) assert them over multi-day simulated timelines; if your change could affect one, extend that block rather than only testing your mechanism:
+
+- A tab with zero user interaction ships zero recordings while it stays open, no matter how many rotations pass.
+- A session with one interaction ships exactly one recording; idle rotations after it add none.
+- No flushed buffer contains events older than the session age cap.
+
 ## Class 3: Network primitive wrappers (fetch and XHR patching)
 
 The highest-severity class: bugs here **break the customer's own site**, not just telemetry, and spread instantly to all SDK versions via the unversioned recorder bundle. Three separate incidents have come from the fetch wrappers. Standing policy from those incidents: no AI-generated PRs in the wrappers, and every change lands with a failing real-browser test first.

--- a/.agents/skills/replay-incident-risk/INCIDENTS.md
+++ b/.agents/skills/replay-incident-risk/INCIDENTS.md
@@ -104,6 +104,30 @@ Bugs and attacks in how the SDK reaches browsers, rather than in SDK logic.
 
 ---
 
+## Class 8: Masking, privacy, and consent (proactive, no incident yet)
+
+No registry incident here yet, and that is the point: a regression in input masking, text masking, canvas masking, or consent/opt-out handling **records data the customer promised their users we would not store**. Nothing throws, recording volume doesn't move, and no alert exists that could fire. Discovery would come from a customer finding a password in a replay, and the recorded data cannot be un-stored.
+
+**Review questions:**
+
+1. Does the change touch masking defaults, selector matching, or the order in which masking is applied vs when the snapshot is serialized? Any path where a node is serialized before masking runs is a leak.
+2. Could a new element type, attribute, or mutation path bypass `maskAllInputs` / `maskTextSelector` / canvas masking? Password inputs must be masked in every code path, including mutations and attribute changes, not just the initial snapshot.
+3. Does the change affect opt-out, consent state, or `disable_session_recording` being respected before the first event is captured (not just before the first flush)?
+4. Add a real-browser test asserting the sensitive value does not appear anywhere in the emitted snapshot bytes.
+
+## Class 9: Capture transport and retry behavior (proactive, no incident yet)
+
+The rate limiter, retry queue, and request queue run on every customer page. A retry bug here scales by the size of the fleet: retries without backoff or jitter become a coordinated flood against capture during any ingestion blip, and over-eager deduplication or dropped queues become silent event loss.
+
+**Review questions:**
+
+1. On a 5xx or network failure, does every retry path keep exponential backoff and jitter, with a bounded retry count?
+2. Can the same event be sent twice (retry after a timeout that actually succeeded), and is that acceptable downstream?
+3. When the rate limiter engages, what is dropped, and is the drop observable (`$rate_limit` style signal) rather than silent?
+4. Walk a page that stays open through a 30-minute capture outage: how many requests does this change cause it to send during and after?
+
+---
+
 ## Cross-cutting lessons
 
 - **npm pinning does not protect customers.** Until extension scripts are strictly versioned everywhere, treat every publish of a lazy-loaded bundle as an immediate fleet-wide deploy to all SDK versions ever released.

--- a/.agents/skills/replay-incident-risk/SKILL.md
+++ b/.agents/skills/replay-incident-risk/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: replay-incident-risk
+description: Cross-reference a posthog-js or rrweb change against past incident patterns before writing, reviewing, or merging it. Use when a diff touches session recording, the recorder or any lazy-loaded extension bundle (entrypoints/), session rotation or idle handling, fetch/XHR wrappers, rrweb record or replay code, recording triggers or remote config, or release workflows. Also use when asked "is this change risky", "could this repeat an incident", or "will this affect recording volume".
+compatibility: Requires a posthog-js checkout with git history (origin/main reachable).
+---
+
+# Replay incident risk review
+
+Changes to posthog-js and the rrweb fork have repeatedly caused severe incidents: fleet-wide recording loss, over-recording that inflated bills, broken customer sites, silent replay corruption, and a stored XSS. Most repeated through a small set of code-level patterns. This skill checks a diff against those patterns.
+
+The registry of patterns and incidents lives next to this file: [INCIDENTS.md](./INCIDENTS.md). Read the matching class sections, not the whole file.
+
+## Workflow
+
+1. Run the mechanical matcher from the repo root:
+
+    ```bash
+    node .agents/skills/replay-incident-risk/check.mjs [base-ref]
+    ```
+
+    It diffs against `origin/main` by default and prints matched incident classes with the touched paths and risky added lines. It is advisory and always exits 0.
+
+2. For every matched class, open the class section in [INCIDENTS.md](./INCIDENTS.md) and answer its **review questions** against the diff. Answer them concretely (walk the code), not by assertion.
+
+3. A path match is not a verdict. Judge whether the change actually has the failure mode:
+    - **Lazy-load boundary**: does the change alter a contract (signature, persisted-state shape, expected core function) crossed by a lazy-loaded bundle? If yes, it deploys fleet-wide instantly, including to npm-pinned customers, and must degrade gracefully with old cores. Absent persisted fields are neutral, never fatal.
+    - **Rotation/idle/flush**: could this change how many recordings ship? Walk an idle background tab through 24 hours and count what gets flushed and billed.
+    - **Fetch/XHR wrappers**: highest bar. All body types, WebKit included, with a second fetch wrapper on the page. A failing real-browser test comes before the fix. No AI-generated changes here without a human owning every line.
+    - **rrweb serialization**: silent-corruption risk. What real-browser assertion would notice this bug if it shipped?
+    - **Replay reconstruction**: recorded content is untrusted. Allowlist attributes; nothing recorded may execute in the viewer's origin.
+    - **Start conditions/config**: when the check can't be evaluated, is fail open vs fail closed a decision or an accident? Does it survive customer proxies stripping query params and headers?
+    - **Delivery channel**: no `pull_request_target` with PR-code checkout, no lifecycle scripts, publish stays on trusted publishing.
+
+4. Report findings in this shape, per matched class: the incident it resembles, whether this diff has the same failure mode (yes / no / can't tell), and if yes or can't tell, the smallest test or code change that removes the doubt. "Can't tell" is a finding, not a pass.
+
+5. If the change plausibly moves recording volume fleet-wide, say so explicitly in the PR description and note that the recordings week-over-week anomaly alert should be watched for a day after release.
+
+## When writing (not just reviewing) code in these areas
+
+Run the check on your own diff before opening the PR. If your change matches the lazy-load boundary class, add or extend a compat test (old pinned core + new lazy bundle) covering your path, including cold start from persisted config with a delayed remote-config response. That gap is exactly how the two largest recorder incidents shipped.

--- a/.agents/skills/replay-incident-risk/SKILL.md
+++ b/.agents/skills/replay-incident-risk/SKILL.md
@@ -15,10 +15,12 @@ The registry of patterns and incidents lives next to this file: [INCIDENTS.md](.
 1. Run the mechanical matcher from the repo root:
 
     ```bash
-    node .agents/skills/replay-incident-risk/check.mjs [base-ref]
+    node .agents/skills/replay-incident-risk/check.mjs [base-ref] [head-ref]
     ```
 
-    It diffs against `origin/main` by default and prints matched incident classes with the touched paths and risky added lines. It is advisory and always exits 0.
+    It diffs `HEAD` against `origin/main` by default and prints matched incident classes with the touched paths and risky added lines. It is advisory and always exits 0, even on internal errors.
+
+    When changing `risk-map.json` itself, also run `check.mjs --validate`: it fails on path patterns matching no tracked file and on anchors that don't resolve to an INCIDENTS.md heading, so dead patterns can't rot silently. CI runs it on every PR.
 
 2. For every matched class, open the class section in [INCIDENTS.md](./INCIDENTS.md) and answer its **review questions** against the diff. Answer them concretely (walk the code), not by assertion.
 

--- a/.agents/skills/replay-incident-risk/check.mjs
+++ b/.agents/skills/replay-incident-risk/check.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 // Advisory checker: matches a diff against past incident classes in risk-map.json.
 // Usage:
-//   node .agents/skills/replay-incident-risk/check.mjs [base-ref] [--json]
-// Defaults to diffing against origin/main (falling back to main). Always exits 0:
-// this is a heads-up, not a gate.
+//   node .agents/skills/replay-incident-risk/check.mjs [base-ref] [head-ref] [--json]
+//   node .agents/skills/replay-incident-risk/check.mjs --validate
+// Defaults to diffing HEAD against origin/main (falling back to main).
+// Advisory mode always exits 0, even on internal errors: this is a heads-up, not a gate.
+// --validate lints risk-map.json itself (dead path patterns, broken anchors) and DOES
+// exit non-zero on failure, so config rot is caught deterministically.
 
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
@@ -11,14 +14,92 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const skillDir = dirname(fileURLToPath(import.meta.url))
-const riskMap = JSON.parse(readFileSync(join(skillDir, 'risk-map.json'), 'utf8'))
+const MAX_HITS_SHOWN = 8
 
 const args = process.argv.slice(2)
 const jsonOutput = args.includes('--json')
-const baseArg = args.find((a) => !a.startsWith('--'))
+const validateMode = args.includes('--validate')
+const positional = args.filter((a) => !a.startsWith('--'))
+const baseArg = positional[0]
+const headRef = positional[1] ?? 'HEAD'
 
 function git(...cmd) {
-    return execFileSync('git', cmd, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+    return execFileSync('git', cmd, { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 })
+}
+
+function loadRiskMap() {
+    return JSON.parse(readFileSync(join(skillDir, 'risk-map.json'), 'utf8'))
+}
+
+// Matches GitHub's heading-to-anchor slugging closely enough for our headings.
+function slugify(heading) {
+    return heading
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-')
+}
+
+function validate() {
+    const riskMap = loadRiskMap()
+    const files = git('ls-files').split('\n').filter(Boolean)
+    const incidentsDoc = readFileSync(join(skillDir, 'INCIDENTS.md'), 'utf8')
+    const anchors = new Set(
+        incidentsDoc
+            .split('\n')
+            .filter((line) => line.startsWith('#'))
+            .map((line) => slugify(line.replace(/^#+\s*/, '')))
+    )
+
+    const problems = []
+    for (const cls of riskMap.classes) {
+        for (const pattern of cls.paths) {
+            let regex
+            try {
+                regex = new RegExp(pattern)
+            } catch (error) {
+                problems.push(`${cls.id}: path pattern does not compile: /${pattern}/ (${error.message})`)
+                continue
+            }
+            if (!files.some((f) => regex.test(f))) {
+                problems.push(`${cls.id}: path pattern matches no tracked file: /${pattern}/`)
+            }
+        }
+        for (const pattern of cls.contentPatterns) {
+            try {
+                new RegExp(pattern)
+            } catch (error) {
+                problems.push(`${cls.id}: content pattern does not compile: /${pattern}/ (${error.message})`)
+            }
+        }
+        if (cls.contentScope) {
+            try {
+                new RegExp(cls.contentScope)
+            } catch (error) {
+                problems.push(`${cls.id}: contentScope does not compile: /${cls.contentScope}/ (${error.message})`)
+            }
+        }
+        if (!anchors.has(cls.anchor)) {
+            problems.push(`${cls.id}: anchor #${cls.anchor} does not resolve to a heading in INCIDENTS.md`)
+        }
+    }
+
+    if (problems.length > 0) {
+        console.error(`risk-map.json validation failed (${problems.length} problem(s)):`)
+        for (const p of problems) console.error(`  - ${p}`)
+        process.exit(1)
+    }
+    console.log(`risk-map.json OK: ${riskMap.classes.length} classes, all path patterns match, all anchors resolve.`)
+    process.exit(0)
+}
+
+function skip(reason) {
+    if (jsonOutput) {
+        console.log(JSON.stringify({ skipped: true, reason, findings: [] }, null, 2))
+    } else {
+        console.log(`Incident-pattern check skipped: ${reason}`)
+    }
+    process.exit(0)
 }
 
 function resolveBase() {
@@ -30,98 +111,121 @@ function resolveBase() {
             /* try next */
         }
     }
-    console.error('Could not resolve a base ref. Pass one explicitly, e.g. `check.mjs origin/main`.')
-    process.exit(2)
+    return null
 }
 
-const base = resolveBase()
-const mergeBase = git('merge-base', base, 'HEAD').trim()
-
-const changedFiles = git('diff', '--name-only', mergeBase, 'HEAD').split('\n').filter(Boolean)
-
-// Added lines per file, so content patterns only fire on what this diff introduces.
-const addedLinesByFile = new Map()
-{
-    const diff = git('diff', '--unified=0', mergeBase, 'HEAD')
-    let currentFile = null
-    for (const line of diff.split('\n')) {
-        const fileHeader = line.match(/^\+\+\+ b\/(.*)$/)
-        if (fileHeader) {
-            currentFile = fileHeader[1]
-            addedLinesByFile.set(currentFile, [])
-            continue
-        }
-        if (currentFile && line.startsWith('+') && !line.startsWith('+++')) {
-            addedLinesByFile.get(currentFile).push(line.slice(1))
-        }
+function run() {
+    const riskMap = loadRiskMap()
+    const base = resolveBase()
+    if (!base) {
+        skip('could not resolve a base ref; pass one explicitly, e.g. `check.mjs origin/main`')
     }
-}
+    const mergeBase = git('merge-base', base, headRef).trim()
 
-const findings = []
-for (const cls of riskMap.classes) {
-    const pathRegexes = cls.paths.map((p) => new RegExp(p))
-    const contentRegexes = cls.contentPatterns.map((p) => new RegExp(p))
+    const changedFiles = git('diff', '--name-only', mergeBase, headRef).split('\n').filter(Boolean)
 
-    const pathHits = changedFiles.filter((f) => pathRegexes.some((r) => r.test(f)))
-
-    const defaultScope = /^packages\/(browser|rrweb)\/.*\.(ts|tsx|js|mjs)$/
-    const testFile = /(__tests__|__mocks__|\.test\.|\.spec\.|\/playwright\/|\/testcafe\/)/
-    const scope = cls.contentScope ? new RegExp(cls.contentScope) : defaultScope
-
-    const contentHits = []
-    for (const [file, lines] of addedLinesByFile) {
-        // Content patterns are only meaningful inside SDK/rrweb source, not docs or test fixtures.
-        if (!scope.test(file) || testFile.test(file)) continue
-        for (const regex of contentRegexes) {
-            const line = lines.find((l) => regex.test(l))
-            if (line) {
-                contentHits.push({ file, pattern: regex.source, line: line.trim().slice(0, 160) })
+    // Added lines per file, so content patterns only fire on what this diff introduces.
+    const addedLinesByFile = new Map()
+    {
+        const diff = git('diff', '--unified=0', mergeBase, headRef)
+        let currentFile = null
+        for (const line of diff.split('\n')) {
+            const fileHeader = line.match(/^\+\+\+ b\/(.*)$/)
+            if (fileHeader) {
+                currentFile = fileHeader[1]
+                addedLinesByFile.set(currentFile, [])
+                continue
+            }
+            if (currentFile && line.startsWith('+') && !line.startsWith('+++')) {
+                addedLinesByFile.get(currentFile).push(line.slice(1))
             }
         }
     }
 
-    // Path match alone is enough for high-risk surfaces; content match alone is a weaker signal,
-    // so require it to co-occur with at least one changed file in the browser/rrweb packages.
-    if (pathHits.length > 0 || contentHits.length > 0) {
-        findings.push({
-            id: cls.id,
-            title: cls.title,
-            anchor: cls.anchor,
-            why: cls.why,
-            pathHits,
-            contentHits,
-            strength: pathHits.length > 0 ? 'path' : 'content',
-        })
+    const findings = []
+    for (const cls of riskMap.classes) {
+        const pathRegexes = cls.paths.map((p) => new RegExp(p))
+        const contentRegexes = cls.contentPatterns.map((p) => new RegExp(p))
+
+        const defaultScope = /^packages\/(browser|rrweb)\/.*\.(ts|tsx|js|mjs)$/
+        const testFile = /(__tests__|__mocks__|\.test\.|\.spec\.|\/playwright\/|\/testcafe\/)/
+        const scope = cls.contentScope ? new RegExp(cls.contentScope) : defaultScope
+
+        const pathHits = changedFiles.filter((f) => pathRegexes.some((r) => r.test(f)))
+
+        const contentHits = []
+        for (const [file, lines] of addedLinesByFile) {
+            // Content patterns are only meaningful inside SDK/rrweb source, not docs or test fixtures.
+            if (!scope.test(file) || testFile.test(file)) continue
+            for (const regex of contentRegexes) {
+                const line = lines.find((l) => regex.test(l))
+                if (line) {
+                    contentHits.push({ file, pattern: regex.source, line: line.trim().slice(0, 160) })
+                }
+            }
+        }
+
+        if (pathHits.length > 0 || contentHits.length > 0) {
+            findings.push({
+                id: cls.id,
+                title: cls.title,
+                anchor: cls.anchor,
+                why: cls.why,
+                pathHits,
+                contentHits,
+                strength: pathHits.length > 0 ? 'path' : 'content',
+            })
+        }
     }
+
+    if (jsonOutput) {
+        console.log(JSON.stringify({ base, mergeBase, changedFiles: changedFiles.length, findings }, null, 2))
+        return
+    }
+
+    if (findings.length === 0) {
+        console.log(`No incident-pattern matches for ${changedFiles.length} changed file(s) vs ${base}.`)
+        return
+    }
+
+    const registry = '.agents/skills/replay-incident-risk/INCIDENTS.md'
+    console.log(`Matched ${findings.length} past incident pattern(s) (diff vs ${base}):\n`)
+    for (const f of findings) {
+        console.log(`## ${f.title} [${f.strength} match]`)
+        console.log(f.why)
+        if (f.pathHits.length) {
+            console.log('  Touched paths:')
+            for (const p of f.pathHits.slice(0, MAX_HITS_SHOWN)) console.log(`    - ${p}`)
+            if (f.pathHits.length > MAX_HITS_SHOWN) {
+                console.log(`    - ...and ${f.pathHits.length - MAX_HITS_SHOWN} more`)
+            }
+        }
+        if (f.contentHits.length) {
+            console.log('  Added lines matching risk patterns:')
+            for (const c of f.contentHits.slice(0, MAX_HITS_SHOWN)) {
+                console.log(`    - ${c.file}: /${c.pattern}/ -> ${c.line}`)
+            }
+            if (f.contentHits.length > MAX_HITS_SHOWN) {
+                console.log(`    - ...and ${f.contentHits.length - MAX_HITS_SHOWN} more`)
+            }
+        }
+        console.log(`  Read: ${registry}#${f.anchor}\n`)
+    }
+    console.log('This check is advisory. It flags resemblance to past incidents, not correctness.')
+    console.log('For a judgment pass on whether this diff has the same failure mode, run the')
+    console.log('`replay-incident-risk` skill in a Claude session from the repo root, or answer the')
+    console.log(`review questions in the matched sections of ${registry} yourself.`)
 }
 
-if (jsonOutput) {
-    console.log(JSON.stringify({ base, mergeBase, changedFiles: changedFiles.length, findings }, null, 2))
-    process.exit(0)
-}
-
-if (findings.length === 0) {
-    console.log(`No incident-pattern matches for ${changedFiles.length} changed file(s) vs ${base}.`)
-    process.exit(0)
-}
-
-const registry = '.agents/skills/replay-incident-risk/INCIDENTS.md'
-console.log(`Matched ${findings.length} past incident pattern(s) (diff vs ${base}):\n`)
-for (const f of findings) {
-    console.log(`## ${f.title} [${f.strength} match]`)
-    console.log(f.why)
-    if (f.pathHits.length) {
-        console.log('  Touched paths:')
-        for (const p of f.pathHits) console.log(`    - ${p}`)
+if (validateMode) {
+    validate()
+} else {
+    try {
+        run()
+    } catch (error) {
+        // Advisory by design: an internal failure must not gate the build.
+        console.error(`Incident-pattern check errored: ${error.message}`)
+        skip('internal error, see stderr')
     }
-    if (f.contentHits.length) {
-        console.log('  Added lines matching risk patterns:')
-        for (const c of f.contentHits.slice(0, 8)) console.log(`    - ${c.file}: /${c.pattern}/ -> ${c.line}`)
-    }
-    console.log(`  Read: ${registry}#${f.anchor}\n`)
 }
-console.log('This check is advisory. It flags resemblance to past incidents, not correctness.')
-console.log('For a judgment pass on whether this diff has the same failure mode, run the')
-console.log('`replay-incident-risk` skill in a Claude session from the repo root, or answer the')
-console.log(`review questions in the matched sections of ${registry} yourself.`)
 process.exit(0)

--- a/.agents/skills/replay-incident-risk/check.mjs
+++ b/.agents/skills/replay-incident-risk/check.mjs
@@ -121,4 +121,7 @@ for (const f of findings) {
     console.log(`  Read: ${registry}#${f.anchor}\n`)
 }
 console.log('This check is advisory. It flags resemblance to past incidents, not correctness.')
+console.log('For a judgment pass on whether this diff has the same failure mode, run the')
+console.log('`replay-incident-risk` skill in a Claude session from the repo root, or answer the')
+console.log(`review questions in the matched sections of ${registry} yourself.`)
 process.exit(0)

--- a/.agents/skills/replay-incident-risk/check.mjs
+++ b/.agents/skills/replay-incident-risk/check.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Advisory checker: matches a diff against past incident classes in risk-map.json.
+// Usage:
+//   node .agents/skills/replay-incident-risk/check.mjs [base-ref] [--json]
+// Defaults to diffing against origin/main (falling back to main). Always exits 0:
+// this is a heads-up, not a gate.
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const skillDir = dirname(fileURLToPath(import.meta.url))
+const riskMap = JSON.parse(readFileSync(join(skillDir, 'risk-map.json'), 'utf8'))
+
+const args = process.argv.slice(2)
+const jsonOutput = args.includes('--json')
+const baseArg = args.find((a) => !a.startsWith('--'))
+
+function git(...cmd) {
+    return execFileSync('git', cmd, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+}
+
+function resolveBase() {
+    for (const candidate of [baseArg, 'origin/main', 'main'].filter(Boolean)) {
+        try {
+            git('rev-parse', '--verify', '--quiet', `${candidate}^{commit}`)
+            return candidate
+        } catch {
+            /* try next */
+        }
+    }
+    console.error('Could not resolve a base ref. Pass one explicitly, e.g. `check.mjs origin/main`.')
+    process.exit(2)
+}
+
+const base = resolveBase()
+const mergeBase = git('merge-base', base, 'HEAD').trim()
+
+const changedFiles = git('diff', '--name-only', mergeBase, 'HEAD').split('\n').filter(Boolean)
+
+// Added lines per file, so content patterns only fire on what this diff introduces.
+const addedLinesByFile = new Map()
+{
+    const diff = git('diff', '--unified=0', mergeBase, 'HEAD')
+    let currentFile = null
+    for (const line of diff.split('\n')) {
+        const fileHeader = line.match(/^\+\+\+ b\/(.*)$/)
+        if (fileHeader) {
+            currentFile = fileHeader[1]
+            addedLinesByFile.set(currentFile, [])
+            continue
+        }
+        if (currentFile && line.startsWith('+') && !line.startsWith('+++')) {
+            addedLinesByFile.get(currentFile).push(line.slice(1))
+        }
+    }
+}
+
+const findings = []
+for (const cls of riskMap.classes) {
+    const pathRegexes = cls.paths.map((p) => new RegExp(p))
+    const contentRegexes = cls.contentPatterns.map((p) => new RegExp(p))
+
+    const pathHits = changedFiles.filter((f) => pathRegexes.some((r) => r.test(f)))
+
+    const defaultScope = /^packages\/(browser|rrweb)\/.*\.(ts|tsx|js|mjs)$/
+    const testFile = /(__tests__|__mocks__|\.test\.|\.spec\.|\/playwright\/|\/testcafe\/)/
+    const scope = cls.contentScope ? new RegExp(cls.contentScope) : defaultScope
+
+    const contentHits = []
+    for (const [file, lines] of addedLinesByFile) {
+        // Content patterns are only meaningful inside SDK/rrweb source, not docs or test fixtures.
+        if (!scope.test(file) || testFile.test(file)) continue
+        for (const regex of contentRegexes) {
+            const line = lines.find((l) => regex.test(l))
+            if (line) {
+                contentHits.push({ file, pattern: regex.source, line: line.trim().slice(0, 160) })
+            }
+        }
+    }
+
+    // Path match alone is enough for high-risk surfaces; content match alone is a weaker signal,
+    // so require it to co-occur with at least one changed file in the browser/rrweb packages.
+    if (pathHits.length > 0 || contentHits.length > 0) {
+        findings.push({
+            id: cls.id,
+            title: cls.title,
+            anchor: cls.anchor,
+            why: cls.why,
+            pathHits,
+            contentHits,
+            strength: pathHits.length > 0 ? 'path' : 'content',
+        })
+    }
+}
+
+if (jsonOutput) {
+    console.log(JSON.stringify({ base, mergeBase, changedFiles: changedFiles.length, findings }, null, 2))
+    process.exit(0)
+}
+
+if (findings.length === 0) {
+    console.log(`No incident-pattern matches for ${changedFiles.length} changed file(s) vs ${base}.`)
+    process.exit(0)
+}
+
+const registry = '.agents/skills/replay-incident-risk/INCIDENTS.md'
+console.log(`Matched ${findings.length} past incident pattern(s) (diff vs ${base}):\n`)
+for (const f of findings) {
+    console.log(`## ${f.title} [${f.strength} match]`)
+    console.log(f.why)
+    if (f.pathHits.length) {
+        console.log('  Touched paths:')
+        for (const p of f.pathHits) console.log(`    - ${p}`)
+    }
+    if (f.contentHits.length) {
+        console.log('  Added lines matching risk patterns:')
+        for (const c of f.contentHits.slice(0, 8)) console.log(`    - ${c.file}: /${c.pattern}/ -> ${c.line}`)
+    }
+    console.log(`  Read: ${registry}#${f.anchor}\n`)
+}
+console.log('This check is advisory. It flags resemblance to past incidents, not correctness.')
+process.exit(0)

--- a/.agents/skills/replay-incident-risk/risk-map.json
+++ b/.agents/skills/replay-incident-risk/risk-map.json
@@ -1,0 +1,124 @@
+{
+  "$comment": "Maps changed paths and diff content to past incident classes in INCIDENTS.md. Used by check.mjs locally and by the replay-incident-risk CI workflow. Patterns are JS regexes (no flags; paths are matched case-sensitively, content patterns against added lines only).",
+  "classes": [
+    {
+      "id": "lazy-load-boundary",
+      "title": "Version skew across the lazy-load boundary",
+      "anchor": "class-1-version-skew-across-the-lazy-load-boundary",
+      "paths": [
+        "^packages/browser/src/entrypoints/",
+        "^packages/browser/src/extensions/replay/external/",
+        "^packages/browser/src/remote-config\\.ts$",
+        "^packages/browser/src/posthog-persistence\\.ts$",
+        "^packages/browser/src/constants\\.ts$",
+        "^packages/browser/src/extensions/extension-bundles\\.ts$"
+      ],
+      "contentPatterns": [],
+      "why": "Lazy-loaded bundles (recorder, surveys, web vitals, tracing headers) are served unversioned from the CDN: this change deploys instantly to every SDK version, including npm-pinned ones. Cross-boundary signature changes and persisted-state shape changes have caused fleet-wide recording loss (Mar 2026), broken surveys (Jul 2025, Oct 2025), and a six-day web-vitals gap (Jan 2026)."
+    },
+    {
+      "id": "rotation-idle-flush",
+      "title": "Session rotation, idle handling, and flush semantics",
+      "anchor": "class-2-session-rotation-idle-handling-and-flush-semantics",
+      "paths": [
+        "^packages/browser/src/sessionid\\.ts$",
+        "^packages/browser/src/extensions/replay/session-recording\\.ts$",
+        "^packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder\\.ts$",
+        "^packages/browser/src/extensions/replay/external/recording-strategies\\.ts$",
+        "^packages/browser/src/extensions/replay/external/flushed-size-tracker\\.ts$"
+      ],
+      "contentPatterns": [
+        "_isIdle",
+        "isIdle",
+        "sessionIdChanged|rotateSession|session.?rotation",
+        "onSessionId|resetSessionId",
+        "flushBuffer|_flushBuffer|clearBuffer"
+      ],
+      "why": "Changes to rotation, idle state, or flushing change how many recordings ship, and every shipped recording bills. In Jul 2026 an idle-state fix made parked tabs ship an unbounded chain of billed zero-interaction recordings for 11 days before a customer bill surfaced it."
+    },
+    {
+      "id": "network-wrappers",
+      "title": "Network primitive wrappers (fetch and XHR patching)",
+      "anchor": "class-3-network-primitive-wrappers-fetch-and-xhr-patching",
+      "paths": [
+        "^packages/browser/src/extensions/replay/external/network-plugin\\.ts$",
+        "^packages/browser/src/entrypoints/tracing-headers\\.ts$",
+        "^packages/browser/src/extensions/tracing-headers"
+      ],
+      "contentPatterns": [
+        "new Request\\(",
+        "(request|input|init|req)\\.body",
+        "window\\.fetch|globalThis\\.fetch|originalFetch",
+        "XMLHttpRequest",
+        "RequestInit"
+      ],
+      "why": "The fetch wrappers have caused three incidents, including breaking customer checkouts and uploads (Jan 2026) and Safari POST failures (May 2026). Standing policy: no AI-generated PRs here, and land a failing real-browser (WebKit included) test first, exercising all body types with another fetch wrapper on the page."
+    },
+    {
+      "id": "rrweb-serialization",
+      "title": "rrweb serialization and snapshot correctness",
+      "anchor": "class-4-rrweb-serialization-and-snapshot-correctness",
+      "paths": [
+        "^packages/rrweb/.*(record|snapshot)",
+        "^packages/rrweb/rrdom"
+      ],
+      "contentPatterns": [
+        "cssText",
+        "adoptedStyleSheets",
+        "insertRule",
+        "getComputedStyle"
+      ],
+      "why": "Serializer bugs corrupt replays silently: no exception, no volume change. In May 2026 a cssText spec quirk silently dropped layout styles for sites using CSS custom properties. Test against framework-generated CSS (Chakra/Panda, Emotion speedy, Tailwind) in a real browser."
+    },
+    {
+      "id": "replay-reconstruction",
+      "title": "Replay reconstruction and player security",
+      "anchor": "class-5-replay-reconstruction-and-player-security",
+      "paths": [
+        "^packages/rrweb/.*replay"
+      ],
+      "contentScope": "^packages/rrweb/.*\\.(ts|tsx|js|mjs)$",
+      "contentPatterns": [
+        "setAttribute\\(",
+        "allow-scripts",
+        "UNSAFE_replayCanvas",
+        "srcdoc",
+        "innerHTML"
+      ],
+      "why": "Recorded page content is untrusted input. Anything the replayer places in the top-level document sits outside the sandbox iframe: copying recorded attributes without an allowlist caused a stored XSS via canvas onerror (Jul 2026). Never copy on* handlers or src/srcset/href you did not construct."
+    },
+    {
+      "id": "start-conditions-config",
+      "title": "Recording start conditions and remote config semantics",
+      "anchor": "class-6-recording-start-conditions-and-remote-config-semantics",
+      "paths": [
+        "^packages/browser/src/extensions/replay/external/triggerMatching\\.ts$",
+        "^packages/browser/src/extensions/replay/external/config\\.ts$",
+        "^packages/browser/src/extensions/replay/external/denylist\\.ts$",
+        "^packages/browser/src/extensions/replay/external/sampling",
+        "^packages/browser/src/posthog-featureflags\\.ts$"
+      ],
+      "contentPatterns": [
+        "sessionRecording\\b.*(false|disabled)",
+        "authorized.?domains",
+        "config=true"
+      ],
+      "why": "Changes to when recording may start fail silently in the suppress direction. Endpoint migrations and config-shape changes have silently stopped recording for large fleets (Jun 2025, Aug 2025). When a check cannot be evaluated (stripped header, missing field, proxy dropping query params), decide deliberately whether to fail open or closed."
+    },
+    {
+      "id": "delivery-channel",
+      "title": "Release and delivery channel integrity",
+      "anchor": "class-7-release-and-delivery-channel-integrity",
+      "paths": [
+        "^\\.github/workflows/"
+      ],
+      "contentScope": "(^\\.github/|package\\.json$)",
+      "contentPatterns": [
+        "pull_request_target",
+        "\"preinstall\"|\"postinstall\"|\"prepublish\"",
+        "NODE_AUTH_TOKEN|NPM_TOKEN"
+      ],
+      "why": "The Nov 2025 supply-chain compromise started with a pull_request_target workflow checking out PR-author code. Never reintroduce that pattern, don't add package lifecycle scripts, and keep publish credentials on OIDC trusted publishing."
+    }
+  ]
+}

--- a/.agents/skills/replay-incident-risk/risk-map.json
+++ b/.agents/skills/replay-incident-risk/risk-map.json
@@ -29,7 +29,6 @@
         "^packages/browser/src/extensions/replay/external/mutation-throttler\\.ts$"
       ],
       "contentPatterns": [
-        "_isIdle",
         "isIdle",
         "sessionIdChanged|rotateSession|session.?rotation",
         "onSessionId|resetSessionId",
@@ -69,7 +68,8 @@
         "insertRule",
         "getComputedStyle"
       ],
-      "why": "Serializer bugs corrupt replays silently: no exception, no volume change. In May 2026 a cssText spec quirk silently dropped layout styles for sites using CSS custom properties. Test against framework-generated CSS (Chakra/Panda, Emotion speedy, Tailwind) in a real browser."
+      "why": "Serializer bugs corrupt replays silently: no exception, no volume change. In May 2026 a cssText spec quirk silently dropped layout styles for sites using CSS custom properties. Test against framework-generated CSS (Chakra/Panda, Emotion speedy, Tailwind) in a real browser.",
+      "contentScope": "^packages/rrweb/.*\\.(ts|tsx|js|mjs)$"
     },
     {
       "id": "replay-reconstruction",
@@ -78,7 +78,7 @@
       "paths": [
         "^packages/rrweb/.*replay"
       ],
-      "contentScope": "^packages/rrweb/.*\\.(ts|tsx|js|mjs)$",
+      "contentScope": "^packages/rrweb/.*replay.*\\.(ts|tsx|js|mjs)$",
       "contentPatterns": [
         "setAttribute\\(",
         "allow-scripts",
@@ -96,7 +96,7 @@
         "^packages/browser/src/extensions/replay/external/triggerMatching\\.ts$",
         "^packages/browser/src/extensions/replay/external/config\\.ts$",
         "^packages/browser/src/extensions/replay/external/denylist\\.ts$",
-        "^packages/browser/src/extensions/replay/external/sampling",
+        "^packages/browser/src/extensions/sampling\\.ts$",
         "^packages/browser/src/posthog-featureflags\\.ts$"
       ],
       "contentPatterns": [
@@ -118,7 +118,7 @@
       ],
       "contentPatterns": [
         "maskAllInputs|maskInputOptions|maskTextSelector|maskInputFn|maskTextFn",
-        "type=[\"']password|\\bpassword\\b",
+        "type=[\"']password",
         "opt_out|optedOut|has_opted_out",
         "disable_session_recording"
       ],
@@ -135,7 +135,7 @@
         "^packages/browser/src/request\\.ts$"
       ],
       "contentPatterns": [
-        "setInterval|setTimeout.*retry|retriesPerformedSoFar",
+        "retriesPerformedSoFar|RetryQueue|retry.?queue",
         "backoff|jitter"
       ],
       "why": "This code runs on every customer page. Retries without backoff and jitter become a coordinated fleet-wide flood against capture during any ingestion blip; queue bugs become silent event loss or duplicates. Walk a page through a 30-minute capture outage and count the requests."

--- a/.agents/skills/replay-incident-risk/risk-map.json
+++ b/.agents/skills/replay-incident-risk/risk-map.json
@@ -25,7 +25,8 @@
         "^packages/browser/src/extensions/replay/session-recording\\.ts$",
         "^packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder\\.ts$",
         "^packages/browser/src/extensions/replay/external/recording-strategies\\.ts$",
-        "^packages/browser/src/extensions/replay/external/flushed-size-tracker\\.ts$"
+        "^packages/browser/src/extensions/replay/external/flushed-size-tracker\\.ts$",
+        "^packages/browser/src/extensions/replay/external/mutation-throttler\\.ts$"
       ],
       "contentPatterns": [
         "_isIdle",
@@ -104,6 +105,40 @@
         "config=true"
       ],
       "why": "Changes to when recording may start fail silently in the suppress direction. Endpoint migrations and config-shape changes have silently stopped recording for large fleets (Jun 2025, Aug 2025). When a check cannot be evaluated (stripped header, missing field, proxy dropping query params), decide deliberately whether to fail open or closed."
+    },
+    {
+      "id": "masking-privacy-consent",
+      "title": "Masking, privacy, and consent",
+      "anchor": "class-8-masking-privacy-and-consent-proactive-no-incident-yet",
+      "paths": [
+        "^packages/browser/src/consent\\.ts$",
+        "^packages/browser/src/extensions/replay/external/sessionrecording-utils\\.ts$",
+        "^packages/rrweb/rrweb/src/record/observers/canvas/canvas-mask\\.ts$",
+        "^packages/rrweb/rrweb-snapshot/"
+      ],
+      "contentPatterns": [
+        "maskAllInputs|maskInputOptions|maskTextSelector|maskInputFn|maskTextFn",
+        "type=[\"']password|\\bpassword\\b",
+        "opt_out|optedOut|has_opted_out",
+        "disable_session_recording"
+      ],
+      "why": "A masking or consent regression records data customers promised their users we would not store: passwords, PII, opted-out sessions. Nothing throws and no volume moves, so no alert can fire, and recorded data cannot be un-stored. Add a real-browser test asserting the sensitive value is absent from the emitted snapshot bytes."
+    },
+    {
+      "id": "capture-transport-retry",
+      "title": "Capture transport and retry behavior",
+      "anchor": "class-9-capture-transport-and-retry-behavior-proactive-no-incident-yet",
+      "paths": [
+        "^packages/browser/src/retry-queue\\.ts$",
+        "^packages/browser/src/rate-limiter\\.ts$",
+        "^packages/browser/src/request-queue\\.ts$",
+        "^packages/browser/src/request\\.ts$"
+      ],
+      "contentPatterns": [
+        "setInterval|setTimeout.*retry|retriesPerformedSoFar",
+        "backoff|jitter"
+      ],
+      "why": "This code runs on every customer page. Retries without backoff and jitter become a coordinated fleet-wide flood against capture during any ingestion blip; queue bugs become silent event loss or duplicates. Walk a page through a 30-minute capture outage and count the requests."
     },
     {
       "id": "delivery-channel",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,14 @@
 # Default owner for the repository
 * @PostHog/team-client-libraries
 
-# the recorder file can have unexpected impact on users' sites
-packages/browser/src/entrypoints/recorder.ts           @PostHog/team-client-libraries @PostHog/team-replay
-
-# Network recorder
-packages/browser/src/extensions/replay/external/network-plugin.ts @PostHog/team-client-libraries
+# Session replay: recorder changes ship fleet-wide via the unversioned CDN bundle and
+# have caused repeated incidents (see .agents/skills/replay-incident-risk/INCIDENTS.md)
+packages/browser/src/extensions/replay/                @PostHog/team-client-libraries @PostHog/team-replay
+packages/browser/src/entrypoints/lazy-recorder.ts      @PostHog/team-client-libraries @PostHog/team-replay
+packages/browser/src/entrypoints/posthog-recorder.ts   @PostHog/team-client-libraries @PostHog/team-replay
+packages/browser/src/entrypoints/recorder-v2.ts        @PostHog/team-client-libraries @PostHog/team-replay
+packages/rrweb/                                        @PostHog/team-client-libraries @PostHog/team-replay
+.agents/skills/replay-incident-risk/                   @PostHog/team-client-libraries @PostHog/team-replay
 
 # Surveys
 packages/browser/src/extensions/surveys/               @PostHog/team-client-libraries @PostHog/team-surveys

--- a/.github/workflows/replay-incident-risk.yml
+++ b/.github/workflows/replay-incident-risk.yml
@@ -38,9 +38,27 @@ jobs:
           node .agents/skills/replay-incident-risk/check.mjs "$BASE" > risk.txt || true
           COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('risk.json','utf8')).findings.length)")
           echo "findings=$COUNT" >> "$GITHUB_OUTPUT"
+
           {
-            echo 'report<<RISK_EOF'
+            echo '<!-- replay-incident-risk -->'
+            echo '## Replay incident risk check'
+            echo ''
+            if [ "$COUNT" != "0" ]; then
+              echo 'This diff touches code involved in past incidents. This is a heads-up, not a verdict: read the matched sections of [INCIDENTS.md](https://github.com/PostHog/posthog-js/blob/main/.agents/skills/replay-incident-risk/INCIDENTS.md) and answer their review questions before merging.'
+              echo ''
+              echo 'For a judgment on whether this diff has the same failure mode, run the `replay-incident-risk` skill locally: open a Claude session in the repo root and ask it to review your diff with that skill. Or run `node .agents/skills/replay-incident-risk/check.mjs` and answer the review questions for each matched class yourself.'
+            else
+              echo 'The current diff no longer matches any past incident pattern.'
+            fi
+            echo ''
+            echo '```'
             cat risk.txt
+            echo '```'
+          } > comment.md
+
+          {
+            echo 'comment<<RISK_EOF'
+            cat comment.md
             echo 'RISK_EOF'
           } >> "$GITHUB_OUTPUT"
           cat risk.txt
@@ -65,12 +83,4 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
-          body: |
-            <!-- replay-incident-risk -->
-            ## Replay incident risk check
-
-            ${{ steps.check.outputs.findings != '0' && 'This diff touches code involved in past incidents. This is a heads-up, not a verdict: read the matched sections of [INCIDENTS.md](https://github.com/PostHog/posthog-js/blob/main/.agents/skills/replay-incident-risk/INCIDENTS.md) and answer their review questions before merging.' || 'The current diff no longer matches any past incident pattern.' }}
-
-            ```
-            ${{ steps.check.outputs.report }}
-            ```
+          body: ${{ steps.check.outputs.comment }}

--- a/.github/workflows/replay-incident-risk.yml
+++ b/.github/workflows/replay-incident-risk.yml
@@ -30,13 +30,18 @@ jobs:
           node-version: 24
           package-manager-cache: false
 
+      - name: Validate risk map
+        run: node .agents/skills/replay-incident-risk/check.mjs --validate
+
       - name: Run incident-pattern check
         id: check
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          BASE="origin/${{ github.event.pull_request.base.ref }}"
-          node .agents/skills/replay-incident-risk/check.mjs "$BASE" --json > risk.json
+          BASE="origin/$BASE_REF"
+          node .agents/skills/replay-incident-risk/check.mjs "$BASE" --json > risk.json || true
           node .agents/skills/replay-incident-risk/check.mjs "$BASE" > risk.txt || true
-          COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('risk.json','utf8')).findings.length)")
+          COUNT=$(node -e "try { console.log(JSON.parse(require('fs').readFileSync('risk.json','utf8')).findings.length) } catch { console.log(0) }")
           echo "findings=$COUNT" >> "$GITHUB_OUTPUT"
 
           {
@@ -56,10 +61,13 @@ jobs:
             echo '```'
           } > comment.md
 
+          # Random delimiter: the report quotes added lines from the PR diff, so a fixed
+          # delimiter would let a crafted diff line inject step outputs.
+          DELIM="RISK_$(openssl rand -hex 16)"
           {
-            echo 'comment<<RISK_EOF'
+            echo "comment<<$DELIM"
             cat comment.md
-            echo 'RISK_EOF'
+            echo "$DELIM"
           } >> "$GITHUB_OUTPUT"
           cat risk.txt
 

--- a/.github/workflows/replay-incident-risk.yml
+++ b/.github/workflows/replay-incident-risk.yml
@@ -1,0 +1,76 @@
+name: Replay incident risk
+
+# Advisory check: flags PR diffs that resemble the code patterns behind past
+# replay/SDK incidents (see .agents/skills/replay-incident-risk/INCIDENTS.md).
+# It never fails the build; it maintains a single PR comment.
+
+on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Run incident-pattern check
+        id: check
+        run: |
+          BASE="origin/${{ github.event.pull_request.base.ref }}"
+          node .agents/skills/replay-incident-risk/check.mjs "$BASE" --json > risk.json
+          node .agents/skills/replay-incident-risk/check.mjs "$BASE" > risk.txt || true
+          COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('risk.json','utf8')).findings.length)")
+          echo "findings=$COUNT" >> "$GITHUB_OUTPUT"
+          {
+            echo 'report<<RISK_EOF'
+            cat risk.txt
+            echo 'RISK_EOF'
+          } >> "$GITHUB_OUTPUT"
+          cat risk.txt
+
+      - name: Skip PR comments for fork PR
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: echo "Skipping incident-risk PR comments for fork PRs because GitHub tokens are read-only."
+
+      - name: Find existing comment
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # pin v4.0.0
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- replay-incident-risk -->"
+
+      - name: Create or update comment
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (steps.check.outputs.findings != '0' || steps.fc.outputs.comment-id != '') }}
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # pin v5.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- replay-incident-risk -->
+            ## Replay incident risk check
+
+            ${{ steps.check.outputs.findings != '0' && 'This diff touches code involved in past incidents. This is a heads-up, not a verdict: read the matched sections of [INCIDENTS.md](https://github.com/PostHog/posthog-js/blob/main/.agents/skills/replay-incident-risk/INCIDENTS.md) and answer their review questions before merging.' || 'The current diff no longer matches any past incident pattern.' }}
+
+            ```
+            ${{ steps.check.outputs.report }}
+            ```


### PR DESCRIPTION
## Problem

Changes to posthog-js and the rrweb fork have repeatedly caused severe incidents: fleet-wide recording loss (Mar 2026), idle-tab over-recording (Aug 2026), fetch-wrapper regressions that broke customer sites (Jan 2026, May 2026), silent replay corruption (May 2026), and more. Most repeated through a small set of code-level patterns, and nothing warns an engineer that a diff resembles a past incident.

## Changes

- `.agents/skills/replay-incident-risk/INCIDENTS.md`: a registry of 7 incident classes with mechanisms and review questions. Internal impact numbers and customer names are omitted.
- `.agents/skills/replay-incident-risk/SKILL.md`: an agent/reviewer skill that cross-references a diff against the registry.
- `.agents/skills/replay-incident-risk/check.mjs` + `risk-map.json`: a dependency-free checker. Run locally with `node .agents/skills/replay-incident-risk/check.mjs [base-ref]`. Always exits 0.
- `.github/workflows/replay-incident-risk.yml`: runs the checker on PRs and maintains one advisory comment when the diff matches an incident class. Modeled on `bundled-size.yaml` (same pinned actions, fork-PR skip).

> [!NOTE]
> The check is advisory only. It flags resemblance to past incidents, it never fails the build.

This PR flags itself (it adds a workflow file, which matches the delivery-channel class). A stacked test PR exercises the recorder-path classes.

## Release info Sub-libraries affected

### Libraries affected

None, no package code changes and no version bump.

## Checklist

- [x] Tests for new code (checker validated against recent recorder commits)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

## 🤖 Agent context

I (actually Claude) built this from a Slack sweep of past replay/SDK incidents. Skills invoked: writing-user-facing-copy, writing-pr-descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)