### PR TITLE
fix(mcp): gate session minting on the revision the request declares

### DIFF
--- a/.changeset/mcp-era-gated-session-mint.md
+++ b/.changeset/mcp-era-gated-session-mint.md
@@ -1,0 +1,9 @@
+---
+'@posthog/mcp': patch
+---
+
+Gate `Mcp-Session-Id` minting on the protocol revision the request declares.
+
+The 2026-07-28 revision removed protocol-level sessions: a server must not mint or echo `Mcp-Session-Id` under it. Until now that held only by accident — the mint hangs off the `initialize` handler and 2026-07-28 has no handshake — so compliance depended on an SDK routing detail rather than on anything the SDK checks.
+
+The era is now resolved per request, from the version an `initialize` body declares or, failing that, from the same fallback chain that resolves client identity. Nothing branches on which SDK major is installed: one v2 server serves both revisions, request by request. An unknown version counts as legacy, so a v1 client that declares nothing keeps the session header it has always had.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -73,6 +73,27 @@ Details: [docs/ARCHITECTURE.md §4](./docs/ARCHITECTURE.md).
 `@modelcontextprotocol/{core,server,client}` v2 — and on both the high-level `McpServer` and the
 low-level `Server`. Shapes are detected at runtime, so neither major is a dependency here.
 
+### Sessions and client identity on a v2 server
+
+Protocol revision is a property of each **request**, not of the server: a v2 server serves both
+`2025-11-25` and `2026-07-28` traffic, and the SDK is instrumented once for both.
+
+- **On `2026-07-28`** there is no `initialize` and no session header — the revision removed
+  protocol-level sessions, and this SDK will not mint one. Session correlation therefore comes from
+  `enableConversationId`, which is **opt-in**. Without it every request is its own `$session_id`.
+- **On `2025-11-25`**, the session id and the client's name and version are exchanged once at
+  `initialize`. If your server builds a fresh `McpServer` per HTTP request — which
+  `createMcpHandler` does by default — the instance serving a later `tools/call` never saw that
+  handshake. The SDK bridges it by minting the `Mcp-Session-Id` token described above, which the
+  client replays on every request.
+
+  **That token only reaches the client if the transport builds response headers _after_ the handler
+  runs.** `@rekog/mcp-nest` with `enableJsonResponse: true` does; `createMcpHandler`'s legacy leg
+  does not, and there is no setting we can reach from inside the server. On that leg, expect
+  `$mcp_client_name` and `$mcp_client_version` to be absent for `2025-11-25` traffic — the protocol
+  version still arrives, because clients send it on the `MCP-Protocol-Version` header of every
+  request.
+
 ### Reading request headers in a callback
 
 If your `identify`, `intentFallback`, `eventProperties` or `beforeSend` reads HTTP headers, it has

--- a/packages/mcp/docs/ARCHITECTURE.md
+++ b/packages/mcp/docs/ARCHITECTURE.md
@@ -371,6 +371,7 @@ The SDK does **not**: call an LLM, inspect tool arguments, build heuristics, or 
 | Identity cache + identify dispatch                                    | `src/extensions/internal.ts`                                          |
 | Session id derivation & timeout                                       | `src/extensions/session.ts`, `src/extensions/ids.ts`                  |
 | Self-encoded session tokens (`Mcp-Session-Id`)                        | `src/extensions/session-token.ts`                                     |
+| Per-request protocol revision + mint gating (ADR-0008/0009)           | `src/extensions/session.ts`, `src/extensions/client-identity.ts`      |
 | `conversation_id` injection + minting                                 | `src/extensions/conversation-id.ts`                                   |
 | `_mcp_instructions` output-schema mirror                              | `src/extensions/output-instructions.ts`                               |
 | Client identity from request `_meta` (2026-07-28)                     | `src/extensions/client-identity.ts`                                   |

--- a/packages/mcp/docs/adr/0009-mint-session-header-on-legacy-era-only.md
+++ b/packages/mcp/docs/adr/0009-mint-session-header-on-legacy-era-only.md
@@ -15,8 +15,9 @@ Dropping the mechanism entirely was considered. It was rejected because it is th
 
 Minting is gated on the revision **the request declares**, resolved through the same per-request chain as identity (ADR-0008): the version an `initialize` body asks for, else envelope → `_meta` → `MCP-Protocol-Version` header.
 
