### PR TITLE
fix(mcp): read the protocol version off the request header

### DIFF
--- a/.changeset/mcp-legacy-era-protocol-version.md
+++ b/.changeset/mcp-legacy-era-protocol-version.md
@@ -1,0 +1,9 @@
+---
+'@posthog/mcp': patch
+---
+
+Record the protocol version for 2025-11-25 traffic served by a per-request server.
+
+That revision carries the negotiated version at the `initialize` handshake, so an MCP SDK v2 server built per HTTP request has no way to know it: the instance handling a later `tools/call` never saw the handshake, and a legacy-era request carries no `_meta` envelope for the identity chain to read. Those events went out with no `$mcp_protocol_version`.
+
+The chain gains the one carrier that era does have — the `MCP-Protocol-Version` request header, which 2025-11-25 requires a client to send on every request after `initialize`. It is read after the protocol-level envelope and `params._meta` and before the server's own accessors, so a modern-era request still prefers the value the protocol gives it, and no era is branched on.

--- a/packages/mcp/src/__tests__/client-identity.test.ts
+++ b/packages/mcp/src/__tests__/client-identity.test.ts
@@ -200,6 +200,36 @@ describe('client-identity', () => {
       expect(identity).toBeUndefined()
     })
 
+    it('reads the MCP-Protocol-Version header, the only per-request carrier a legacy request has', () => {
+      const identity = resolveClientIdentity({
+        request: requestWithMeta(undefined),
+        extra: { requestInfo: { headers: { 'mcp-protocol-version': '2025-11-25' } } } as CompatibleRequestHandlerExtra,
+      })
+      expect(identity).toEqual({ protocolVersion: '2025-11-25' })
+    })
+
+    it('reads the same header off a v2 context, where it is a WHATWG Headers', () => {
+      const extra = {
+        http: { req: new Request('https://example.com/mcp', { headers: { 'MCP-Protocol-Version': '2026-07-28' } }) },
+      } as unknown as CompatibleRequestHandlerExtra
+      expect(resolveClientIdentity({ request: requestWithMeta(undefined), extra })?.protocolVersion).toBe('2026-07-28')
+    })
+
+    it('prefers the protocol-level envelope over the header when both are present', () => {
+      const extra = {
+        mcpReq: { envelope: { [META_PROTOCOL_VERSION_KEY]: '2026-07-28' } },
+        requestInfo: { headers: { 'mcp-protocol-version': '2025-11-25' } },
+      } as unknown as CompatibleRequestHandlerExtra
+      expect(resolveClientIdentity({ request: requestWithMeta(undefined), extra })?.protocolVersion).toBe('2026-07-28')
+    })
+
+    it('ignores a junk header rather than recording it', () => {
+      const extra = {
+        requestInfo: { headers: { 'mcp-protocol-version': 'x'.repeat(200) } },
+      } as CompatibleRequestHandlerExtra
+      expect(resolveClientIdentity({ request: requestWithMeta(undefined), extra })).toBeUndefined()
+    })
+
     it('returns undefined when no source answers', () => {
       expect(resolveClientIdentity({ request: requestWithMeta(undefined) })).toBeUndefined()
     })

--- a/packages/mcp/src/extensions/client-identity.ts
+++ b/packages/mcp/src/extensions/client-identity.ts
@@ -1,5 +1,7 @@
 import type { CompatibleRequestHandlerExtra, McpEvent, MCPRequestLike, MCPServerLike } from '../types'
 import { hasClientVersionAccessor, hasNegotiatedProtocolVersionAccessor } from './detect'
