### PR TITLE
fix(mcp): wrap request handlers registered by method string

### DIFF
--- a/.changeset/mcp-string-method-request-handlers.md
+++ b/.changeset/mcp-string-method-request-handlers.md
@@ -1,0 +1,7 @@
+---
+'@posthog/mcp': patch
+---
+
+Wrap request handlers registered with a method string, and stop breaking three-argument registrations. MCP TypeScript SDK v2 calls `setRequestHandler('tools/call', handler)` where v1 passed a Zod schema, so `instrument()` could not name those registrations and left them unwrapped — a handler bound after `instrument()` silently replaced the analytics wrapper, and no `$mcp_tool_call` or `$mcp_tools_list` was captured. Frameworks that attach handlers post-construction, such as `@rekog/mcp-nest`, do exactly this on every request.
+
+The patched `setRequestHandler` now also forwards every argument it is given. v2's three-argument form for custom methods — `setRequestHandler(method, { params, result }, handler)` — previously lost its handler and threw `setRequestHandler: handler is required`, taking down the host server rather than just instrumentation.

--- a/packages/mcp/src/__tests__/string-method-registration.test.ts
+++ b/packages/mcp/src/__tests__/string-method-registration.test.ts
@@ -1,0 +1,240 @@
+import { ListToolsRequestSchema, PingRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { instrument } from '../index'
+import type { CompatibleRequestHandlerExtra, MCPRequestLike, MCPServerLike } from '../types'
+import { EventCapture, fakePostHog } from './test-utils'
+
+/**
+ * Coverage for the two things MCP SDK v2 changed about `setRequestHandler`, both
+ * of which our patch used to get wrong:
+ *
+ * 1. **The first argument is a method string, not a Zod schema.** v1 carries the
+ *    method as a literal on the request schema's shape; v2 passes the string.
+ *    A registration we cannot name is one we cannot wrap, so a handler bound
+ *    after `instrument()` silently *replaced* the analytics wrapper — the exact
+ *    shape `@rekog/mcp-nest` produces (#4449), where handlers are attached in a
+ *    `serverMutator` hook after instrumentation.
+ * 2. **There is a three-argument form.** `setRequestHandler(method, { params,
+ *    result }, handler)` registers a custom method. The old two-parameter
+ *    wrapper dropped the third argument, so the SDK saw the schemas object where
+ *    the handler belongs and threw `setRequestHandler: handler is required` —
+ *    breaking the *host's* server, not just our instrumentation.
+ *
+ * The double below reproduces v2's `Protocol.setRequestHandler` semantics
+ * (`@modelcontextprotocol/server@2.0.0`, `src`'s `setRequestHandler`) rather
+ * than importing it: v2 is not a dependency of this package, and what is under
+ * test is our wrapper's contract with those semantics. The end-to-end run
+ * against the real v2 SDK lives in the dual-era testbed.
+ */
+
+interface V2Schemas {
+  params: { parse(value: unknown): unknown }
+  result?: unknown
+}
+
+type V2Handler = (request: unknown, ctx: unknown) => unknown
+
+/** Spec methods v2 accepts in the two-argument form; everything else needs schemas. */
+const SPEC_METHODS = new Set(['initialize', 'ping', 'tools/list', 'tools/call'])
+
+class V2ServerDouble {
+  _requestHandlers = new Map<string, (request: MCPRequestLike, extra?: CompatibleRequestHandlerExtra) => Promise<any>>()
+  _serverInfo = { name: 'v2-double', version: '1.0.0' }
+
+  getClientVersion(): { name: string; version: string } {
+    return { name: 'test client', version: '1.0' }
+  }
+
+  // Mirrors v2's overloads: (method, handler) for spec methods, and
+  // (method, schemas, handler) for custom ones.
+  setRequestHandler(method: unknown, schemasOrHandler?: V2Schemas | V2Handler, maybeHandler?: V2Handler): void {
+    if (typeof method !== 'string') {
+      throw new TypeError(`'${String(method)}' is not a spec request method`)
+    }
+    let stored: V2Handler
+    if (typeof schemasOrHandler === 'function') {
+      if (!SPEC_METHODS.has(method)) {
+        throw new TypeError(`'${method}' is not a spec request method; pass schemas as the second argument.`)
+      }
+      stored = schemasOrHandler
+    } else if (maybeHandler) {
+      const schemas = schemasOrHandler as V2Schemas
+      stored = (request, ctx) => maybeHandler(schemas.params.parse((request as MCPRequestLike).params), ctx)
+    } else {
+      throw new TypeError('setRequestHandler: handler is required')
+    }
+    this._requestHandlers.set(method, stored as (request: MCPRequestLike) => Promise<any>)
+  }
+}
+
+function makeServer(): MCPServerLike {
+  return new V2ServerDouble() as unknown as MCPServerLike
+}
+
+/** Dispatches through the handler map, the way the SDK's request loop does. */
+function dispatch(server: MCPServerLike, request: MCPRequestLike, extra?: CompatibleRequestHandlerExtra) {
+  const handler = server._requestHandlers.get(request.method as string)
+  if (!handler) {
+    throw new Error(`no handler for ${request.method}`)
+  }
+  return handler(request, extra)
+}
+
+const TOOLS = [
+  {
+    name: 'get_trends',
+    description: 'Return a trends time series for an event.',
+    inputSchema: { type: 'object', properties: { event: { type: 'string' } }, required: ['event'] },
+  },
+]
+
+describe('setRequestHandler with string method names (MCP SDK v2)', () => {
+  let eventCapture: EventCapture
+
+  beforeEach(async () => {
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+  })
+
+  afterEach(async () => {
+    await eventCapture.stop()
+  })
+
+  it('wraps a tools/call handler registered after instrument() with a string method', async () => {
+    const server = makeServer()
+    instrument(server, fakePostHog(), { context: false })
+
+    server.setRequestHandler('tools/call', (async (request: MCPRequestLike) => ({
+      content: [{ type: 'text', text: `trends for ${request.params?.arguments?.event}` }],
+    })) as any)
+
+    const result = (await dispatch(server, {
+      method: 'tools/call',
+      params: { name: 'get_trends', arguments: { event: 'pageview' } },
+    })) as { content: { text: string }[] }
+    await new Promise((r) => setTimeout(r, 20))
+
+    // The application handler still runs and its result is returned untouched.
+    expect(result.content[0].text).toBe('trends for pageview')
+
+    const toolCalls = eventCapture.findCapturesByEvent('$mcp_tool_call')
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0].properties.$mcp_tool_name).toBe('get_trends')
+    expect(toolCalls[0].properties.$mcp_is_error).toBe(false)
+  })
+
+  it('wraps a tools/list handler registered after instrument() with a string method', async () => {
+    const server = makeServer()
+    instrument(server, fakePostHog(), { context: true })
+
+    server.setRequestHandler('tools/list', (async () => ({ tools: TOOLS })) as any)
+
+    const response = (await dispatch(server, { method: 'tools/list', params: {} })) as {
+      tools: { name: string; inputSchema?: { properties?: Record<string, unknown> } }[]
+    }
+    await new Promise((r) => setTimeout(r, 20))
+
+    // The injected `context` parameter is the user-visible proof the wrapper survived.
+    expect(response.tools.find((t) => t.name === 'get_trends')?.inputSchema?.properties?.context).toBeDefined()
+
+    const listings = eventCapture.findCapturesByEvent('$mcp_tools_list')
+    expect(listings).toHaveLength(1)
+    expect(listings[0].properties.$mcp_listed_tool_names).toEqual(expect.arrayContaining(['get_trends']))
+  })
+
+  it('forwards the three-argument custom-method form instead of breaking the host server', async () => {
+    const server = makeServer()
+    instrument(server, fakePostHog(), { context: true })
+
+    const handler = jest.fn(async (params: unknown) => ({ echoed: params }))
+    const schemas = { params: { parse: (value: unknown) => value } }
+
+    // Before the fix this threw `setRequestHandler: handler is required`, and
+    // because the SDK builds a fresh server per HTTP request the throw repeated
+    // on every request — the host server returned 500 across the board.
+    expect(() => (server.setRequestHandler as any)('acme/search', schemas, handler)).not.toThrow()
+
+    const result = await dispatch(server, { method: 'acme/search', params: { query: 'trends' } } as MCPRequestLike)
+    expect(handler).toHaveBeenCalledWith({ query: 'trends' }, undefined)
+    expect(result).toEqual({ echoed: { query: 'trends' } })
+  })
+
+  it('does not treat an inherited Object property name as a patch', async () => {
+    const server = makeServer()
+    instrument(server, fakePostHog(), { context: true })
+
+    // `patches['toString']` resolves to `Object.prototype.toString` under a bare
+    // index, which a truthiness check would accept as a handler patch.
+    const handler = jest.fn(async (params: unknown) => ({ ok: params }))
+    expect(() =>
+      (server.setRequestHandler as any)('toString', { params: { parse: (v: unknown) => v } }, handler)
+    ).not.toThrow()
+
+    const result = await dispatch(server, { method: 'toString', params: { a: 1 } } as MCPRequestLike)
+    expect(result).toEqual({ ok: { a: 1 } })
+  })
+
+  it('leaves an unpatched method registered by string untouched', async () => {
+    const server = makeServer()
+    instrument(server, fakePostHog(), { context: true })
+
+    const handler = (async () => ({})) as any
+    server.setRequestHandler('ping', handler)
+
+    // Not one of our patched methods, so the map holds exactly what was registered.
+    expect(server._requestHandlers.get('ping')).toBe(handler)
+  })
+})
+
+/**
+ * The v1 registration form has to keep behaving exactly as it did — it is what
+ * essentially all traffic runs on today.
+ */
+describe('setRequestHandler with Zod schemas (MCP SDK v1) is unchanged', () => {
+  let eventCapture: EventCapture
+
+  beforeEach(async () => {
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+  })
+
+  afterEach(async () => {
+    await eventCapture.stop()
+  })
+
+  it('still resolves the method off a v1 request schema and wraps the handler', async () => {
+    // A v1-shaped double: it accepts the Zod schema and keys the map off the
+    // method literal, the way `Protocol.setRequestHandler` does on v1.
+    const server = makeServer()
+    const v1Style = (schema: any, handler: any) => {
+      const method = schema.shape.method.value
+      server._requestHandlers.set(method, handler)
+    }
+    ;(server as any).setRequestHandler = v1Style
+
+    instrument(server, fakePostHog(), { context: true })
+    server.setRequestHandler(ListToolsRequestSchema, (async () => ({ tools: TOOLS })) as any)
+
+    const response = (await dispatch(server, { method: 'tools/list', params: {} })) as {
+      tools: { name: string; inputSchema?: { properties?: Record<string, unknown> } }[]
+    }
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(response.tools.find((t) => t.name === 'get_trends')?.inputSchema?.properties?.context).toBeDefined()
+    expect(eventCapture.findCapturesByEvent('$mcp_tools_list')).toHaveLength(1)
+  })
+
+  it('leaves an unpatched v1 schema registration untouched', async () => {
+    const server = makeServer()
+    const v1Style = (schema: any, handler: any) => {
+      const method = schema.shape.method.value
+      server._requestHandlers.set(method, handler)
+    }
+    ;(server as any).setRequestHandler = v1Style
+
+    instrument(server, fakePostHog(), { context: true })
+    const handler = (async () => ({})) as any
+    server.setRequestHandler(PingRequestSchema, handler)
+
+    expect(server._requestHandlers.get('ping')).toBe(handler)
+  })
+})

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -32,7 +32,7 @@ import { resolveToolCallIntent, setEventIntent, setExplicitContextIntent } from 
 import { getServerTrackingData, handleIdentify, setServerTrackingData, withIdentity } from './internal'
 import type { LoggerFn } from './logger'
 import { buildCapturedMcpParameters } from './mcp-payloads'
