### PR TITLE
docs(mcp): ADR log + comment audit for @posthog/mcp

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,9 @@ packages/react-native/                                 @PostHog/team-client-libr
 # AI
 /packages/ai/package.json                              @PostHog/team-client-libraries @PostHog/team-llm-analytics
 
+# MCP Analytics
+packages/mcp/                                          @PostHog/team-client-libraries @PostHog/mcp-analytics
+
 # Web Analytics
 packages/browser/src/page-view.ts                      @PostHog/team-client-libraries @PostHog/team-web-analytics
 packages/browser/src/sessionid.ts                      @PostHog/team-client-libraries @PostHog/team-web-analytics

--- a/packages/mcp/docs/ARCHITECTURE.md
+++ b/packages/mcp/docs/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 This document describes the internals of the `@posthog/mcp` SDK and the exact PostHog event/property contract it emits.
 
+It documents the **current state** only. The reasoning behind architectural decisions — what problem forced them, what was rejected, what trade-offs were accepted — lives in [`docs/adr/`](./adr/) (see [ADR-0001](./adr/0001-record-architecture-decisions.md) for the conventions). When this document says "see ADR-NNNN", that's where the why is.
+
 ## TL;DR
 
 - `instrument(server, posthog, options?)` wraps an MCP server, intercepts request handlers, and pushes structured events through a small in-memory pipeline into PostHog via the host's `posthog-node` client (`posthog.capture()`). It returns an `McpAnalytics` handle.