+import { readHeaderValue } from './headers'
+import { getRequestHeaders } from './request-headers'
 
 /**
  * Client identity — who is calling, and which spec revision they speak.
@@ -13,7 +15,11 @@ import { hasClientVersionAccessor, hasNegotiatedProtocolVersionAccessor } from '
  *      the time a handler runs they are here and `params._meta` is empty.
  *   2. `request.params._meta` — where 2026-07-28 puts them on the wire, and
  *      where they still are on any server that does not lift them.
- *   3. the server's own accessors — `getClientVersion()` from a legacy
+ *   3. the `MCP-Protocol-Version` request header, which 2025-11-25 requires a
+ *      client to send on every request after `initialize` — the only per-request
+ *      carrier a legacy-era request has, and therefore the only one that
+ *      survives a per-request server instance.
+ *   4. the server's own accessors — `getClientVersion()` from a legacy
  *      `initialize` handshake, `getNegotiatedProtocolVersion()` on v2.
  *
  * The 2026-07-28 revision removed the `initialize` handshake and the
@@ -24,6 +30,10 @@ import { hasClientVersionAccessor, hasNegotiatedProtocolVersionAccessor } from '
  */
 export const META_CLIENT_INFO_KEY = 'io.modelcontextprotocol/clientInfo'
 export const META_PROTOCOL_VERSION_KEY = 'io.modelcontextprotocol/protocolVersion'
