### PR TITLE
fix(replay): don't open a recording that holds only idle markers

### DIFF
--- a/.changeset/drop-marker-only-recordings.md
+++ b/.changeset/drop-marker-only-recordings.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): don't open a recording that holds only idle lifecycle markers

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -366,6 +366,7 @@ describe('Lazy SessionRecording', () => {
                         },
                     })
                 )
+                sessionRecording.onRRwebEmit(createFullSnapshot({ timestamp: Date.now() }))
                 const snapshot = createCustomSnapshot({ timestamp: Date.now() })
                 sessionRecording.onRRwebEmit(snapshot)
                 ;(posthog.capture as Mock).mockClear()
@@ -392,6 +393,7 @@ describe('Lazy SessionRecording', () => {
                         },
                     })
                 )
+                sessionRecording.onRRwebEmit(createFullSnapshot({ timestamp: Date.now() }))
                 const snapshot = createCustomSnapshot({ timestamp: Date.now() })
                 sessionRecording.onRRwebEmit(snapshot)
                 ;(posthog.capture as Mock).mockClear()
@@ -427,6 +429,7 @@ describe('Lazy SessionRecording', () => {
                         },
                     })
                 )
+                sessionRecording.onRRwebEmit(createFullSnapshot({ timestamp: Date.now() }))
                 const snapshot = createCustomSnapshot({ timestamp: Date.now() })
                 sessionRecording.onRRwebEmit(snapshot)
                 ;(posthog.capture as Mock).mockClear()
@@ -461,6 +464,7 @@ describe('Lazy SessionRecording', () => {
                         },
                     })
                 )
+                sessionRecording.onRRwebEmit(createFullSnapshot({ timestamp: Date.now() }))
                 const snapshot = createCustomSnapshot({ timestamp: Date.now() })
                 sessionRecording.onRRwebEmit(snapshot)
                 ;(posthog.capture as Mock).mockClear()
@@ -491,6 +495,7 @@ describe('Lazy SessionRecording', () => {
                         },
                     })
                 )
+                sessionRecording.onRRwebEmit(createFullSnapshot({ timestamp: Date.now() }))
                 const snapshot = createCustomSnapshot({ timestamp: Date.now() })
                 sessionRecording.onRRwebEmit(snapshot)
                 ;(posthog.capture as Mock).mockClear()
@@ -2145,6 +2150,48 @@ describe('Lazy SessionRecording', () => {
                     expect(shippedSessionIds()).toEqual(new Set([sessionId]))
                 })
 
