### PR TITLE
fix(surveys): stop Chrome renderer crash (grey tab) on survey close

### DIFF
--- a/.changeset/survey-view-transition-crash.md
+++ b/.changeset/survey-view-transition-crash.md
@@ -1,0 +1,9 @@
+---
+'posthog-js': patch
+---
+
+Fix a Chrome renderer crash (grey "Aw, Snap" tab) that could occur when closing an in-app survey.
+
+The survey close path wrapped the survey container's DOM removal in `document.startViewTransition`. Removing the element inside the transition callback left the captured snapshot pointing at a removed node, which on heavy SPAs triggered a Chromium renderer crash and took down the whole tab.
+
+The close path now only animates a fade-out inside the transition and lets React tear the container down once the transition settles. It also guards against overlapping transitions (a second close while one is animating) and always settles the popup state if the transition is skipped or interrupted, so the survey can never be left visible with a stale reference.

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -262,6 +262,199 @@ describe('usePopupVisibility', () => {
     })
 })
 
+describe('usePopupVisibility view-transition close path', () => {
+    const mockSurvey: Survey = {
+        id: 'testSurvey1',
+        name: 'Test survey 1',
+        description: 'Test survey description 1',
+        type: SurveyType.Popover,
+        linked_flag_key: null,
+        targeting_flag_key: null,
+        internal_targeting_flag_key: null,
+        questions: [
+            {
+                question: 'How satisfied are you with our newest product?',
+                description: 'This is a question description',
+                descriptionContentType: 'text',
+                type: SurveyQuestionType.Rating,
+                display: 'number',
+                scale: 10,
+                lowerBoundLabel: 'Not Satisfied',
+                upperBoundLabel: 'Very Satisfied',
+                id: 'question-a',
+            },
+        ],
+        appearance: {},
+        conditions: null,
+        start_date: '2021-01-01T00:00:00.000Z',
+        end_date: null,
+        current_iteration: null,
+        current_iteration_start_date: null,
+        feature_flag_keys: null,
+    }
+    const mockPostHog = createMockPostHog({
+        getActiveMatchingSurveys: jest.fn().mockImplementation((callback) => callback([mockSurvey])),
+        get_session_replay_url: jest.fn(),
+        capture: jest.fn().mockImplementation((eventName) => eventName),
+    })
+    const removeSurvey = jest.fn()
+
+    // Installs a controllable mock for document.startViewTransition. Returns
+    // helpers to resolve/reject the transition.finished promise so tests can
+    // drive the async settle path deterministically.
+    const installViewTransitionMock = () => {
+        let resolveFinished: () => void
+        let rejectFinished: (reason?: any) => void
+        const finished = new Promise<void>((resolve, reject) => {
+            resolveFinished = resolve
+            rejectFinished = reject
+        })
+        const updateCallback = jest.fn()
+        const skipTransition = jest.fn()
+        const startViewTransition = jest.fn((cb: () => void) => {
+            // Mimic the browser: run the update callback synchronously.
+            cb()
+            return { finished, updateCallbackDone: finished, ready: Promise.resolve(), skipTransition }
+        })
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            writable: true,
+            value: startViewTransition,
+        })
+        return {
+            startViewTransition,
+            updateCallback,
+            skipTransition,
+            // Call the stored resolver, then return a promise that resolves on the
+            // next microtask so callers can `await` inside act() and let the
+            // transition.finished .then(finish) callback flush before asserting.
+            resolve: () => {
+                resolveFinished()
+                return Promise.resolve()
+            },
+            reject: (reason?: any) => {
+                rejectFinished(reason)
+                return Promise.resolve()
+            },
+        }
+    }
+
+    beforeEach(() => {
+        removeSurvey.mockClear()
+    })
+
+    afterAll(() => {
+        // jsdom has no startViewTransition; restore that state.
+        // @ts-expect-error - deleting a property that may have been added by a test
+        delete document.startViewTransition
+    })
+
+    test('hides the popup synchronously when startViewTransition is unavailable', () => {
+        // @ts-expect-error - jsdom does not define startViewTransition
+        delete document.startViewTransition
+        expect(document.startViewTransition).toBeUndefined()
+
+        const { result } = renderHook(() => usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true))
+        expect(result.current.isPopupVisible).toBe(true)
+
+        act(() => {
+            result.current.hidePopupWithViewTransition()
+        })
+
+        expect(result.current.isPopupVisible).toBe(false)
+        expect(removeSurvey).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not remove the survey container inside the transition callback', () => {
+        const vt = installViewTransitionMock()
+        const container = document.createElement('div')
+        document.body.appendChild(container)
+
+        const { result } = renderHook(() =>
+            usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true, {
+                current: container,
+            } as any)
+        )
+
+        act(() => {
+            result.current.hidePopupWithViewTransition()
+        })
+
+        // The transition ran...
+        expect(vt.startViewTransition).toHaveBeenCalledTimes(1)
+        // ...but the callback only faded the container out, it did NOT remove it.
+        expect(container.parentNode).not.toBeNull()
+        expect(container.style.opacity).toBe('0')
+        // And the popup is still "visible" until the transition settles.
+        expect(result.current.isPopupVisible).toBe(true)
+        expect(removeSurvey).not.toHaveBeenCalled()
+
+        // Settling the transition tears the DOM down via the React path.
+        return act(async () => {
+            await vt.resolve()
+        }).then(() => {
+            expect(result.current.isPopupVisible).toBe(false)
+            expect(removeSurvey).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    test('settles the popup state even if the transition is interrupted (finished rejects)', () => {
+        const vt = installViewTransitionMock()
+
+        const { result } = renderHook(() => usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true))
+
+        act(() => {
+            result.current.hidePopupWithViewTransition()
+        })
+        expect(result.current.isPopupVisible).toBe(true)
+
+        // An interrupted/skipped transition rejects transition.finished.
+        return act(async () => {
+            await vt.reject(new Error('transition skipped'))
+        }).then(() => {
+            // The popup must still end up hidden — no stale visible state.
+            expect(result.current.isPopupVisible).toBe(false)
+            expect(removeSurvey).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    test('does not start a second transition on repeated close calls', () => {
+        const vt = installViewTransitionMock()
+        const container = document.createElement('div')
+        document.body.appendChild(container)
+
+        const { result } = renderHook(() =>
+            usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true, {
+                current: container,
+            } as any)
+        )
+
+        act(() => {
+            result.current.hidePopupWithViewTransition()
+            // A second close while the first transition is still animating.
+            result.current.hidePopupWithViewTransition()
+        })
+
+        expect(vt.startViewTransition).toHaveBeenCalledTimes(1)
+    })
+
+    test('falls back to a plain remove if startViewTransition throws', () => {
+        const vt = installViewTransitionMock()
+        vt.startViewTransition.mockImplementation(() => {
+            throw new Error('not allowed in this document state')
+        })
+
+        const { result } = renderHook(() => usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true))
+
+        act(() => {
+            result.current.hidePopupWithViewTransition()
+        })
+
+        expect(result.current.isPopupVisible).toBe(false)
+        expect(removeSurvey).toHaveBeenCalledTimes(1)
+    })
+})
+
 describe('SurveyManager', () => {
     let mockPostHog: PostHog
     let surveyManager: SurveyManager

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1144,6 +1144,12 @@ export function usePopupVisibility(
     )
     const [isSurveySent, setIsSurveySent] = useState(false)
 
+    // Tracks whether a view transition is already in flight so a second close
+    // (e.g. Enter + button click, or a dismiss fired while the thank-you screen
+    // is animating out) doesn't start an overlapping transition. Overlapping
+    // transitions on the same document are a known source of renderer crashes.
+    const isTransitionInFlightRef = useRef(false)
+
     const hidePopupWithViewTransition = () => {
         const removeDOMAndHidePopup = () => {
             if (isPopup) {
@@ -1152,20 +1158,51 @@ export function usePopupVisibility(
             setIsPopupVisible(false)
         }
 
-        if (!document.startViewTransition) {
+        // No View Transitions API (jsdom, older browsers): tear down synchronously.
+        if (typeof document === 'undefined' || !document.startViewTransition) {
             removeDOMAndHidePopup()
             return
         }
 
-        const transition = document.startViewTransition(() => {
-            surveyContainerRef?.current?.remove()
-        })
+        // A transition is already animating the close. Don't start a second one —
+        // overlapping transitions on the same document are themselves a renderer
+        // crash risk. The in-flight transition's `finish` will hide the popup.
+        if (isTransitionInFlightRef.current) {
+            return
+        }
 
-        transition.finished.then(() => {
-            setTimeout(() => {
-                removeDOMAndHidePopup()
-            }, 100)
-        })
+        isTransitionInFlightRef.current = true
+
+        const finish = () => {
+            isTransitionInFlightRef.current = false
+            removeDOMAndHidePopup()
+        }
+
+        try {
+            // The transition callback only animates the fade-out of the survey
+            // container. It must NOT own the DOM teardown — removing the element
+            // inside the callback (the previous behaviour) is what triggered a
+            // Chromium renderer crash (grey "Aw, Snap" tab) on heavy SPAs, because
+            // the transition's captured snapshot ended up pointing at a removed
+            // node. React unmounts the container via setIsPopupVisible(false) +
+            // removeSurveyFromFocus once the transition settles.
+            const transition = document.startViewTransition(() => {
+                if (surveyContainerRef?.current) {
+                    surveyContainerRef.current.style.opacity = '0'
+                }
+            })
+
+            // `transition.finished` rejects if the transition is skipped or
+            // interrupted (e.g. tab backgrounded, reduced motion, another transition
+            // supersedes it). Always settle the state so the popup is never left
+            // visible with a stale ref.
+            transition.finished.then(finish, finish)
+        } catch (error) {
+            // startViewTransition can throw if the document is not in a state that
+            // allows a transition (e.g. during unload). Fall back to a plain remove.
+            logger.warn('View transition failed, removing survey without animation:', error)
+            finish()
+        }
     }
 
     const handleSurveyClosed = (event: CustomEvent) => {


### PR DESCRIPTION
## Problem

Closing an in-app survey could crash the Chrome tab — the whole page went grey ("Aw, Snap") — on heavy SPAs. A JS exception cannot do that; this is a **renderer (tab) crash**, and the trigger was the survey close path.

## Root cause

The close path in `usePopupVisibility` wrapped the survey container's DOM removal inside the View Transitions API:

```js
const transition = document.startViewTransition(() => {
  surveyContainerRef?.current?.remove()
})
transition.finished.then(() => { ... })
```

Removing the element **inside** the transition callback left the transition's captured snapshot pointing at a removed node. On complex pages this triggered a Chromium renderer crash (a known class of view-transition bug — Chromium landed a related fix in Oct 2025, `b83917a`, crashtest `replace-html.html`). The result was a flat grey crashed tab, not a thrown exception — which is why it looked like "the page crashed" rather than a normal survey bug.

## Fix

- The transition callback now only **animates a fade-out** (`opacity: 0`). React tears the container down via `setIsPopupVisible(false)` + `removeSurveyFromFocus` once the transition settles, so the snapshot never points at a removed node.
- **Guard against overlapping transitions** (a second close while one is animating — e.g. Enter + button click), which is itself a renderer crash risk.
- **Always settle the popup state** when `transition.finished` resolves OR rejects (skipped/interrupted transition, e.g. tab backgrounded / reduced motion), so the survey can never be left visible with a stale reference.
- **Fall back to a plain synchronous remove** if `startViewTransition` throws (e.g. during unload).

## Tests

The view-transition close path was previously untested — jsdom has no `startViewTransition`, so only the synchronous fallback path ever ran. Added a `usePopupVisibility view-transition close path` suite with a controllable `startViewTransition` mock:

- container is **not** removed inside the transition callback (only faded), and the popup hides + `removeSurveyFromFocus` runs once the transition settles
- an **interrupted** transition (`finished` rejects) still hides the popup — no stale visible state
- repeated close calls do **not** start a second transition
- `startViewTransition` throwing falls back to a plain remove
- no-API path still tears down synchronously (unchanged behaviour)

All 236 survey tests pass; prettier + eslint clean.

## Notes

- This is a real-world crash reported against the PostHog app page itself (a heavy SPA), reproduced on close.
- Behaviour is unchanged for browsers without the View Transitions API and in jsdom.
- Includes a changeset (`posthog-js: patch`).