### PR TITLE
fix(ai): declare gemini cache reporting as inclusive on generations

### DIFF
--- a/.changeset/gemini-cache-reporting-exclusive.md
+++ b/.changeset/gemini-cache-reporting-exclusive.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+fix(gemini): declare Gemini's cache accounting model on generations with cache reads, so ingestion prices cached tokens from `$ai_cache_reporting_exclusive` instead of inferring it from the token counts

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -165,6 +165,11 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
       ...(usage.reasoningTokens ? { $ai_reasoning_tokens: usage.reasoningTokens } : {}),
       ...(usage.cacheReadInputTokens ? { $ai_cache_read_input_tokens: usage.cacheReadInputTokens } : {}),
       ...(usage.cacheCreationInputTokens ? { $ai_cache_creation_input_tokens: usage.cacheCreationInputTokens } : {}),
+      // Checked against undefined rather than truthiness, because false is the meaningful
+      // value here and a truthiness guard would drop it.
+      ...(usage.cacheReportingExclusive !== undefined
+        ? { $ai_cache_reporting_exclusive: usage.cacheReportingExclusive }
+        : {}),
       ...(usage.webSearchCount ? { $ai_web_search_count: usage.webSearchCount } : {}),
       ...(usage.rawUsage ? { $ai_usage: usage.rawUsage } : {}),
     }

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -4,7 +4,7 @@ import { uuidv7, ErrorTracking as CoreErrorTracking, toJsonSafeValue } from '@po
 import { version } from '../package.json'
 import type { TokenUsage } from './types'
 import { stringifyError } from './serializeError'
-import { AIEvent, CostOverride, getTokensSource, withPrivacyMode } from './utils'
+import { AIEvent, CostOverride, getTokensSource, hasTokenOverrides, withPrivacyMode } from './utils'
 import { warnIfPostHogAiGateway } from './gatewayWarning'
 
 /**
@@ -161,13 +161,24 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
       }
     }
 
+    // The caller's own token counts override the SDK-derived ones further down, via the
+    // `options.properties` spread.
+    const tokensOverridden = hasTokenOverrides(options.properties)
+
     const additionalTokenValues = {
       ...(usage.reasoningTokens ? { $ai_reasoning_tokens: usage.reasoningTokens } : {}),
       ...(usage.cacheReadInputTokens ? { $ai_cache_read_input_tokens: usage.cacheReadInputTokens } : {}),
       ...(usage.cacheCreationInputTokens ? { $ai_cache_creation_input_tokens: usage.cacheCreationInputTokens } : {}),
       // Checked against undefined rather than truthiness, because false is the meaningful
       // value here and a truthiness guard would drop it.
-      ...(usage.cacheReportingExclusive !== undefined
+      //
+      // Dropped entirely when the caller overrides the token counts: the flag describes how
+      // the SDK-derived counts relate to each other, so against passthrough counts it can be
+      // wrong in the expensive direction. Declaring inclusive over counts that are actually
+      // exclusive makes ingestion subtract the cache pool that was never in the input. A
+      // caller who knows their own accounting model can still pass
+      // `$ai_cache_reporting_exclusive` themselves, and that value wins.
+      ...(usage.cacheReportingExclusive !== undefined && !tokensOverridden
         ? { $ai_cache_reporting_exclusive: usage.cacheReportingExclusive }
         : {}),
       ...(usage.webSearchCount ? { $ai_web_search_count: usage.webSearchCount } : {}),

--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -80,6 +80,11 @@ export class WrappedModels {
             (metadata as GenerateContentResponseUsageMetadata & { thoughtsTokenCount?: number })?.thoughtsTokenCount ??
             0,
           cacheReadInputTokens: metadata?.cachedContentTokenCount ?? 0,
+          // Gemini counts cachedContentTokenCount inside promptTokenCount, so declare the
+          // accounting model rather than leaving ingestion to infer it. Under explicit
+          // context caching the two counts come from separate measurements and can disagree
+          // by a few percent, which makes inference from the counts alone unreliable.
+          ...(metadata?.cachedContentTokenCount ? { cacheReportingExclusive: false } : {}),
           webSearchCount: calculateGoogleWebSearchCount(response),
           rawUsage: metadata,
         },
@@ -196,6 +201,9 @@ export class WrappedModels {
               (metadata as GenerateContentResponseUsageMetadata & { thoughtsTokenCount?: number }).thoughtsTokenCount ??
               0,
             cacheReadInputTokens: metadata.cachedContentTokenCount ?? 0,
+            // See the non-streaming path: Gemini counts cachedContentTokenCount inside
+            // promptTokenCount, so the accounting model is declared rather than inferred.
+            ...(metadata.cachedContentTokenCount ? { cacheReportingExclusive: false } : {}),
             webSearchCount: usage.webSearchCount,
             rawUsage: metadata,
           }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -95,6 +95,10 @@ export interface TokenUsage {
   reasoningTokens?: unknown // Use unknown since various providers return different types
   cacheReadInputTokens?: unknown // Use unknown for provider flexibility
   cacheCreationInputTokens?: unknown // Use unknown for provider flexibility
+  // Whether cache tokens are counted separately from inputTokens. Providers that report
+  // them as a subset of inputTokens set this false. Left undefined when the provider's
+  // accounting model is not known, in which case ingestion infers it from the counts.
+  cacheReportingExclusive?: boolean
   webSearchCount?: number // Count of web search queries/calls used
   rawUsage?: unknown // Raw provider usage metadata for backend processing
 }

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -28,11 +28,16 @@ const TOKEN_PROPERTY_KEYS = new Set([
   '$ai_reasoning_tokens',
 ])
 
+/**
+ * Whether the caller supplied their own token counts, which override the ones the SDK
+ * derived from the provider response.
+ */
+export function hasTokenOverrides(posthogProperties?: Record<string, unknown>): boolean {
+  return !!posthogProperties && Object.keys(posthogProperties).some((key) => TOKEN_PROPERTY_KEYS.has(key))
+}
+
 export function getTokensSource(posthogProperties?: Record<string, unknown>): string {
-  if (posthogProperties && Object.keys(posthogProperties).some((key) => TOKEN_PROPERTY_KEYS.has(key))) {
-    return 'passthrough'
-  }
-  return 'sdk'
+  return hasTokenOverrides(posthogProperties) ? 'passthrough' : 'sdk'
 }
 
 // limit large outputs by truncating to 200kb (approx 200k bytes)

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -699,6 +699,58 @@ describe('PostHogGemini - Jest test suite', () => {
       expect(properties['$ai_cache_reporting_exclusive']).toBe(false)
     })
 
