### PR TITLE
chore(replay): add recording volume invariant tests

### DIFF
--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2053,6 +2053,79 @@ describe('Lazy SessionRecording', () => {
                 })
             })
 
+            describe('recording volume invariants', () => {
+                // Billing-level invariants over long simulated timelines. The mechanics of
+                // holding rotation-born sessions are covered above; these assert the outcome
+                // that matters regardless of mechanism: how many recordings a tab ships.
+
+                function shippedSessionIds(): Set<string> {
+                    return new Set(
+                        (posthog.capture as Mock).mock.calls
+                            .filter(([eventName]) => eventName === '$snapshot')
+                            .map(([, properties]) => properties.$session_id)
+                    )
+                }
+
+                function emitInactiveWithoutAssertion(activityTimestamp: number): void {
+                    _emit({
+                        event: 123,
+                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                        data: { source: 0, adds: [], attributes: [], removes: [], texts: [] },
+                        timestamp: activityTimestamp,
+                    })
+                }
+
+                function runIdleRotations(fromTimestamp: number, days: number): void {
+                    let timestamp = fromTimestamp
+                    const endTimestamp = fromTimestamp + days * 24 * 60 * 60 * 1000
+                    let rotationCount = 0
+                    while (timestamp < endTimestamp) {
+                        timestamp += sessionManager['_sessionTimeoutMs'] + 1000
+                        rotationCount++
+                        sessionIdGeneratorMock.mockImplementation(() => `volume-rotation-${rotationCount}`)
+                        jest.setSystemTime(new Date(timestamp))
+                        sessionManager.checkAndGetSessionAndWindowId(false, timestamp)
+                        emitInactiveWithoutAssertion(timestamp + 10)
+                        jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                    }
+                }
+
+                beforeEach(() => {
+                    jest.useFakeTimers().setSystemTime(new Date(startingTimestamp))
+                })
+
+                it('a tab with zero user interaction ships zero recordings across three days of rotations', () => {
+                    runIdleRotations(startingTimestamp, 3)
+
+                    expect(shippedSessionIds()).toEqual(new Set())
+                })
+
+                it('a single interaction ships exactly one session and later idle rotations add none', () => {
+                    emitActiveEvent(startingTimestamp + 100)
+                    jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                    expect(shippedSessionIds()).toEqual(new Set([sessionId]))
+
+                    runIdleRotations(startingTimestamp + 100, 2)
+
+                    expect(shippedSessionIds()).toEqual(new Set([sessionId]))
+                })
+
+                it('no flushed batch spans more than the 24 hour session age cap', () => {
+                    emitActiveEvent(startingTimestamp + 100)
+                    runIdleRotations(startingTimestamp + 100, 2)
+
+                    const dayInMillis = 24 * 60 * 60 * 1000
+                    const snapshotCalls = (posthog.capture as Mock).mock.calls.filter(
+                        ([eventName]) => eventName === '$snapshot'
+                    )
+                    expect(snapshotCalls.length).toBeGreaterThan(0)
+                    for (const [, properties] of snapshotCalls) {
+                        const timestamps = properties.$snapshot_data.map((event: eventWithTime) => event.timestamp)
+                        expect(Math.max(...timestamps) - Math.min(...timestamps)).toBeLessThanOrEqual(dayInMillis)
+                    }
+                })
+            })
+
             it('takes a full snapshot for the new session on a second idle rotation without user interaction', () => {
                 // Regression test for #4202, reported production sequence: interaction, idle,
                 // rotation (restart leaves _isIdle 'unknown'), no further interaction, second

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2075,28 +2075,62 @@ describe('Lazy SessionRecording', () => {
                     })
                 }
 
-                function runIdleRotations(fromTimestamp: number, days: number): void {
+                // An idle tab rotates through two distinct paths, and both must stay silent:
+                // - organic: the recorder's own per-emit readOnly session check enforces the
+                //   24 hour cap (one rotation per day of pure idleness)
+                // - external: another caller rotates the session on the activity timeout
+                //   (a sibling tab, or any non-readonly check every ~30 idle minutes); the
+                //   recorder hears it via the session manager listener. This is the Jul 2026
+                //   incident path: one billed recording per external rotation, unbounded.
+                function runOrganicIdleEmits(fromTimestamp: number, days: number): void {
+                    let timestamp = fromTimestamp
+                    const endTimestamp = fromTimestamp + days * 24 * 60 * 60 * 1000
+                    sessionIdGeneratorMock.mockClear()
+                    sessionIdGeneratorMock.mockImplementation(() => `volume-organic-${uuidv7()}`)
+                    while (timestamp < endTimestamp) {
+                        timestamp += sessionManager['_sessionTimeoutMs'] + 1000
+                        jest.setSystemTime(new Date(timestamp))
+                        emitInactiveWithoutAssertion(timestamp)
+                        jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                    }
+                    // the readOnly per-emit check must rotate at each 24 hour cap; if this
+                    // stops happening, idle tabs accrete multi-day recordings again
+                    expect(sessionIdGeneratorMock.mock.calls.length).toBeGreaterThanOrEqual(days)
+                }
+
+                function runExternalRotations(fromTimestamp: number, days: number): number {
                     let timestamp = fromTimestamp
                     const endTimestamp = fromTimestamp + days * 24 * 60 * 60 * 1000
                     let rotationCount = 0
+                    sessionIdGeneratorMock.mockClear()
+                    sessionIdGeneratorMock.mockImplementation(() => `volume-external-${uuidv7()}`)
                     while (timestamp < endTimestamp) {
                         timestamp += sessionManager['_sessionTimeoutMs'] + 1000
                         rotationCount++
-                        sessionIdGeneratorMock.mockImplementation(() => `volume-rotation-${rotationCount}`)
                         jest.setSystemTime(new Date(timestamp))
                         sessionManager.checkAndGetSessionAndWindowId(false, timestamp)
                         emitInactiveWithoutAssertion(timestamp + 10)
                         jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
                     }
+                    // guard against a silent no-op loop: every step must have rotated the session
+                    expect(sessionIdGeneratorMock).toHaveBeenCalledTimes(rotationCount)
+                    return rotationCount
                 }
 
                 beforeEach(() => {
                     jest.useFakeTimers().setSystemTime(new Date(startingTimestamp))
                 })
 
-                it('a tab with zero user interaction ships zero recordings across three days of rotations', () => {
-                    runIdleRotations(startingTimestamp, 3)
+                it('a purely idle tab ships zero recordings across three days of cap rotations', () => {
+                    runOrganicIdleEmits(startingTimestamp, 3)
 
+                    expect(shippedSessionIds()).toEqual(new Set())
+                })
+
+                it('a tab whose session is rotated externally every idle timeout ships zero recordings across three days', () => {
+                    const rotations = runExternalRotations(startingTimestamp, 3)
+
+                    expect(rotations).toBeGreaterThan(100)
                     expect(shippedSessionIds()).toEqual(new Set())
                 })
 
@@ -2105,23 +2139,60 @@ describe('Lazy SessionRecording', () => {
                     jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
                     expect(shippedSessionIds()).toEqual(new Set([sessionId]))
 
-                    runIdleRotations(startingTimestamp + 100, 2)
+                    const rotations = runExternalRotations(startingTimestamp + 100, 2)
 
+                    expect(rotations).toBeGreaterThan(50)
                     expect(shippedSessionIds()).toEqual(new Set([sessionId]))
                 })
 
-                it('no flushed batch spans more than the 24 hour session age cap', () => {
-                    emitActiveEvent(startingTimestamp + 100)
-                    runIdleRotations(startingTimestamp + 100, 2)
+                it('an interaction after many idle rotations ships one session, not the held backlog', () => {
+                    runExternalRotations(startingTimestamp, 1)
 
-                    const dayInMillis = 24 * 60 * 60 * 1000
-                    const snapshotCalls = (posthog.capture as Mock).mock.calls.filter(
-                        ([eventName]) => eventName === '$snapshot'
-                    )
-                    expect(snapshotCalls.length).toBeGreaterThan(0)
-                    for (const [, properties] of snapshotCalls) {
-                        const timestamps = properties.$snapshot_data.map((event: eventWithTime) => event.timestamp)
-                        expect(Math.max(...timestamps) - Math.min(...timestamps)).toBeLessThanOrEqual(dayInMillis)
+                    const interactionTimestamp = jest.now() + 1000
+                    jest.setSystemTime(new Date(interactionTimestamp))
+                    emitActiveEvent(interactionTimestamp)
+                    jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+
+                    const shipped = shippedSessionIds()
+                    expect(shipped.size).toEqual(1)
+                    expect(shipped).toEqual(new Set([sessionRecording['_lazyLoadedSessionRecording']['_sessionId']]))
+                })
+
+                it('a continuously active tab rotates at the 24 hour cap and no shipped session spans longer', () => {
+                    const hourInMillis = 60 * 60 * 1000
+                    const dayInMillis = 24 * hourInMillis
+                    sessionIdGeneratorMock.mockImplementation(() => `volume-active-${uuidv7()}`)
+
+                    // activity every 10 minutes keeps the session inside the 30 minute
+                    // activity timeout, so the only legitimate rotation is the 24 hour cap
+                    const stepMillis = 10 * 60 * 1000
+                    let timestamp = startingTimestamp
+                    const endTimestamp = startingTimestamp + 50 * hourInMillis
+                    while (timestamp < endTimestamp) {
+                        timestamp += stepMillis
+                        jest.setSystemTime(new Date(timestamp))
+                        emitActiveEvent(timestamp, false)
+                        jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                    }
+
+                    const spanBySession = new Map<string, { min: number; max: number }>()
+                    for (const [eventName, properties] of (posthog.capture as Mock).mock.calls) {
+                        if (eventName !== '$snapshot') continue
+                        for (const event of properties.$snapshot_data as eventWithTime[]) {
+                            const span = spanBySession.get(properties.$session_id) ?? {
+                                min: event.timestamp,
+                                max: event.timestamp,
+                            }
+                            span.min = Math.min(span.min, event.timestamp)
+                            span.max = Math.max(span.max, event.timestamp)
+                            spanBySession.set(properties.$session_id, span)
+                        }
+                    }
+
+                    // 50 active hours must rotate at the cap into at least two sessions
+                    expect(spanBySession.size).toBeGreaterThanOrEqual(2)
+                    for (const [, span] of spanBySession) {
+                        expect(span.max - span.min).toBeLessThanOrEqual(dayInMillis)
                     }
                 })
             })


### PR DESCRIPTION
## Problem

The recorder's idle and rotation tests assert the mechanics of the current fix (held epochs, releases). No test asserts the billing-level outcome: how many recordings a tab ships over a long timeline. A future change could ship recordings through a different mechanism and pass every existing test. That is the shape of the Aug 2026 over-recording incident, where idle tabs shipped one billed recording per rotation.

## Changes

- Adds a `recording volume invariants` block to `lazy-sessionrecording.test.ts` with five scenario tests over multi-day fake-timer timelines.
- Idle rotation is exercised through both real paths: the recorder's own readOnly per-emit check (rotates at the 24 hour cap), and external rotations from the session manager (the incident path, one rotation per idle timeout).
- Scenarios: purely idle tab ships nothing over three days; externally-rotated idle tab ships nothing over three days; one interaction ships exactly one session; an interaction after a day of held rotations ships one session, not the backlog; a continuously active tab (activity inside the 30 minute timeout) rotates at the 24 hour cap and no shipped session spans longer.
- Each idle helper asserts its rotations actually happened, so a silent no-op loop cannot pass.
- The tests count `$session_id` values in `$snapshot` captures, not internal recorder state, so they survive refactors of the hold mechanism.

Mutation verification: disabling the `holdNextEpoch` decisions fails four tests; disabling `sessionPastMaximumLength` in `sessionid.ts` fails the organic-idle and active-tab tests. Every test fails under at least one mutation. All 331 tests in the file pass in under 1 second.

Companion to #4440, which documents these invariants in the incident registry.

## Release info Sub-libraries affected

### Libraries affected

None, test-only change, no version bump.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

## 🤖 Agent context

I (actually Claude) reworked these after review. Skills invoked: writing-tests, writing-pr-descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)