### PR TITLE
feat(browser): default script versioning to fallback

### DIFF
--- a/.agents/skills/replay-incident-risk/INCIDENTS.md
+++ b/.agents/skills/replay-incident-risk/INCIDENTS.md
@@ -8,7 +8,7 @@ Each entry describes the mechanism, not the blast radius. Internal impact number
 
 ## Class 1: Version skew across the lazy-load boundary
 
-**The single most repeated cause.** The recorder, surveys, web-vitals, and tracing-headers extensions are lazy-loaded from the CDN. With `strict_script_versioning: false` (the default for most teams), the `?v=` query param is only a cache-buster: the CDN serves the **latest published bundle to every SDK version, including npm-pinned ones** (`external-scripts-loader.ts`). Publishing an extension change is a fleet-wide deploy with no rollout control.
+**The single most repeated cause.** The recorder, surveys, web-vitals, and tracing-headers extensions are lazy-loaded from the CDN. With `strict_script_versioning: false`, the `?v=` query param is only a cache-buster: the CDN serves the **latest published bundle to every SDK version, including npm-pinned ones** (`external-scripts-loader.ts`). The default `'fallback'` mode loads the exact SDK version first but can still use this legacy path if the versioned asset is unavailable. Publishing an extension change remains a fleet-wide deploy with no rollout control for SDKs that use the legacy path.
 
 The canonical failure: new extension code assumes something only newer cores provide (a function, a config field, a persisted value), or changes a cross-boundary function signature. Old cores load the new bundle and break.
 

--- a/.changeset/versioned-script-fallback.md
+++ b/.changeset/versioned-script-fallback.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+Default external dependency loading to versioned asset paths with automatic fallback to legacy paths, and add a `strict_script_versioning: 'fallback'` mode.