+    test('drops the cache reporting flag when the caller overrides token counts', async () => {
+      mockGeminiResponse = {
+        text: 'Cached answer',
+        candidates: [{ content: { parts: [{ text: 'Cached answer' }] }, finishReason: 'STOP' }],
+        usageMetadata: {
+          promptTokenCount: 23000,
+          candidatesTokenCount: 8,
+          cachedContentTokenCount: 25000,
+        },
+      }
+      ;(client as any).client.models.generateContent = jest.fn().mockResolvedValue(mockGeminiResponse)
+
+      await client.models.generateContent({
+        model: 'gemini-2.0-flash-001',
+        contents: 'Test',
+        posthogDistinctId: 'test-id',
+        posthogProperties: { $ai_input_tokens: 400, $ai_cache_read_input_tokens: 25000 },
+      })
+
+      const { properties } = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0]
+      expect(properties['$ai_tokens_source']).toBe('passthrough')
+      expect(properties['$ai_input_tokens']).toBe(400)
+      expect(properties).not.toHaveProperty('$ai_cache_reporting_exclusive')
+    })
+
+    test('keeps an explicit cache reporting flag from the caller', async () => {
+      mockGeminiResponse = {
+        text: 'Cached answer',
+        candidates: [{ content: { parts: [{ text: 'Cached answer' }] }, finishReason: 'STOP' }],
+        usageMetadata: {
+          promptTokenCount: 23000,
+          candidatesTokenCount: 8,
+          cachedContentTokenCount: 25000,
+        },
+      }
+      ;(client as any).client.models.generateContent = jest.fn().mockResolvedValue(mockGeminiResponse)
+
+      await client.models.generateContent({
+        model: 'gemini-2.0-flash-001',
+        contents: 'Test',
+        posthogDistinctId: 'test-id',
+        posthogProperties: {
+          $ai_input_tokens: 400,
+          $ai_cache_read_input_tokens: 25000,
+          $ai_cache_reporting_exclusive: true,
+        },
+      })
+
+      const { properties } = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0]
+      expect(properties['$ai_cache_reporting_exclusive']).toBe(true)
+    })
+
     test('omits the cache reporting flag when no tokens were cached', async () => {
       ;(client as any).client.models.generateContent = jest.fn().mockResolvedValue(mockGeminiResponse)
 

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -675,6 +675,44 @@ describe('PostHogGemini - Jest test suite', () => {
     ])
   })
 
