### PR TITLE
fix(mcp): keep the conversation prompt-back out of the captured error

### DIFF
--- a/.changeset/mcp-clean-error-message.md
+++ b/.changeset/mcp-clean-error-message.md
@@ -1,0 +1,9 @@
+---
+'@posthog/mcp': patch
+---
+
+Keep the conversation-id prompt-back out of `$mcp_error_message`.
+
+With `enableConversationId` on, a `[SERVER]: Reuse conversation_id=…` block is appended to a tool result so the agent echoes the handle back on later calls. The captured error was read from that already-appended result, so a failed call reported `"intentional failure [SERVER]: Reuse conversation_id=019f…"` — a fresh uuid inside the error message on every call, which splits one recurring failure into a new error group each time it happens.
+
+The error is now read from the result as the tool produced it, before the handle is written in. It bites hardest on MCP SDK v2, where a thrown error is flattened into an `isError` result before the SDK hands it to us, so that result is the only description of the failure available. The agent still receives the prompt-back on failed calls — that is when it matters most, since otherwise the retry starts a new conversation and the failure and its fix land in different sessions.

--- a/packages/mcp/src/__tests__/v2-high-level-server.test.ts
+++ b/packages/mcp/src/__tests__/v2-high-level-server.test.ts
@@ -184,6 +184,41 @@ describe('instrument() on an MCP SDK v2 high-level server', () => {
   })
 
   /**
+   * `enableConversationId` appends a `[SERVER]: Reuse conversation_id=…` block to
+   * the result so the agent echoes the handle back. On v2 a thrown error is
+   * already flattened into an `isError` result by the time we see it, so that
+   * result *is* our only description of the failure — and reading the error off
+   * the delivered copy would splice a fresh uuid into `$mcp_error_message`,
+   * turning one recurring failure into a new error group on every call.
+   *
+   * The agent must still receive the prompt-back on a failed call: a tool that
+   * fails on the first call of a conversation is exactly when the handle matters,
+   * or the retry starts a new conversation and the failure and its fix land in
+   * different sessions. So both halves are asserted here — clean message out to
+   * PostHog, handle still delivered to the caller.
+   */
+  it('keeps the conversation prompt-back out of the captured error message', async () => {
+    const server = makeV2Server()
+    instrument(server, fakePostHog(), { context: false, enableConversationId: true })
+
+    const result = await dispatch(
+      server,
+      { method: 'tools/call', params: { name: 'fail_always', arguments: {} } },
+      v2Ctx()
+    )
+    await new Promise((r) => setTimeout(r, 20))
+
+    const call = eventCapture.findCapturesByEvent('$mcp_tool_call')[0]
+    expect(call.properties.$mcp_is_error).toBe(true)
+    expect(call.properties.$mcp_error_message).toBe('intentional failure')
+    expect(call.properties.$mcp_error_message).not.toMatch(/conversation_id/)
+
+    // The caller still gets the handle, on the failed call.
+    const delivered = (result.content as { text: string }[]).map((block) => block.text).join('\n')
+    expect(delivered).toMatch(/Reuse conversation_id=/)
+  })
+
+  /**
    * The one thing the stale executor does cost us, measured: v2 flattens a throw
    * into an `isError` result before our callback wrapper would have stashed the
    * original error, and the wrapper never runs anyway because dispatch goes

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -139,7 +139,9 @@ export async function captureToolCall(params: TraceToolCallParams): Promise<unkn
   }
 
   const finalResult = applyConversationInstructions(preparedEvent?.event ?? null, result, conversation, ownership)
-  publishSuccessfulToolEvent(server, preparedEvent, finalResult, startTime, data.logger, takeCapturedError)
+  // `result`, not `finalResult`: the error is read from what the tool produced,
+  // before the conversation handle was written into it. See below.
+  publishSuccessfulToolEvent(server, preparedEvent, finalResult, startTime, data.logger, takeCapturedError, result)
   return finalResult
 }
 
@@ -288,13 +290,26 @@ function applyConversationInstructions(
   return updated
 }
 
+/**
+ * @param result - what the caller receives, conversation handle included.
+ * @param resultBeforeInstructions - the same result as the tool produced it.
+ *
+ * The two differ once `enableConversationId` mints a handle, and the difference
+ * matters for errors. A tool that fails returns its message in `content`, and on
+ * MCP SDK v2 that flattened `isError` result is the only description of the
+ * failure we get — the throw never reaches our callback wrapper. Reading the
+ * error off the *delivered* result would therefore append the prompt-back to it,
+ * putting a fresh uuid inside `$mcp_error_message` on every failed call and
+ * splitting one recurring failure into as many groups as there were calls.
+ */
 function publishSuccessfulToolEvent(
   server: MCPServerLike,
   preparedEvent: PreparedToolEvent | null,
   result: unknown,
   startTime: Date,
   logger: LoggerFn,
-  takeCapturedError?: () => unknown
+  takeCapturedError?: () => unknown,
+  resultBeforeInstructions?: unknown
 ): void {
   if (!preparedEvent) {
     return
@@ -304,7 +319,7 @@ function publishSuccessfulToolEvent(
     if (isToolResultError(result)) {
       event.isError = true
       const capturedError = takeCapturedError?.()
-      event.error = captureException(capturedError ?? result)
+      event.error = captureException(capturedError ?? resultBeforeInstructions ?? result)
     } else {
       event.isError = false
     }


### PR DESCRIPTION
> Stacked on #4466

With `enableConversationId` on, a `[SERVER]: Reuse conversation_id=…` block is appended to a tool result so the agent echoes the handle back on later calls. The captured error was read from that **already-appended** result, so a failed call reported:

```
$mcp_error_message = "intentional failure [SERVER]: Reuse conversation_id=019fdc0c-631c-7656-a0d7-3c268527d5ee
                      on every subsequent tool call in this conversation. …"
```

A fresh uuid inside the message on every failure, so one recurring failure becomes a new error group each time it occurs — the exact signal error grouping exists to give you, destroyed by the feature meant to correlate it.

The error is now read from the result **as the tool produced it**, before the handle is written in. What the caller receives does not change: the agent still gets the prompt-back on a failed call, which is when it matters most — otherwise the retry opens a new conversation and the failure and its fix land in different sessions. Both halves are asserted, because the tempting wrong fix is to withhold the handle.

v2-specific in practice: on v1 the throw is stashed by the tool-callback wrapper and captured from there, so the appended result is never read. v2 flattens the throw into an `isError` result before our wrapper sees it, which makes that result the only description of the failure available.

## The harness could not see this, so I fixed the harness

The matrix already asserts `$mcp_error_message === 'intentional failure'` — and it was **green before this change**. Its fixture drives four tool calls, fails on the **last** one, and echoes the handle it received from the first. So on the failing call the handle is already minted, no prompt-back is appended to that result, and there is nothing to pollute. The column was green because the fixture never reached the code, which in a grid is indistinguishable from green because the code is right.

`dual-era/probe-first-call-error.mjs` covers the ordering it misses: the **first** call of a conversation failing — a bad argument, an expired token, a cold dependency. Run against the parent branch's build it reproduces the bug verbatim, and against this one:

```
parent branch    ✗ $mcp_error_message is clean   "intentional failure [SERVER]: Reuse conversation_id=019f…"
this branch      ✓ error captured
                 ✓ $mcp_error_message is clean   "intentional failure"
                 ✓ handle still delivered to the caller
```

It is wired into `run-all.mjs` and runs on every pass from now on.

## Matrix

No cell moved, and the grid is not where the evidence lives — see above.

```
                            calls  errors  schema  session  client  protocol  warnings  header  alive
──────────────────────────────────────────────────────────────────────────────────────────────────────
 v1  stateful   high          ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateful   low           ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateless  high          ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
 v1  stateless  low           ✓      ✓       ✓        ✓       ✓        ✓         ✓        ·       ·
──────────────────────────────────────────────────────────────────────────────────────────────────────
 v2  high  2025  conv=off     ✓      ✓       ✓        ·       ✗        ✓         ✓        ✓       ✓
 v2  high  2025  conv=on      ✓      ✓       ✓        ✓       ✗        ✓         ✓        ✓       ✓
 v2  high  2026  conv=off     ✓      ✓       ✓        ·       ✓        ✓         ✓        ✓       ✓
 v2  high  2026  conv=on      ✓      ✓       ✓        ✓       ✓        ✓         ✓        ✓       ✓
 v2  low   2025  conv=off     ✓      ✓       ✓        ·       ✗        ✓         ✓        ✓       ✓
 v2  low   2025  conv=on      ✓      ✓       ✓        ✗       ✗        ✓         ✓        ✓       ✓
 v2  low   2026  conv=off     ✓      ✓       ✓        ·       ✓        ✓         ✓        ✓       ✓
 v2  low   2026  conv=on      ✓      ✓       ✓        ✗       ✓        ✓         ✓        ✓       ✓

 late-handler probe                                        9/9  (unchanged)
 first-call-error probe                                    3/3  (new — 2/3 on the parent branch)
 nest v1   instrument(server) / instrument(server.server)   15/16 · 15/16  (unchanged)
 nest v2   instrument(server) / instrument(server.server)   25/33 · 25/33  (unchanged)
```

`error message is clean` stays red on both Nest rows for an unrelated reason this PR cannot touch: NestJS's `RpcExceptionsHandler` replaces the thrown error with `"Internal server error"` before it reaches the MCP layer, so every distinct failure on a mcp-nest server groups together regardless. Worth a docs note to those users; not our bug.

587 unit tests green, lint and build clean. Revert-checked: backing the fix out fails exactly one unit test, plus the new probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Supersedes #4467, which GitHub auto-closed when its base branch was deleted on merge and would not let me reopen. Same commit, rebased onto `main`, already approved there.