### PR TITLE
fix(types): accept Segment Analytics SDK types

### DIFF
--- a/.changeset/segment-analytics-next-types.md
+++ b/.changeset/segment-analytics-next-types.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+fix(types): accept current and legacy Segment Analytics SDK types in the Segment integration config

--- a/packages/browser/src/extensions/segment-integration.ts
+++ b/packages/browser/src/extensions/segment-integration.ts
@@ -28,6 +28,8 @@ import type { SegmentUser, SegmentAnalytics, SegmentContext, SegmentPlugin } fro
 // Re-export for backwards compatibility
 export type { SegmentUser, SegmentAnalytics, SegmentContext, SegmentPlugin }
 
+type SegmentIntegrationUser = Awaited<ReturnType<SegmentAnalytics['user']>>
+
 const logger = createLogger('[SegmentIntegration]')
 
 const createSegmentIntegration = (posthog: PostHog): SegmentPlugin => {
@@ -75,7 +77,7 @@ function setupPostHogFromSegment(posthog: PostHog, done: () => void) {
         return done()
     }
 
-    const bootstrapUser = (user: SegmentUser) => {
+    const bootstrapUser = (user: SegmentIntegrationUser) => {
         // Use segments anonymousId instead
         const getSegmentAnonymousId = () => user.anonymousId() || uuidv7()
         posthog.config.get_device_id = getSegmentAnonymousId
@@ -96,7 +98,7 @@ function setupPostHogFromSegment(posthog: PostHog, done: () => void) {
     if ('then' in segmentUser && isFunction(segmentUser.then)) {
         segmentUser.then(bootstrapUser)
     } else {
-        bootstrapUser(segmentUser as SegmentUser)
+        bootstrapUser(segmentUser as SegmentIntegrationUser)
     }
 }
 

--- a/packages/types/src/__tests__/segment.spec.ts
+++ b/packages/types/src/__tests__/segment.spec.ts
@@ -53,8 +53,8 @@ describe('SegmentAnalytics', () => {
             id: () => undefined,
         }
         const legacyUserId: string | undefined = legacyUser.id()
-        const getLegacyRegisterResult = (analytics: SegmentAnalytics): Promise<void> =>
-            analytics.register({} as SegmentPlugin)
+        const getLegacyRegisterResult = (analytics: SegmentAnalytics, integration: SegmentPlugin): Promise<void> =>
+            analytics.register(integration)
 
         expect(legacyUserId).toBeUndefined()
         expect(getLegacyRegisterResult).toEqual(expect.any(Function))

--- a/packages/types/src/__tests__/segment.spec.ts
+++ b/packages/types/src/__tests__/segment.spec.ts
@@ -1,0 +1,58 @@
+import * as ts from 'typescript'
+
+import type { SegmentAnalytics, SegmentPlugin } from '../segment'
+
+type SegmentId = string | null | undefined
+
+type AnalyticsNextUser = {
+    anonymousId(id?: SegmentId): SegmentId
+    id(id?: SegmentId): SegmentId
+}
+
+// Relevant public shape shared by @segment/analytics-next 1.8.0 through 1.84.1.
+type AnalyticsNextSnippet = {
+    user(): AnalyticsNextUser
+    register(...plugins: unknown[]): Promise<unknown>
+}
+
+type AnalyticsNextBrowser = {
+    user(): Promise<AnalyticsNextUser>
+    register(...plugins: unknown[]): Promise<unknown>
+}
+
+// Preserve the narrower contract accepted by previous posthog-js versions.
+type LegacySegmentAnalytics = {
+    user(): {
+        anonymousId(): string | undefined
+        id(): string | undefined
+    }
+    register(integration: SegmentPlugin): Promise<void>
+}
+
+const acceptsSegmentAnalytics = (analytics: SegmentAnalytics): void => {
+    void analytics
+}
+
+describe('SegmentAnalytics', () => {
+    it('accepts current and legacy Segment SDK shapes', () => {
+        acceptsSegmentAnalytics({} as AnalyticsNextSnippet)
+        acceptsSegmentAnalytics({} as AnalyticsNextBrowser)
+        acceptsSegmentAnalytics({} as LegacySegmentAnalytics)
+
+        const program = ts.createProgram([__filename], {
+            module: ts.ModuleKind.CommonJS,
+            moduleResolution: ts.ModuleResolutionKind.Node10,
+            noEmit: true,
+            skipLibCheck: true,
+            strict: true,
+            target: ts.ScriptTarget.ES2022,
+            types: ['jest', 'node'],
+        })
+        const errors = ts
+            .getPreEmitDiagnostics(program)
+            .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)
+            .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+
+        expect(errors).toEqual([])
+    })
+})

--- a/packages/types/src/__tests__/segment.spec.ts
+++ b/packages/types/src/__tests__/segment.spec.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript'
 
-import type { SegmentAnalytics, SegmentPlugin } from '../segment'
+import type { SegmentAnalytics, SegmentPlugin, SegmentUser } from '../segment'
 
 type SegmentId = string | null | undefined
 
@@ -9,15 +9,24 @@ type AnalyticsNextUser = {
     id(id?: SegmentId): SegmentId
 }
 
+type AnalyticsNextPlugin = {
+    name: string
+    type: 'before' | 'after' | 'destination' | 'enrichment' | 'utility'
+}
+
+type AnalyticsNextContext = {
+    event: Record<string, unknown>
+}
+
 // Relevant public shape shared by @segment/analytics-next 1.8.0 through 1.84.1.
 type AnalyticsNextSnippet = {
     user(): AnalyticsNextUser
-    register(...plugins: unknown[]): Promise<unknown>
+    register(...plugins: AnalyticsNextPlugin[]): Promise<AnalyticsNextContext>
 }
 
 type AnalyticsNextBrowser = {
     user(): Promise<AnalyticsNextUser>
-    register(...plugins: unknown[]): Promise<unknown>
+    register(...plugins: AnalyticsNextPlugin[]): Promise<AnalyticsNextContext>
 }
 
 // Preserve the narrower contract accepted by previous posthog-js versions.
@@ -38,6 +47,17 @@ describe('SegmentAnalytics', () => {
         acceptsSegmentAnalytics({} as AnalyticsNextSnippet)
         acceptsSegmentAnalytics({} as AnalyticsNextBrowser)
         acceptsSegmentAnalytics({} as LegacySegmentAnalytics)
+
+        const legacyUser: SegmentUser = {
+            anonymousId: () => undefined,
+            id: () => undefined,
+        }
+        const legacyUserId: string | undefined = legacyUser.id()
+        const getLegacyRegisterResult = (analytics: SegmentAnalytics): Promise<void> =>
+            analytics.register({} as SegmentPlugin)
+
+        expect(legacyUserId).toBeUndefined()
+        expect(getLegacyRegisterResult).toEqual(expect.any(Function))
 
         const program = ts.createProgram([__filename], {
             module: ts.ModuleKind.CommonJS,

--- a/packages/types/src/segment.ts
+++ b/packages/types/src/segment.ts
@@ -6,8 +6,8 @@
  * Segment user object
  */
 export type SegmentUser = {
-    anonymousId(): string | undefined
-    id(): string | undefined
+    anonymousId(): string | null | undefined
+    id(): string | null | undefined
 }
 
 /**
@@ -15,7 +15,7 @@ export type SegmentUser = {
  */
 export type SegmentAnalytics = {
     user: () => SegmentUser | Promise<SegmentUser>
-    register: (integration: SegmentPlugin) => Promise<void>
+    register: (integration: any) => Promise<any>
 }
 
 /**

--- a/packages/types/src/segment.ts
+++ b/packages/types/src/segment.ts
@@ -6,6 +6,11 @@
  * Segment user object
  */
 export type SegmentUser = {
+    anonymousId(): string | undefined
+    id(): string | undefined
+}
+
+type SegmentAnalyticsUser = {
     anonymousId(): string | null | undefined
     id(): string | null | undefined
 }
@@ -14,7 +19,11 @@ export type SegmentUser = {
  * Segment analytics object used for integration with PostHog
  */
 export type SegmentAnalytics = {
-    user: () => SegmentUser | Promise<SegmentUser>
+    user: () => SegmentAnalyticsUser | Promise<SegmentAnalyticsUser>
+    /**
+     * Segment SDK versions use different plugin and resolved value types. `any` keeps current SDK types assignable
+     * without breaking legacy consumers that expect `Promise<void>`.
+     */
     register: (integration: any) => Promise<any>
 }
 


### PR DESCRIPTION
## Problem

Passing an `AnalyticsSnippet` from recent `@segment/analytics-next` versions to `posthog.init({ segment })` fails TypeScript validation. Segment user IDs can be `null`, and its `register` method returns a context instead of `void`.

Fixes #1683.

## Changes

- Accept nullable Segment user IDs in the config-facing integration type without changing the exported `SegmentUser` contract.
- Accept the `register` signatures used by current and older Segment SDK versions while preserving the legacy `Promise<void>` result contract.
- Use the broader config-facing user type inside the browser integration.
- Add compile-time coverage for constrained Segment plugins, synchronous snippets, asynchronous browser instances, and previous PostHog Segment contracts.
- Add patch changesets for `posthog-js` and `@posthog/types`.

The compatibility check also passed against published `@segment/analytics-next` versions 1.8.0, 1.20.0, and 1.84.1.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The public type remains structural, so Segment does not become a dependency of `@posthog/types`. The exported `SegmentUser` and legacy `Promise<void>` result remain unchanged while the config-facing shape accepts current Segment types. Compatibility was checked against the oldest published Analytics Next release, an intermediate release, and the current release. Pi autoreview reported no actionable findings.