-- Any revision **at or after** `2026-07-28` is treated as sessionless. Revisions sort as ISO dates, so a future one is modern by default — sessions were removed, not re-added.
-- An **unknown** version counts as legacy. A client that declares nothing is on a transport that has always carried a session header, and taking it away would be the regression this guard exists to prevent.
+- Any revision **at or after** `2026-07-28` is treated as sessionless. Revisions sort as ISO dates, so a future one is modern by default — sessions were removed, not re-added. The spec's rolling `draft` counts as modern for the same reason.
+- Only **date-shaped** tokens are compared as dates. The comparison is lexicographic, so without that guard any junk string starting above `'2'` would sort as modern and lose the header — the opposite of the rule below.
+- An **unknown** version counts as legacy, including unknown because it was malformed. A client that declares nothing, or declares nonsense, is one we should assume still wants the header it has always had; taking it away is the regression this guard exists to prevent.
 - The gate lives in the session layer, not in the handler, so the policy is stated once.
 
 ## Consequences

--- a/packages/mcp/docs/adr/0009-mint-session-header-on-legacy-era-only.md
+++ b/packages/mcp/docs/adr/0009-mint-session-header-on-legacy-era-only.md
@@ -1,0 +1,30 @@
+# ADR-0009: Mint `Mcp-Session-Id` on 2025-11-25 requests, never on 2026-07-28
+
+- Status: Accepted. Closes the era-gating follow-up left open by ADR-0003.
+- Date: 2026-08-07
+
+## Context
+
+ADR-0003 mints the `Mcp-Session-Id` response header at `initialize` as a self-encoded token, so a stateless deployment keeps one session and its client identity across pods. The 2026-07-28 revision removes protocol-level sessions outright: a server **MUST NOT** mint or echo that header under it.
+
+We complied, but only by accident. The mint hangs off the `initialize` handler and 2026-07-28 has no handshake, so the code was never reached — spec compliance rested on an SDK routing detail rather than on anything we check, and a host routing an initialize-shaped request over a modern connection would have been answered with a header the revision forbids. The testbed's "no `Mcp-Session-Id` on a 2026-era response" assertion passed for that wrong reason.
+
+Dropping the mechanism entirely was considered. It was rejected because it is the only session story a v2 operator gets by default: `enableConversationId` (ADR-0004) stays opt-in, so removing the mint too would leave every v2 deployment with fragmented sessions on **both** revisions out of the box.
+
+## Decision
+
+Minting is gated on the revision **the request declares**, resolved through the same per-request chain as identity (ADR-0008): the version an `initialize` body asks for, else envelope → `_meta` → `MCP-Protocol-Version` header.
+
+- Any revision **at or after** `2026-07-28` is treated as sessionless. Revisions sort as ISO dates, so a future one is modern by default — sessions were removed, not re-added.
+- An **unknown** version counts as legacy. A client that declares nothing is on a transport that has always carried a session header, and taking it away would be the regression this guard exists to prevent.
+- The gate lives in the session layer, not in the handler, so the policy is stated once.
+
+## Consequences
+
+- We knowingly carry a mechanism the newer revision deleted, for as long as clients keep taking the legacy leg. It retires itself: as they migrate, fewer requests reach it and it goes quiet with no deprecation project.
+- Compliance is now a property we assert rather than one we inherit from where the call happens to sit. It is also testable in isolation, which the previous arrangement was not.
+- No testbed cell moves. The assertion it protects already passed — the change is *why* it passes, which is the kind of fix that has to be argued rather than measured.
+
+## References
+
+- PostHog/posthog-js#4466 (this change), ADR-0003, ADR-0004, ADR-0008

--- a/packages/mcp/src/__tests__/session-id.test.ts
+++ b/packages/mcp/src/__tests__/session-id.test.ts
@@ -1,8 +1,8 @@
 import { instrument } from '../index'
 import { getServerTrackingData } from '../extensions/internal'
-import { deriveSessionIdFromMCPSession, getSessionId } from '../extensions/session'
+import { deriveSessionIdFromMCPSession, getSessionId, isModernEraRequest } from '../extensions/session'
 import { MCP_SESSION_HEADER, encodeSessionId } from '../extensions/session-token'
