### PR TITLE
fix(mcp): install and type-check cleanly on a v2-only project

### DIFF
--- a/.changeset/mcp-v2-optional-peers.md
+++ b/.changeset/mcp-v2-optional-peers.md
@@ -2,8 +2,10 @@
 '@posthog/mcp': patch
 ---
 
-Declare both MCP TypeScript SDK majors as optional peers, so a v2-only project installs cleanly.
+Install and type-check cleanly on a project that has only MCP SDK v2.
 
-`@modelcontextprotocol/sdk` (v1) was a required peer, so installing `@posthog/mcp` into a project built on `@modelcontextprotocol/server` (v2) pulled the entire v1 SDK in as an auto-installed peer — 87 packages where 1 was wanted — and any tooling that walks the dependency tree reported it as missing when it was absent.
+`@modelcontextprotocol/sdk` (v1) was a required peer, so installing `@posthog/mcp` into a project built on `@modelcontextprotocol/server` (v2) pulled the entire v1 SDK in as an auto-installed peer — 87 packages where 1 was wanted — and tooling that walks the dependency tree reported it as missing when it was absent. Both majors are now declared and both are optional, which is what the code has always assumed: no `@modelcontextprotocol/*` package is imported at runtime, and server shapes are detected structurally.
 
-Neither major is required at runtime: no `@modelcontextprotocol/*` package is imported in shipped code, and server shapes are detected structurally. Both are now declared and both are marked optional, so the manifest states what is supported without forcing either into the tree.
+Making the peer optional exposed a second half of the same problem. The published type declarations still imported `CallToolResult` and `ListToolsResult` from `@modelcontextprotocol/sdk/types.js`, so a consumer without the v1 SDK hit `TS2307` on an install that otherwise worked — fine at runtime, broken under `tsc` without `skipLibCheck`. Those MCP wire shapes are now declared structurally in `types.ts` too.
+
+The shapes we read are open-ended, so a value typed by either SDK assigns to them. What the package hands back is typed precisely and stays assignable to the SDK's own `CallToolResult`, so `getMoreToolsResult()` can still be returned straight from a tool callback.

--- a/.changeset/mcp-v2-optional-peers.md
+++ b/.changeset/mcp-v2-optional-peers.md
@@ -1,0 +1,9 @@
+---
+'@posthog/mcp': patch
+---
+
+Declare both MCP TypeScript SDK majors as optional peers, so a v2-only project installs cleanly.
+
+`@modelcontextprotocol/sdk` (v1) was a required peer, so installing `@posthog/mcp` into a project built on `@modelcontextprotocol/server` (v2) pulled the entire v1 SDK in as an auto-installed peer — 87 packages where 1 was wanted — and any tooling that walks the dependency tree reported it as missing when it was absent.
+
+Neither major is required at runtime: no `@modelcontextprotocol/*` package is imported in shipped code, and server shapes are detected structurally. Both are now declared and both are marked optional, so the manifest states what is supported without forcing either into the tree.

--- a/packages/mcp/docs/ARCHITECTURE.md
+++ b/packages/mcp/docs/ARCHITECTURE.md
@@ -383,4 +383,5 @@ The SDK does **not**: call an LLM, inspect tool arguments, build heuristics, or 
 | Exception capture & stack-trace parsing                               | `src/extensions/exceptions.ts`                                        |
 | MCP SDK version compat shims                                          | `src/extensions/compatibility.ts`, `src/extensions/mcp-sdk-compat.ts` |
 | Structural capability probes (both SDK majors)                        | `src/extensions/detect.ts`                                            |
+| MCP wire shapes, declared not imported (ADR-0007)                     | `src/types.ts`                                                        |
 | Request headers on either SDK major (`getRequestHeaders`)             | `src/extensions/request-headers.ts`                                   |

