### PR TITLE
fix(mcp): instrument high-level MCP SDK v2 servers

### DIFF
--- a/.changeset/mcp-v2-high-level-compatibility.md
+++ b/.changeset/mcp-v2-high-level-compatibility.md
@@ -1,0 +1,20 @@
+---
+'@posthog/mcp': patch
+---
+
+Instrument high-level `McpServer` instances from MCP TypeScript SDK v2, and read request headers from either SDK major.
+
+The compatibility gate required `typeof server.tool === 'function'`. SDK v2 dropped the deprecated `tool()` in favour of `registerTool()`, so every v2 high-level server failed the check — and since `instrument()` catches compatibility failures and returns a working-looking handle, it failed silently: no throw, no warning at the call site, and no `$mcp_*` events at all. The gate now accepts either registration method, and every shape question it asks is answered by a structural probe in the new `detect.ts` rather than by a version or protocol constant.
+
+Opening the gate is also what first sends v2-shaped request context to header reads, so both halves ship together. The SDK's own reads go through a new `getRequestHeaders(extra)`, which takes headers from v2's `ctx.http.req` (a WHATWG `Request`, whose headers only answer to `.get()`) as well as v1's `extra.requestInfo.headers`, and returns a plain lowercase-keyed object either way. It is duck-typed on `.entries` rather than `instanceof Headers`, so a `Headers` from another realm — workerd and other edge runtimes — is read correctly.
+
+`getRequestHeaders` is exported, because `identify`, `intentFallback`, `eventProperties` and `beforeSend` still receive the SDK's `extra` unchanged — we deliberately do not synthesise a v1 `requestInfo` on v2, as a partially faked shape is worse than an absent one. Hosts reading headers in a callback migrate in one line:
+
+```ts
+import { getRequestHeaders } from '@posthog/mcp'
+
+identify: async (request, extra) => {
+  const auth = getRequestHeaders(extra)?.['authorization']
+  // ...
+}
+```

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -67,6 +67,45 @@ if (body?.method === 'initialize' && !req.headers[MCP_SESSION_HEADER]) {
 
 Details: [docs/ARCHITECTURE.md §4](./docs/ARCHITECTURE.md).
 
+## MCP TypeScript SDK v2
+
+`instrument()` works on both SDK majors — `@modelcontextprotocol/sdk` v1 and
+`@modelcontextprotocol/{core,server,client}` v2 — and on both the high-level `McpServer` and the
+low-level `Server`. Shapes are detected at runtime, so neither major is a dependency here.
+
+### Reading request headers in a callback
+
+If your `identify`, `intentFallback`, `eventProperties` or `beforeSend` reads HTTP headers, it has
+to change. The two majors put the request in different places and in different shapes: v1 attaches
+a plain object at `extra.requestInfo.headers`, v2 attaches the WHATWG `Request` at `extra.http.req`,
+whose `headers` only answers to `.get()`. A v1-shaped read returns `undefined` on v2 — an
+`identify()` written that way returns `null` and every event goes anonymous.
+
+The SDK hands your callback whatever the MCP SDK handed it, unchanged; it does **not** fake a v1
+shape on v2, because a partially synthesised `requestInfo` is a more convincing lie than an absent
+one. Read headers through the exported helper instead, which handles both majors, lowercases keys,
+and duck-types `Headers` so it also works on edge runtimes:
+
+```ts
+import { getRequestHeaders } from '@posthog/mcp'
+
+identify: async (request, extra) => {
+  const auth = getRequestHeaders(extra)?.['authorization'] // v1 and v2
+  // ...
+}
+```
+
+### If you switched to `instrument(server.server)`
+
+Before v2 support landed, the compatibility gate rejected high-level v2 servers, and the usual
+workaround was to instrument the underlying low-level server. `instrument(server)` now works, so
+you can go back to the documented call.
+
+Whether the workaround costs you anything depends on your stack: instrumenting the low-level server
+skips the high-level tool registry, so tool descriptions and callback-level wrapping come only from
+what is advertised over `tools/list`. If your framework never calls `registerTool()` — `@rekog/mcp-nest`
+does not — the registry is empty and the two calls behave the same.
+
 ## Developing locally
 
 To test local changes in a consumer app (e.g. a dummy MCP server), symlink **both**

--- a/packages/mcp/docs/ARCHITECTURE.md
+++ b/packages/mcp/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ The host application supplies its own `posthog-node` client as the positional `p
 
 `instrument()` does five things (`src/index.ts`):
 
-1. Validate `server` is either a low-level `Server` or a high-level `McpServer`, and unwrap the latter to get the underlying `Server`.
+1. Validate `server` is either a low-level `Server` or a high-level `McpServer`, and unwrap the latter to get the underlying `Server`. Both MCP TypeScript SDK majors are supported, and which one you have is never read — capabilities are detected by object shape in `src/extensions/detect.ts` (ADR-0005).
 2. Wrap the user-provided `posthog` client in an `McpEventSink`.
 3. Build per-server tracking state (session id, identity cache, callbacks, the sink) stored in a module-level `WeakMap`.
 4. Replace the `tools/call` and `initialize` handlers on the underlying `Server` instance with wrappers, and (for `McpServer`) install a `Proxy` on `_registeredTools` so any tool registered _after_ `instrument()` is also wrapped.
@@ -382,3 +382,5 @@ The SDK does **not**: call an LLM, inspect tool arguments, build heuristics, or 
 | STDIO-safe logger sink                                                | `src/extensions/logger.ts`                                            |
 | Exception capture & stack-trace parsing                               | `src/extensions/exceptions.ts`                                        |
 | MCP SDK version compat shims                                          | `src/extensions/compatibility.ts`, `src/extensions/mcp-sdk-compat.ts` |
+| Structural capability probes (both SDK majors)                        | `src/extensions/detect.ts`                                            |
+| Request headers on either SDK major (`getRequestHeaders`)             | `src/extensions/request-headers.ts`                                   |

--- a/packages/mcp/docs/adr/0005-detect-sdk-capabilities-by-shape.md
+++ b/packages/mcp/docs/adr/0005-detect-sdk-capabilities-by-shape.md
@@ -1,0 +1,31 @@
+# ADR-0005: Detect SDK capabilities by object shape, never by version
+
+- Status: Accepted
+- Date: 2026-08-07
+
+## Context
+
+There are now two MCP TypeScript SDK majors in the wild under different package names — `@modelcontextprotocol/sdk` v1 and `@modelcontextprotocol/{core,server,client}` v2 — and a consumer installs whichever one they use. They disagree about the API surface this package depends on: v2's `McpServer` dropped the deprecated `tool()` and kept only `registerTool()`, `setRequestHandler` takes a method string rather than a Zod schema, and the per-request `extra` became a `ctx` carrying a WHATWG `Request`.
+
+The compatibility gate asserted `typeof server.tool === 'function'`, so every v2 high-level server failed it. Because `instrument()` catches compatibility failures and returns a working-looking handle, it failed *silently*: no throw, no console warning, and no `$mcp_*` events at all. It was reported from the field as "the integration looks healthy while `$mcp_*` events stop entirely" (PostHog/posthog-js#4449).
+
+Version-based branching was considered and rejected. It answers the wrong question twice over: the same capability appears under different *names* rather than at different versions, and protocol revision is a property of each **request**, not of the installed package — v2's exported `LATEST_PROTOCOL_VERSION` still reads `2025-11-25` while the same server serves `2026-07-28` traffic (see ADR-0008).
+
+## Decision
+
+Every question about what a server object can do is answered by a structural probe over that object, in `src/extensions/detect.ts`. `compatibility.ts` delegates to those probes instead of testing properties inline.
+
+- A capability check accepts **any** shape that provides it: `canRegisterTools()` is satisfied by `registerTool()` or `tool()`.
+- Probes take `unknown` and duck-type. Nothing imports an SDK type to describe an SDK object.
+- No shipped code references any `@modelcontextprotocol/*` package, at runtime or as a type — pinned by `sdk-import-boundary.test.ts` (see ADR-0007).
+
+## Consequences
+
+- Supporting a third shape is a probe, not a branch: the gate stays flat as the SDKs diverge.
+- A capability we probe for but never use is a lie that will eventually reject a valid server. Probes are added when something reads the thing they describe, not defensively.
+- The probes assert less than the SDK's own types would. That is deliberate — they describe what this package actually touches, so an SDK changing anything else cannot reject a server that still works.
+- `instrument()` still swallows compatibility failures. This ADR removes today's trigger, not the silence; making a rejection loud is a separate, deliberate behaviour change.
+
+## References
+
+- PostHog/posthog-js#4449 (field report), #4462 (this change), #4450 and #4461 (the dispatch prerequisites)

--- a/packages/mcp/docs/adr/0006-raw-extra-to-host-callbacks.md
+++ b/packages/mcp/docs/adr/0006-raw-extra-to-host-callbacks.md
@@ -1,0 +1,41 @@
+# ADR-0006: Host callbacks receive the SDK's `extra` unchanged
+
+- Status: Accepted
+- Date: 2026-08-07
+
+## Context
+
+`identify`, `intentFallback`, `eventProperties` and `beforeSend` all receive the per-request `extra` object the MCP SDK hands our handler. Hosts routinely read HTTP headers off it — an auth token in `identify` is the common case.
+
+The two SDK majors put the request in different places **and** different shapes: v1 attaches a plain object at `extra.requestInfo.headers`; v2 attaches the WHATWG `Request` at `extra.http.req`, whose `headers` is a `Headers` that only answers to `.get()`. Every v1-shaped read therefore returns `undefined` on v2, and an `identify()` written that way returns `null` and sends every event anonymous. Confirmed on the reporter's stack in PostHog/posthog-js#4449.
+
+Opening the compatibility gate (ADR-0005) is what first sends v2-shaped `extra` to these callbacks, so the two ship together: the gate alone converts "no events" into "events with no user", which is the same looks-healthy-but-wrong failure.
+
+Normalising `extra` toward v1 before handing it over was considered and rejected. Synthesising a `requestInfo` fabricates a shape the SDK deliberately removed; a host reading any field we did not fake gets a convincing partial lie, which is worse than a shape that is honestly absent. It would also confuse v2-native hosts whose code is already correct.
+
+## Decision
+
+Host callbacks receive whatever the SDK handed us, unchanged. Instead, `getRequestHeaders(extra)` is **exported**, so a host's migration is one line rather than a hand-written two-branch read:
+
+```ts
+import { getRequestHeaders } from '@posthog/mcp'
+identify: async (request, extra) => getRequestHeaders(extra)?.['authorization']
+```
+
+- It returns a plain, lowercase-keyed bag — not a `Headers`-like `.get()` interface — so existing `headers['authorization']` code changes the *path* and keeps the *access style*.
+- It normalises **by shape, not by source**: both locations are checked for both shapes, because a framework may hand us a plain object where the SDK hands `Headers`.
+- `Headers` is duck-typed on `.entries`, never `instanceof` — workerd and other edge runtimes are a different realm.
+- Every internal header read goes through it too, including `readTransportIdentity`, which had shipped reading the v1 location only.
+
+`headers.ts` keeps answering a different question — reading one value out of a bag — and the two compose.
+
+## Consequences
+
+- A host on v2 must change its callbacks. That is a documented migration in the README, not a silent behaviour change: we cannot fix their code, only make the fix one line.
+- Two independent precedents agree: #4449 asked for documentation rather than normalisation, and AgentCat's v2 rewrite also passes raw `extra` to customer hooks and projects it only for the event payload.
+- The exported helper is now public API, so its return shape is frozen by the usual rules.
+
+## References
+
+- PostHog/posthog-js#4449, #4462 (this change), ADR-0005
+

--- a/packages/mcp/src/__tests__/compatibility.test.ts
+++ b/packages/mcp/src/__tests__/compatibility.test.ts
@@ -31,6 +31,21 @@ describe('isCompatibleServerType', () => {
     expect(log).not.toHaveBeenCalled()
   })
 
+  // MCP SDK v2's McpServer dropped the deprecated tool() and kept registerTool().
+  // Demanding tool() rejected every v2 high-level server, and instrument()
+  // swallows the rejection — so the integration captured nothing, silently.
+  it('accepts a high-level server that has registerTool() but no tool()', () => {
+    const wrapper = { server: validLowLevelServer(), _registeredTools: {}, registerTool: () => {} }
+    expect(isCompatibleServerType(wrapper, log)).toBe(wrapper)
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  it('rejects a high-level server with neither registration method', () => {
+    const wrapper = { server: validLowLevelServer(), _registeredTools: {} }
+    expect(() => isCompatibleServerType(wrapper, log)).toThrow(/registerTool\(\) or tool\(\)/)
+    expect(log).toHaveBeenCalled()
+  })
+
   it.each([
     ['null', null, /Server must be an object/],
     ['undefined', undefined, /Server must be an object/],

--- a/packages/mcp/src/__tests__/request-headers.test.ts
+++ b/packages/mcp/src/__tests__/request-headers.test.ts
@@ -1,0 +1,106 @@
+import { getRequestHeaders } from '../extensions/request-headers'
+
+/**
+ * A stand-in for a WHATWG `Headers` from another realm: it quacks the same way
+ * but fails `instanceof Headers`, which is exactly the workerd case.
+ */
+class ForeignHeaders {
+  private readonly entriesList: [string, string][]
+
+  constructor(entries: [string, string][]) {
+    this.entriesList = entries
+  }
+
+  get(name: string): string | null {
+    const match = this.entriesList.find(([key]) => key.toLowerCase() === name.toLowerCase())
+    return match ? match[1] : null
+  }
+
+  entries(): Iterable<[string, string]> {
+    return this.entriesList[Symbol.iterator]()
+  }
+}
+
+describe('getRequestHeaders', () => {
+  describe('v1 shape — extra.requestInfo.headers', () => {
+    it('reads a plain header object', () => {
+      const extra = { requestInfo: { headers: { authorization: 'Bearer v1', 'mcp-session-id': 'abc' } } }
+      expect(getRequestHeaders(extra)).toEqual({ authorization: 'Bearer v1', 'mcp-session-id': 'abc' })
+    })
+
+    it('lowercases keys so a host reads them the documented way', () => {
+      const extra = { requestInfo: { headers: { Authorization: 'Bearer v1', 'X-Tenant': 'acme' } } }
+      expect(getRequestHeaders(extra)).toEqual({ authorization: 'Bearer v1', 'x-tenant': 'acme' })
+    })
+
+    it('keeps repeated headers as an array', () => {
+      const extra = { requestInfo: { headers: { 'set-cookie': ['a=1', 'b=2'] } } }
+      expect(getRequestHeaders(extra)?.['set-cookie']).toEqual(['a=1', 'b=2'])
+    })
+
+    it('drops undefined values, which Node header bags carry', () => {
+      const extra = { requestInfo: { headers: { authorization: 'Bearer v1', 'x-missing': undefined } } }
+      expect(getRequestHeaders(extra)).toEqual({ authorization: 'Bearer v1' })
+    })
+  })
+
+  describe('v2 shape — extra.http.req.headers', () => {
+    it('reads a WHATWG Headers instance', () => {
+      const extra = {
+        http: { req: new Request('https://example.com/mcp', { headers: { authorization: 'Bearer v2' } }) },
+      }
+      expect(getRequestHeaders(extra)).toEqual(expect.objectContaining({ authorization: 'Bearer v2' }))
+    })
+
+    it('duck-types Headers rather than using instanceof, for cross-realm objects', () => {
+      const extra = {
+        http: {
+          req: {
+            headers: new ForeignHeaders([
+              ['Authorization', 'Bearer v2'],
+              ['x-tenant', 'acme'],
+            ]),
+          },
+        },
+      }
+      expect(getRequestHeaders(extra)).toEqual({ authorization: 'Bearer v2', 'x-tenant': 'acme' })
+    })
+
+    it('accepts a plain object where the SDK would hand Headers, since a framework may substitute one', () => {
+      const extra = { http: { req: { headers: { Authorization: 'Bearer v2' } } } }
+      expect(getRequestHeaders(extra)).toEqual({ authorization: 'Bearer v2' })
+    })
+
+    it('prefers the v2 location when both are present', () => {
+      const extra = {
+        http: { req: { headers: { authorization: 'from-v2' } } },
+        requestInfo: { headers: { authorization: 'from-v1' } },
+      }
+      expect(getRequestHeaders(extra)?.['authorization']).toBe('from-v2')
+    })
+  })
+
+  describe('no headers to read', () => {
+    it.each([
+      ['undefined extra', undefined],
+      ['null extra', null],
+      ['a non-object extra', 'nope'],
+      ['stdio/in-memory extra with neither field', { sessionId: 'abc' }],
+      ['a v2 context with no HTTP request', { http: {} }],
+      ['a requestInfo with no headers', { requestInfo: {} }],
+      ['a non-object headers value', { requestInfo: { headers: 'oops' } }],
+    ])('returns undefined for %s', (_label, extra) => {
+      expect(getRequestHeaders(extra)).toBeUndefined()
+    })
+
+    it('never throws when reading headers blows up', () => {
+      const exploding = {
+        get: () => null,
+        entries: () => {
+          throw new Error('boom')
+        },
+      }
+      expect(getRequestHeaders({ http: { req: { headers: exploding } } })).toBeUndefined()
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/v2-high-level-server.test.ts
+++ b/packages/mcp/src/__tests__/v2-high-level-server.test.ts
@@ -183,6 +183,86 @@ describe('instrument() on an MCP SDK v2 high-level server', () => {
     expect(eventCapture.findCapturesByEvent('$exception')).toHaveLength(1)
   })
 
+  /**
+   * The one thing the stale executor does cost us, measured: v2 flattens a throw
+   * into an `isError` result before our callback wrapper would have stashed the
+   * original error, and the wrapper never runs anyway because dispatch goes
+   * through the executor. So the error's **class** is lost — everything else
+   * survives, because the `tools/call` request-handler patch sees the result.
+   *
+   * This is a documented limitation, not an aspiration: if wrapping the executor
+   * ever lands, this test should start failing and be updated to expect the real
+   * class name.
+   */
+  it('captures message and error flag but degrades the error class to Error', async () => {
+    const server = makeV2Server()
+    class RateLimitError extends Error {}
+    ;(server as unknown as V2McpServerDouble).registerTool(
+      'rate_limited',
+      { description: 'Throws a subclass.' },
+      async () => {
+        throw new RateLimitError('rate limited')
+      }
+    )
+    instrument(server, fakePostHog(), { context: false })
+
+    await dispatch(server, { method: 'tools/call', params: { name: 'rate_limited', arguments: {} } }, v2Ctx())
+    await new Promise((r) => setTimeout(r, 20))
+
+    const call = eventCapture.findCapturesByEvent('$mcp_tool_call')[0]
+    expect(call.properties.$mcp_is_error).toBe(true)
+    expect(call.properties.$mcp_error_message).toBe('rate limited')
+    // Not 'RateLimitError' — the class does not survive v2's flattening.
+    expect(call.properties.$mcp_error_type).toBe('Error')
+
+    const exceptionList = eventCapture.findCapturesByEvent('$exception')[0].properties.$exception_list as {
+      type: string
+      value: string
+    }[]
+    expect(exceptionList[0]).toEqual(expect.objectContaining({ type: 'Error', value: 'rate limited' }))
+  })
+
+  /**
+   * v2 builds a tool's `executor` from its `handler` **once at registration**,
+   * and dispatch calls the executor — so our callback wrapper, installed after
+   * registration, never runs on v2. The stripping of SDK-injected arguments does
+   * not depend on it: the `tools/call` request-handler patch strips them before
+   * the SDK ever dispatches, and the callback wrapper is a defensive second pass
+   * for hosts that invoke a tool callback directly. This asserts the primary
+   * path, which is what a real v2 server takes.
+   */
+  it('strips the injected context argument before the tool runs, despite the stale executor', async () => {
+    const server = makeV2Server()
+    const seen: unknown[] = []
+    ;(server as unknown as V2McpServerDouble).registerTool(
+      'watch_args',
+      {
+        description: 'Records the arguments it was called with.',
+        inputSchema: { type: 'object', properties: { event: { type: 'string' } } },
+      },
+      async (args: unknown) => {
+        seen.push(args)
+        return { content: [{ type: 'text', text: 'ok' }] }
+      }
+    )
+
+    instrument(server, fakePostHog(), { context: true })
+
+    await dispatch(
+      server,
+      {
+        method: 'tools/call',
+        params: { name: 'watch_args', arguments: { event: 'pageview', context: 'user asked for trends' } },
+      },
+      v2Ctx()
+    )
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toEqual({ event: 'pageview' })
+    expect(eventCapture.findCapturesByEvent('$mcp_tool_call')[0].properties.$mcp_intent).toBe('user asked for trends')
+  })
+
   it('captures a tools/list and injects the analytics parameter into the advertised schema', async () => {
     const server = makeV2Server()
     instrument(server, fakePostHog(), { context: true })

--- a/packages/mcp/src/__tests__/v2-high-level-server.test.ts
+++ b/packages/mcp/src/__tests__/v2-high-level-server.test.ts
@@ -1,0 +1,227 @@
+import { instrument, getRequestHeaders } from '../index'
+import type {
+  CompatibleRequestHandlerExtra,
+  HighLevelMCPServerLike,
+  MCPRequestLike,
+  MCPServerLike,
+  RegisteredTool,
+} from '../types'
+import { EventCapture, fakePostHog } from './test-utils'
+
+/**
+ * MCP SDK v2's high-level `McpServer` dropped the deprecated `.tool()` and kept
+ * only `registerTool()`. Our compatibility gate demanded `.tool()`, so every v2
+ * high-level server was rejected — and because `instrument()` swallows
+ * compatibility failures and returns a working-looking handle, it was rejected
+ * *silently*: no throw, no events, a healthy-looking integration and a flat
+ * dashboard (#4449).
+ *
+ * The doubles below reproduce v2's shapes rather than importing them, because v2
+ * is not a dependency of this package (`sdk-import-boundary.test.ts` pins that)
+ * and what is under test is our contract with those shapes:
+ *
+ * - the tool registry holds `handler`, plus an `executor` built from it **once
+ *   at registration**, which is what dispatch actually calls;
+ * - handlers are registered by method string on the low-level server;
+ * - the per-request context carries the HTTP request at `ctx.http.req` as a
+ *   WHATWG `Request`, whose headers only answer to `.get()` — where v1 put a
+ *   plain object at `extra.requestInfo.headers`.
+ *
+ * The end-to-end run against the real v2 SDK lives in the dual-era testbed.
+ */
+
+type ToolHandler = (args: unknown, ctx: unknown) => Promise<unknown>
+
+interface V2RegisteredTool extends RegisteredTool {
+  executor: ToolHandler
+}
+
+/** v2 builds `executor` from `handler` at registration time, not per call. */
+function buildExecutor(handler: ToolHandler): ToolHandler {
+  return async (args, ctx) => handler(args, ctx)
+}
+
+class V2McpServerDouble {
+  _registeredTools: Record<string, RegisteredTool> = {}
+  server: MCPServerLike
+
+  constructor() {
+    this.server = new V2LowLevelServerDouble(() => this._registeredTools) as unknown as MCPServerLike
+  }
+
+  // Note: no `tool()`. v2 removed it.
+  registerTool(name: string, config: { description?: string; inputSchema?: unknown }, handler: ToolHandler): void {
+    const tool: V2RegisteredTool = {
+      description: config.description,
+      inputSchema: config.inputSchema,
+      handler,
+      executor: buildExecutor(handler),
+      enabled: true,
+      update: (updates: { handler?: ToolHandler }) => {
+        if (updates.handler) {
+          tool.handler = updates.handler
+          tool.executor = buildExecutor(updates.handler)
+        }
+      },
+    } as unknown as V2RegisteredTool
+    this._registeredTools[name] = tool
+  }
+}
+
+class V2LowLevelServerDouble {
+  _requestHandlers = new Map<string, (request: MCPRequestLike, ctx?: CompatibleRequestHandlerExtra) => Promise<any>>()
+  _serverInfo = { name: 'v2-high-level-double', version: '1.0.0' }
+
+  constructor(private readonly getTools: () => Record<string, RegisteredTool>) {
+    // The high-level server binds its own dispatchers, as v2's McpServer does.
+    this._requestHandlers.set('tools/list', async () => ({
+      tools: Object.entries(this.getTools()).map(([name, tool]) => ({
+        name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      })),
+    }))
+    this._requestHandlers.set('tools/call', async (request, ctx) => {
+      const name = String(request.params?.name)
+      const tool = this.getTools()[name] as V2RegisteredTool | undefined
+      if (!tool) {
+        throw new Error(`Unknown tool: ${name}`)
+      }
+      // v2 dispatches through `executor`, and flattens a throw into an
+      // isError result rather than letting it escape the handler.
+      try {
+        return await tool.executor(request.params?.arguments, ctx)
+      } catch (error) {
+        return { content: [{ type: 'text', text: String((error as Error).message) }], isError: true }
+      }
+    })
+  }
+
+  getClientVersion(): { name: string; version: string } {
+    return { name: 'v2 test client', version: '2.0.0' }
+  }
+
+  setRequestHandler(method: string, handler: (request: MCPRequestLike, ctx?: unknown) => Promise<any>): void {
+    this._requestHandlers.set(method, handler as any)
+  }
+}
+
+function makeV2Server(): HighLevelMCPServerLike {
+  const server = new V2McpServerDouble()
+  server.registerTool('get_trends', { description: 'Return a trends time series.' }, async (args: any) => ({
+    content: [{ type: 'text', text: `trends for ${args?.event}` }],
+  }))
+  server.registerTool('fail_always', { description: 'Always throws.' }, async () => {
+    throw new Error('intentional failure')
+  })
+  return server as unknown as HighLevelMCPServerLike
+}
+
+/** v2's per-request context: the HTTP request is a WHATWG `Request` at `http.req`. */
+function v2Ctx(headers: Record<string, string> = {}): CompatibleRequestHandlerExtra {
+  return {
+    http: { req: new Request('https://example.com/mcp', { method: 'POST', headers }) },
+  } as unknown as CompatibleRequestHandlerExtra
+}
+
+function dispatch(
+  server: HighLevelMCPServerLike,
+  request: MCPRequestLike,
+  ctx?: CompatibleRequestHandlerExtra
+): Promise<any> {
+  const handler = server.server._requestHandlers.get(request.method as string)
+  if (!handler) {
+    throw new Error(`no handler for ${request.method}`)
+  }
+  return handler(request, ctx as any)
+}
+
+describe('instrument() on an MCP SDK v2 high-level server', () => {
+  let eventCapture: EventCapture
+
+  beforeEach(async () => {
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+  })
+
+  afterEach(async () => {
+    await eventCapture.stop()
+  })
+
+  it('captures a tool call on a server that has registerTool() but no tool()', async () => {
+    const server = makeV2Server()
+    expect((server as unknown as { tool?: unknown }).tool).toBeUndefined()
+
+    instrument(server, fakePostHog(), { context: false })
+
+    const result = await dispatch(
+      server,
+      { method: 'tools/call', params: { name: 'get_trends', arguments: { event: 'pageview' } } },
+      v2Ctx()
+    )
+    await new Promise((r) => setTimeout(r, 20))
+
+    // The application's tool still runs and its result comes back untouched.
+    expect(result.content[0].text).toBe('trends for pageview')
+
+    const toolCalls = eventCapture.findCapturesByEvent('$mcp_tool_call')
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0].properties.$mcp_tool_name).toBe('get_trends')
+    expect(toolCalls[0].properties.$mcp_is_error).toBe(false)
+  })
+
+  it('captures a failing tool call as an error', async () => {
+    const server = makeV2Server()
+    instrument(server, fakePostHog(), { context: false })
+
+    await dispatch(server, { method: 'tools/call', params: { name: 'fail_always', arguments: {} } }, v2Ctx())
+    await new Promise((r) => setTimeout(r, 20))
+
+    const toolCalls = eventCapture.findCapturesByEvent('$mcp_tool_call')
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0].properties.$mcp_is_error).toBe(true)
+    expect(eventCapture.findCapturesByEvent('$exception')).toHaveLength(1)
+  })
+
+  it('captures a tools/list and injects the analytics parameter into the advertised schema', async () => {
+    const server = makeV2Server()
+    instrument(server, fakePostHog(), { context: true })
+
+    const response = await dispatch(server, { method: 'tools/list', params: {} }, v2Ctx())
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(response.tools.find((t: any) => t.name === 'get_trends')?.inputSchema?.properties?.context).toBeDefined()
+
+    const listings = eventCapture.findCapturesByEvent('$mcp_tools_list')
+    expect(listings).toHaveLength(1)
+    expect(listings[0].properties.$mcp_listed_tool_names).toEqual(expect.arrayContaining(['get_trends']))
+  })
+
+  it('lets a host resolve identity from v2 headers through the exported getRequestHeaders', async () => {
+    const server = makeV2Server()
+    const seen: unknown[] = []
+    const identify = jest.fn(async (_request: unknown, extra: unknown) => {
+      seen.push(extra)
+      const auth = getRequestHeaders(extra)?.['authorization']
+      return typeof auth === 'string' ? { distinctId: auth.replace('Bearer ', '') } : null
+    })
+
+    instrument(server, fakePostHog(), { context: false, identify })
+
+    await dispatch(
+      server,
+      { method: 'tools/call', params: { name: 'get_trends', arguments: { event: 'pageview' } } },
+      v2Ctx({ authorization: 'Bearer user-42' })
+    )
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(identify).toHaveBeenCalled()
+    // The callback receives the SDK's own context, unchanged — we do not
+    // synthesise a v1 `requestInfo` on top of it.
+    expect((seen[0] as { http?: { req?: Request } })?.http?.req).toBeInstanceOf(Request)
+    expect((seen[0] as { requestInfo?: unknown })?.requestInfo).toBeUndefined()
+
+    const toolCalls = eventCapture.findCapturesByEvent('$mcp_tool_call')
+    expect(toolCalls[0].distinct_id).toBe('user-42')
+  })
+})

--- a/packages/mcp/src/__tests__/v2-high-level-server.test.ts
+++ b/packages/mcp/src/__tests__/v2-high-level-server.test.ts
@@ -277,6 +277,29 @@ describe('instrument() on an MCP SDK v2 high-level server', () => {
     expect(listings[0].properties.$mcp_listed_tool_names).toEqual(expect.arrayContaining(['get_trends']))
   })
 
+  /**
+   * The transport-identity headers (`user-agent`, `x-anthropic-client`) are read
+   * through the same helper, so the feature that captures which *product* is
+   * calling works on v2 as well. Read the v1 way it finds nothing here, because
+   * v2 has no `extra.requestInfo` at all — the failure this whole PR is about,
+   * in a feature that landed after it was written.
+   */
+  it('captures the transport identity headers on a v2 context', async () => {
+    const server = makeV2Server()
+    instrument(server, fakePostHog(), { context: false })
+
+    await dispatch(
+      server,
+      { method: 'tools/call', params: { name: 'get_trends', arguments: { event: 'pageview' } } },
+      v2Ctx({ 'user-agent': 'claude-code/2.1.0 (cli)', 'x-anthropic-client': 'claude-code' })
+    )
+    await new Promise((r) => setTimeout(r, 20))
+
+    const call = eventCapture.findCapturesByEvent('$mcp_tool_call')[0]
+    expect(call.properties.$mcp_client_user_agent).toBe('claude-code/2.1.0 (cli)')
+    expect(call.properties.$mcp_vendor_client).toBe('claude-code')
+  })
+
   it('lets a host resolve identity from v2 headers through the exported getRequestHeaders', async () => {
     const server = makeV2Server()
     const seen: unknown[] = []

--- a/packages/mcp/src/extensions/compatibility.ts
+++ b/packages/mcp/src/extensions/compatibility.ts
@@ -4,6 +4,16 @@
 // Licensed under the MIT License: https://github.com/agentcathq/agentcat-typescript-sdk/blob/main/LICENSE
 
 import type { HighLevelMCPServerLike, MCPServerLike } from '../types'
+import {
+  canRegisterTools,
+  canSetRequestHandler,
+  hasClientVersionAccessor,
+  hasNestedLowLevelServer,
+  hasRequestHandlerMap,
+  hasServerInfo,
+  hasToolRegistry,
+  isBareServerShape,
+} from './detect'
 import type { LoggerFn } from './logger'
 
 type ServerRecord = Record<string, unknown>
@@ -28,13 +38,11 @@ export function logCompatibilityWarning(logger: LoggerFn): void {
 }
 
 export function isHighLevelServer(server: unknown): server is ServerRecord & { server: ServerRecord } {
-  return (
-    !!server && typeof server === 'object' && 'server' in server && !!server.server && typeof server.server === 'object'
-  )
+  return hasNestedLowLevelServer(server)
 }
 
 export function isLowLevelServer(server: unknown): server is ServerRecord {
-  return !!server && typeof server === 'object' && !('server' in server)
+  return isBareServerShape(server)
 }
 
 export function isCompatibleServerType(server: unknown, logger: LoggerFn): MCPServerLike | HighLevelMCPServerLike {
@@ -46,16 +54,20 @@ export function isCompatibleServerType(server: unknown, logger: LoggerFn): MCPSe
   }
 
   if (isHighLevelServer(server)) {
-    if (!server._registeredTools || typeof server._registeredTools !== 'object') {
+    if (!hasToolRegistry(server)) {
       logCompatibilityWarning(logger)
       throw new Error(
         'PostHog MCP analytics SDK compatibility error: High-level server must have _registeredTools object. This requires MCP SDK v1.11 or higher.'
       )
     }
-    if (typeof server.tool !== 'function') {
+    // Either registration method is enough. v1 has both; v2 dropped the
+    // deprecated tool() and kept registerTool(). Demanding tool() rejected every
+    // v2 high-level server, and instrument() swallows the rejection — so the
+    // integration looked healthy and captured nothing.
+    if (!canRegisterTools(server)) {
       logCompatibilityWarning(logger)
       throw new Error(
-        'PostHog MCP analytics SDK compatibility error: High-level server must have tool() method. This requires MCP SDK v1.11 or higher.'
+        'PostHog MCP analytics SDK compatibility error: High-level server must have a registerTool() or tool() method. This requires MCP SDK v1.11 or higher.'
       )
     }
 
@@ -76,41 +88,30 @@ function validateLowLevelServer(server: unknown, logger: LoggerFn): void {
     )
   }
 
-  const serverRecord = server as ServerRecord
-
-  if (typeof serverRecord.setRequestHandler !== 'function') {
+  if (!canSetRequestHandler(server)) {
     logCompatibilityWarning(logger)
     throw new Error(
       'PostHog MCP analytics SDK compatibility error: Server must have a setRequestHandler method. This requires MCP SDK v1.11 or higher.'
     )
   }
 
-  if (!(serverRecord._requestHandlers && serverRecord._requestHandlers instanceof Map)) {
+  // A real Map with a working get(), which is what the handler patch reads and
+  // writes. Both majors keep it.
+  if (!hasRequestHandlerMap(server)) {
     logCompatibilityWarning(logger)
     throw new Error(
       'PostHog MCP analytics SDK compatibility error: Server._requestHandlers is not accessible. This requires MCP SDK v1.11 or higher.'
     )
   }
 
-  if (typeof serverRecord._requestHandlers.get !== 'function') {
-    logCompatibilityWarning(logger)
-    throw new Error(
-      'PostHog MCP analytics SDK compatibility error: Server._requestHandlers must be a Map with a get method. This requires MCP SDK v1.11 or higher.'
-    )
-  }
-
-  if (typeof serverRecord.getClientVersion !== 'function') {
+  if (!hasClientVersionAccessor(server)) {
     logCompatibilityWarning(logger)
     throw new Error(
       'PostHog MCP analytics SDK compatibility error: Server.getClientVersion must be a function. This requires MCP SDK v1.11 or higher.'
     )
   }
 
-  if (
-    !serverRecord._serverInfo ||
-    typeof serverRecord._serverInfo !== 'object' ||
-    !('name' in serverRecord._serverInfo)
-  ) {
+  if (!hasServerInfo(server)) {
     logCompatibilityWarning(logger)
     throw new Error(
       'PostHog MCP analytics SDK compatibility error: Server._serverInfo is not accessible or missing name. This requires MCP SDK v1.11 or higher.'

--- a/packages/mcp/src/extensions/detect.ts
+++ b/packages/mcp/src/extensions/detect.ts
@@ -1,0 +1,78 @@
+/**
+ * Structural feature probes.
+ *
+ * Every question about the shape of a server object is answered here, by
+ * duck-typing the object in front of us — never by reading a package version or
+ * a protocol constant. Two reasons this is a rule and not a preference:
+ *
+ * - The two SDK majors expose the same capability under different names (v1's
+ *   `.tool()` vs v2's `.registerTool()`), so "which SDK is installed" answers a
+ *   different question than "can this object register a tool".
+ * - A single v2 server serves both protocol eras, request by request, so no
+ *   module-level constant describes it. v2's exported `LATEST_PROTOCOL_VERSION`
+ *   is `2025-11-25`.
+ *
+ * Nothing here imports `@modelcontextprotocol/*`; that boundary is pinned by
+ * `sdk-import-boundary.test.ts`.
+ */
+
+type UnknownRecord = Record<string, unknown>
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === 'object' ? (value as UnknownRecord) : undefined
+}
+
+function hasMethod(value: unknown, key: string): boolean {
+  return typeof asRecord(value)?.[key] === 'function'
+}
+
+/** A high-level `McpServer` wrapper: it holds the low-level server on `.server`. */
+export function hasNestedLowLevelServer(server: unknown): server is UnknownRecord & { server: UnknownRecord } {
+  const record = asRecord(server)
+  return !!record && 'server' in record && !!asRecord(record.server)
+}
+
+/** No `.server` property, so the object is itself the low-level `Server`. */
+export function isBareServerShape(server: unknown): boolean {
+  const record = asRecord(server)
+  return !!record && !('server' in record)
+}
+
+/** The high-level registry we read tool metadata from and wrap callbacks in. */
+export function hasToolRegistry(server: unknown): boolean {
+  return !!asRecord(asRecord(server)?._registeredTools)
+}
+
+/**
+ * The object can register a tool.
+ *
+ * v1 offers both `tool()` and `registerTool()`; v2 dropped the deprecated
+ * `tool()` and keeps only `registerTool()`. Requiring `tool()` specifically is
+ * what made `instrument()` reject every v2 high-level server — and, because
+ * `instrument()` swallows compatibility errors, reject it silently.
+ */
+export function canRegisterTools(server: unknown): boolean {
+  return hasMethod(server, 'registerTool') || hasMethod(server, 'tool')
+}
+
+/** Handler registration, which we patch to wrap late registrations. */
+export function canSetRequestHandler(server: unknown): boolean {
+  return hasMethod(server, 'setRequestHandler')
+}
+
+/** The live handler map we read and write directly. A real `Map` on both majors. */
+export function hasRequestHandlerMap(server: unknown): boolean {
+  const handlers = asRecord(server)?._requestHandlers
+  return handlers instanceof Map && typeof handlers.get === 'function'
+}
+
+/** `getClientVersion()` — still present on v2, and a link in B1's identity chain. */
+export function hasClientVersionAccessor(server: unknown): boolean {
+  return hasMethod(server, 'getClientVersion')
+}
+
+/** `_serverInfo`, which names the server on every event. */
+export function hasServerInfo(server: unknown): boolean {
+  const info = asRecord(asRecord(server)?._serverInfo)
+  return !!info && 'name' in info
+}

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -34,6 +34,7 @@ import { getServerTrackingData, handleIdentify, setServerTrackingData, withIdent
 import type { LoggerFn } from './logger'
 import { buildCapturedMcpParameters } from './mcp-payloads'
 import { readRequestHandlerMethod } from './mcp-sdk-compat'
+import { getRequestHeaders } from './request-headers'
 import { getSessionId, getSessionInfo, newSessionId } from './session'
 import { encodeSessionId, readMcpSessionHeader, writeSessionIdToTransport } from './session-token'
 import { getReportMissingToolDescriptor, resolveMissingCapabilityToolName } from './tools'
@@ -688,8 +689,8 @@ function mintStatelessSessionOnInitialize(
   extra: CompatibleRequestHandlerExtra | undefined
 ): string | undefined {
   try {
-    const headers = extra?.requestInfo?.headers
-    if (!headers || typeof headers !== 'object') {
+    const headers = getRequestHeaders(extra)
+    if (!headers) {
       return undefined // not an HTTP transport (stdio/in-memory) — nothing to mint into
     }
     if (readMcpSessionHeader(headers)) {

--- a/packages/mcp/src/extensions/request-headers.ts
+++ b/packages/mcp/src/extensions/request-headers.ts
@@ -1,0 +1,76 @@
+import type { RequestHeaderBag } from '../types'
+
+/**
+ * Reads the HTTP request headers off the `extra` (v1) / `ctx` (v2) object the
+ * MCP SDK hands a request handler, and returns them as a plain object with
+ * lowercase keys. Returns `undefined` when the request did not come over HTTP —
+ * stdio and in-memory transports carry no headers at all.
+ *
+ * The two SDK majors put them in different places and in different shapes: v1
+ * attaches a plain object at `extra.requestInfo.headers`, while v2 attaches the
+ * WHATWG `Request` at `ctx.http.req`, whose `headers` is a `Headers` instance
+ * that only answers to `.get()`. A v1-shaped read returns `undefined` on v2,
+ * which is why this exists.
+ *
+ * Normalisation is **by shape, not by source**: a framework is free to hand us a
+ * plain object where the SDK hands `Headers`, so both fields are checked for
+ * both shapes. `Headers` is duck-typed on `.entries` rather than `instanceof` —
+ * workerd and other edge runtimes are a different realm and would fail the
+ * identity check on a perfectly good object.
+ *
+ * Exported from the package for host callbacks. `identify`, `intentFallback`,
+ * `eventProperties` and `beforeSend` receive the SDK's `extra` unchanged — we
+ * deliberately do not synthesise a v1 shape on v2, because a fabricated
+ * `requestInfo` is a convincing partial lie about a shape the SDK removed on
+ * purpose. So a host that reads headers reads them through this instead:
+ *
+ * ```ts
+ * import { getRequestHeaders } from '@posthog/mcp'
+ *
+ * identify: async (request, extra) => {
+ *   const auth = getRequestHeaders(extra)?.['authorization']
+ *   // ...
+ * }
+ * ```
+ */
+export function getRequestHeaders(extra: unknown): RequestHeaderBag | undefined {
+  if (!extra || typeof extra !== 'object') {
+    return undefined
+  }
+  const record = extra as Record<string, unknown>
+  const http = record.http as { req?: { headers?: unknown } } | undefined
+  const requestInfo = record.requestInfo as { headers?: unknown } | undefined
+  const source = http?.req?.headers ?? requestInfo?.headers
+  if (!source || typeof source !== 'object') {
+    return undefined
+  }
+  return toHeaderBag(source)
+}
+
+/**
+ * Flattens either shape into a lowercase-keyed bag. Never throws: a header read
+ * failing must not take a tool call down with it.
+ */
+function toHeaderBag(source: object): RequestHeaderBag | undefined {
+  try {
+    const entries = isHeadersLike(source) ? [...source.entries()] : Object.entries(source)
+    const bag: RequestHeaderBag = {}
+    for (const [key, value] of entries) {
+      if (typeof key !== 'string' || value === undefined || value === null) {
+        continue
+      }
+      if (typeof value === 'string' || Array.isArray(value)) {
+        bag[key.toLowerCase()] = value as string | string[]
+      }
+    }
+    return bag
+  } catch {
+    return undefined
+  }
+}
+
+/** Duck-typed, never `instanceof` — an edge runtime's `Headers` is another realm's class. */
+function isHeadersLike(source: object): source is { entries(): Iterable<[string, string]> } {
+  const candidate = source as { entries?: unknown; get?: unknown }
+  return typeof candidate.entries === 'function' && typeof candidate.get === 'function'
+}

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -14,6 +14,7 @@ import type {
 import { INACTIVITY_TIMEOUT_IN_MINUTES } from './constants'
 import { deterministicPrefixedId, newPrefixedId } from './ids'
 import { getServerTrackingData, setServerTrackingData } from './internal'
+import { getRequestHeaders } from './request-headers'
 import { decodeSessionId, readMcpSessionHeader } from './session-token'
 import type { SessionTokenPayload } from './session-token'
 
@@ -110,7 +111,7 @@ function applyTokenClientIdentity(
   data: MCPAnalyticsData,
   extra?: CompatibleRequestHandlerExtra
 ): SessionTokenPayload | undefined {
-  const token = decodeSessionId(readMcpSessionHeader(extra?.requestInfo?.headers))
+  const token = decodeSessionId(readMcpSessionHeader(getRequestHeaders(extra)))
   if (!token) {
     return undefined
   }

--- a/packages/mcp/src/extensions/transport-identity.ts
+++ b/packages/mcp/src/extensions/transport-identity.ts
@@ -1,5 +1,6 @@
 import type { CompatibleRequestHandlerExtra, McpEvent } from '../types'
 import { readHeaderValue } from './headers'
+import { getRequestHeaders } from './request-headers'
 
 /**
  * Transport-level client identity: the two request headers that say *which
@@ -43,12 +44,17 @@ export interface TransportIdentity {
 }
 
 /**
- * Reads the transport identity headers off `extra.requestInfo.headers`. Returns
- * `undefined` when the request carries neither — including every stdio and
- * in-memory request, which has no `requestInfo` at all. Never throws.
+ * Reads the transport identity headers off the request. Returns `undefined`
+ * when the request carries neither — including every stdio and in-memory
+ * request, which has no HTTP headers at all. Never throws.
+ *
+ * Sourced through `getRequestHeaders` rather than `extra.requestInfo.headers`
+ * directly: MCP SDK v2 puts the request at `extra.http.req` as a WHATWG
+ * `Request`, so a v1-shaped read finds nothing and this whole feature would be
+ * silently inert on exactly the servers being adopted now.
  */
 export function readTransportIdentity(extra: CompatibleRequestHandlerExtra | undefined): TransportIdentity | undefined {
-  const headers = extra?.requestInfo?.headers
+  const headers = getRequestHeaders(extra)
   if (!headers) {
     return undefined
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -210,6 +210,9 @@ export {
   PostHogMCPAnalyticsEvent,
   PostHogMCPAnalyticsProperty,
 } from './extensions/constants'
+// Host callbacks receive the SDK's `extra`/`ctx` unchanged, and the two SDK
+// majors carry HTTP headers in different places and shapes. This reads either.
+export { getRequestHeaders } from './extensions/request-headers'
 export { PostHogMCP, type PostHogMCPOptions } from './extensions/posthog-mcp'
 export { getMoreToolsResult } from './extensions/tools'
 export { setLogger } from './extensions/logger'
@@ -229,6 +232,7 @@ export type {
   MissingCapabilityCaptureData,
   PreparedToolCall,
   PrepareToolListOptions,
+  RequestHeaderBag,
   ToolCallCaptureData,
   ToolsListCaptureData,
   UserIdentity,

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -225,13 +225,31 @@ export interface CompatibleRequestInfoLike {
   [key: string]: unknown
 }
 
+/**
+ * The HTTP request an MCP SDK v2 server attaches to the handler context, as a
+ * WHATWG `Request` — so `headers` answers to `.get()`, not to indexing.
+ */
+export interface CompatibleHttpRequestLike {
+  req?: { headers?: unknown; [key: string]: unknown }
+  [key: string]: unknown
+}
+
 export interface CompatibleRequestHandlerExtra {
   headers?: Record<string, string | string[]>
   sessionId?: string
   /** Present on HTTP transports only — headers ride every request, unlike `clientInfo`. */
   requestInfo?: CompatibleRequestInfoLike
+  /** Where MCP SDK v2 puts the same thing. Read both through `getRequestHeaders`. */
+  http?: CompatibleHttpRequestLike
   [key: string]: unknown
 }
+
+/**
+ * HTTP headers normalised to lowercase keys, as `getRequestHeaders` returns
+ * them — a plain bag, so a host's existing `headers['authorization']` keeps
+ * working when only the source of the headers changes.
+ */
+export type RequestHeaderBag = Record<string, string | string[]>
 
 export interface ServerClientInfoLike {
   name?: string


### PR DESCRIPTION
## What
> Part 1 of PRs stack that will close #4449

`@posthog/mcp` now instruments high-level `McpServer` instances from **MCP TypeScript SDK v2**, and reads HTTP request headers from either SDK major.

The compatibility gate required `typeof server.tool === 'function'`. SDK v2 dropped the deprecated `tool()` in favour of `registerTool()`, so every v2 high-level server failed the check — and since `instrument()` catches compatibility failures and returns a working-looking handle, it failed **silently**: no throw, no warning at the call site, and no `$mcp_*` events at all. The gate now accepts either registration method, and every shape question it asks is answered by a structural probe in a new `detect.ts` rather than by a version or protocol constant — v2 is never imported, and a single v2 server serves both protocol eras, so version checks answer the wrong question.

Opening the gate is also what first sends v2-shaped request context to header reads, so both halves ship together — otherwise "no events" becomes "events with no user". Our own reads go through a new `getRequestHeaders(extra)`, which takes headers from v2's `ctx.http.req` (a WHATWG `Request`, whose headers only answer to `.get()`) as well as v1's `extra.requestInfo.headers`, returning a plain lowercase-keyed object either way. It duck-types `Headers` on `.entries` rather than `instanceof`, so a `Headers` from another realm — workerd and other edge runtimes — reads correctly.

`getRequestHeaders` is **exported**. Host callbacks (`identify`, `intentFallback`, `eventProperties`, `beforeSend`) keep receiving the SDK's `extra` unchanged, because synthesising a v1 `requestInfo` on v2 fakes a shape the SDK removed on purpose — a partial lie is worse than an honest absence. So a host reading headers migrates in one line instead of hand-rolling a two-branch read:

```ts
import { getRequestHeaders } from '@posthog/mcp'

identify: async (request, extra) => {
  const auth = getRequestHeaders(extra)?.['authorization'] // v1 and v2
}
```

## What was tested

- **Unit:** 564 tests green, lint and build clean. New coverage for the v2 high-level shape (registry holding `handler` + an `executor` built at registration, handlers registered by method string, a WHATWG `Request` context) and for the header reader across both majors, `Headers`/plain-object/cross-realm shapes. Revert-checked — backing out the gate fails 4 tests, backing out the v2 header location fails 5.
- **Integration**, over real HTTP with raw JSON-RPC (never the SDK `Client`, which negotiates the legacy era and would report green having exercised none of `2026-07-28`): SDK v1 `1.30.0` and SDK v2 `2.0.0`, high-level and low-level, stateful/stateless and per-request/long-lived, both protocol eras, with and without `enableConversationId`.
- **Customer stacks:** NestJS + `@rekog/mcp-nest` 1.9.x on SDK v1, and 2.0.0 on SDK v2, stateless per-request, each via `instrument(server)` and `instrument(server.server)`.

### Matrix

```
                            calls  errors  schema  session  client  protocol  warnings  header  alive 
──────────────────────────────────────────────────────────────────────────────────────────────────────
 v1  stateful   high          ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateful   low           ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateless  high          ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateless  low           ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
──────────────────────────────────────────────────────────────────────────────────────────────────────
 v2  high  2025  conv=off    ✗→✓    ✗→✓      ✓        ·       ✗        ✗        ✗→✓       ✓       ✓
 v2  high  2025  conv=on     ✗→✓    ✗→✓     ✗→✓      ✗→✓      ✗        ✗        ✗→✓       ✓       ✓
 v2  high  2026  conv=off    ✗→✓    ✗→✓      ✓        ·      ✗→✓       ✗        ✗→✓       ✓       ✓
 v2  high  2026  conv=on     ✗→✓    ✗→✓     ✗→✓      ✗→✓     ✗→✓       ✗        ✗→✓       ✓       ✓
 v2  low   2025  conv=off     ✓      ✓       ✓        ·       ✗        ✗         ✓        ✓       ✓
 v2  low   2025  conv=on      ✓      ✓       ✓        ✗       ✗        ✗         ✓        ✓       ✓
 v2  low   2026  conv=off     ✓      ✓       ✓        ·       ✓        ✗         ✓        ✓       ✓
 v2  low   2026  conv=on      ✓      ✓       ✓        ✗       ✓        ✗         ✓        ✓       ✓

 late-handler probe                                      9/9  (unchanged)
 nest v1   instrument(server) / instrument(server.server)   15/16 · 15/16  (unchanged)
 nest v2   instrument(server) / instrument(server.server)   9/33 → 24/33 · 9/33 → 24/33
```

`x → y` marks a cell this PR moved. `·` means the assertion does not apply to that row.


**Measured against the same run on `main`:**

- All four `v1` rows unchanged — that is the requirement, and the point of running them.
- The four `v2 high` rows go ✗ → ✓ on `calls` `errors` `schema` `warnings`, becoming identical to the `v2 low` rows. That convergence was the falsifiable prediction: the gate was the only difference between the two paths, so if the numbers had not met, something else was in the way.
- Same convergence on the customer stack: the two Nest paths land on the same score from opposite directions.
- Two cells moved that were not predicted, both traced before being banked. `session` ✗ → ✓ on `v2 high … conv=on`: the high-level path resolves tool-parameter ownership from the live registry, so `conversation_id` correlates on a per-request server. And `client name` / `protocol version` ✗ → ✓ on the Nest 2025-era lane: normalising our own header reads made the existing stateless session mint reachable on v2, and the token it mints already carries them. It cannot reach modern-era traffic — the mint hangs off `initialize`, which `2026-07-28` does not have — and the assertion that a 2026-era response carries no `Mcp-Session-Id` stays green.

### Known limitation on v2, measured and pinned

v2 builds a tool's `executor` from its `handler` **once at registration**, and dispatch calls the executor — so the callback wrapper `instrument()` installs afterwards never runs on a v2 high-level server. Both halves of what that means are now tests, because the intuitive reading is wrong in one direction:

- It does **not** leak SDK-injected arguments into the application's tool. The strip happens in the `tools/call` request-handler patch before the SDK dispatches; the callback wrapper is only a second pass for hosts invoking a tool callback directly. A tool registered before `instrument()` and called with `{ event, context }` receives exactly `{ event }`, and `$mcp_intent` is still captured.
- It does cost the error's **class**: a thrown `RateLimitError` reaches PostHog as `$mcp_error_type = "Error"`, with `$mcp_error_message`, `$mcp_is_error` and the `$exception` sibling all intact.

Wrapping the executor is deliberately not in this PR: it has to mutate the registered tool in place, since v2's `update()` / `enable()` / `disable()` close over the original object and `update({ callback })` regenerates the executor. That is a change to the registration path with its own failure modes, and it is tracked separately. The pinning test is written to fail if it ever lands.

### Still red on v2, each owned by follow-up work

`protocol` (we read `params._meta`; v2 lifts the reserved keys into the request envelope) · `client name` on 2025-era traffic where the transport cannot carry a response header · error-message cleanliness · `$mcp_intent` ownership on the low-level path — also red on v1, so not a v2 regression. The harness's `identify()` deliberately reads headers the v1 way and stays red on purpose: that callback *is* the assertion that we do not rewrite `extra` behind a host's back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related to: https://github.com/PostHog/posthog/issues/64016