-import type { HighLevelMCPServerLike } from '../types'
+import type { CompatibleRequestHandlerExtra, HighLevelMCPServerLike, MCPRequestLike } from '../types'
 import { EventCapture, fakePostHog } from './test-utils'
 import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
 
@@ -348,5 +348,43 @@ describe('Session ID Management', () => {
 
       await eventCapture.stop()
     })
+  })
+})
+
+/**
+ * Which protocol revision *this request* is governed by. It decides whether a
+ * session header may be minted at all, so it has to be per request: one MCP SDK
+ * v2 server serves both eras, and v2's exported `LATEST_PROTOCOL_VERSION` still
+ * reads `2025-11-25`, so no module constant describes the traffic.
+ */
+describe('isModernEraRequest', () => {
+  const call = (request: MCPRequestLike, extra?: CompatibleRequestHandlerExtra) => isModernEraRequest(request, extra)
+
+  it('reads the version an initialize request declares', () => {
+    expect(call({ method: 'initialize', params: { protocolVersion: '2026-07-28' } })).toBe(true)
+    expect(call({ method: 'initialize', params: { protocolVersion: '2025-11-25' } })).toBe(false)
+  })
+
+  it('treats any later revision as modern — sessions were removed, not re-added', () => {
+    expect(call({ method: 'initialize', params: { protocolVersion: '2027-03-01' } })).toBe(true)
+  })
+
+  it('falls back to the identity chain when the request body declares nothing', () => {
+    const viaHeader = { requestInfo: { headers: { 'mcp-protocol-version': '2026-07-28' } } }
+    expect(call({ method: 'tools/call', params: { name: 'echo' } }, viaHeader as CompatibleRequestHandlerExtra)).toBe(
+      true
+    )
+
+    const viaEnvelope = {
+      mcpReq: { envelope: { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' } },
+    } as unknown as CompatibleRequestHandlerExtra
+    expect(call({ method: 'tools/call', params: { name: 'echo' } }, viaEnvelope)).toBe(true)
+  })
+
+  it('treats an unknown version as legacy', () => {
+    // A v1 client on a transport that has always carried a session header.
+    // Guessing "modern" here would take that away from them.
+    expect(call({ method: 'tools/call', params: { name: 'echo' } })).toBe(false)
+    expect(call({ method: 'tools/call', params: { name: 'echo' } }, { requestInfo: { headers: {} } })).toBe(false)
   })
 })

--- a/packages/mcp/src/__tests__/session-id.test.ts
+++ b/packages/mcp/src/__tests__/session-id.test.ts
@@ -381,6 +381,22 @@ describe('isModernEraRequest', () => {
     expect(call({ method: 'tools/call', params: { name: 'echo' } }, viaEnvelope)).toBe(true)
   })
 
+  it.each([
+    ['junk that sorts above the revision', 'garbage'],
+    ['a truncated token', '2026'],
+    ['an empty-ish token', '   '],
+  ])('treats %s as legacy rather than comparing it as a date', (_label, protocolVersion) => {
+    // Lexicographically 'garbage' > '2026-07-28', so an unguarded comparison
+    // would call it modern and withhold the session header from a client that
+    // simply sent something malformed. Unknown means legacy — including unknown
+    // because it was junk.
+    expect(call({ method: 'initialize', params: { protocolVersion } })).toBe(false)
+  })
+
+  it("treats the spec's rolling draft as modern", () => {
+    expect(call({ method: 'initialize', params: { protocolVersion: 'draft' } })).toBe(true)
+  })
+
   it('treats an unknown version as legacy', () => {
     // A v1 client on a transport that has always carried a session header.
     // Guessing "modern" here would take that away from them.

--- a/packages/mcp/src/__tests__/stateless-session.test.ts
+++ b/packages/mcp/src/__tests__/stateless-session.test.ts
@@ -171,30 +171,18 @@ describe('Stateless session minting', () => {
      * a host that routes an initialize-shaped request on a modern connection is
      * still answered correctly.
      */
-    it('does not mint for a request that declares 2026-07-28', async () => {
-      const { server, lowLevel } = createPod('pod-modern')
+    it.each([
+      ['2026-07-28', 'the revision that removed sessions'],
+      ['2027-03-01', 'any later revision — they were removed, not re-added'],
+    ])('does not mint for a request declaring %s (%s)', async (protocolVersion) => {
+      const { server, lowLevel } = createPod(`pod-${protocolVersion}`)
       const transport: { sessionId?: string } = {}
       setFakeTransport(server, transport)
 
       await invokeHandler(
         lowLevel,
         'initialize',
-        { ...INITIALIZE_REQUEST, params: { ...INITIALIZE_REQUEST.params, protocolVersion: '2026-07-28' } },
-        { requestInfo: { headers: {} } }
-      )
-
-      expect(transport.sessionId).toBeUndefined()
-    })
-
-    it('does not mint for a revision newer than 2026-07-28 either', async () => {
-      const { server, lowLevel } = createPod('pod-future')
-      const transport: { sessionId?: string } = {}
-      setFakeTransport(server, transport)
-
-      await invokeHandler(
-        lowLevel,
-        'initialize',
-        { ...INITIALIZE_REQUEST, params: { ...INITIALIZE_REQUEST.params, protocolVersion: '2027-03-01' } },
+        { ...INITIALIZE_REQUEST, params: { ...INITIALIZE_REQUEST.params, protocolVersion } },
         { requestInfo: { headers: {} } }
       )
 

--- a/packages/mcp/src/__tests__/stateless-session.test.ts
+++ b/packages/mcp/src/__tests__/stateless-session.test.ts
@@ -163,6 +163,44 @@ describe('Stateless session minting', () => {
       expect(getServerTrackingData(lowLevel)?.sessionSource).toBe('generated')
     })
 
+    /**
+     * 2026-07-28 removed sessions from the protocol — a server MUST NOT mint or
+     * echo `Mcp-Session-Id` under it. That era has no `initialize` handshake, so
+     * today this branch is unreachable through a real v2 server; the gate exists
+     * so compliance does not depend on that routing detail staying true, and so
+     * a host that routes an initialize-shaped request on a modern connection is
+     * still answered correctly.
+     */
+    it('does not mint for a request that declares 2026-07-28', async () => {
+      const { server, lowLevel } = createPod('pod-modern')
+      const transport: { sessionId?: string } = {}
+      setFakeTransport(server, transport)
+
+      await invokeHandler(
+        lowLevel,
+        'initialize',
+        { ...INITIALIZE_REQUEST, params: { ...INITIALIZE_REQUEST.params, protocolVersion: '2026-07-28' } },
+        { requestInfo: { headers: {} } }
+      )
+
+      expect(transport.sessionId).toBeUndefined()
+    })
+
+    it('does not mint for a revision newer than 2026-07-28 either', async () => {
+      const { server, lowLevel } = createPod('pod-future')
+      const transport: { sessionId?: string } = {}
+      setFakeTransport(server, transport)
+
+      await invokeHandler(
+        lowLevel,
+        'initialize',
+        { ...INITIALIZE_REQUEST, params: { ...INITIALIZE_REQUEST.params, protocolVersion: '2027-03-01' } },
+        { requestInfo: { headers: {} } }
+      )
+
+      expect(transport.sessionId).toBeUndefined()
+    })
+
     it('leaves session state untouched when the transport write fails', async () => {
       const { server, lowLevel } = createPod('pod-frozen')
       setFakeTransport(server, Object.freeze({}))

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -35,7 +35,7 @@ import type { LoggerFn } from './logger'
 import { buildCapturedMcpParameters } from './mcp-payloads'
 import { readRequestHandlerMethod } from './mcp-sdk-compat'
 import { getRequestHeaders } from './request-headers'
-import { getSessionId, getSessionInfo, newSessionId } from './session'
+import { getSessionId, getSessionInfo, isModernEraRequest, newSessionId } from './session'
 import { encodeSessionId, readMcpSessionHeader, writeSessionIdToTransport } from './session-token'
 import { getReportMissingToolDescriptor, resolveMissingCapabilityToolName } from './tools'
 import { applyResolvedMetadata, isToolResultError } from './tracing-helpers'
@@ -698,6 +698,14 @@ function mintStatelessSessionOnInitialize(
     const headers = getRequestHeaders(extra)
     if (!headers) {
       return undefined // not an HTTP transport (stdio/in-memory) — nothing to mint into
+    }
+    // 2026-07-28 removed sessions from the protocol: a server MUST NOT mint or
+    // echo `Mcp-Session-Id` under it. Today that era never reaches here anyway,
+    // because it has no `initialize` — but relying on that is relying on an SDK
+    // routing detail to keep us spec-compliant, so the era is asked directly.
+    // Per request, never per server: the same v2 server serves both.
+    if (isModernEraRequest(request, extra, server)) {
+      return undefined
     }
     if (readMcpSessionHeader(headers)) {
       return undefined // client already replays a session id (ours or the transport's)

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -31,6 +31,18 @@ import type { SessionTokenPayload } from './session-token'
 export const MODERN_PROTOCOL_REVISION = '2026-07-28'
 
 /**
+ * Revisions are ISO dates, and only a date-shaped token may be compared as one.
+ * Without this the comparison is lexicographic over arbitrary input, so any
+ * string starting above `'2'` — every junk value beginning with a letter —
+ * sorts as modern and silently loses the session header. Unknown must mean
+ * legacy, so anything that is not a date is not compared at all.
+ */
+const REVISION_SHAPE = /^\d{4}-\d{2}-\d{2}$/
+
+/** The spec's rolling draft sits ahead of every dated revision, sessions included. */
+const DRAFT_REVISION = 'draft'
+
+/**
  * Whether *this request* is governed by 2026-07-28 or later.
  *
  * Era is a property of the request, never of the installed SDK: one v2 server
@@ -53,7 +65,13 @@ export function isModernEraRequest(
   const version =
     (typeof requested === 'string' && requested.length > 0 ? requested : undefined) ??
     resolveClientIdentity({ request, extra, server })?.protocolVersion
-  return !!version && version >= MODERN_PROTOCOL_REVISION
+  if (!version) {
+    return false
+  }
+  if (version === DRAFT_REVISION) {
+    return true
+  }
+  return REVISION_SHAPE.test(version) && version >= MODERN_PROTOCOL_REVISION
 }
 
 export function newSessionId(): string {

--- a/packages/mcp/src/extensions/session.ts
+++ b/packages/mcp/src/extensions/session.ts
@@ -7,16 +7,54 @@ import { version } from '../version'
 import type {
   CompatibleRequestHandlerExtra,
   MCPAnalyticsData,
+  MCPRequestLike,
   MCPServerLike,
   ServerClientInfoLike,
   SessionInfo,
 } from '../types'
 import { INACTIVITY_TIMEOUT_IN_MINUTES } from './constants'
 import { deterministicPrefixedId, newPrefixedId } from './ids'
+import { resolveClientIdentity } from './client-identity'
 import { getServerTrackingData, setServerTrackingData } from './internal'
 import { getRequestHeaders } from './request-headers'
 import { decodeSessionId, readMcpSessionHeader } from './session-token'
 import type { SessionTokenPayload } from './session-token'
+
+/**
+ * The revision that removed protocol-level sessions. A request declaring this or
+ * anything later must not be answered with an `Mcp-Session-Id`.
+ *
+ * Compared as a string, which is safe and stable because MCP revisions are
+ * ISO dates: any future revision sorts above this one and is treated as modern,
+ * which is the right default — sessions were removed, not re-added.
+ */
+export const MODERN_PROTOCOL_REVISION = '2026-07-28'
+
+/**
+ * Whether *this request* is governed by 2026-07-28 or later.
+ *
+ * Era is a property of the request, never of the installed SDK: one v2 server
+ * serves both, request by request, and v2's exported `LATEST_PROTOCOL_VERSION`
+ * still reads `2025-11-25`. So the version is resolved from the request itself —
+ * an `initialize` body declares the version it is asking for, and every other
+ * request carries it in the envelope, `_meta`, or the `MCP-Protocol-Version`
+ * header — and only then compared.
+ *
+ * Unknown means legacy. A request that declares nothing is a v1 client on a
+ * transport that has always had a session header, and taking it away from them
+ * would be the regression.
+ */
+export function isModernEraRequest(
+  request: MCPRequestLike,
+  extra?: CompatibleRequestHandlerExtra,
+  server?: MCPServerLike
+): boolean {
+  const requested = request.params?.protocolVersion
+  const version =
+    (typeof requested === 'string' && requested.length > 0 ? requested : undefined) ??
+    resolveClientIdentity({ request, extra, server })?.protocolVersion
+  return !!version && version >= MODERN_PROTOCOL_REVISION
+}
 
 export function newSessionId(): string {
   return newPrefixedId('ses')


### PR DESCRIPTION
## What

> Stacked on #4465

The 2026-07-28 revision removed protocol-level sessions: a server **must not** mint or echo `Mcp-Session-Id` under it. We complied, but only by accident — the mint hangs off the `initialize` handler and that revision has no handshake, so nothing ever reached the code. Compliance rested on an SDK routing detail instead of on anything we check, and a host routing an initialize-shaped request over a modern connection would have been answered with a header the revision forbids.

The revision is now resolved **per request**, in the session layer:

```ts
isModernEraRequest(request, extra, server)
//  the version an `initialize` body declares
//  ↳ else envelope → params._meta → MCP-Protocol-Version header → server accessors
```

Three properties worth checking in review, each with a test:

- **Per request, never per server.** One v2 server serves both revisions, and v2's exported `LATEST_PROTOCOL_VERSION` still reads `2025-11-25`, so no module constant describes the traffic. Nothing here branches on which SDK major is installed.
- **Later revisions count as modern.** `2027-03-01` is treated as sessionless — they were removed, not re-added, so the safe default for an unknown *future* revision is to stay quiet.
- **An unknown version counts as legacy.** A v1 client that declares nothing is on a transport that has always carried a session header; guessing "modern" would take it away, which is the regression this guard exists to prevent.

## Docs

The README now states what a v2 operator gets per era, including the part we cannot fix from inside the server: the minted token only reaches the client if the transport builds response headers **after** the handler runs. `@rekog/mcp-nest` with `enableJsonResponse: true` does; `createMcpHandler`'s legacy leg does not, and no setting we can reach changes that. So on that leg `$mcp_client_name` / `$mcp_client_version` are absent for 2025-11-25 traffic, while the protocol version still arrives via the header. Better said plainly than left looking like a bug.

It also states the 2026-07-28 consequence operators keep discovering the hard way: with no protocol session and `enableConversationId` opt-in, every request is its own `$session_id` until they turn it on.

## What was measured

**No cell moved, and that is the claim.** The harness already asserted `no Mcp-Session-Id on a 2026-era response` and it already passed — for the wrong reason. This PR makes it pass for the right one, so the grid is identical to the parent branch:

```
                            calls  errors  schema  session  client  protocol  warnings  header  alive
──────────────────────────────────────────────────────────────────────────────────────────────────────
 v1  stateful   high          ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateful   low           ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateless  high          ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateless  low           ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
──────────────────────────────────────────────────────────────────────────────────────────────────────
 v2  high  2025  conv=off     ✓      ✓       ✓        ·       ✗        ✓         ✓        ✓       ✓
 v2  high  2025  conv=on      ✓      ✓       ✓        ✓       ✗        ✓         ✓        ✓       ✓
 v2  high  2026  conv=off     ✓      ✓       ✓        ·       ✓        ✓         ✓        ✓       ✓
 v2  high  2026  conv=on      ✓      ✓       ✓        ✓       ✓        ✓         ✓        ✓       ✓
 v2  low   2025  conv=off     ✓      ✓       ✓        ·       ✗        ✓         ✓        ✓       ✓
 v2  low   2025  conv=on      ✓      ✓       ✓        ✗       ✗        ✓         ✓        ✓       ✓
 v2  low   2026  conv=off     ✓      ✓       ✓        ·       ✓        ✓         ✓        ✓       ✓
 v2  low   2026  conv=on      ✓      ✓       ✓        ✗       ✓        ✓         ✓        ✓       ✓

 late-handler probe                                      9/9  (unchanged)
 nest v1   instrument(server) / instrument(server.server)   15/16 · 15/16  (unchanged)
 nest v2   instrument(server) / instrument(server.server)   25/33 · 25/33  (unchanged)
```

The real risk here was the opposite of a missing cell: over-applying the gate and killing the *legitimate* mint on 2025-11-25 traffic, which is what currently gives the Nest harness its client name and version. It still passes — `client name recorded` does not appear in the failing set, and both Nest scores hold at 25/33.

586 unit tests green, lint and build clean. Revert-checked: removing the gate fails exactly the two new mint tests and nothing else. The predicate is unit-tested directly (declared version, later revision, header-only fallback, unknown-means-legacy) rather than only through the mint, because the SDK's own `initialize` schema rejects the hand-crafted requests some of those cases need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