--- a/packages/mcp/docs/adr/0007-both-sdk-majors-are-optional-peers.md
+++ b/packages/mcp/docs/adr/0007-both-sdk-majors-are-optional-peers.md
@@ -1,0 +1,33 @@
+# ADR-0007: Both SDK majors are optional peers, and no SDK types ship in our declarations
+
+- Status: Accepted
+- Date: 2026-08-07
+
+## Context
+
+`@modelcontextprotocol/sdk` (v1) was a **required** peer dependency. Once v2 shipped under different package names, a project built on `@modelcontextprotocol/server` that installed `@posthog/mcp` had npm auto-install the entire v1 SDK it will never load — measured at 87 packages where 1 was wanted — and any tooling that walks the dependency tree reported the peer as missing whenever it was absent.
+
+Neither major is required at runtime: server shapes are detected structurally (ADR-0005) and no `@modelcontextprotocol/*` package is imported in shipped code.
+
+Making the peer optional exposed a second half of the same problem. The published declarations still imported `CallToolResult` and `ListToolsResult` from `@modelcontextprotocol/sdk/types.js`, so a consumer that legitimately had no v1 SDK hit `TS2307` under `tsc` without `skipLibCheck` — an install that runs fine and will not compile. Reproduced against a project with only `@modelcontextprotocol/server@2.0.0` installed: two errors, from `dist/types.d.ts` and `dist/extensions/tools.d.ts`.
+
+## Decision
+
+Both majors are declared as peers and both are marked `optional` in `peerDependenciesMeta`. v2 also joins `devDependencies`, pinned `~2.0.0` to match the existing `~1.29.0` on v1 — patch-only for both, because this package duck-types SDK internals (`_requestHandlers`, `_registeredTools`, `_serverInfo`) that carry no semver guarantee, so adopting a new minor should be a reviewed commit rather than install-time drift.
+
+The MCP wire shapes are declared structurally in `src/types.ts` rather than imported:
+
+- Shapes we **read** are open-ended and fully optional, so a value typed by either major assigns to them.
+- What we **return** is typed precisely, because that is the direction that breaks callers silently — `getMoreToolsResult()` must stay assignable to the SDK's own `CallToolResult`, which `report-missing.test.ts` asserts at compile time.
+
+`sdk-import-boundary.test.ts` is widened from "no runtime reference" to "no reference at all, not even type-only", since a type-only import survives into the published `.d.ts`.
+
+## Consequences
+
+- A v1 consumer is unaffected: they already install the SDK explicitly, because they construct the server with it.
+- Our types assert less than the SDK's. A change in an SDK field we do not model cannot break a consumer's build through us — and cannot warn them either.
+- Verifying this needs a consumer-shaped check (install a tarball into a project with only the other major, type-check without `skipLibCheck`); the workspace's own build cannot see it, because both majors are present here.
+
+## References
+
+- PostHog/posthog-js#4464 (this change), ADR-0005

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-env": "catalog:",
     "@babel/preset-typescript": "catalog:",
     "@modelcontextprotocol/sdk": "~1.29.0",
+    "@modelcontextprotocol/server": "~2.0.0",
     "@posthog-tooling/tsconfig-base": "workspace:*",
     "@rslib/core": "catalog:",
     "@types/jest": "catalog:",
@@ -57,7 +58,16 @@
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.26.0",
+    "@modelcontextprotocol/server": ">=2.0.0",
     "posthog-node": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    },