--- a/packages/browser/playwright/mocked/surveys/url-prefill.spec.ts
+++ b/packages/browser/playwright/mocked/surveys/url-prefill.spec.ts
@@ -51,6 +51,20 @@ test.describe('surveys - URL prefill with auto-submit', () => {
         )
         await surveysAPICall
 
+        await page.evaluate(
+            () =>
+                new Promise<void>((resolve, reject) => {
+                    const ph = (window as any).posthog
+                    ph.onSurveysLoaded((_surveys: unknown[], context?: { isLoaded: boolean; error?: string }) => {
+                        if (context?.isLoaded) {
+                            resolve()
+                        } else {
+                            reject(new Error(context?.error ?? 'Surveys failed to load'))
+                        }
+                    })
+                })
+        )
+
         // The hosted survey page renders on demand and passes the custom URL params as properties.
         await page.evaluate((survey) => {
             const ph = (window as any).posthog

--- a/packages/browser/playwright/mocked/surveys/url-prefill.spec.ts
+++ b/packages/browser/playwright/mocked/surveys/url-prefill.spec.ts
@@ -33,7 +33,7 @@ test.describe('surveys - URL prefill with auto-submit', () => {
         page,
         context,
     }) => {
-        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+        await page.route('**/surveys/**', async (route) => {
             await route.fulfill({ json: { surveys: [prefillSurvey] } })
         })
 
@@ -49,7 +49,6 @@ test.describe('surveys - URL prefill with auto-submit', () => {
             page,
             context
         )
-        await surveysAPICall
 
         await page.evaluate(
             () =>

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -3166,8 +3166,8 @@
           "name": "disable_external_dependency_loading"
         },
         {
-          "description": "Determines whether PostHog should load external dependency scripts from\nsemver-qualified asset paths such as /static/1.370.0/recorder.js instead\nof the legacy /static/recorder.js?v=1.370.0 form.",
-          "type": "boolean",
+          "description": "Determines whether PostHog should load external dependency scripts from\nsemver-qualified asset paths such as /static/1.370.0/recorder.js instead\nof the legacy /static/recorder.js?v=1.370.0 form. Set to `true` to use only\nversioned paths, `false` to use only legacy paths, or `'fallback'` to try\nthe versioned path first and retry with the legacy path if it fails.",
+          "type": "boolean | \"fallback\"",
           "name": "strict_script_versioning"
         },
         {

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -178,7 +178,7 @@ describe('config', () => {
             const posthog = new PostHog()
             posthog._init('test-token')
 
-            expect(posthog.config.strict_script_versioning).toBe(false)
+            expect(posthog.config.strict_script_versioning).toBe('fallback')
             expect(posthog.config.asset_host).toBeNull()
         })
 

--- a/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
@@ -74,6 +74,24 @@ describe('external-scripts-loader', () => {
             expect(callback).toHaveBeenCalledTimes(2)
         })
 
+        it('does not add duplicate scripts when called before the document body exists', () => {
+            const body = document!.body
+            body.remove()
+            const firstCallback = jest.fn()
+            const secondCallback = jest.fn()
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', firstCallback)
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', secondCallback)
+            document!.documentElement.appendChild(body)
+            document!.dispatchEvent(new Event('DOMContentLoaded'))
+
+            const scripts = document!.getElementsByTagName('script')
+            expect(scripts).toHaveLength(1)
+            scripts[0].dispatchEvent(new Event('load'))
+            expect(firstCallback).toHaveBeenCalledTimes(1)
+            expect(secondCallback).toHaveBeenCalledTimes(1)
+        })
+
         it('adds script when no preexisting scripts exist', () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
             const scripts = document!.getElementsByTagName('script')
@@ -89,10 +107,113 @@ describe('external-scripts-loader', () => {
             expect(callback).toHaveBeenCalledWith('uh-oh')
         })
 
+        it('falls back to the legacy asset path when a versioned asset fails to load', () => {
+            mockPostHog.config.strict_script_versioning = 'fallback'
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+            let scripts = document!.getElementsByTagName('script')
+            expect(scripts[0].src).toBe('https://us-assets.i.posthog.com/static/1.0.0/recorder.js')
+
+            scripts[0].dispatchEvent(new Event('error'))
+            scripts = document!.getElementsByTagName('script')
+            expect(scripts).toHaveLength(1)
+            expect(scripts[0].src).toBe('https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0')
+            expect(callback).not.toHaveBeenCalled()
+
+            scripts[0].dispatchEvent(new Event('load'))
+            expect(callback).toHaveBeenCalledWith(undefined, expect.any(Event))
+        })
+
+        it('returns the legacy asset error when both paths fail to load', () => {
+            mockPostHog.config.strict_script_versioning = 'fallback'
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+            document!.getElementsByTagName('script')[0].dispatchEvent(new Event('error'))
+            document!.getElementsByTagName('script')[0].onerror!('legacy-error')
+
+            expect(callback).toHaveBeenCalledWith('legacy-error')
+        })
+
+        it('coalesces concurrent callers across the fallback attempt', () => {
+            mockPostHog.config.strict_script_versioning = 'fallback'
+            const firstCallback = jest.fn()
+            const secondCallback = jest.fn()
+            const lateCallback = jest.fn()
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', firstCallback)
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', secondCallback)
+            document!.getElementsByTagName('script')[0].dispatchEvent(new Event('error'))
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', lateCallback)
+
+            const scripts = document!.getElementsByTagName('script')
+            expect(scripts).toHaveLength(1)
+            expect(scripts[0].src).toBe('https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0')
+            scripts[0].dispatchEvent(new Event('load'))
+
+            for (const loadCallback of [firstCallback, secondCallback, lateCallback]) {
+                expect(loadCallback).toHaveBeenCalledTimes(1)
+                expect(loadCallback).toHaveBeenCalledWith(undefined, expect.any(Event))
+            }
+        })
+
+        it('shares the terminal fallback error with concurrent and later callers', () => {
+            mockPostHog.config.strict_script_versioning = 'fallback'
+            const firstCallback = jest.fn()
+            const secondCallback = jest.fn()
+            const lateCallback = jest.fn()
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', firstCallback)
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', secondCallback)
+            document!.getElementsByTagName('script')[0].dispatchEvent(new Event('error'))
+
+            const fallbackScript = document!.getElementsByTagName('script')[0]
+            fallbackScript.dispatchEvent(new Event('error'))
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', lateCallback)
+
+            expect(document!.getElementsByTagName('script')).toHaveLength(1)
+            for (const loadCallback of [firstCallback, secondCallback, lateCallback]) {
+                expect(loadCallback).toHaveBeenCalledTimes(1)
+                expect(loadCallback).toHaveBeenCalledWith(expect.any(Event))
+            }
+        })
+
+        it('does not fall back when strict versioning is enabled', () => {
+            mockPostHog.config.strict_script_versioning = true
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+            document!.getElementsByTagName('script')[0].dispatchEvent(new Event('error'))
+
+            expect(document!.getElementsByTagName('script')).toHaveLength(1)
+            expect(callback).toHaveBeenCalledWith(expect.any(Event))
+        })
+
+        it('does not fall back after a versioned asset loads successfully', () => {
+            mockPostHog.config.strict_script_versioning = 'fallback'
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+            document!.getElementsByTagName('script')[0].dispatchEvent(new Event('load'))
+
+            expect(document!.getElementsByTagName('script')).toHaveLength(1)
+            expect(callback).toHaveBeenCalledWith(undefined, expect.any(Event))
+        })
+
         it('keeps the legacy toolbar cache-busting path by default', () => {
             jest.useFakeTimers()
             jest.setSystemTime(1726067100000)
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'toolbar', callback)
+            expect(document!.getElementsByTagName('script')[0].src).toBe(
+                'https://us-assets.i.posthog.com/static/toolbar.js?v=1.0.0&t=1726067100000'
+            )
+        })
+
+        it('cache-busts the legacy toolbar path when falling back', () => {
+            jest.useFakeTimers()
+            jest.setSystemTime(1726067100000)
+            mockPostHog.config.strict_script_versioning = 'fallback'
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'toolbar', callback)
+            document!.getElementsByTagName('script')[0].dispatchEvent(new Event('error'))
+
             expect(document!.getElementsByTagName('script')[0].src).toBe(
                 'https://us-assets.i.posthog.com/static/toolbar.js?v=1.0.0&t=1726067100000'
             )

--- a/packages/browser/src/entrypoints/external-scripts-loader.ts
+++ b/packages/browser/src/entrypoints/external-scripts-loader.ts
@@ -5,55 +5,68 @@ import { createLogger } from '@posthog/browser-common/utils/logger'
 
 const logger = createLogger('[ExternalScriptsLoader]')
 
+const findScript = (url: string): HTMLScriptElement | undefined => {
+    const scripts = document?.querySelectorAll('script')
+    if (scripts) {
+        for (let i = 0; i < scripts.length; i++) {
+            if (scripts[i].src === url) {
+                return scripts[i]
+            }
+        }
+    }
+    return undefined
+}
+
 const loadScript = (posthog: PostHog, url: string, callback: (error?: string | Event, event?: Event) => void) => {
     if (posthog.config.disable_external_dependency_loading) {
         logger.warn(`${url} was requested but loading of external scripts is disabled.`)
         return callback('Loading of external scripts is disabled')
     }
 
-    // If we add a script more than once then the browser will parse and execute it
-    // So, even if idempotent we waste parsing and processing time
-    const existingScripts = document?.querySelectorAll('script')
-    if (existingScripts) {
-        for (let i = 0; i < existingScripts.length; i++) {
-            if (existingScripts[i].src === url) {
-                const alreadyExistingScriptTag = existingScripts[i]
-
-                if ((alreadyExistingScriptTag as any).__posthog_loading_callback_fired) {
-                    // script already exists and fired its load event,
-                    // we call the callback again, they need to be idempotent
-                    return callback()
-                }
-
-                // eslint-disable-next-line posthog-js/no-add-event-listener
-                alreadyExistingScriptTag.addEventListener('load', (event) => {
-                    // it hasn't already loaded
-                    // we probably called loadScript twice in quick succession,
-                    // so we attach a callback to the onload event
-                    ;(alreadyExistingScriptTag as any).__posthog_loading_callback_fired = true
-                    callback(undefined, event)
-                })
-                alreadyExistingScriptTag.onerror = (error) => callback(error)
-
-                return // and finish processing here
-            }
+    // Share the result when the same script is requested more than once so the browser
+    // only downloads and executes it once.
+    const existingScript = findScript(url)
+    if (existingScript) {
+        if ((existingScript as any).__posthog_loading_callback_fired) {
+            return callback()
         }
+        const existingError = (existingScript as any).__posthog_loading_error
+        if (existingError) {
+            return callback(existingError)
+        }
+
+        // eslint-disable-next-line posthog-js/no-add-event-listener
+        existingScript.addEventListener('load', (event) => {
+            ;(existingScript as any).__posthog_loading_callback_fired = true
+            callback(undefined, event)
+        })
+        // eslint-disable-next-line posthog-js/no-add-event-listener
+        existingScript.addEventListener('error', (error) => {
+            ;(existingScript as any).__posthog_loading_error = error
+            callback(error)
+        })
+        return
     }
 
     const addScript = () => {
         if (!document) {
             return callback('document not found')
         }
+        if (findScript(url)) {
+            return loadScript(posthog, url, callback)
+        }
         let scriptTag: HTMLScriptElement | null = document.createElement('script')
         scriptTag.type = 'text/javascript'
         scriptTag.crossOrigin = 'anonymous'
         scriptTag.src = url
         scriptTag.onload = (event) => {
-            // mark the script as having had its callback fired, so we can avoid double-calling it
             ;(scriptTag as any).__posthog_loading_callback_fired = true
             callback(undefined, event)
         }
-        scriptTag.onerror = (error) => callback(error)
+        scriptTag.onerror = (error) => {
+            ;(scriptTag as any).__posthog_loading_error = error
+            callback(error)
+        }
 
         if (posthog.config.prepare_external_dependency_script) {
             scriptTag = posthog.config.prepare_external_dependency_script(scriptTag)
@@ -85,6 +98,23 @@ const loadScript = (posthog: PostHog, url: string, callback: (error?: string | E
     }
 }
 
+const fallbackScripts: Record<string, string> = {}
+
+const legacyScriptUrl = (posthog: PostHog, kind: PostHogExtensionKind): string => {
+    let scriptPath = `/static/${kind}.js?v=${posthog.version}`
+
+    if (kind === 'toolbar') {
+        // toolbar.js has a 24-hour CDN TTL but contains a rotating token valid for
+        // only 5 minutes. Bust the cache on a 5-minute boundary so the browser always
+        // fetches a fresh copy with a valid token.
+        const fiveMinutesInMillis = 5 * 60 * 1000
+        const timestampToNearestFiveMinutes = Math.floor(Date.now() / fiveMinutesInMillis) * fiveMinutesInMillis
+        scriptPath = `${scriptPath}&t=${timestampToNearestFiveMinutes}`
+    }
+
+    return posthog.requestRouter.endpointFor('assets', scriptPath)
+}
+
 assignableWindow.__PosthogExtensions__ = assignableWindow.__PosthogExtensions__ || {}
 assignableWindow.__PosthogExtensions__.loadExternalDependency = (
     posthog: PostHog,
@@ -98,28 +128,43 @@ assignableWindow.__PosthogExtensions__.loadExternalDependency = (
         return
     }
 
-    let url: string
-
-    if (posthog.config.strict_script_versioning) {
+    const scriptVersioning = posthog.config.strict_script_versioning
+    if (scriptVersioning) {
         // posthog.version is baked into the executing array.js bundle, so this points at
         // the exact semver-qualified sibling asset without relying on alias redirects.
-        url = posthog.requestRouter.endpointFor('assets', `/static/${posthog.version}/${kind}.js`)
-    } else {
-        let scriptUrlToLoad = `/static/${kind}.js?v=${posthog.version}`
-
-        if (kind === 'toolbar') {
-            // toolbar.js has a 24-hour CDN TTL but contains a rotating token valid for
-            // only 5 minutes. Bust the cache on a 5-minute boundary so the browser always
-            // fetches a fresh copy with a valid token.
-            const fiveMinutesInMillis = 5 * 60 * 1000
-            const timestampToNearestFiveMinutes = Math.floor(Date.now() / fiveMinutesInMillis) * fiveMinutesInMillis
-            scriptUrlToLoad = `${scriptUrlToLoad}&t=${timestampToNearestFiveMinutes}`
+        const url = posthog.requestRouter.endpointFor('assets', `/static/${posthog.version}/${kind}.js`)
+        const existingFallback = fallbackScripts[url]
+        if (scriptVersioning === 'fallback' && existingFallback) {
+            if (findScript(existingFallback)) {
+                loadScript(posthog, existingFallback, callback)
+                return
+            }
+            delete fallbackScripts[url]
         }
 
-        url = posthog.requestRouter.endpointFor('assets', scriptUrlToLoad)
+        loadScript(
+            posthog,
+            url,
+            scriptVersioning === 'fallback'
+                ? (error, event) => {
+                      if (!error) {
+                          callback(undefined, event)
+                      } else if (typeof error === 'string') {
+                          callback(error)
+                      } else {
+                          const fallbackUrl = legacyScriptUrl(posthog, kind)
+                          fallbackScripts[url] = fallbackUrl
+                          const failedScript = findScript(url)
+                          failedScript?.parentNode?.removeChild(failedScript)
+                          loadScript(posthog, fallbackUrl, callback)
+                      }
+                  }
+                : callback
+        )
+        return
     }
 
-    loadScript(posthog, url, callback)
+    loadScript(posthog, legacyScriptUrl(posthog, kind), callback)
 }
 
 assignableWindow.__PosthogExtensions__.loadSiteApp = (

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -271,7 +271,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     disable_product_tours: false,
     disableDeviceModel: false,
     disable_external_dependency_loading: false,
-    strict_script_versioning: false,
+    strict_script_versioning: 'fallback',
     enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',
     ip: false,

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -312,7 +312,8 @@ exports[`config snapshot for PostHogConfig 1`] = `
   ],
   "strict_script_versioning": [
     "false",
-    "true"
+    "true",
+    "\\"fallback\\""
   ],
   "asset_host": [
     "null",

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1450,11 +1450,13 @@ export interface PostHogConfig {
     /**
      * Determines whether PostHog should load external dependency scripts from
      * semver-qualified asset paths such as /static/1.370.0/recorder.js instead
-     * of the legacy /static/recorder.js?v=1.370.0 form.
+     * of the legacy /static/recorder.js?v=1.370.0 form. Set to `true` to use only
+     * versioned paths, `false` to use only legacy paths, or `'fallback'` to try
+     * the versioned path first and retry with the legacy path if it fails.
      *
-     * @default false
+     * @default 'fallback'
      */
-    strict_script_versioning: boolean
+    strict_script_versioning: boolean | 'fallback'
 
     /**
      * Optional host override for static assets loaded by PostHog, such as


### PR DESCRIPTION
## Problem

Lazy-loaded browser extensions currently default to mutable legacy asset paths, so an older core can load the latest extension bundle and cross the core/extension compatibility boundary. Strict versioned paths avoid that skew, but previously had no recovery path if an immutable asset was unavailable.

## Changes

- Extend `strict_script_versioning` to `true | false | 'fallback'` and default it to `'fallback'`.
- Load the exact SDK-versioned extension first, then retry the legacy path after a script load error.
- Preserve `true` as versioned-only and `false` as legacy-only.
- Coalesce concurrent loads onto one script attempt, remove failed versioned tags before fallback, and retain terminal fallback errors so later callers complete instead of hanging.
- Keep remote config and site app loading unchanged.
- Add focused coverage for routing, fallback success/failure, concurrent and pre-body callers, terminal failures, toolbar cache busting, and config typing/defaults.

Validation included the focused Jest suites, lint, typecheck, a production browser build, and a real Chromium smoke test against a separate local `asset_host`. The total `array.js` delta is approximately +0.12 KiB gzip in the fast bundle comparison.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent, its read-only reviewer subagent, and `agent-browser` for a real-browser proxy smoke test. The design keeps the existing callback API and uses script-element state for load coalescing rather than adding a Promise abstraction, minimizing default bundle impact while ensuring all concurrent callers receive the same terminal result.