-import { getLiteralValue, getObjectShape } from './mcp-sdk-compat'
+import { readRequestHandlerMethod } from './mcp-sdk-compat'
 import { getSessionId, getSessionInfo, newSessionId } from './session'
 import { encodeSessionId, readMcpSessionHeader, writeSessionIdToTransport } from './session-token'
 import { getReportMissingToolDescriptor, resolveMissingCapabilityToolName } from './tools'
@@ -428,18 +428,31 @@ export function patchRequestHandlers(server: MCPServerLike, patches: Record<stri
   }
 
   // Monkey patch dynamically added handlers (registered after instrument()).
-  const originalSetRequestHandler = server.setRequestHandler.bind(server)
-  server.setRequestHandler = ((requestSchema: unknown, originalHandler: MCPRequestHandler) => {
-    const shape = getObjectShape(requestSchema)
-    const handlerName = shape?.method ? getLiteralValue(shape.method) : undefined
-    const patch = typeof handlerName === 'string' ? patches[handlerName] : undefined
-    if (!patch || typeof handlerName !== 'string') {
-      return originalSetRequestHandler(requestSchema, originalHandler)
+  //
+  // Variadic, and every argument is forwarded verbatim. The registration form is
+  // the SDK's business, not ours — only *that* a registration happened is ours.
+  // SDK v2 has a three-argument form for custom methods,
+  // `setRequestHandler(method, { params, result }, handler)`, and a two-parameter
+  // wrapper drops the handler: the SDK then sees the schemas object where the
+  // handler should be and throws `setRequestHandler: handler is required`, which
+  // takes down the host server rather than just our instrumentation.
+  const originalSetRequestHandler = server.setRequestHandler.bind(server) as (...args: unknown[]) => unknown
+  server.setRequestHandler = ((...args: unknown[]) => {
+    const handlerName = readRequestHandlerMethod(args[0])
+    // `hasOwnProperty`, not a bare index: `handlerName` is now an arbitrary
+    // caller-supplied string, and a custom method named `toString` would
+    // otherwise resolve to an inherited function and be treated as a patch.
+    const patch =
+      handlerName !== undefined && Object.prototype.hasOwnProperty.call(patches, handlerName)
+        ? patches[handlerName]
+        : undefined
+    if (handlerName === undefined || !patch) {
+      return originalSetRequestHandler(...args)
     }
 
     // Register first so the MCP SDK's request/result validation stays inside
     // our analytics wrapper, matching handlers that existed before instrument().
-    const result = originalSetRequestHandler(requestSchema, originalHandler)
+    const result = originalSetRequestHandler(...args)
     const registeredHandler = server._requestHandlers.get(handlerName)
     if (registeredHandler) {
       rememberOriginalRequestHandler(server, handlerName, registeredHandler)

--- a/packages/mcp/src/extensions/mcp-sdk-compat.ts
+++ b/packages/mcp/src/extensions/mcp-sdk-compat.ts
@@ -143,6 +143,24 @@ export function getObjectShape(schema: unknown): Record<string, unknown> | undef
   return rawShape
 }
 
+/**
+ * Reads the method name a `setRequestHandler` registration is for.
+ *
+ * The two SDK majors disagree on what the first argument is: v1 passes the Zod
+ * schema for the request and carries the method as a literal on its shape, v2
+ * passes the method string itself. A registration we cannot name is one we
+ * cannot match against a patch — which is how a handler registered after
+ * `instrument()` on v2 ends up replacing our wrapper instead of being wrapped.
+ */
+export function readRequestHandlerMethod(requestSchema: unknown): string | undefined {
+  if (typeof requestSchema === 'string') {
+    return requestSchema
+  }
+  const shape = getObjectShape(requestSchema)
+  const method = shape?.method ? getLiteralValue(shape.method) : undefined
+  return typeof method === 'string' ? method : undefined
+}
+
 export function getLiteralValue(schema: unknown): unknown {
   if (!schema || typeof schema !== 'object') {
     return


### PR DESCRIPTION
Groundwork for supporting MCP TypeScript SDK v2 servers.

## The problem

SDK v2 registers request handlers with a **method string** — `setRequestHandler('tools/call', handler)` — where v1 passed a Zod schema that carried the method as a literal on its shape. Our patched setter only knew how to read the Zod form, so a v2 registration could not be named, could not be matched to a patch, and went through unwrapped.

That matters most for handlers bound *after* `instrument()`, which is the normal order for stateless/per-request servers where instrumentation runs in a server-mutator hook before the framework attaches its handlers. Instead of being wrapped, the late registration **replaced** the analytics wrapper: no `$mcp_tool_call`, no `$mcp_tools_list`, no injected `context` parameter. Nothing throws, so the integration looks healthy while events stop.

There is a second, louder failure. v2's setter has a three-argument form for custom methods:

```ts
server.setRequestHandler('acme/search', { params, result }, handler)
```

Our wrapper took two parameters and dropped the third, so the SDK saw the schemas object where the handler belongs and threw `setRequestHandler: handler is required`. Since v2 builds a fresh server per HTTP request, that throw repeats on every request — the **host's** server returns 500 across the board, caused by instrumenting it.

## The fix

- `readRequestHandlerMethod()` reads either registration form: the string if the first argument is one, otherwise the existing Zod-shape literal read. Duck-typed per call, no version check and no SDK import.
- The patched `setRequestHandler` is variadic and forwards `...args` verbatim on both the passthrough and the wrap path. The registration form is the SDK's business; only *that* a registration happened is ours.
- Patch lookup moves to `hasOwnProperty` — the method name is now an arbitrary caller-supplied string, and a custom method called `toString` would otherwise resolve to an inherited function and be treated as a patch.

v1 is untouched by construction: the Zod branch is the same code it was, and it runs first-class rather than as a fallback.

## Measured

Dual-era testbed, local build overlaid, 12 runs across both SDK majors × high/low × both protocol eras. Before → after, **four cells move and they are all `alive`** (the 3-argument custom registration check):

```
                              calls errors schema session client protocol warnings header alive
v1  stateful   high             ✓      ✓      ✓      ✓       ✓       ✓        ✓       ·     ·      unchanged
v1  stateful   low              ✓      ✓      ✓      ✓       ✓       ✓        ✓       ·     ·      unchanged
v1  stateless  high             ✓      ✓      ✓      ✓       ✓       ✓        ✓       ·     ·      unchanged
v1  stateless  low              ✓      ✓      ✓      ✓       ✓       ✓        ✓       ·     ·      unchanged
v2  high  (×4 era/conv combos) ✗      ✗     ✓/✗    ·/✗      ✗       ✗        ✗       ✓     ✓      unchanged
v2  low   2025  conv=off        ✓      ✓      ✓      ·       ✗       ✗        ✓       ✓   ✗ → ✓
v2  low   2025  conv=on         ✓      ✓      ✓      ✗       ✗       ✗        ✓       ✓   ✗ → ✓
v2  low   2026  conv=off        ✓      ✓      ✓      ·       ✓       ✗        ✓       ✓   ✗ → ✓
v2  low   2026  conv=on         ✓      ✓      ✓      ✗       ✓       ✗        ✓       ✓   ✗ → ✓
```

No v1 row regresses. The `v2 high` rows are unchanged because the compatibility gate still rejects a v2 high-level server before any of this runs — a separate change, deliberately not bundled here.

The late-registration probe — handlers attached after `instrument()` on both majors, driven over raw JSON-RPC — goes **7/9 → 9/9**. The two that flip are `$mcp_tool_call captured` and `tool name recorded` for a v2 handler registered late.

## Tests

- 540/540 unit tests pass; lint and build clean.
- 7 new tests. Revert-checked: 4 of them fail with the fix backed out.
- The v2 packages are not a dependency of this one, so the new tests drive a double built to `Protocol.setRequestHandler`'s actual v2 semantics — two-arg spec form, three-arg custom form, `handler is required`, and the `_requestHandlers` map keying — read out of `@modelcontextprotocol/server@2.0.0`'s shipped code rather than assumed. End-to-end coverage against the real SDK is the testbed above.

## Scope

Naming the registration is a prerequisite for v2 support, not the whole of it. Instrumenting a v2 high-level server, client identity and protocol version on modern-era requests, header reads off `extra.http.req`, and tool-parameter ownership on a per-request instance are all still open and each lands on its own.