+    "@modelcontextprotocol/server": {
+      "optional": true
+    }
   },
   "keywords": [
     "posthog",

--- a/packages/mcp/src/__tests__/report-missing.test.ts
+++ b/packages/mcp/src/__tests__/report-missing.test.ts
@@ -1,4 +1,5 @@
 import { type CallToolResult, CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult as V2CallToolResult } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import { instrument } from '../index'
 import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from '../extensions/constants'
@@ -313,8 +314,16 @@ describe('reportMissing (get_more_tools virtual tool)', () => {
  * the exported surface; internal descriptors are read by us, never handed on.
  */
 describe('results we hand back stay assignable to the SDK types', () => {
-  it('getMoreToolsResult() satisfies CallToolResult', () => {
+  it('getMoreToolsResult() satisfies v1 CallToolResult', () => {
     const result: CallToolResult = getMoreToolsResult()
+    expect(result.content).toHaveLength(1)
+  })
+
+  // Both majors, because either can drift away from our structural type — and v2
+  // is the likelier of the two, being the newer schema. Available only because
+  // this package now carries v2 as a devDependency.
+  it('getMoreToolsResult() satisfies v2 CallToolResult', () => {
+    const result: V2CallToolResult = getMoreToolsResult()
     expect(result.content).toHaveLength(1)
   })
 })

--- a/packages/mcp/src/__tests__/report-missing.test.ts
+++ b/packages/mcp/src/__tests__/report-missing.test.ts
@@ -1,9 +1,10 @@
-import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { type CallToolResult, CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import { instrument } from '../index'
 import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from '../extensions/constants'
 import { MCPAnalyticsEventType } from '../extensions/event-types'
 import { getServerTrackingData } from '../extensions/internal'
+import { getMoreToolsResult } from '../index'
 import { EventCapture, fakePostHog } from './test-utils'
 import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
 
@@ -299,5 +300,21 @@ describe('reportMissing (get_more_tools virtual tool)', () => {
 
       await capture.stop()
     })
+  })
+})
+
+/**
+ * Shipped code declares the MCP wire shapes structurally instead of importing
+ * them, because both SDK majors are optional peers and a type import of one
+ * would break `tsc` for a consumer that installed the other. The risk that
+ * creates is the *other* direction: a host passing what we return straight back
+ * to the SDK. This is a compile-time assertion — if the type we return drifts
+ * away from the SDK's, this file stops compiling, which is the point. It covers
+ * the exported surface; internal descriptors are read by us, never handed on.
+ */
+describe('results we hand back stay assignable to the SDK types', () => {
+  it('getMoreToolsResult() satisfies CallToolResult', () => {
+    const result: CallToolResult = getMoreToolsResult()
+    expect(result.content).toHaveLength(1)
   })
 })

--- a/packages/mcp/src/__tests__/sdk-import-boundary.test.ts
+++ b/packages/mcp/src/__tests__/sdk-import-boundary.test.ts
@@ -99,11 +99,28 @@ describe('MCP SDK import boundary', () => {
     expect(offenders).toEqual([])
   })
 
+  /**
+   * Stronger than the runtime rule above, and for a different reason: both SDK
+   * majors are *optional* peer dependencies, so a v2-only consumer has no v1 SDK
+   * on disk. A type-only import survives into the published `.d.ts`, where it is
+   * a `TS2307` for anyone type-checking without `skipLibCheck` — an install that
+   * runs fine but will not compile. So the wire shapes are declared
+   * structurally in `types.ts` instead of imported.
+   */
+  it('never references a @modelcontextprotocol package at all, not even as a type', () => {
+    const offenders = files.filter((file) => scan(readFileSync(file, 'utf8')).references.length > 0)
+    expect(offenders.map((file) => file.slice(SRC.length + 1))).toEqual([])
+  })
+
   it('recognises the type-only imports it is meant to allow', () => {
-    // Without this, a scanner that silently matches nothing would pass the test
-    // above forever while checking nothing at all.
-    const erasedCount = files.reduce((total, file) => total + scan(readFileSync(file, 'utf8')).erased.length, 0)
-    expect(erasedCount).toBeGreaterThan(0)
+    // Without this, a scanner that silently matches nothing would pass the tests
+    // above forever while checking nothing at all. Asserted against a fixture
+    // rather than against `src`, which is now deliberately free of them.
+    const { erased, references } = scan(`import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'`)
+    expect(erased).toHaveLength(1)
+    expect(references).toHaveLength(1)
+    expect(erased[0].start).toBeLessThanOrEqual(references[0])
+    expect(erased[0].end).toBeGreaterThan(references[0])
   })
 
   it.each([

--- a/packages/mcp/src/extensions/instrument-highlevel.ts
+++ b/packages/mcp/src/extensions/instrument-highlevel.ts
@@ -3,9 +3,9 @@
 // Copyright (c) 2025 AgentCat, Inc. (formerly MCPcat)
 // Licensed under the MIT License: https://github.com/agentcathq/agentcat-typescript-sdk/blob/main/LICENSE
 
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import type {
   CompatibleRequestHandlerExtra,
+  CompatibleToolResultLike,
   HighLevelMCPServerLike,
   MCPServerLike,
   RegisteredTool,
@@ -173,7 +173,7 @@ function addTracingToToolCallbackInternal(
     return tool
   }
 
-  const wrappedCallback = async (...params: unknown[]): Promise<CallToolResult> => {
+  const wrappedCallback = async (...params: unknown[]): Promise<CompatibleToolResultLike> => {
     let args: unknown
     let extra: CompatibleRequestHandlerExtra
 
@@ -192,13 +192,13 @@ function addTracingToToolCallbackInternal(
     })
     try {
       if (cleanedArgs === undefined) {
-        const handler = originalCallback as (extra: CompatibleRequestHandlerExtra) => Promise<CallToolResult>
+        const handler = originalCallback as (extra: CompatibleRequestHandlerExtra) => Promise<CompatibleToolResultLike>
         return await handler(extra)
       }
       const handler = originalCallback as (
         args: unknown,
         extra: CompatibleRequestHandlerExtra
-      ) => Promise<CallToolResult>
+      ) => Promise<CompatibleToolResultLike>
       return await handler(cleanedArgs, extra)
     } catch (error) {
       if (error instanceof Error) {

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -3,10 +3,10 @@
 // Copyright (c) 2025 AgentCat, Inc. (formerly MCPcat)
 // Licensed under the MIT License: https://github.com/agentcathq/agentcat-typescript-sdk/blob/main/LICENSE
 
-import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
 import type {
   AnalyticsParameterOwnership,
   CompatibleRequestHandlerExtra,
+  CompatibleToolsListLike,
   MCPAnalyticsData,
   MCPRequestLike,
   MCPServerLike,
@@ -471,7 +471,7 @@ export async function isToolAdvertised(
   }
 
   try {
-    const response = (await listHandler({ method: 'tools/list', params: {} }, extra)) as ListToolsResult
+    const response = (await listHandler({ method: 'tools/list', params: {} }, extra)) as CompatibleToolsListLike
     if (!response || !Array.isArray(response.tools)) {
       return undefined
     }
@@ -496,7 +496,7 @@ export async function handleListToolsRequest(
   request: MCPRequestLike,
   extra: CompatibleRequestHandlerExtra | undefined,
   logger: LoggerFn
-): Promise<{ tools: ListToolsResult['tools'] }> {
+): Promise<{ tools: CompatibleToolsListLike['tools'] }> {
   const data = getServerTrackingData(server)
   const startTime = new Date()
   const sessionId = getSessionId(server, extra)
@@ -554,7 +554,7 @@ export async function handleListToolsRequest(
 
 function cacheToolAnalyticsParameterOwnership(
   cache: Map<string, AnalyticsParameterOwnership>,
-  tools: ListToolsResult['tools']
+  tools: CompatibleToolsListLike['tools']
 ): void {
   // Merge pages and concurrent enumerations; repeated tool names overwrite stale schemas.
   for (const tool of tools) {
@@ -564,7 +564,7 @@ function cacheToolAnalyticsParameterOwnership(
   }
 }
 
-function collectListedToolNames(tools: ListToolsResult['tools'] | undefined): string[] | undefined {
+function collectListedToolNames(tools: CompatibleToolsListLike['tools'] | undefined): string[] | undefined {
   if (!tools || tools.length === 0) {
     return
   }
@@ -580,10 +580,10 @@ async function getTracedToolsList(
   event: McpEvent,
   logger: LoggerFn,
   requestAttribution: SessionInfo
-): Promise<ListToolsResult['tools']> {
+): Promise<CompatibleToolsListLike['tools']> {
   try {
     const data = getServerTrackingData(server)
-    const originalResponse = (await originalListToolsHandler(request, extra)) as ListToolsResult
+    const originalResponse = (await originalListToolsHandler(request, extra)) as CompatibleToolsListLike
     // Injection must not mutate arrays reused or frozen by the server.
     let tools = [...(originalResponse.tools || [])]
 
@@ -635,7 +635,10 @@ async function getTracedToolsList(
   }
 }
 
-export function cacheToolDescriptions(cache: Map<string, string>, tools: ListToolsResult['tools'] | undefined): void {
+export function cacheToolDescriptions(
+  cache: Map<string, string>,
+  tools: CompatibleToolsListLike['tools'] | undefined
+): void {
   if (!tools) {
     return
   }
@@ -656,7 +659,10 @@ export function readToolMetaCategory(meta: unknown): string | undefined {
   return typeof category === 'string' && category.length > 0 ? category : undefined
 }
 
-export function cacheToolCategories(cache: Map<string, string>, tools: ListToolsResult['tools'] | undefined): void {
+export function cacheToolCategories(
+  cache: Map<string, string>,
+  tools: CompatibleToolsListLike['tools'] | undefined
+): void {
   if (!tools) {
     return
   }

--- a/packages/mcp/src/extensions/tools.ts
+++ b/packages/mcp/src/extensions/tools.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2025 AgentCat, Inc. (formerly MCPcat)
 // Licensed under the MIT License: https://github.com/agentcathq/agentcat-typescript-sdk/blob/main/LICENSE
 
-import { type CallToolResult, type ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
+import type { CompatibleTextToolResult, CompatibleToolsListLike } from '../types'
 import { log, type LoggerFn } from './logger'
 
 export const GET_MORE_TOOLS_NAME = 'get_more_tools' as const
@@ -17,7 +17,7 @@ export function resolveMissingCapabilityToolName(options?: { missingCapabilityTo
   return options?.missingCapabilityToolName ?? GET_MORE_TOOLS_NAME
 }
 
-type ReportMissingToolDescriptor = ListToolsResult['tools'][number]
+type ReportMissingToolDescriptor = CompatibleToolsListLike['tools'][number]
 
 export function getReportMissingToolDescriptor(name: string = GET_MORE_TOOLS_NAME): ReportMissingToolDescriptor {
   return {
@@ -53,7 +53,7 @@ export function getReportMissingToolDescriptor(name: string = GET_MORE_TOOLS_NAM
  * report was recorded (custom dispatcher path); the `instrument()` path returns
  * it automatically.
  */
-export function getMoreToolsResult(): CallToolResult {
+export function getMoreToolsResult(): CompatibleTextToolResult {
   return {
     content: [
       {
@@ -64,7 +64,7 @@ export function getMoreToolsResult(): CallToolResult {
   }
 }
 
-export function handleReportMissing(args: { context: string }, logger: LoggerFn = log): CallToolResult {
+export function handleReportMissing(args: { context: string }, logger: LoggerFn = log): CompatibleTextToolResult {
   logger(`Missing tool reported: ${JSON.stringify(args)}`)
   return getMoreToolsResult()
 }

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -3,8 +3,8 @@
 // Copyright (c) 2025 AgentCat, Inc. (formerly MCPcat)
 // Licensed under the MIT License: https://github.com/agentcathq/agentcat-typescript-sdk/blob/main/LICENSE
 
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import type { ErrorTracking } from '@posthog/core'
+import type { AnalyticsInjectableJsonSchema } from './extensions/analytics-parameters'
 import type { MCPAnalyticsEventType } from './extensions/event-types'
 import type { IdentityCache } from './extensions/internal'
 import type { PostHogCaptureEvent } from './extensions/posthog-events'
@@ -17,6 +17,54 @@ export type JsonRecord = Record<string, unknown>
 export type ErrorProperties = ErrorTracking.ErrorProperties
 /** A single parsed stack frame. Re-exported from `@posthog/core`. */
 export type StackFrame = ErrorTracking.StackFrame
+
+/**
+ * The MCP wire shapes we touch, declared structurally rather than imported from
+ * `@modelcontextprotocol/sdk`.
+ *
+ * Both SDK majors are **optional** peers — a v2-only consumer has no v1 SDK
+ * installed — so a type import of it in shipped `.d.ts` output is a `TS2307`
+ * for anyone type-checking without `skipLibCheck`. These are deliberately loose
+ * (open-ended, everything optional): they describe what we *read* off an SDK
+ * result, and an SDK-typed value assigns to them cleanly. What we hand back to
+ * the SDK is typed precisely instead — see {@link CompatibleTextToolResult}.
+ */
+export interface CompatibleToolResultLike {
+  content?: unknown[]
+  structuredContent?: JsonRecord
+  isError?: boolean
+  _meta?: JsonRecord
+  [key: string]: unknown
+}
+
+/** One entry of a `tools/list` response, as we read it. */
+export interface CompatibleToolDescriptorLike {
+  name: string
+  title?: string
+  description?: string
+  /** The advertised JSON Schema, as the analytics parameters are injected into it. */
+  inputSchema?: AnalyticsInjectableJsonSchema
+  outputSchema?: unknown
+  _meta?: JsonRecord
+  [key: string]: unknown
+}
+
+/** A `tools/list` response, as we read it. */
+export interface CompatibleToolsListLike {
+  tools: CompatibleToolDescriptorLike[]
+  nextCursor?: string
+  [key: string]: unknown
+}
+
+/**
+ * A text-only tool result *we* construct and a host may hand straight back to
+ * the SDK. Typed precisely, not loosely, so it stays assignable to the SDK's own
+ * `CallToolResult` — the direction that would silently break callers.
+ */
+export interface CompatibleTextToolResult {
+  content: { type: 'text'; text: string }[]
+  isError?: boolean
+}
 
 export interface MCPRequestParamsLike {
   arguments?: JsonRecord
@@ -128,8 +176,11 @@ export type MaybePromise<T> = T | Promise<T>
 export type MCPAnalyticsIntentSource = 'context_parameter' | 'inferred'
 
 export type ToolCallback =
-  | ((args: unknown, extra: CompatibleRequestHandlerExtra) => CallToolResult | Promise<CallToolResult>)
-  | ((extra: CompatibleRequestHandlerExtra) => CallToolResult | Promise<CallToolResult>)
+  | ((
+      args: unknown,
+      extra: CompatibleRequestHandlerExtra
+    ) => CompatibleToolResultLike | Promise<CompatibleToolResultLike>)
+  | ((extra: CompatibleRequestHandlerExtra) => CompatibleToolResultLike | Promise<CompatibleToolResultLike>)
 
 // RegisteredTool type that supports both MCP SDK 1.23- (callback) and 1.24+ (handler)
 export type RegisteredTool = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,6 +618,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ~1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/server':
+        specifier: ~2.0.0
+        version: 2.0.0
       '@posthog-tooling/tsconfig-base':
         specifier: workspace:*
         version: link:../../tooling/tsconfig-base
@@ -4844,6 +4847,10 @@ packages:
     resolution: {integrity: sha512-TaW4jTGVE1/ln2VGFChnheMh589QCAZy1MVnLvjjSzZ4pEAa4WYAWPwFkDVZbSdPQdLfZy7LuTyZjWRkhX9/Gg==}
     engines: {node: '>=6'}
 
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -4853,6 +4860,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@module-federation/error-codes@0.16.0':
     resolution: {integrity: sha512-TfmA45b8vvISniGudMg8jjIy1q3tLPon0QN/JdFp5f8AJ8/peICN5b+dkEQnWsAVg2fEusYhk9dO7z3nUeJM8A==}
@@ -22755,6 +22766,10 @@ snapshots:
 
   '@miherlosev/esm@3.2.26': {}
 
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.17(hono@4.12.34)
@@ -22828,6 +22843,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@module-federation/error-codes@0.16.0': {}
 


### PR DESCRIPTION
## What

> Stacked on #4462

A project built on `@modelcontextprotocol/server` (v2) could not adopt `@posthog/mcp` cleanly. Two halves of the same problem, and the second only becomes reachable once the first is fixed, so they ship together.

**1. The v1 SDK was a required peer.** Installing this package therefore dragged the entire v1 SDK into a v2-only project — one it will never load — and dependency-tree tooling reported it as missing whenever it was absent. Both majors are now declared and both are optional, which is what the code has always assumed: shipped code imports no `@modelcontextprotocol/*` package (pinned by `sdk-import-boundary.test.ts`) and detects server shapes structurally.

```jsonc
"peerDependencies": {
  "@modelcontextprotocol/sdk": ">=1.26.0",     // v1
  "@modelcontextprotocol/server": ">=2.0.0",   // v2
  "posthog-node": "^5.0.0"
},
"peerDependenciesMeta": {
  "@modelcontextprotocol/sdk": { "optional": true },
  "@modelcontextprotocol/server": { "optional": true }
}
```

**2. The published types still imported the v1 SDK.** Once the peer is optional, a consumer legitimately has no v1 SDK on disk — but `dist/types.d.ts` and `dist/extensions/tools.d.ts` imported `CallToolResult` / `ListToolsResult` from `@modelcontextprotocol/sdk/types.js`. That is a `TS2307` for anyone type-checking without `skipLibCheck`: an install that runs fine and will not compile. Shipping only the first half would have traded a noisy install for a confusing compile error, so the MCP wire shapes are now declared structurally in `types.ts` as well.

The shapes we *read* are deliberately open-ended, so a value typed by either SDK major assigns to them. What we *return* stays precise — that is the direction that would break callers silently — so `getMoreToolsResult()` can still be handed straight back to the SDK.

v2 also joins `devDependencies` at `~2.0.0`, matching the existing `~1.29.0` on v1. pnpm auto-installs the optional peer into the workspace regardless, so this adds nothing to the tree; it declares *which* version this repo develops against. Patch-only on purpose for both majors: this package duck-types SDK internals (`_requestHandlers`, `_registeredTools`, `_serverInfo`) that carry no semver guarantee, so adopting a new minor should be a reviewed commit rather than install-time drift.

## What was measured

**Install**, into a project with `@modelcontextprotocol/server@2.0.0` + `posthog-node@5`, from a packed tarball carrying the old manifest and then the new one:

```
before   added 87 packages    including @modelcontextprotocol/sdk@1.30.0, pulled in as a required peer
after    added  1 package     @modelcontextprotocol/sdk → UNMET OPTIONAL DEPENDENCY, correctly absent
```

**Type-check**, same project, `skipLibCheck: false`, `moduleResolution: nodenext`:

```
before   dist/types.d.ts(1,37):            error TS2307: Cannot find module '@modelcontextprotocol/sdk/types.js'
         dist/extensions/tools.d.ts(1,59): error TS2307: Cannot find module '@modelcontextprotocol/sdk/types.js'
after    no errors from @posthog/mcp
```

**Tests.** 564 unit tests green, lint and build clean. `report-missing.test.ts` now asserts at compile time that `getMoreToolsResult()` is still assignable to the SDK's `CallToolResult`, so a structural type drifting away from the SDK's fails the build rather than a consumer's. `sdk-import-boundary.test.ts` gains the stronger rule this implies — no `@modelcontextprotocol` reference in shipped source *at all*, not merely no runtime one — and its scanner self-check moves to a fixture, since `src` no longer contains the type-only import it used to look for.

**Behaviour.** Types are erased, so no runtime change is expected; the testbed confirms none. All four `v1` matrix rows all-green, `v2` rows identical to the parent branch, late-handler probe 9/9, `nest v1` 15/16 · 15/16, `nest v2` 24/33 · 24/33 — every number unchanged from `#4462`.

```
                              calls errors schema session client protocol warnings header alive
 v1  stateful   high             ✓      ✓      ✓      ✓       ✓       ✓        ✓       ·     ·
 v1  stateful   low              ✓      ✓      ✓      ✓       ✓       ✓        ✓       ·     ·
 v1  stateless  high             ✓      ✓      ✓      ✓       ✓       ✓        ✓       ·     ·
 v1  stateless  low              ✓      ✓      ✓      ✓       ✓       ✓        ✓       ·     ·
 v2  high  2025  conv=off        ✓      ✓      ✓      ·       ✗       ✗        ✓       ✓     ✓
 v2  high  2025  conv=on         ✓      ✓      ✓      ✓       ✗       ✗        ✓       ✓     ✓
 v2  high  2026  conv=off        ✓      ✓      ✓      ·       ✓       ✗        ✓       ✓     ✓
 v2  high  2026  conv=on         ✓      ✓      ✓      ✓       ✓       ✗        ✓       ✓     ✓
 v2  low   2025  conv=off        ✓      ✓      ✓      ·       ✗       ✗        ✓       ✓     ✓
 v2  low   2025  conv=on         ✓      ✓      ✓      ✗       ✗       ✗        ✓       ✓     ✓
 v2  low   2026  conv=off        ✓      ✓      ✓      ·       ✓       ✗        ✓       ✓     ✓
 v2  low   2026  conv=on         ✓      ✓      ✓      ✗       ✓       ✗        ✓       ✓     ✓
```

`protocol` is red here because the fix for it is the next branch in the stack, not because anything regressed.

## Noticed, not fixed here

The same v2-only type-check surfaces `posthog-node/dist/extensions/express.d.ts` referencing `express`, which is optional there too — the identical bug in a different package. Left alone rather than smuggled into this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