+                // The Jul 2026 idle-rotation family: an idle tab rotates, the markers for the
+                // rotation land in the new session's empty buffer, and shipping them opens a
+                // recording that bills the customer and plays back as nothing.
+                function rotateToASessionWithNoContent(): void {
+                    const rotateAt = startingTimestamp + sessionManager['_sessionTimeoutMs'] + 1000
+                    jest.setSystemTime(new Date(rotateAt))
+                    sessionIdGeneratorMock.mockImplementation(() => 'rotated-empty-session')
+                    sessionManager.checkAndGetSessionAndWindowId(false, rotateAt)
+                    releaseInteractionHold()
+                    ;(posthog.capture as Mock).mockClear()
+                }
+
+                it.each([
+                    ['idle markers alone never open a recording', 'sessionIdle', 0],
+                    ['session-linking markers still open one, the chain needs them', '$session_ending', 1],
+                ])('%s', (_name, tag, expectedRecordings) => {
+                    rotateToASessionWithNoContent()
+
+                    _emit(createCustomSnapshot({ timestamp: Date.now() }, {}, tag as string))
+                    sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
+
+                    expect(shippedSessionIds().size).toEqual(expectedRecordings)
+                })
+
+                it('holds idle markers until content arrives, then ships them with it', () => {
+                    rotateToASessionWithNoContent()
+
+                    _emit(createCustomSnapshot({ timestamp: Date.now() }, {}, 'sessionIdle'))
+                    sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
+                    expect(shippedSessionIds().size).toEqual(0)
+
+                    _emit(createFullSnapshot({ timestamp: Date.now() }))
+                    sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
+
+                    const shipped = (posthog.capture as Mock).mock.calls.filter(([name]) => name === '$snapshot')
+                    expect(shipped).toHaveLength(1)
+                    expect((shipped[0][1].$snapshot_data as any[]).map((e) => e.type)).toEqual([
+                        EventType.Custom,
+                        EventType.FullSnapshot,
+                    ])
+                })
+
                 it('an interaction after many idle rotations ships one session, not the held backlog', () => {
                     runExternalRotations(startingTimestamp, 1)
 
@@ -2926,6 +2973,9 @@ describe('Lazy SessionRecording', () => {
             })
 
             it('does not compress custom events', () => {
+                _emit(createFullSnapshot())
+                sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
+                ;(posthog.capture as Mock).mockClear()
                 _emit(createCustomSnapshot(undefined, { tag: 'wat' }))
                 sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
 
@@ -4308,6 +4358,7 @@ describe('Lazy SessionRecording', () => {
                 document.dispatchEvent(new Event('visibilitychange'))
 
                 sessionRecording.startIfEnabledOrStop()
+                sessionRecording.onRRwebEmit(createFullSnapshot({ timestamp: Date.now() }))
                 const snapshot = createCustomSnapshot({ timestamp: Date.now() })
                 sessionRecording.onRRwebEmit(snapshot)
                 ;(posthog.capture as Mock).mockClear()

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2174,6 +2174,18 @@ describe('Lazy SessionRecording', () => {
                     expect(shippedSessionIds().size).toEqual(expectedRecordings)
                 })
 
+                it('drops held markers once they pass the buffer size cap', () => {
+                    rotateToASessionWithNoContent()
+                    const lazy = sessionRecording['_lazyLoadedSessionRecording']
+
+                    _emit(createCustomSnapshot({ timestamp: Date.now() }, {}, 'sessionIdle'))
+                    lazy['_buffer'].size = RECORDING_MAX_EVENT_SIZE + 1
+                    lazy['_flushBuffer']()
+
+                    expect(shippedSessionIds().size).toEqual(0)
+                    expect(lazy['_buffer'].data).toEqual([])
+                })
+
                 it('holds idle markers until content arrives, then ships them with it', () => {
                     rotateToASessionWithNoContent()
 

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1895,12 +1895,35 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         }
     }
 
+    // Custom events are lifecycle markers (sessionIdle, $session_id_change, ...). A buffer holding
+    // nothing else has no content to render, so shipping it as a session's first block opens a
+    // recording that bills the customer and plays back as nothing. Once the session has a
+    // FullSnapshot, later marker-only blocks append to real content and are fine.
+    // $session_starting and $session_ending are exempt: they only exist in this stream, and
+    // dropping them would break the linking chain through a session that recorded nothing.
+    private _wouldOpenRecordingWithMarkersOnly(): boolean {
+        if (this._lastFullSnapshotSessionId === this._buffer.sessionId || this._buffer.data.length === 0) {
+            return false
+        }
+        return this._buffer.data.every(
+            (event) =>
+                event?.type === EventType.Custom && !isSessionEndingEvent(event) && !isSessionStartingEvent(event)
+        )
+    }
+
     private _flushBuffer(): SnapshotBuffer {
         this._clearFlushBufferTimer()
 
         // hold the buffer rather than ship a billable recording for an epoch nobody touched
         if (this._holdFlushUntilInteraction) {
             return this._buffer
+        }
+
+        // keep the markers rather than open a recording with them: the next capture schedules another
+        // flush, so they ship alongside the content that follows, and go with the page if none does
+        if (this._wouldOpenRecordingWithMarkersOnly()) {
+            // markers alone are unplayable, so past the cap they aren't worth the memory either
+            return this._buffer.size > RECORDING_MAX_EVENT_SIZE ? this._clearBuffer() : this._buffer
         }
 
         // never flush while a sampling decision is missing (e.g. wiped by posthog.reset()) — an

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -525,7 +525,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     private _strategy: RecordingStrategy | undefined
     private _fullSnapshotTimer?: ReturnType<typeof setInterval>
     private _fullSnapshotTimestamps: Array<[string, number]> = []
-    // ship-time FullSnapshot tracking for _ensureFullSnapshotForSession (unlike _fullSnapshotTimestamps, which records emit-time debug telemetry)
+    // the session a FullSnapshot was last captured for, read by _ensureFullSnapshotForSession and by
+    // the marker-only flush guard (unlike _fullSnapshotTimestamps, which records emit-time debug
+    // telemetry). Capture-time, not ship-time: a buffer cleared before it flushed leaves this set.
     private _lastFullSnapshotSessionId: string | undefined = undefined
     private _fullSnapshotHealAttemptedFor: string | undefined = undefined
 
@@ -1922,7 +1924,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // keep the markers rather than open a recording with them: the next capture schedules another
         // flush, so they ship alongside the content that follows, and go with the page if none does
         if (this._wouldOpenRecordingWithMarkersOnly()) {
-            // markers alone are unplayable, so past the cap they aren't worth the memory either
+            // unplayable either way, so a flush that finds them past the cap drops them rather than
+            // holding them. Only a flush checks this, so it bounds the common case, not every case
             return this._buffer.size > RECORDING_MAX_EVENT_SIZE ? this._clearBuffer() : this._buffer
         }
 

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -752,6 +752,7 @@
         "_windowId",
         "_windowIdGenerator",
         "_window_id_storage_key",
+        "_wouldOpenRecordingWithMarkersOnly",
         "_write",
         "_writeActivationTimestamps",
         "_writeEntry",

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -4184,6 +4184,26 @@
           "name": "thankYouMessageCloseButtonText"
         },
         {
+          "type": "boolean",
+          "name": "displayIntroScreen"
+        },
+        {
+          "type": "string",
+          "name": "introScreenHeader"
+        },
+        {
+          "type": "string",
+          "name": "introScreenDescription"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "introScreenDescriptionContentType"
+        },
+        {
+          "type": "string",
+          "name": "introScreenButtonText"
+        },
+        {
           "type": "string",
           "name": "borderColor"
         },
@@ -4386,6 +4406,18 @@
         {
           "type": "string",
           "name": "backButtonText"
+        },
+        {
+          "type": "string",
+          "name": "introScreenButtonText"
+        },
+        {
+          "type": "string",
+          "name": "introScreenDescription"
+        },
+        {
+          "type": "string",
+          "name": "introScreenHeader"
         },
         {
           "type": "string",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -4661,6 +4661,26 @@
           "name": "thankYouMessageCloseButtonText"
         },
         {
+          "type": "boolean",
+          "name": "displayIntroScreen"
+        },
+        {
+          "type": "string",
+          "name": "introScreenHeader"
+        },
+        {
+          "type": "string",
+          "name": "introScreenDescription"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "introScreenDescriptionContentType"
+        },
+        {
+          "type": "string",
+          "name": "introScreenButtonText"
+        },
+        {
           "type": "string",
           "name": "borderColor"
         },
@@ -4762,6 +4782,26 @@
         {
           "type": "string",
           "name": "thankYouMessageCloseButtonText"
+        },
+        {
+          "type": "boolean",
+          "name": "displayIntroScreen"
+        },
+        {
+          "type": "string",
+          "name": "introScreenHeader"
+        },
+        {
+          "type": "string",
+          "name": "introScreenDescription"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "introScreenDescriptionContentType"
+        },
+        {
+          "type": "string",
+          "name": "introScreenButtonText"
         },
         {
           "type": "string",
@@ -4999,6 +5039,18 @@
         {
           "type": "string",
           "name": "backButtonText"
+        },
+        {
+          "type": "string",
+          "name": "introScreenButtonText"
+        },
+        {
+          "type": "string",
+          "name": "introScreenDescription"
+        },
+        {
+          "type": "string",
+          "name": "introScreenHeader"
         },
         {
           "type": "string",


### PR DESCRIPTION
## Problem

Small follow-up to the idle-tab recording incident fixed in #4407.

An idle tab rotates its session, and the lifecycle markers for that rotation (`sessionIdle`, `$session_id_change`) land in the new session's empty buffer. Flushing them opens a recording with no Meta and no FullSnapshot, so it plays back as nothing while still counting as a recording.

#4407 stopped these rotations shipping a full payload. The markers were left shipping on their own, which this tidies up.

## Changes

- `_flushBuffer` will not open a recording when every event in the buffer is a custom-event marker and the session has no FullSnapshot yet.
- The markers are kept rather than dropped, so they ship with the content that follows. Past the buffer size cap they are cleared instead.
- `$session_starting` and `$session_ending` are exempt. They exist only in the replay stream and session linking needs them.
- The gate sits in `_flushBuffer`, so it covers the idle, scheduled and unload flushes as one rule.
- Seven existing tests emitted a lone synthetic custom event. Real rrweb emits Meta and FullSnapshot first, so each now stages a full snapshot and keeps its original assertion.
- This guards the flush, not the rotation that leaves the buffer empty.
- No visual change.

## Testing

Three cases in the `recording volume invariants` block: markers alone open no recording, linking markers still do, and held markers ship with the content that follows. Two of the three fail without this change. Full replay suite passes locally, 764 tests.

Not run: Playwright, and the repo typecheck, which fails on pre-existing errors in surveys and rrweb unrelated to this diff.

### Libraries affected

- [x] posthog-js (web)

## 🤖 Agent context

I (actually Claude) wrote this while looking into replay volume after the idle-tab fix. The diagnosis came from reading production recording payloads. Skills invoked: `writing-pr-descriptions`, `writing-tests`, `writing-code-comments`.