+  describe('Cache reporting', () => {
+    test('declares inclusive cache reporting when cached tokens are present', async () => {
+      mockGeminiResponse = {
+        text: 'Cached answer',
+        candidates: [{ content: { parts: [{ text: 'Cached answer' }] }, finishReason: 'STOP' }],
+        usageMetadata: {
+          promptTokenCount: 23000,
+          candidatesTokenCount: 8,
+          cachedContentTokenCount: 25000,
+        },
+      }
+      ;(client as any).client.models.generateContent = jest.fn().mockResolvedValue(mockGeminiResponse)
+
+      await client.models.generateContent({
+        model: 'gemini-2.0-flash-001',
+        contents: 'Test',
+        posthogDistinctId: 'test-id',
+      })
+
+      const { properties } = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0]
+      expect(properties['$ai_cache_read_input_tokens']).toBe(25000)
+      expect(properties['$ai_cache_reporting_exclusive']).toBe(false)
+    })
+
+    test('omits the cache reporting flag when no tokens were cached', async () => {
+      ;(client as any).client.models.generateContent = jest.fn().mockResolvedValue(mockGeminiResponse)
+
+      await client.models.generateContent({
+        model: 'gemini-2.0-flash-001',
+        contents: 'Test',
+        posthogDistinctId: 'test-id',
+      })
+
+      const { properties } = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0]
+      expect(properties).not.toHaveProperty('$ai_cache_reporting_exclusive')
+    })
+  })
+
   describe('Web Search Tracking', () => {
     test('should detect grounding metadata (binary detection)', async () => {
       mockGeminiResponse = {


### PR DESCRIPTION
## Problem

Cache-heavy Gemini generations can be priced wrong in AI observability, because the SDK never tells ingestion how Gemini counts cache tokens.

Gemini counts `cachedContentTokenCount` inside `promptTokenCount`, so cache reads are a subset of input, not a separate pool. The SDK reports both numbers but declares nothing, so ingestion infers the accounting model from the token counts.

That inference is unreliable for Gemini. Under explicit context caching the two counts come from separate measurements: the cache object is counted when it is created, and the prompt is counted per request. They describe the same tokens but can disagree by a few percent, which puts the cache pool just above the input total and makes the counts look like two separate pools. Ingestion then bills the full input at the prompt rate and the cache again at the cache rate, so a nearly fully cached prompt bills several times over.

This is the JS counterpart of PostHog/posthog-python#860.

## Changes

- `TokenUsage` gains `cacheReportingExclusive?: boolean`, left undefined when a provider's accounting model is not known.
- The Gemini wrapper sets it to false on generations that report cache reads, on both the streaming and non-streaming paths.
- `captureAiGeneration` maps it onto `$ai_cache_reporting_exclusive`.

The property mapping checks `!== undefined` rather than truthiness. Every neighbouring field in `additionalTokenValues` uses a truthiness guard, which is correct for counts but would silently drop `false`, the only value this field ever carries.

The flag is set only when cache reads are present, so generations without caching do not carry an extra property.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

## How did you test this code?

- Ran `npx jest` in `packages/ai`. 764 passed. Two failures in `tests/openai-agents-resolution.test.ts` are unrelated and fail the same way on a clean checkout.
- Added two cases to `tests/gemini.test.ts`. The first asserts `$ai_cache_reporting_exclusive` is `false` when cached tokens are present, which fails if the flag stops being set or if the property mapping reverts to a truthiness guard. The second asserts the property is absent when nothing was cached, which guards against sending it on every generation.
- Ran `npx tsc --noEmit`. The only errors are missing `posthog-node` declarations, caused by declaration-file generation failing in this sandbox. No errors in the changed files.
- Did not run a live Gemini call.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (the PostHog Slack app, running Claude) traced this from a Slack thread on Gemini cost reconciliation, and a PostHog engineer directed the fix. I did not set an assignee because I could not verify their GitHub handle in session.

The Python change landed first and needed the flag threaded through three separate tagging sites. The JS side has one central property mapper, so this diff is smaller, and the only real trap was the truthiness guard described above.

**Public artifact:** no customer or session material reached this PR. The token values in the new tests are invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1786121664214699?thread_ts=1786121664.214699&cid=C087XQ7K9K7)*
