### PR TITLE
fix(react-native-plugin): compile with React Native 0.86

### DIFF
--- a/.changeset/fuzzy-pandas-smile.md
+++ b/.changeset/fuzzy-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Fix Android compilation with React Native 0.86.

--- a/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
+++ b/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
@@ -485,7 +485,7 @@ class PosthogReactNativePluginModule(
     if (!config.capturePushNotificationOpened) {
       return
     }
-    val intent = currentActivity?.intent ?: return
+    val intent = reactApplicationContext.currentActivity?.intent ?: return
     // A relaunch from recents redelivers the original tray intent to a fresh activity;
     // capturing it would count a days-old tap as a new open.
     if (intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0) {


### PR DESCRIPTION
## Problem

Android apps using `@posthog/react-native-plugin` 2.3.0 cannot compile with React Native 0.86.2. React Native's `ReactContextBaseJavaModule` is now implemented in Kotlin, so the inherited Java synthetic property access for `currentActivity` no longer resolves.

Fixes #4455.

## Changes

- Access the current activity through `reactApplicationContext`, matching React Native's documented replacement while preserving the existing cold-start push-open behavior.
- Add a patch changeset for `@posthog/react-native-plugin`.

Validated with:

- React Native 0.86.2 Android `assembleDebug`
- React Native 0.79.6 plugin `compileDebugKotlin`
- `pnpm --filter=@posthog/react-native-plugin test:unit`
- `pnpm --filter=@posthog/react-native-plugin typecheck`
- `pnpm --filter=@posthog/react-native-plugin build`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prepared with the Pi coding agent using local shell and Gradle validation, plus fresh-context scout and reviewer agents. The implementation follows React Native's documented activity accessor and was compiled against both React Native 0.86.2 and the repository's existing 0.79.6 native example.