@@ -73,24 +75,23 @@ The pipeline lives in an exported `processMcpEvent()` function in `src/extension
 ## 4. Session & identity
 
 - **Session ID format**: `ses_<uuidv7>` (`src/extensions/ids.ts`). Uses `uuidv7` from `@posthog/core`.
-- **Session resolution** (`getSessionId`, `src/extensions/session.ts`) — three sources, in order:
-  1. **Session token** (the replayed `mcp-session-id` request header): use the session id inside it and save the token's client name/version for events. See "Session tokens" below.
-  2. **Transport session id** (`extra.sessionId`, stateful servers): hash it (`deriveSessionIdFromMCPSession`) so the same MCP session maps to the same PostHog session across restarts.
-  3. **Memory**: keep the current id. Only generated sessions roll over, after **30 minutes of inactivity**; token/MCP sessions live as long as the client replays them.
-- **Session tokens — stateless / multi-pod continuity** (`src/extensions/session-token.ts`):
-  - **Problem**: a stateless server keeps nothing between requests, so sessions fragment to one per request and `$mcp_client_name`/`$mcp_client_version` go missing after `initialize`.
-  - **Mechanism**: the `Mcp-Session-Id` header is the only value clients replay on every request (spec: MUST; any visible-ASCII string is allowed). At `initialize`, when neither the client nor the transport supplied a session id, `mintStatelessSessionOnInitialize` sets the response header to `base64url(JSON)` with shortened keys (`sid` = session id, `cn`/`cv` = client name/version, `pv` = protocol version). Any pod decodes the replayed header — no store, no sticky routing, no client changes. The mint runs before the handler negotiates, so it first writes the client's _requested_ `pv`; once the handler returns, `initialize` re-mints the token with the _negotiated_ version, so every pod that replays it reports the version the session actually uses (not the requested one, which differs on a server downgrade).
+- **Session resolution** (`getSessionId`, `src/extensions/session.ts`) — four sources, first match wins:
+  1. **Conversation handle** (an agent-carried `conversation_id` tool argument, `enableConversationId: true`): hash it (`deriveSessionIdFromConversation`) — the 2026-07-28 anchor. Never persisted to shared state. See ADR-0004.
+  2. **Session token** (the replayed `mcp-session-id` request header): use the session id inside it and save the token's client name/version for events. See "Session tokens" below.
+  3. **Transport session id** (`extra.sessionId`, stateful servers): hash it (`deriveSessionIdFromMCPSession`) so the same MCP session maps to the same PostHog session across restarts.
+  4. **Memory**: keep the current id. Only generated sessions roll over, after **30 minutes of inactivity**; conversation/token/MCP sessions live as long as the client replays them.
+- **Session tokens — stateless / multi-pod continuity on MCP 2025-11-25** (`src/extensions/session-token.ts`, ADR-0003):
+  - At `initialize`, when neither the client nor the transport supplied a session id, `mintStatelessSessionOnInitialize` sets the `Mcp-Session-Id` response header to `base64url(JSON)` with shortened keys (`sid` = session id, `cn`/`cv` = client name/version, `pv` = protocol version). Any pod decodes the replayed header — no store, no sticky routing, no client changes. The token is unsigned and re-minted after the handler runs so it carries the _negotiated_ protocol version, not the requested one.
   - **JSON-mode constraint**: the auto-mint reaches the wire only with `enableJsonResponse: true` (headers are built after handlers run). SSE flushes headers first, so SSE servers set the header themselves with the exported `encodeSessionId`; the SDK still decodes it. Stateless mode also needs the SDK's usual fresh-transport-per-request pattern.
-  - **Trust**: unsigned — it carries only what the client already self-reports at `initialize`. A stateless server answering `DELETE` with 405 is spec-compliant.
   - **Degradation**: clients that don't replay the header fall back to the pre-token behavior — a generated session per request.
-  - **Shelf life**: the MCP 2026-07-28 revision (RC) removes `Mcp-Session-Id` and moves client info into per-request `_meta`; supporting it will be its own change.
+- **MCP 2026-07-28 (stateless revision)**: the revision removes `initialize` and the `Mcp-Session-Id` header, so the token machinery is legacy-only there. The session anchor is the agent-carried `conversation_id` (source 1 above), and client name/version + protocol version travel in every request's `params._meta` (`src/extensions/client-identity.ts`), stamped per-event so concurrent requests can't cross-attribute. `$mcp_initialize` is no longer a universal session anchor — anchor analysis on the first `$mcp_tool_call`. Era detection (suppressing the header for these clients) is an open follow-up. See ADR-0004.
 - **`distinct_id`** (`posthog-events.ts`): `identifyActorGivenId || sessionId || "anonymous"`. Pre-identify events are session-scoped; once `options.identify()` returns a user, subsequent events attribute to that user and PostHog's standard identity merge takes over.
 - **Person processing**: events for sessions with **no resolved identity** carry `$process_person_profile: false`, so anonymous MCP sessions don't each mint a throwaway person profile (the distinct id is just the session id). Once an identity is resolved, person processing stays on so `$set` lands on a real person.
 - **`$identify` event** (`handleIdentify`, `src/extensions/internal.ts`): `options.identify()` is resolved on **every** request (that's what stamps `distinct_id`/`$set`), but the standalone `$identify` event is published **at most once per session**. It fires when either:
   - the identity **materially changed** vs. the one cached for this session, or
   - the identity is **first-seen** for this server instance _and_ the session wasn't already announced at `initialize` (i.e. not a token session replaying past its handshake).
 
-  "First-seen" is decided by an `IdentityCache` (bounded LRU, max 1000 entries) keyed by session id and **per-server** (one instance per server's tracking data via the `WeakMap`) — which a stateless pod resets on every request. So on a token session, a first-seen identity on a non-`initialize` request is treated as already announced at the handshake and suppressed. **Consequences on stateless deployments**: an identity that only becomes resolvable after `initialize`, or that changes mid-session (each pod's cache is empty, so "changed" can't be detected), gets no `$identify` of its own. Person **properties** are still safe — every event carries `distinct_id`/`$set`, so `$set` lands on the person regardless. What a suppressed `$identify` skips is the identity **transition**: any pre-identify (anonymous, session-scoped) events emitted before the user resolved — e.g. a `$mcp_initialize` handled while `identify()` returned `null` — are not aliased/merged onto that person. This is inherent to statelessness (no pod can know a sibling already announced the session, and the replayed token is minted once at `initialize`), and is deferred to the planned stateless-by-default rework rather than worked around here. To drop `$identify` entirely, return `null` from `beforeSend` for `event === '$identify'`.
+  "First-seen" is decided by an `IdentityCache` (bounded LRU, max 1000 entries) keyed by session id and **per-server** (one instance per server's tracking data via the `WeakMap`) — which a stateless pod resets on every request. So on a token session, a first-seen identity on a non-`initialize` request is treated as already announced at the handshake and suppressed. On stateless deployments this means an identity that only resolves after `initialize`, or changes mid-session, gets no standalone `$identify`; person properties still land, because every event carries `distinct_id`/`$set`. Accepted as inherent to statelessness — see ADR-0003's consequences. To drop `$identify` entirely, return `null` from `beforeSend` for `event === '$identify'`.
 
 - **Groups (`$groups`)**: if `options.identify()` returns a `groups?: Record<string, string>` field (groupType → groupKey), it is stamped onto every event for that session as `$groups`. Callers never hand-write the `$groups` dollar-key themselves — they just return `groups` from `identify`.
 - **Person properties (`$set`)**: the `properties` object returned from `options.identify()` is written verbatim to `$set` (same as posthog-node's `identify({ distinctId, properties })`). Put `name`/`email`/etc in there.
@@ -304,11 +305,7 @@ An explicit SDK-owned context always wins. If the SDK injected `context` and its
 
 ### Why the fallback exists
 
-The `context` parameter is advertised as required in JSON Schema but **not enforced at the SDK validation layer** — a tool call with `arguments: {}` succeeds and lands in PostHog with `$mcp_intent` empty.
-
-The MCP SDK validates against the Zod schema the tool was originally registered with, and `@posthog/mcp` does not (and can't safely) re-derive Zod from the mutated JSON Schema. So for clients that ignore the JSON Schema hint — raw cURL, in-house agents, schema-blind crawlers — `intentFallback` is the only way to keep intent coverage non-zero.
-
-For a tightly-controlled internal MCP server with a single well-behaved client, the fallback is dead code.
+The `context` parameter is advertised as required in JSON Schema but **not enforced at the SDK validation layer** — a tool call with `arguments: {}` succeeds and lands in PostHog with `$mcp_intent` empty (ADR-0002 records why enforcement isn't possible). For clients that ignore the JSON Schema hint — raw cURL, in-house agents, schema-blind crawlers — `intentFallback` is the only way to keep intent coverage non-zero. For a tightly-controlled internal MCP server with a single well-behaved client, the fallback is dead code.
 
 ### What the SDK does NOT do
 
@@ -371,7 +368,11 @@ The SDK does **not**: call an LLM, inspect tool arguments, build heuristics, or 
 | Intent resolution (context arg + fallback)                            | `src/extensions/intent.ts`                                            |
 | Identity cache + identify dispatch                                    | `src/extensions/internal.ts`                                          |
 | Session id derivation & timeout                                       | `src/extensions/session.ts`, `src/extensions/ids.ts`                  |
+| Self-encoded session tokens (`Mcp-Session-Id`)                        | `src/extensions/session-token.ts`                                     |
 | `conversation_id` injection + minting                                 | `src/extensions/conversation-id.ts`                                   |
+| `_mcp_instructions` output-schema mirror                              | `src/extensions/output-instructions.ts`                               |
+| Client identity from request `_meta` (2026-07-28)                     | `src/extensions/client-identity.ts`                                   |
+| Injected-argument ownership tracking                                  | `src/extensions/analytics-parameters.ts`                              |
 | `get_more_tools` virtual tool                                         | `src/extensions/tools.ts`                                             |
 | Auto-redaction & binary stubbing                                      | `src/extensions/sanitization.ts`, `src/extensions/mcp-payloads.ts`    |
 | Size / depth / breadth caps                                           | `src/extensions/truncation.ts`                                        |

--- a/packages/mcp/docs/ARCHITECTURE.md
+++ b/packages/mcp/docs/ARCHITECTURE.md
@@ -2,7 +2,16 @@
 
 This document describes the internals of the `@posthog/mcp` SDK and the exact PostHog event/property contract it emits.
 
-It documents the **current state** only. The reasoning behind architectural decisions — what problem forced them, what was rejected, what trade-offs were accepted — lives in [`docs/adr/`](./adr/) (see [ADR-0001](./adr/0001-record-architecture-decisions.md) for the conventions). When this document says "see ADR-NNNN", that's where the why is.
+It documents the **current state** only. The reasoning behind architectural decisions — what problem forced them, what was rejected, what trade-offs were accepted — lives in [`docs/adr/`](./adr/). When this document says "see ADR-NNNN", that's where the why is.
+
+## Decision records
+
+One line per ADR; the record itself has the context and trade-offs. Not every change gets an ADR — [ADR-0001](./adr/0001-record-architecture-decisions.md) has the conventions and the bar for what counts as architecturally significant. A PR that adds an ADR also adds its line here.
+
+- [ADR-0001](./adr/0001-record-architecture-decisions.md) — Record architecture decisions: the conventions, and when (not) to write one.
+- [ADR-0002](./adr/0002-tools-list-analytics-affordances.md) — Analytics affordances (`context` param, `get_more_tools`) are injected via `tools/list`.
+- [ADR-0003](./adr/0003-self-encoded-session-tokens.md) — Self-encoded session tokens on `Mcp-Session-Id` (MCP 2025-11-25; superseded by 0004 for 2026-07-28).
+- [ADR-0004](./adr/0004-conversation-id-as-session-anchor.md) — `conversation_id` anchors `$session_id` under the stateless 2026-07-28 revision.
 
 ## TL;DR
 

--- a/packages/mcp/docs/ARCHITECTURE.md
+++ b/packages/mcp/docs/ARCHITECTURE.md
@@ -2,16 +2,7 @@
 
 This document describes the internals of the `@posthog/mcp` SDK and the exact PostHog event/property contract it emits.
 
-It documents the **current state** only. The reasoning behind architectural decisions — what problem forced them, what was rejected, what trade-offs were accepted — lives in [`docs/adr/`](./adr/). When this document says "see ADR-NNNN", that's where the why is.
-
-## Decision records
-
-One line per ADR; the record itself has the context and trade-offs. Not every change gets an ADR — [ADR-0001](./adr/0001-record-architecture-decisions.md) has the conventions and the bar for what counts as architecturally significant. A PR that adds an ADR also adds its line here.
-
-- [ADR-0001](./adr/0001-record-architecture-decisions.md) — Record architecture decisions: the conventions, and when (not) to write one.
-- [ADR-0002](./adr/0002-tools-list-analytics-affordances.md) — Analytics affordances (`context` param, `get_more_tools`) are injected via `tools/list`.
-- [ADR-0003](./adr/0003-self-encoded-session-tokens.md) — Self-encoded session tokens on `Mcp-Session-Id` (MCP 2025-11-25; superseded by 0004 for 2026-07-28).
-- [ADR-0004](./adr/0004-conversation-id-as-session-anchor.md) — `conversation_id` anchors `$session_id` under the stateless 2026-07-28 revision.
+It documents the **current state** only. The reasoning behind architectural decisions — what problem forced them, what was rejected, what trade-offs were accepted — lives in [`docs/adr/`](./adr/); the filenames are the index. When this document says "see ADR-NNNN", that's where the why is. Not every change gets an ADR: [ADR-0001](./adr/0001-record-architecture-decisions.md) has the conventions and the bar for what counts as architecturally significant.
 
 ## TL;DR
 

--- a/packages/mcp/docs/adr/0001-record-architecture-decisions.md
+++ b/packages/mcp/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,26 @@
+# ADR-0001: Record architecture decisions
+
+- Status: Accepted
+- Date: 2026-08-06
+
+## Context
+
+`@posthog/mcp` accumulates design decisions quickly — session identity has already crossed two MCP protocol revisions (2025-11-25 and 2026-07-28), and the reasoning behind each choice was living in two lossy places: long inline comment essays that drift and duplicate, and PR descriptions that nobody re-reads. `ARCHITECTURE.md` kept absorbing rationale too, growing into a mix of "what is" and "why it became so".
+
+## Decision
+
+We record architecturally significant decisions as Architecture Decision Records in `docs/adr/`, using the lightweight Nygard format: Status, Context, Decision, Consequences (plus References for PRs/issues).
+
+Conventions:
+
+- One decision per record, numbered sequentially (`NNNN-short-title.md`).
+- ADRs are immutable once accepted. Reversing or amending a decision gets a **new** ADR; the old one's Status becomes `Superseded by ADR-NNNN`.
+- `docs/ARCHITECTURE.md` stays the source of truth for the **current state** of the system. A PR that changes an architectural decision ships the ADR and the (small) ARCHITECTURE.md diff together.
+- Inline comments state the constraint and point at the ADR for the full story, instead of retelling it.
+
+## Consequences
+
+- Recall is cheap: "why does `$session_id` come from a hash?" is answered by one file with the trade-offs preserved, including the options we rejected.
+- Comments shrink: rationale lives in exactly one place, so the same fact is no longer retold in three files that drift independently.
+- Writing an ADR is a forcing function on new decisions — if the Context/Consequences are hard to write, the decision isn't understood yet.
+- ADRs 0002–0004 are backfilled from merged work; from here on, records are written as decisions are made.

--- a/packages/mcp/docs/adr/0001-record-architecture-decisions.md
+++ b/packages/mcp/docs/adr/0001-record-architecture-decisions.md
@@ -13,9 +13,9 @@ We record architecturally significant decisions as Architecture Decision Records
 
 Conventions:
 
-- One decision per record, numbered sequentially (`NNNN-short-title.md`).
+- One decision per record, numbered sequentially (`NNNN-short-title.md`). The filename doubles as the index entry — make it say what was decided, not just the topic. There is no separate index file to maintain.
 - ADRs are immutable once accepted. Reversing or amending a decision gets a **new** ADR; the old one's Status becomes `Superseded by ADR-NNNN`.
-- `docs/ARCHITECTURE.md` stays the source of truth for the **current state** of the system. A PR that changes an architectural decision ships the ADR and the (small) ARCHITECTURE.md diff together, including the ADR's one-line entry in the index there.
+- `docs/ARCHITECTURE.md` stays the source of truth for the **current state** of the system. A PR that changes an architectural decision ships the ADR and the (small) ARCHITECTURE.md diff together.
 - Inline comments state the constraint and point at the ADR for the full story, instead of retelling it.
 
 ### When to write one (and when not to)

--- a/packages/mcp/docs/adr/0001-record-architecture-decisions.md
+++ b/packages/mcp/docs/adr/0001-record-architecture-decisions.md
@@ -15,8 +15,19 @@ Conventions:
 
 - One decision per record, numbered sequentially (`NNNN-short-title.md`).
 - ADRs are immutable once accepted. Reversing or amending a decision gets a **new** ADR; the old one's Status becomes `Superseded by ADR-NNNN`.
-- `docs/ARCHITECTURE.md` stays the source of truth for the **current state** of the system. A PR that changes an architectural decision ships the ADR and the (small) ARCHITECTURE.md diff together.
+- `docs/ARCHITECTURE.md` stays the source of truth for the **current state** of the system. A PR that changes an architectural decision ships the ADR and the (small) ARCHITECTURE.md diff together, including the ADR's one-line entry in the index there.
 - Inline comments state the constraint and point at the ADR for the full story, instead of retelling it.
+
+### When to write one (and when not to)
+
+ADRs are for **architecturally significant** decisions only — the log loses its value if it records everything. Write one when a decision:
+
+- constrains future work or is expensive to reverse (a wire contract, an event/property name, a cross-SDK contract like the session-id derivation);
+- spans repos or SDKs, or responds to an MCP protocol revision;
+- deliberately accepts a trade-off or known gap that would otherwise resurface as "why don't we just...?" in every future review;
+- would otherwise need a multi-paragraph comment essay to justify inline.
+
+Do **not** write one for refactors, renames, bug fixes, dependency bumps, test changes, or anything the diff and its tests fully explain. Rule of thumb: if the PR description needs a "why not X instead" section, it's an ADR; if the diff speaks for itself, it isn't. When in doubt, start writing the Context section — if there's nothing non-obvious to say, stop.
 
 ## Consequences
 

--- a/packages/mcp/docs/adr/0002-tools-list-analytics-affordances.md
+++ b/packages/mcp/docs/adr/0002-tools-list-analytics-affordances.md
@@ -1,0 +1,30 @@
+# ADR-0002: Analytics affordances are injected via `tools/list`
+
+- Status: Accepted
+- Date: 2026-08-06 (backfilled; decisions shipped 2026-02 through 2026-05)
+
+## Context
+
+The differentiator of MCP analytics is **intent** — not "ran `query_run` 14 times" but "was trying to find a churn cohort". The agent is the only party that knows its intent, and the only channel the SDK controls to ask for it is the tool schemas the server advertises. Separately, we want to learn about capabilities agents *looked for but didn't find*, which by definition never show up as tool calls.
+
+## Decision
+
+The SDK decorates every `tools/list` response it intercepts:
+
+1. **`context` parameter** — injected into each tool's input JSON Schema, advertised as required, with a description telling the agent to state what it is trying to accomplish. Captured as `$mcp_intent` (`$mcp_intent_source: "context_parameter"`) and stripped from the arguments before the tool's own validation runs.
+2. **`get_more_tools` virtual tool** — appended when `reportMissing` is on. Calls to it emit `$mcp_missing_capability` (a capability gap, not a tool invocation), with the agent's description as `$mcp_intent`. The name resolves through a single helper so injection and detection can't drift, and if a real tool already uses the name, the SDK warns and delegates to the real handler (fail open) rather than intercepting it.
+
+Two deliberate limits:
+
+- **Schema mutation is conservative.** Tools whose schema already declares the parameter, or is composed (`oneOf`/`allOf`/`anyOf`/`$ref`), are skipped with a warning — there is no single `properties` bag to extend safely. `additionalProperties: false` is lifted only on schemas we do extend, since the injected key would otherwise invalidate them.
+- **"Required" is advisory.** The MCP SDK validates calls against the Zod schema the tool was registered with, and the SDK cannot safely re-derive Zod from the mutated JSON Schema — so a call without `context` still succeeds, just without intent. The `intentFallback` option exists for exactly those clients (tagged `$mcp_intent_source: "inferred"`); the SDK deliberately does no inference itself.
+
+## Consequences
+
+- Intent coverage depends on agent compliance; schema-blind clients need `intentFallback` or produce events with no `$mcp_intent` at all (and no synthetic `"none"` value).
+- Every injected affordance must be stripped on the inbound path (arguments cleaned before dispatch), which is why argument "ownership" is tracked per tool from the advertised listing.
+- The virtual tool means dashboards must treat `$mcp_missing_capability` separately from `$mcp_tool_call` — it is deliberately not a tool invocation.
+
+## References
+
+- PostHog/posthog-js#3653 (initial SDK), #3976 / #3993 (late handler registration), #4356 (preserve real tools named `get_more_tools`), #4379 (reserved-argument ownership)

--- a/packages/mcp/docs/adr/0003-self-encoded-session-tokens.md
+++ b/packages/mcp/docs/adr/0003-self-encoded-session-tokens.md
@@ -1,0 +1,31 @@
+# ADR-0003: Self-encoded session tokens on `Mcp-Session-Id`
+
+- Status: Accepted for MCP 2025-11-25 clients. Superseded by ADR-0004 for the 2026-07-28 revision, which removes the header.
+- Date: 2026-08-06 (backfilled; shipped 2026-06 in PostHog/posthog-js#4123)
+
+## Context
+
+On stateless MCP servers (a fresh `Server` + transport per request — serverless, workers, horizontally-scaled pods) every request became its own session, and `$mcp_client_name` / `$mcp_client_version` went missing after `initialize` (they are only sent in the init body, and `getClientVersion()` is empty on any instance that didn't handle it). A real customer saw `sessions == tool_calls` and a 100% "Other" client breakdown.
+
+Under the 2025-11-25 spec, the only value a compliant client replays on **every** request is the `Mcp-Session-Id` response header, and the spec allows any visible-ASCII string in it.
+
+## Decision
+
+At `initialize`, when neither the client nor the transport supplied a session id, mint the `Mcp-Session-Id` header as a self-encoded token: `base64url(JSON)` with shortened keys (`sid` = session id, `cn`/`cv` = client name/version, `pv` = protocol version). Any pod decodes the replayed header and recovers the same `$session_id` plus client metadata — no server-side store, no sticky routing, no client changes.
+
+Supporting choices:
+
+- **Unsigned.** The token carries only what the client already self-reports at `initialize`; there is nothing to forge that the client couldn't send directly.
+- **Two-phase protocol version.** The mint runs before the handler negotiates, so it stores the client's *requested* version; after the handler returns, the token is re-minted with the *negotiated* version so pods that replay it report the version the session actually runs on.
+- **Transport constraints accepted.** The auto-mint reaches the wire only when response headers are built after the handler runs (StreamableHTTP with `enableJsonResponse: true`). SSE flushes headers first, so SSE servers set the header themselves with the exported `encodeSessionId`; the SDK still decodes it either way.
+- **Scope split on read.** The token's session id is per-chat; its client identity is per-connection. A request whose session is anchored elsewhere (ADR-0004) still adopts the token's client identity — on a pod that never saw `initialize`, the token is the only source of it.
+
+## Consequences
+
+- Clients that don't replay the header degrade to the old behavior: one generated session per request.
+- `$identify` is published at most once per session, and a token session is assumed to have been announced at `initialize` by whichever pod handled it. Known gap: an identity that only resolves *after* `initialize` on a stateless deployment gets no standalone `$identify` (person properties still land via `$set` on every event). Inherent to statelessness; accepted rather than worked around.
+- The 2026-07-28 revision removes the header outright (servers MUST NOT mint or echo it), so this whole mechanism is legacy-only for clients on that revision — see ADR-0004. Era detection to gate it explicitly is an open follow-up.
+
+## References
+
+- PostHog/posthog-js#4123 (tokens), #4210 (negotiated protocol version), #4144 ($identify once per session), PostHog/posthog#68635 (customer report)

--- a/packages/mcp/docs/adr/0004-conversation-id-as-session-anchor.md
+++ b/packages/mcp/docs/adr/0004-conversation-id-as-session-anchor.md
@@ -1,0 +1,37 @@
+# ADR-0004: `conversation_id` is the session anchor for the stateless MCP revision
+
+- Status: Accepted
+- Date: 2026-08-06 (backfilled; shipped 2026-07/08 in PostHog/posthog-js#4428 and companions)
+
+## Context
+
+The MCP **2026-07-28** revision removes protocol-level sessions: no `initialize` handshake, no `Mcp-Session-Id` header (SEP-2575 / SEP-2567). Every session id the SDK could previously produce comes from the transport, and all of them die on reconnect, restart, or a per-request server instance. The spec's own guidance for state across calls is an explicit handle: *"returning an explicit handle from a creation tool and accepting that handle as an argument on subsequent calls."*
+
+The SDK already had that handle built but inert: `enableConversationId` injects a `conversation_id` parameter and prompts the agent to echo it. Only the agent survives the whole conversation, so only the agent can carry the session.
+
+## Decision
+
+When the agent supplies a `conversation_id`, `$session_id` is derived from it — outranking the session token (ADR-0003) and the transport id.
+
+The load-bearing details:
+
+- **Deterministic, unsalted hash.** Two pods that never met must agree on the session, and this revision leaves them no shared state to agree through. The derivation (`deterministicPrefixedId('ses', conversationId)`) is therefore the **cross-SDK contract**: posthog-python must reproduce it byte for byte or a conversation splits by serving SDK.
+- **Hashed, not verbatim.** A bare uuidv7 as `$session_id` would land in the Session Replay namespace and render a "View recording" button that resolves to nothing. `$mcp_conversation_id` still carries the raw handle for joins.
+- **Only echoes of our own mint are trusted.** A supplied handle is accepted only if shaped like a uuidv7 (lowercased — some hosts uppercase uuids, and the hash is case-sensitive); anything else is treated as absent: mint fresh, prompt back. Deterministic derivation means two callers sending the same string share a session, and agents that ignore instructions invent colliding strings (`conv-1`, `1`), not conforming uuidv7s. Residual risk — two callers echoing the *same* well-formed uuidv7 — is accepted: closing it needs a signed handle (a shared secret on every pod), and `$session_id` is an analytics grouping key, not security-bearing.
+- **Never persisted.** The handle belongs to one request; the resolution path returns before the shared-state writes, because persisting it would leak one chat's session onto a concurrent chat's `tools/list`.
+- **Prompt-back rides two channels.** A text block on the minting response only (repeating it would put a `[SERVER]:` line in front of the user on every result), and — for tools that declare an `outputSchema` — an `_mcp_instructions` key mirrored into `structuredContent` on *every* response. The second channel exists because clients that read `structuredContent` drop `content` entirely: measured against Claude Code, echo rate was 100% for schema-less tools and 0% for schema-declaring ones before the mirror. Declaring the key on the advertised schema is what makes the write safe — clients ajv-validate against `additionalProperties: false`. Errored results also carry the prompt-back: a failure on the first call is exactly when the retry must stay in the same session.
+- **Undelivered handles are cleared.** If neither channel could carry a minted handle, the agent never received it, so it is stripped off the event rather than showing analytics an id nobody holds.
+
+Companion decision (same revision): client name/version and protocol version now travel in every request's `params._meta` under reverse-DNS keys. They are stamped onto the per-request event, never onto server-wide state, so concurrent requests from different clients can't cross-attribute (#4237).
+
+## Consequences
+
+- `enableConversationId` stays opt-in; without a handle, behavior is exactly ADR-0003's.
+- `$mcp_initialize` / `$mcp_tools_list` still get the transport-derived id — the handle only rides `tools/call` arguments. `$mcp_initialize` is no longer a universal session anchor; anchor analysis on the first `$mcp_tool_call`.
+- Tool-argument "ownership" (which advertised schemas declared `_mcp_instructions`) is cached per instance from `tools/list`. A per-request instance that never served a listing fails closed and skips the `structuredContent` mirror — guessing would fail the customer's entire tool result under `additionalProperties: false`. Open follow-up: a process-scoped ownership cache.
+- Era detection (gating the ADR-0003 token machinery off for 2026-07-28 clients, which must not see the header) is an open follow-up.
+
+## References
+
+- PostHog/posthog-js#4428 (anchor), #4430 (`_mcp_instructions` declaration), #4431 (structuredContent mirror), #4433 (handle on errors and capability gaps), #4237 (`_meta` client identity)
+- MCP 2026-07-28 spec, Stateful Tools: https://modelcontextprotocol.io/specification/2026-07-28/server/tools#stateful-tools

--- a/packages/mcp/src/extensions/compatibility.ts
+++ b/packages/mcp/src/extensions/compatibility.ts
@@ -21,26 +21,22 @@ type ServerRecord = Record<string, unknown>
  * - Server info structure
  */
 
-// Function to log compatibility information
 export function logCompatibilityWarning(logger: LoggerFn): void {
   logger(
     'PostHog MCP analytics SDK Compatibility: This version only supports Model Context Protocol TypeScript SDK v1.11 and above. Please upgrade if using an older version.'
   )
 }
 
-// Check if server has high-level structure (wrapper with .server property)
 export function isHighLevelServer(server: unknown): server is ServerRecord & { server: ServerRecord } {
   return (
     !!server && typeof server === 'object' && 'server' in server && !!server.server && typeof server.server === 'object'
   )
 }
 
-// Check if server has low-level structure (no .server property)
 export function isLowLevelServer(server: unknown): server is ServerRecord {
   return !!server && typeof server === 'object' && !('server' in server)
 }
 
-// Type guard function that validates server compatibility and returns typed server
 export function isCompatibleServerType(server: unknown, logger: LoggerFn): MCPServerLike | HighLevelMCPServerLike {
   if (!server || typeof server !== 'object') {
     logCompatibilityWarning(logger)
@@ -50,7 +46,6 @@ export function isCompatibleServerType(server: unknown, logger: LoggerFn): MCPSe
   }
 
   if (isHighLevelServer(server)) {
-    // Validate high-level server requirements
     if (!server._registeredTools || typeof server._registeredTools !== 'object') {
       logCompatibilityWarning(logger)
       throw new Error(
@@ -64,18 +59,15 @@ export function isCompatibleServerType(server: unknown, logger: LoggerFn): MCPSe
       )
     }
 
-    // Validate the underlying low-level server
     const targetServer = server.server
     validateLowLevelServer(targetServer, logger)
 
     return server as unknown as HighLevelMCPServerLike
   }
-  // Direct low-level server validation
   validateLowLevelServer(server, logger)
   return server as MCPServerLike
 }
 
-// Helper function to validate low-level server requirements
 function validateLowLevelServer(server: unknown, logger: LoggerFn): void {
   if (!server || typeof server !== 'object') {
     logCompatibilityWarning(logger)
@@ -100,7 +92,6 @@ function validateLowLevelServer(server: unknown, logger: LoggerFn): void {
     )
   }
 
-  // Validate that _requestHandlers contains functions with compatible signatures
   if (typeof serverRecord._requestHandlers.get !== 'function') {
     logCompatibilityWarning(logger)
     throw new Error(

--- a/packages/mcp/src/extensions/context-parameters.ts
+++ b/packages/mcp/src/extensions/context-parameters.ts
@@ -41,7 +41,6 @@ export function addContextParameterToTool<TTool extends ContextInjectableTool>(
   contextDescriptionOverride?: string,
   logger: LoggerFn = log
 ): TTool {
-  // Create a shallow copy of the tool to avoid modifying the original
   const modifiedTool = { ...tool }
   const toolName = tool.name || 'unknown'
   const schema = modifiedTool.inputSchema as AnalyticsInjectableJsonSchema | undefined
@@ -55,10 +54,6 @@ export function addContextParameterToTool<TTool extends ContextInjectableTool>(
     return modifiedTool
   }
 
-  // Note: If additionalProperties is false, we'll need to remove that constraint
-  // when adding context, otherwise the schema would be invalid. We handle this
-  // after the deep copy below.
-
   if (!modifiedTool.inputSchema) {
     modifiedTool.inputSchema = {
       type: 'object',
@@ -69,29 +64,26 @@ export function addContextParameterToTool<TTool extends ContextInjectableTool>(
 
   const contextDescription = contextDescriptionOverride || DEFAULT_CONTEXT_PARAMETER_DESCRIPTION
 
-  // Deep copy the inputSchema to avoid mutations
+  // Deep copy: the server may reuse or freeze the schema object it handed us.
   modifiedTool.inputSchema = JSON.parse(JSON.stringify(modifiedTool.inputSchema)) as AnalyticsInjectableJsonSchema
 
   const inputSchema = modifiedTool.inputSchema as AnalyticsInjectableJsonSchema
 
-  // Ensure properties object exists
   if (!inputSchema.properties) {
     inputSchema.properties = {}
   }
 
-  // Handle additionalProperties: false - must remove this constraint since we're adding context
-  // The MCP SDK adds this constraint when converting Zod schemas to JSON Schema
+  // The MCP SDK emits `additionalProperties: false` when converting Zod schemas;
+  // left in place it would make the injected `context` key invalid.
   if (inputSchema.additionalProperties === false) {
     inputSchema.additionalProperties = undefined
   }
 
-  // Add context property
   inputSchema.properties.context = {
     type: 'string',
     description: contextDescription,
   }
 
-  // Add context to required array
   if (Array.isArray(inputSchema.required)) {
     if (!inputSchema.required.includes('context')) {
       inputSchema.required.push('context')

--- a/packages/mcp/src/extensions/conversation-id.ts
+++ b/packages/mcp/src/extensions/conversation-id.ts
@@ -102,20 +102,9 @@ export type ConversationIdResolution =
  * derivation is deterministic so that two pods agree — which also means two
  * *callers* sending the same string land in the same session. The strings agents
  * invent are not random (`conv-1`, `1`, `session`), so trusting them verbatim
- * would silently merge unrelated conversations, potentially across users.
- *
- * A compliant agent echoes the uuidv7 we minted and is unaffected. Anything else
- * is treated exactly as if the handle were absent: mint, and prompt back. Shape
+ * would silently merge unrelated conversations, potentially across users. Shape
  * rather than a registry of issued ids, because a per-request server has no
- * memory of what it minted.
- *
- * This narrows the problem, it does not prove provenance: a caller supplying a
- * well-formed uuidv7 is trusted, so two that pick the *same* one still merge. That
- * residue is far smaller than the case it replaces — an agent ignoring the
- * parameter description reaches for `conv-1` or `1`, not a conforming uuidv7 — and
- * closing it needs a signed handle, i.e. a secret shared by every pod. Worth doing
- * if this ever anchors something security-bearing; `$session_id` is an analytics
- * grouping key, so it does not today.
+ * memory of what it minted. Residual risk and why it's accepted: ADR-0004.
  */
 export function resolveConversationId(enabled: boolean, args: unknown): ConversationIdResolution {
   if (!enabled) {
@@ -123,10 +112,9 @@ export function resolveConversationId(enabled: boolean, args: unknown): Conversa
   }
   const supplied = extractConversationId(args)
   if (supplied && MINTED_CONVERSATION_ID.test(supplied)) {
-    // Lowercased because the shape test is case-insensitive but the hash behind
-    // `$session_id` is not. Some hosts normalise uuids to uppercase, and an
-    // uppercased echo of our own handle would otherwise clear the gate and then
-    // land in a different session than the call that minted it.
+    // Lowercased: the shape test is case-insensitive but the hash behind
+    // `$session_id` is not, so an uppercased echo (some hosts normalise uuids)
+    // would land in a different session than the call that minted it.
     return { minted: false, conversationId: supplied.toLowerCase() }
   }
   return { minted: true, conversationId: uuidv7() }

--- a/packages/mcp/src/extensions/instrument-highlevel.ts
+++ b/packages/mcp/src/extensions/instrument-highlevel.ts
@@ -280,7 +280,6 @@ export function instrumentHighLevelServer(server: HighLevelMCPServerLike, logger
     const lowLevelServer = server.server
     const mcpAnalyticsData = getServerTrackingData(lowLevelServer)
 
-    // Patch already existing handlers, and patch setRequestHandler to capture dynamically created handlers.
     const handlers: Record<string, HandlerPatch> = {
       initialize: (trackedServer, originalHandler, request, extra) =>
         handleInitializeRequest(trackedServer, originalHandler, request, extra, logger),

--- a/packages/mcp/src/extensions/instrument-lowlevel.ts
+++ b/packages/mcp/src/extensions/instrument-lowlevel.ts
@@ -32,7 +32,6 @@ type MCPRequestExtra = Parameters<MCPRequestHandler>[1]
  */
 export function instrumentLowLevelServer(server: MCPServerLike, logger: LoggerFn): void {
   try {
-    // Patch already existing handlers, and patch setRequestHandler to capture dynamically created handlers.
     const hadCallToolHandler = server._requestHandlers.has('tools/call')
     const traceToolCall: HandlerPatch = (server, originalHandler, request, extra) =>
       handleToolCallRequest(server, originalHandler, request, extra, logger)

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -157,22 +157,13 @@ function getActiveAnalyticsParameterOwnership(
   return {
     context: !isMissingCapabilityTool && isContextEnabled(data.options.context) && ownership?.context === true,
     conversationId: data.options.enableConversationId === true && ownership?.conversationId === true,
-    // Deliberately read off `listed`, never the override. This asks whether
-    // `tools/list` actually declared `_mcp_instructions`, and only the advertised
-    // JSON Schema can answer it — an override is built from the live registry,
-    // which on the high-level path holds Zod.
-    //
-    // The cache is per-instance, so this is not merely "before the first
-    // `tools/list`": an instance that never serves a listing never writes the
-    // mirror at all. That is the per-request server pattern — `tools/list` lands
-    // on one instance, `tools/call` on a cold one — where the handle falls back
-    // to the `content` block and a structuredContent-only client misses it.
-    //
-    // Failing closed is deliberate. Writing a key the advertised schema did not
-    // declare fails the *entire* tool result under `additionalProperties: false`,
-    // so guessing costs the caller their result, while not guessing costs us one
-    // delivery channel. The fix is a process-scoped ownership cache, so a listing
-    // served by any instance answers for the rest — not a per-call guess.
+    // Deliberately read off `listed`, never the override: only the advertised
+    // JSON Schema can say whether `tools/list` declared `_mcp_instructions` (an
+    // override is built from the live registry, which holds Zod on the
+    // high-level path). An instance that never served a listing has no answer
+    // and fails closed — writing an undeclared key fails the customer's entire
+    // tool result under `additionalProperties: false`. See ADR-0004 for the
+    // per-request-instance gap this leaves and the planned fix.
     outputInstructions: data.options.enableConversationId === true && listed?.outputInstructions === true,
   }
 }
@@ -250,19 +241,14 @@ async function prepareToolCallEvent(
 }
 
 /**
- * Delivers the conversation session handle back to the agent, over both channels a tool
- * result has:
+ * Delivers the conversation session handle back to the agent over both channels
+ * a tool result has: mirrored into `structuredContent` on every response (for
+ * tools whose output schema declares the key), and as a `content` text block on
+ * the minting response only. Why two channels and why those cadences: ADR-0004.
  *
- * - `structuredContent`, on *every* response for a tool whose output schema we
- *   declared the key on. Clients that read structured results never see the text
- *   block, and re-sending it each time lets an agent that dropped the session handle read
- *   it back.
- * - `content`, as a text block, only on the response that minted the session handle.
- *   Repeating it every call would put a `[SERVER]:` line in front of the user on
- *   every single tool result.
- *
- * If neither channel could carry a session handle we minted, the agent never received it,
- * so clear it off the event rather than showing analytics an id nobody has.
+ * If neither channel could carry a session handle we minted, the agent never
+ * received it, so clear it off the event rather than showing analytics an id
+ * nobody has.
  */
 function applyConversationInstructions(
   event: McpEvent | null,
@@ -364,13 +350,7 @@ export type HandlerPatch = (
   extra: CompatibleRequestHandlerExtra | undefined
 ) => Promise<unknown>
 
-/**
- * Applies the `patches` (keyed by method, e.g. `initialize`, `tools/list`) to the
- * handlers already registered, and patches `setRequestHandler` so matching
- * handlers registered later are patched too. The latter is what makes adapters
- * that register handlers post-construction work — e.g. `@rekog/mcp-nest` hands a
- * bare server to instrument() and only then registers its handlers.
- */
+/** Pre-patch handlers, kept so `isToolAdvertised` can query the raw listing. */
 const originalRequestHandlers = new WeakMap<MCPServerLike, Map<string, MCPRequestHandler>>()
 
 function rememberOriginalRequestHandler(
@@ -417,8 +397,14 @@ export function registerFallbackRequestHandler(
   server._requestHandlers.set(handlerName, (request, extra) => patch(server, fallbackHandler, request, extra))
 }
 
+/**
+ * Applies the `patches` (keyed by method, e.g. `initialize`, `tools/list`) to the
+ * handlers already registered, and patches `setRequestHandler` so matching
+ * handlers registered later are patched too. The latter is what makes adapters
+ * that register handlers post-construction work — e.g. `@rekog/mcp-nest` hands a
+ * bare server to instrument() and only then registers its handlers.
+ */
 export function patchRequestHandlers(server: MCPServerLike, patches: Record<string, HandlerPatch>): void {
-  // Monkey patch existing handlers.
   for (const [handlerName, patch] of Object.entries(patches)) {
     const originalHandler = server._requestHandlers.get(handlerName)
     if (originalHandler) {
@@ -683,7 +669,7 @@ export function cacheToolCategories(cache: Map<string, string>, tools: ListTools
  * client name/version is lost after `initialize`. Fix: mint the
  * `Mcp-Session-Id` response header as a token carrying both. Clients replay
  * the header on every request, so any pod recovers them with no server-side
- * store (decoded in `getSessionId`).
+ * store (decoded in `getSessionId`). See ADR-0003.
  *
  * The header only reaches the wire when response headers are built after the
  * handler runs — StreamableHTTP with `enableJsonResponse: true`. SSE flushes

--- a/packages/mcp/src/extensions/internal.ts
+++ b/packages/mcp/src/extensions/internal.ts
@@ -166,11 +166,10 @@ export async function handleIdentify(
       // was already announced by whichever pod handled `initialize`, so only the
       // handshake, or a genuine change a long-lived server observed, publishes
       // $identify. Every event still carries distinct_id/$set regardless, so
-      // person properties are never lost. Known gap: if identity is null at
-      // `initialize` but resolves later on a token session, that first $identify
-      // is suppressed too, so any pre-identify (anonymous) events aren't aliased
-      // onto the user. Inherent to statelessness (no pod knows a sibling already
-      // announced); revisit with the stateless-by-default rework.
+      // person properties are never lost. Known accepted gap (ADR-0003): an
+      // identity resolving only after `initialize` on a token session gets no
+      // standalone $identify, so its pre-identify events aren't aliased onto
+      // the user.
       const changed = previousIdentity !== undefined && !areIdentitiesEqual(previousIdentity, mergedIdentity)
       const firstSeen = previousIdentity === undefined
       const announcedAtInitialize =

--- a/packages/mcp/src/extensions/output-instructions.ts
+++ b/packages/mcp/src/extensions/output-instructions.ts
@@ -3,17 +3,15 @@ import { log } from './logger'
 import type { AnalyticsInjectableJsonSchema } from './analytics-parameters'
 
 /**
- * The `conversation_id` session handle reaches the agent as a text block appended to the
- * tool result. That block is invisible to any client that reads
- * `structuredContent` instead of `content` — which is what clients do whenever a
- * tool declares an `outputSchema`. Measured against Claude Code, correlation for
- * such tools drops to zero.
- *
- * The fix is to mirror the session handle into `structuredContent` as well, which this
- * module does in two halves that must stay in that order:
+ * Mirrors the `conversation_id` session handle into `structuredContent`, in two
+ * halves that must stay in that order:
  *
  *   1. declare `_mcp_instructions` on the tool's advertised `outputSchema`
  *   2. write it into the result's `structuredContent`
+ *
+ * Needed because clients that read `structuredContent` — which they do whenever
+ * a tool declares an `outputSchema` — never see the `content` text block that
+ * carries the handle (ADR-0004).
  *
  * The declaration is what makes the write safe. The MCP client ajv-validates
  * `structuredContent` against the schema from `tools/list`, and

--- a/packages/mcp/src/extensions/posthog-mcp.ts
+++ b/packages/mcp/src/extensions/posthog-mcp.ts
@@ -72,10 +72,6 @@ export interface PostHogMCPOptions extends PostHogOptions {
  * ```
  */
 export class PostHogMCP extends PostHog {
-  // Reuses the shared sink so MCP events flow through the identical
-  // sanitize/truncate/fan-out pipeline as the `instrument()` path; the sink
-  // publishes via `this` (the inherited `capture()`), so the client's own
-  // `beforeSend` and batching apply.
   readonly #sink = new McpEventSink(this)
 
   // The get_more_tools name lives here (not on the per-call options) so that
@@ -85,7 +81,6 @@ export class PostHogMCP extends PostHog {
   constructor(apiKey: string, options: PostHogMCPOptions = {}) {
     super(apiKey, options)
     this.#missingCapabilityToolName = options.missingCapabilityToolName ?? GET_MORE_TOOLS_NAME
-    // Report `$lib: 'posthog-node-mcp'` instead of the inherited `posthog-node`.
     applyMcpLibIdentity(this)
   }
 

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -30,9 +30,10 @@ export function deriveSessionIdFromMCPSession(mcpSessionId: string): string {
 }
 
 /**
- * Derives the SDK session id from the agent's conversation handle. Deterministic
- * and unsalted on purpose: two pods that never met must agree on the session, and
- * the 2026-07-28 revision leaves them no shared state to agree through.
+ * Derives the SDK session id from the agent's conversation handle (ADR-0004).
+ * Deterministic and unsalted on purpose: two pods that never met must agree on
+ * the session, and the 2026-07-28 revision leaves them no shared state to agree
+ * through.
  *
  * Hashed rather than used verbatim so an MCP session can never collide with a
  * Session Replay id — a bare uuidv7 would render a "View recording" button that
@@ -69,26 +70,16 @@ export function getSessionId(
     throw new Error('Server tracking data not found')
   }
 
-  // 1. The agent's conversation handle. It outranks both steps below because it
-  // is the only id that survives reconnects, restarts, and the per-request
-  // server instances the 2026-07-28 revision introduces. Hashed rather than used
-  // verbatim so it can never collide with Session Replay ids.
-  //
-  // This returns instead of falling through to the shared-state writes at the
-  // end: the handle belongs to this one request, and persisting it would leak
-  // one chat's session onto a concurrent chat's `tools/list`.
-  //
-  // `lastActivity` therefore does not advance either, so a conversation that
-  // always echoes lets the in-memory fallback age past the inactivity timeout —
-  // and a later call carrying no handle rotates it. That is the honest reading:
-  // the fallback session really has been idle for that whole time.
+  // 1. The agent's conversation handle — the only id that survives reconnects,
+  // restarts, and the per-request server instances of the 2026-07-28 revision
+  // (ADR-0004). Returns before the shared-state writes at the end: the handle
+  // belongs to this one request, and persisting it (or advancing lastActivity)
+  // would leak one chat's session onto a concurrent chat's `tools/list`.
   if (conversationId) {
-    // The handle decides the *session*, but the request may still carry our token,
-    // and on a stateless instance that never processed `initialize` its payload is
-    // the only place client identity exists. Restore that before returning: the
-    // early return is about not persisting a session, not about ignoring what the
-    // request told us about the client. Without this, tool calls and `$identify`
-    // go out unattributed on exactly the deployments this branch exists for.
+    // The session comes from the handle, but on an instance that never processed
+    // `initialize` the request's token is still the only source of client
+    // identity — without this, tool calls and `$identify` go out unattributed
+    // on exactly the deployments this branch exists for.
     applyTokenClientIdentity(data, extra)
     return deriveSessionIdFromConversation(conversationId)
   }
@@ -110,14 +101,10 @@ export function getSessionId(
 /**
  * Restores the client name/version and protocol version baked into our token at
  * mint time, and hands the decoded token back so the caller can also take the
- * session id from it.
- *
- * Split out from step 2 because the two halves of the token have different
- * scopes. The session id it carries is per-chat, so a conversation-anchored
- * request must not adopt it. The client identity is per-connection — the same
- * client for every request on it — so a conversation-anchored request should,
- * and on a stateless instance that never saw `initialize` this is the only
- * source of it.
+ * session id from it. Split from step 2 because the token's two halves have
+ * different scopes: its session id is per-chat (a conversation-anchored request
+ * must not adopt it), its client identity is per-connection (every request on
+ * the connection should).
  */
 function applyTokenClientIdentity(
   data: MCPAnalyticsData,
@@ -139,9 +126,8 @@ function applyTokenClientIdentity(
  * issued. Returns undefined when the request carried neither, which is what
  * sends the caller on to 3.
  *
- * Both are 2025-11-25 mechanisms. The 2026-07-28 revision removed that header
- * outright — servers MUST NOT mint or echo it — so this entire step becomes
- * legacy-only once era detection lands.
+ * Both are 2025-11-25 mechanisms; the 2026-07-28 revision removed the header
+ * outright, so this step is legacy-only once era detection lands (ADR-0003).
  */
 function readSessionIdFromRequest(data: MCPAnalyticsData, extra?: CompatibleRequestHandlerExtra): string | undefined {
   // 2a. A token we minted at `initialize` and the client replayed. It rides the
@@ -203,8 +189,8 @@ export function getSessionInfo(
   const actorInfo = data?.identifiedSessions.get(sessionId ?? data.sessionId)
 
   const sessionInfo: SessionInfo = {
-    ipAddress: undefined, // grab from django
-    sdkLanguage: 'TypeScript', // hardcoded for now
+    ipAddress: undefined,
+    sdkLanguage: 'TypeScript',
     sdkVersion: version,
     serverName: server._serverInfo?.name,
     serverVersion: server._serverInfo?.version,

--- a/packages/mcp/src/extensions/sink.ts
+++ b/packages/mcp/src/extensions/sink.ts
@@ -92,9 +92,8 @@ async function applyBeforeSend(
 }
 
 /**
- * Wraps a user-supplied `posthog-node` client. Runs every MCP event through the
- * sanitize → truncate pipeline, fans it out into the `$mcp_*` / `$exception`
- * events, applies `beforeSend`, and hands each to `posthog.capture()`.
+ * Wraps a user-supplied `posthog-node` client: runs every MCP event through
+ * {@link processMcpEvent} and hands each surviving payload to `posthog.capture()`.
  *
  * The SDK does not own the client lifecycle — the host application constructs
  * the `PostHog` instance and is responsible for `shutdown()` (matching
@@ -107,9 +106,8 @@ export class McpEventSink {
   ) {}
 
   /**
-   * Push an MCP event through the pipeline (sanitize → truncate → fan out →
-   * beforeSend → capture). Errors at any stage are logged and the event is
-   * dropped, never re-thrown into tool code.
+   * Errors at any stage are logged and the event is dropped, never re-thrown
+   * into tool code.
    */
   async capture(event: McpEvent, options: McpCaptureOptions): Promise<void> {
     const result = await processMcpEvent(event, options, this.logger)

--- a/packages/mcp/src/extensions/tools.ts
+++ b/packages/mcp/src/extensions/tools.ts
@@ -36,15 +36,12 @@ export function getReportMissingToolDescriptor(name: string = GET_MORE_TOOLS_NAM
     },
     annotations: {
       title: 'Get More Tools',
-      // Doesn't mutate state on the MCP server
       readOnlyHint: true,
-      // Interacts with external entities because we store this in analytics
+      // Interacts with an external entity: the report lands in analytics.
       openWorldHint: true,
-      // A tool like `get_more_tools` would usually NOT be idempontent, but since we are
-      // only using this to keep track of missing tools/feedback/analytics, it is actually idempontent.
-      // It's also preferable to track it as idempontent to make agents more prone to call it proactively.
+      // Only records the gap, so repeat calls are harmless — and advertising it
+      // as idempotent makes agents more willing to call it proactively.
       idempotentHint: true,
-      // Never deletes any data from the MCP server
       destructiveHint: false,
     },
   }


### PR DESCRIPTION
## Problem

The MCP analytics SDK's design rationale lives in two lossy places: multi-paragraph inline comment essays (which duplicate each other and drift), and PR descriptions nobody re-reads. `ARCHITECTURE.md` had absorbed decision narratives too — and gone stale: it still said 2026-07-28 stateless support "will be its own change" (it shipped in #4428/#4430/#4431/#4433), and its session-resolution section was missing the `conversation_id` step.

## Changes

**1. `docs/adr/` — decision records (Nygard format)**

- ADR-0001: the conventions (ADRs immutable, `ARCHITECTURE.md` = current state, ADR = decision trace, shipped together)
- ADR-0002: tools/list analytics affordances (`context` param + `get_more_tools`) — backfilled from the pre-stateless era
- ADR-0003: self-encoded session tokens on `Mcp-Session-Id` (2025-11-25) — from #4123/#4210/#4144
- ADR-0004: `conversation_id` as the session anchor (2026-07-28 stateless revision) — from #4428/#4430/#4431/#4433/#4237, including the hashing/shape-gate trade-offs, the two prompt-back channels, and the open follow-ups (era detection, process-scoped ownership cache)

**2. `ARCHITECTURE.md` slimmed to current state** — decision narratives replaced with ADR links; staleness fixed (session resolution is now the real four-step precedence); file map extended with the stateless-era modules.

**3. Comment audit across `src/`** (A Philosophy of Software Design bar):

- kept: interface JSDoc and load-bearing WHY comments (cross-SDK hash contract, `$groups` workaround, concurrency snapshots, fail-closed ownership)
- compressed: design essays down to the constraint + ADR pointer (`session.ts`, `conversation-id.ts`, `instrumentation.ts`, `output-instructions.ts`)
- deduped: facts retold in 2–3 files now have one canonical home
- deleted: comments restating adjacent code (`compatibility.ts`, `context-parameters.ts`), stale inline TODOs, and one misplaced JSDoc moved onto the function it documents

No runtime changes — comments and markdown only.

## Testing

- `pnpm -F @posthog/mcp lint` — clean
- `pnpm -F @posthog/mcp test:unit` — 39 suites, 515 tests green
- (`@posthog/core` fresh-clone build-order failure with `@posthog/types` is pre-existing and untouched by this diff)

## Release info Sub-libraries affected

- [ ] None — docs/comments only, no publish needed

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*