### PR TITLE
fix(replay): ship only the buffer the flush validated

### DIFF
--- a/.changeset/flush-validated-buffer-only.md
+++ b/.changeset/flush-validated-buffer-only.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): never ship a buffer swapped in by a re-entrant session rotation mid-flush

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2204,6 +2204,48 @@ describe('Lazy SessionRecording', () => {
                     ])
                 })
 
+                it("a session rotation adopted mid-flush does not ship the new epoch's buffer", () => {
+                    // Production rrweb delivers addCustomEvent synchronously through emit, which is
+                    // what makes rotation adoption re-entrant.
+                    _addCustomEvent.mockImplementation((tag: string, payload: any) => {
+                        _emit({ type: EventType.Custom, data: { tag, payload }, timestamp: Date.now() })
+                    })
+                    try {
+                        const lazy = sessionRecording['_lazyLoadedSessionRecording']!
+                        emitActiveEvent(startingTimestamp + 100)
+                        jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                        ;(posthog.capture as Mock).mockClear()
+                        expect(lazy['_buffer'].data).toEqual([])
+
+                        const rotateAt = startingTimestamp + sessionManager['_sessionTimeoutMs'] + 1000
+                        jest.setSystemTime(new Date(rotateAt))
+                        sessionIdGeneratorMock.mockImplementation(() => 'toctou-rotated-session')
+
+                        // The flush consults the session manager after its hold and content checks
+                        // (sampling, minimum duration, status). In production that consultation can
+                        // adopt a pending rotation and re-enter the recorder; inject the same
+                        // re-entry at the same point.
+                        const strategy = lazy['_strategy']!
+                        expect(strategy).toBeTruthy()
+                        const originalEnsure = strategy.ensureSamplingDecision.bind(strategy)
+                        jest.spyOn(strategy, 'ensureSamplingDecision').mockImplementation((sid: string) => {
+                            sessionManager.checkAndGetSessionAndWindowId(false, rotateAt)
+                            return originalEnsure(sid)
+                        })
+
+                        lazy['_flushBuffer']()
+
+                        // the re-entrant pass holds the rotation-born epoch; the outer flush, which
+                        // validated the old empty buffer, must not ship the rebound one
+                        const rotatedShips = (posthog.capture as Mock).mock.calls
+                            .filter(([name]) => name === '$snapshot')
+                            .filter(([, props]) => props.$session_id === 'toctou-rotated-session')
+                        expect(rotatedShips).toEqual([])
+                    } finally {
+                        _addCustomEvent.mockReset()
+                    }
+                })
+
                 it('an interaction after many idle rotations ships one session, not the held backlog', () => {
                     runExternalRotations(startingTimestamp, 1)
 

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2215,7 +2215,6 @@ describe('Lazy SessionRecording', () => {
                         emitActiveEvent(startingTimestamp + 100)
                         jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
                         ;(posthog.capture as Mock).mockClear()
-                        expect(lazy['_buffer'].data).toEqual([])
 
                         const rotateAt = startingTimestamp + sessionManager['_sessionTimeoutMs'] + 1000
                         jest.setSystemTime(new Date(rotateAt))
@@ -2226,7 +2225,6 @@ describe('Lazy SessionRecording', () => {
                         // adopt a pending rotation and re-enter the recorder; inject the same
                         // re-entry at the same point.
                         const strategy = lazy['_strategy']!
-                        expect(strategy).toBeTruthy()
                         const originalEnsure = strategy.ensureSamplingDecision.bind(strategy)
                         jest.spyOn(strategy, 'ensureSamplingDecision').mockImplementation((sid: string) => {
                             sessionManager.checkAndGetSessionAndWindowId(false, rotateAt)
@@ -2237,6 +2235,48 @@ describe('Lazy SessionRecording', () => {
 
                         // the re-entrant pass holds the rotation-born epoch; the outer flush, which
                         // validated the old empty buffer, must not ship the rebound one
+                        const rotatedShips = (posthog.capture as Mock).mock.calls
+                            .filter(([name]) => name === '$snapshot')
+                            .filter(([, props]) => props.$session_id === 'toctou-rotated-session')
+                        expect(rotatedShips).toEqual([])
+                    } finally {
+                        _addCustomEvent.mockReset()
+                    }
+                })
+
+                it('a rotation adopted mid-flush does not get the new buffer cleared or relabeled by the capture path', () => {
+                    _addCustomEvent.mockImplementation((tag: string, payload: any) => {
+                        _emit({ type: EventType.Custom, data: { tag, payload }, timestamp: Date.now() })
+                    })
+                    try {
+                        const lazy = sessionRecording['_lazyLoadedSessionRecording']!
+                        emitActiveEvent(startingTimestamp + 100)
+                        jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                        ;(posthog.capture as Mock).mockClear()
+
+                        const rotateAt = startingTimestamp + sessionManager['_sessionTimeoutMs'] + 1000
+                        jest.setSystemTime(new Date(rotateAt))
+                        sessionIdGeneratorMock.mockImplementation(() => 'toctou-rotated-session')
+                        const strategy = lazy['_strategy']!
+                        const originalEnsure = strategy.ensureSamplingDecision.bind(strategy)
+                        jest.spyOn(strategy, 'ensureSamplingDecision').mockImplementation((sid: string) => {
+                            sessionManager.checkAndGetSessionAndWindowId(false, rotateAt)
+                            return originalEnsure(sid)
+                        })
+
+                        // a lifecycle event targeted at another session forces the capture path to
+                        // flush and then rebind the buffer with the event's pre-rotation target ids
+                        _emit(
+                            createCustomSnapshot(
+                                { timestamp: rotateAt },
+                                { currentSessionId: 'other-session', currentWindowId: 'other-window' },
+                                '$session_ending'
+                            )
+                        )
+
+                        // the rotation-born epoch keeps its own identity: not relabeled with the
+                        // stale target, and nothing shipped under it
+                        expect(lazy['_buffer'].sessionId).not.toEqual('other-session')
                         const rotatedShips = (posthog.capture as Mock).mock.calls
                             .filter(([name]) => name === '$snapshot')
                             .filter(([, props]) => props.$session_id === 'toctou-rotated-session')

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1916,6 +1916,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     private _flushBuffer(): SnapshotBuffer {
         this._clearFlushBufferTimer()
 
+        // every check below validates this buffer; the ship at the bottom must not touch any other
+        const validatedBuffer = this._buffer
+
         // hold the buffer rather than ship a billable recording for an epoch nobody touched
         if (this._holdFlushUntilInteraction) {
             return this._buffer
@@ -1937,6 +1940,17 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         if (this.status === BUFFERING || this.status === PAUSED || this.status === DISABLED || isBelowMinimumDuration) {
             this._scheduleFlushBuffer()
+            return this._buffer
+        }
+
+        // the sampling, duration and status reads above consult the session manager, which can
+        // synchronously adopt a pending session rotation and re-enter this recorder: stop(),
+        // restart, and the replay of queued events all run before control returns here. When that
+        // happens this._buffer is the NEW epoch's buffer — typically held, and never validated by
+        // the checks above — and shipping it here is how held rotation-born markers leaked out as
+        // empty billable recordings. The re-entrant pass already flushed or held the new epoch
+        // correctly, so this outer pass must ship only the buffer it validated, or nothing.
+        if (this._buffer !== validatedBuffer) {
             return this._buffer
         }
 

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1914,10 +1914,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     }
 
     private _flushBuffer(): SnapshotBuffer {
+        // cleared before the re-entrant reads below, so a flush they schedule survives this call
         this._clearFlushBufferTimer()
-
-        // every check below validates this buffer; the ship at the bottom must not touch any other
-        const validatedBuffer = this._buffer
 
         // hold the buffer rather than ship a billable recording for an epoch nobody touched
         if (this._holdFlushUntilInteraction) {
@@ -1932,6 +1930,11 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             return this._buffer.size > RECORDING_MAX_EVENT_SIZE ? this._clearBuffer() : this._buffer
         }
 
+        // the reads below consult the session manager, which can synchronously adopt a pending
+        // session rotation and re-enter this recorder, swapping this._buffer for the new epoch's;
+        // that pass flushes or holds it itself, so ship only the buffer these checks validated
+        const validatedBuffer = this._buffer
+
         // never flush while a sampling decision is missing (e.g. wiped by posthog.reset()) — an
         // undecided session reads as ACTIVE and would leak a batch it then decides not to record
         this._strategy?.ensureSamplingDecision(this.sessionId)
@@ -1943,20 +1946,13 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             return this._buffer
         }
 
-        // the sampling, duration and status reads above consult the session manager, which can
-        // synchronously adopt a pending session rotation and re-enter this recorder: stop(),
-        // restart, and the replay of queued events all run before control returns here. When that
-        // happens this._buffer is the NEW epoch's buffer — typically held, and never validated by
-        // the checks above — and shipping it here is how held rotation-born markers leaked out as
-        // empty billable recordings. The re-entrant pass already flushed or held the new epoch
-        // correctly, so this outer pass must ship only the buffer it validated, or nothing.
         if (this._buffer !== validatedBuffer) {
             return this._buffer
         }
 
-        if (this._buffer.data.length > 0) {
+        if (validatedBuffer.data.length > 0) {
             const snapshotHostname = this._currentMaskedHostname()
-            const snapshotEvents = splitBuffer(this._buffer)
+            const snapshotEvents = splitBuffer(validatedBuffer)
             snapshotEvents.forEach((snapshotBuffer) => {
                 this._flushedSizeTracker?.trackSize(snapshotBuffer.sessionId, snapshotBuffer.size)
                 this._captureSnapshot({
@@ -2050,7 +2046,14 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                 !this._holdFlushUntilInteraction &&
                 this._buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE)
         ) {
+            const sessionBeforeFlush = this._sessionId
             this._buffer = this._flushBuffer()
+            // a rotation adopted re-entrantly during that flush owns this._buffer now; clearing it
+            // or relabeling it with this event's pre-rotation ids would mis-attribute the new
+            // epoch, so drop the stale event instead
+            if (this._sessionId !== sessionBeforeFlush) {
+                return
+            }
             // A suppressed flush (e.g. buffering, paused, held, below minimum duration) returns the buffer un-drained, and relabeling the prior session's events would mis-attribute them, so discard them instead.
             if (sessionChanged && this._buffer.data.length > 0) {
                 this._buffer = this._clearBuffer()


### PR DESCRIPTION
## Problem

Small follow-up to the idle-rotation fixes in #4407 and #4477.

`_flushBuffer` validates `this._buffer` (hold, content, sampling, duration, status), but its mid-flush session-manager reads can synchronously adopt a pending session rotation and re-enter the recorder: stop, restart, and the replay of queued events all run before control returns. `this._buffer` is then the new epoch's buffer, which none of the checks saw, and the outer flush ships it. That let an idle rotation's lifecycle markers slip past the guards from the earlier PRs as an empty recording.

## Changes

- `_flushBuffer` snapshots `this._buffer` before the re-entrancy-capable reads and refuses to ship if it was swapped by the time it ships; the ship block reads the validated snapshot, so the invariant is structural.
- `_captureSnapshotBuffered` gets the matching guard: if a rotation was adopted during its flush call, it drops the stale event instead of clearing or relabeling the new epoch's buffer with pre-rotation ids.
- The re-entrant pass already flushed or held the new epoch correctly, so the outer pass gives way to it.
- One local variable; no new class members, so `terser-mangled-names.json` is unchanged.
- No visual change.

## Testing

- Two tests in the `recording volume invariants` block: a rotation adopted mid-flush ships nothing under the rotated session id, and the capture path leaves the rotation-born buffer's identity and contents alone. It injects the re-entry at the call the production behavior pointed to, with realistic synchronous custom-event routing. Each is red without its guard, green with it.
- Full replay suite passes locally, 767 tests.
- Also verified against the built minified bundle in real Chromium (hidden tab, simulated rotation cycles): the marker-only recording reproduces without the fix and does not occur with it.
- Not run: Playwright suite, and the repo typecheck, which fails on pre-existing errors unrelated to this diff.

### Libraries affected

- [x] posthog-js (web)

## 🤖 Agent context

I (actually Claude) traced this by instrumenting the minified bundle in a Playwright harness: per-flush logging of the hold flag, guard predicate, and buffer contents showed the suppressed inner flush and the outer flush shipping the swapped buffer. Skills invoked: `writing-pr-descriptions`, `writing-tests`, `writing-code-comments`.

