### PR TITLE
fix(replay): treat undated persisted recording configs as stale in core

### DIFF
--- a/.changeset/replay-undated-persisted-config-stale.md
+++ b/.changeset/replay-undated-persisted-config-stale.md
@@ -1,0 +1,9 @@
+---
+'posthog-js': patch
+---
+
+Fix session recording starting from arbitrarily old persisted configs.
+
+Recording configs persisted by SDK versions before 1.347.2 carry no `cache_timestamp`. The core freshness check treated these undated configs as always fresh, so the recorder started immediately under their settings. A device whose stored config predated a customer's config change kept recording under the old triggers, sample rate, and masking settings indefinitely.
+
+The core now treats undated persisted configs as stale. Recording waits for a fresh remote config before it starts, the same path every dated config older than one hour already takes. The lazy recorder bundle is unchanged: it still accepts undated configs, because old cores that load the latest bundle cannot recover from a rejected config (INC-749).

--- a/packages/browser/src/__tests__/extensions/replay/sessionRecording-onRemoteConfig.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/sessionRecording-onRemoteConfig.test.ts
@@ -508,6 +508,23 @@ describe('SessionRecording', () => {
             expect(sessionRecording.status).toBe('awaiting_config')
         })
 
+        it('awaits config when config fetch fails and persisted config has no cache_timestamp', () => {
+            // configs persisted by pre-cache_timestamp SDK versions can be arbitrarily old,
+            // so they must not start recording under their stale trigger/sampling settings
+            posthog.persistence?.register({
+                [SESSION_RECORDING_REMOTE_CONFIG]: {
+                    enabled: true,
+                    endpoint: '/s/',
+                },
+            })
+
+            // Remote config fetch fails
+            sessionRecording.onRemoteConfig(makeFlagsResponse({}))
+
+            expect(loadScriptMock).toHaveBeenCalled()
+            expect(sessionRecording.status).toBe('awaiting_config')
+        })
+
         it('transitions to missing_config when config refresh fails', () => {
             posthog.persistence?.register({
                 [SESSION_RECORDING_REMOTE_CONFIG]: {

--- a/packages/browser/src/extensions/replay/session-recording.ts
+++ b/packages/browser/src/extensions/replay/session-recording.ts
@@ -324,10 +324,13 @@ export class SessionRecording implements Extension {
             logger.warn('persisted remote config for session recording is invalid and will be ignored', e)
             return false
         }
-        // default to now so that configs persisted by older SDK versions
-        // (which never set cache_timestamp) are treated as fresh
-        const cacheTimestamp = config.cache_timestamp ?? Date.now()
-        return Date.now() - cacheTimestamp <= RECORDING_REMOTE_CONFIG_TTL_MS
+        // configs persisted by SDK versions that predate cache_timestamp have unknown age.
+        // Treat them as stale so recording waits for a fresh config instead of starting
+        // under arbitrarily old trigger/sampling settings.
+        if (isNullish(config.cache_timestamp)) {
+            return false
+        }
+        return Date.now() - config.cache_timestamp <= RECORDING_REMOTE_CONFIG_TTL_MS
     }
 
     private _onScriptLoaded(startReason?: SessionStartReason) {


### PR DESCRIPTION
## Problem

- Customers who change their recording config keep getting recordings under the old settings, from returning devices, for months.
- Configs persisted by SDKs before 1.347.2 have no `cache_timestamp`.
- The core freshness check treats these undated configs as always fresh (`cache_timestamp ?? Date.now()`).
- The recorder then starts immediately under the undated config's triggers, sample rate, and masking settings.
- Field data from one affected customer: 2,504 devices in 14 days started recordings from configs up to 10 months old. 16% of the devices repeated, because short visits never persist a fresh config.
- Validation: 100% of the affected devices ran a pre-1.347 SDK in their history. Zero affected devices were created after the customer's fleet moved to a timestamp-writing SDK.

## Changes

- The core freshness check now treats a persisted config without `cache_timestamp` as stale.
- Stale configs take the existing awaiting-config path: recording waits for a fresh remote config, then starts. Every dated config older than one hour already takes this path on each return visit.
- The lazy recorder bundle is unchanged, on purpose. Old cores load the latest bundle from the CDN and cannot recover from a rejected config. Rejecting undated configs in the bundle re-creates INC-749 (Mar 2026, fleet-wide recording loss). The `replay-incident-risk` check flagged this. The first draft changed the bundle; I reverted that part.

> [!NOTE]
> This change can move recording volume down fleet-wide. Devices with undated persistence wait one flags round-trip before recording, once each, and stop recording under obsolete permissive configs. Watch the recordings week-over-week anomaly alert for a day after release.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session, driven by Kim Dugan (support engineering). Root-caused a customer report: recordings started under a recording config the customer replaced weeks earlier.
- The investigation ruled out the server side. Postgres, Redis, S3, and the CDN all served the correct config. Live client debug feeds showed the recorder starting from an undated persisted config in localStorage.
- Device-cohort queries validated the cause from two directions: version history (100% of affected devices ran a pre-1.347 SDK) and device creation dates (zero affected devices created after the fleet moved to a timestamp-writing SDK).
- Skills invoked: writing-pr-descriptions, replay-incident-risk. The incident check matched the first draft against INC-749 (lazy bundle rejecting persisted config from old cores). I reverted the lazy-bundle change and kept the core-only fix.
- Tests: 18 replay unit suites pass (879 tests). Not run: `pnpm typecheck` and `pnpm lint` — both fail identically on origin/main in this environment (stale vendor artifact, plugin resolution).