+/** Required on every post-`initialize` request by 2025-11-25 (and sent by modern clients too). */
+export const PROTOCOL_VERSION_HEADER = 'mcp-protocol-version'
+/** A version string is a date-like token; anything longer is junk we should not record. */
+const MAX_PROTOCOL_VERSION_LENGTH = 64
 
 export interface MetaClientInfo {
   clientName?: string
@@ -101,6 +111,28 @@ export function readEnvelopeClientInfo(extra: CompatibleRequestHandlerExtra | un
 }
 
 /**
+ * Reads the protocol version off the request headers.
+ *
+ * This is what closes the gap on **2025-11-25 traffic served by a per-request
+ * server**: that era carries identity at the handshake, and the instance
+ * handling a later `tools/call` never saw it. The header rides every request, so
+ * it survives where the handshake does not. Carries no client name — that still
+ * depends on the replayed session token.
+ */
+export function readHeaderProtocolVersion(
+  extra: CompatibleRequestHandlerExtra | undefined
+): MetaClientInfo | undefined {
+  // `getRequestHeaders` answers *where* the headers are on either SDK major;
+  // `readHeaderValue` answers how to read one value out of the bag it returns —
+  // repeated values, mixed case, blank strings. Two questions, one place each.
+  const protocolVersion = readHeaderValue(getRequestHeaders(extra), PROTOCOL_VERSION_HEADER)
+  if (!protocolVersion || protocolVersion.length > MAX_PROTOCOL_VERSION_LENGTH) {
+    return undefined
+  }
+  return { protocolVersion }
+}
+
+/**
  * Asks the server itself. `getClientVersion()` answers on any server that
  * handled an `initialize` (and v2 hosts such as `createMcpHandler` backfill it
  * from the envelope); `getNegotiatedProtocolVersion()` exists on v2 only, which
@@ -148,7 +180,12 @@ export function readServerClientIdentity(server: unknown): MetaClientInfo | unde
  * keeps it a fallback: any request that identifies itself wins outright.
  */
 export function resolveClientIdentity({ request, extra, server }: ClientIdentitySources): MetaClientInfo | undefined {
-  const chain = [readEnvelopeClientInfo(extra), readMetaClientInfo(request), readServerClientIdentity(server)]
+  const chain = [
+    readEnvelopeClientInfo(extra),
+    readMetaClientInfo(request),
+    readHeaderProtocolVersion(extra),
+    readServerClientIdentity(server),
+  ]
   const result: MetaClientInfo = {}
   for (const source of chain) {
     if (!source) {


### PR DESCRIPTION
## What

> Stacked on #4463

Events from 2025-11-25 traffic on an MCP SDK v2 server now carry `$mcp_protocol_version`.

That revision negotiates the version at the `initialize` handshake, and `createMcpHandler` builds a fresh server **per HTTP request** — so the instance serving a later `tools/call` never saw the handshake. A legacy-era request also carries no `_meta` envelope, so every link the identity chain gained in the parent branch is genuinely empty on this traffic. The events went out undated.

The era does have exactly one per-request carrier: the **`MCP-Protocol-Version` header**, which 2025-11-25 requires a client to send on every request after `initialize`. It rides each request, so it survives a per-request instance. It joins the chain after the protocol-level envelope and `params._meta`, and before the server's own accessors:

```
envelope  →  params._meta  →  MCP-Protocol-Version header  →  getClientVersion() / getNegotiatedProtocolVersion()
```

Still a chain, not a branch — a modern-era request prefers what the protocol hands it, and nothing tests which era it is. Read through the same `getRequestHeaders` helper, so it works whether the SDK presents headers as a plain object (v1) or a WHATWG `Headers` (v2). A value longer than a version token is ignored rather than recorded.

This closes the protocol half of legacy-era identity. The **client name** half is not closed by it and is not claimed: no header carries `clientInfo`, so that still depends on the replayed session token reaching the client, which `createMcpHandler`'s legacy leg cannot do — it builds response headers before the handler runs.

## A fixture bug this exposed

The testbed's legacy lane was not sending `MCP-Protocol-Version` at all — it simulated a client that does not exist under the spec, and hid this gap behind a red cell that looked like an SDK failure. Fixed in the harness alongside.

That raises the obvious question of which change moved the cell, so I ran it both ways:

```
old build + fixed fixture     protocol ✗ on all four 2025-era v2 rows      ← fixture alone changes nothing
new build + fixed fixture     protocol ✓ on all eight v2 rows
```

## Matrix

```
                            calls  errors  schema  session  client  protocol  warnings  header  alive 
──────────────────────────────────────────────────────────────────────────────────────────────────────
 v1  stateful   high          ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateful   low           ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateless  high          ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateless  low           ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
──────────────────────────────────────────────────────────────────────────────────────────────────────
 v2  high  2025  conv=off     ✓      ✓       ✓        ·       ✗       ✗→✓        ✓        ✓       ✓
 v2  high  2025  conv=on      ✓      ✓       ✓        ✓       ✗       ✗→✓        ✓        ✓       ✓
 v2  high  2026  conv=off     ✓      ✓       ✓        ·       ✓        ✓         ✓        ✓       ✓
 v2  high  2026  conv=on      ✓      ✓       ✓        ✓       ✓        ✓         ✓        ✓       ✓
 v2  low   2025  conv=off     ✓      ✓       ✓        ·       ✗       ✗→✓        ✓        ✓       ✓
 v2  low   2025  conv=on      ✓      ✓       ✓        ✗       ✗       ✗→✓        ✓        ✓       ✓
 v2  low   2026  conv=off     ✓      ✓       ✓        ·       ✓        ✓         ✓        ✓       ✓
 v2  low   2026  conv=on      ✓      ✓       ✓        ✗       ✓        ✓         ✓        ✓       ✓

 late-handler probe                                      9/9  (unchanged)
 nest v1   instrument(server) / instrument(server.server)   15/16 · 15/16  (unchanged)
 nest v2   instrument(server) / instrument(server.server)   25/33 · 25/33
```

`x → y` marks a cell this PR moved. `·` means the assertion does not apply to that row.


**Moved:** `protocol` ✗ → ✓ on the four 2025-era `v2` rows, completing that column across all eight. Nothing else — all four `v1` rows, the probe and both `nest v1` scores are unchanged.

**Unchanged and expected:** the Nest scores. That harness already recorded the protocol version on its 2025-era lane, because its transport can carry the minted session token and the token packs it — so the header is a second route to a value it already had.

580 unit tests green, lint and build clean. New coverage for the header link, its precedence under the envelope, reading it off a v2 `Headers`, and rejecting a junk value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

