### PR TITLE
chore: expand Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,5 +38,16 @@ updates:
           - dependency-name: '*'
             update-types: ['version-update:semver-major']
       open-pull-requests-limit: 1
-      reviewers:
-          - 'PostHog/team-client-libraries'
+    - package-ecosystem: 'github-actions'
+      cooldown:
+          default-days: 7
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+          time: '10:00'
+          timezone: 'UTC'
+      groups:
+          github-actions:
+              patterns:
+                  - '*'


### PR DESCRIPTION
## Problem

Dependabot currently updates only the allowed AI-provider npm dependencies. GitHub Actions references are not covered, so workflow dependency updates must be handled separately.

## Changes

- Keep the npm updater limited to its existing AI-provider allow list and group.
- Remove the npm updater's automatic reviewer assignment.
- Add a GitHub Actions updater at the repository root. It runs weekly on Monday at 10:00 UTC, applies a seven-day cooldown, and groups all action updates into `github-actions`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the requested repository configuration change. The Pi autoreview skill reviewed the exact signed commit and reported no actionable findings.
