### PR TITLE
fix(node): resolve shutdown timeouts without rejecting

### DIFF
--- a/.changeset/calm-timers-resolve.md
+++ b/.changeset/calm-timers-resolve.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-node': patch
+---
+
+Log shutdown timeouts without rejecting, and correct the Node.js `shutdown()` return type to `Promise<void>`.

--- a/packages/core/src/__tests__/posthog.shutdown.spec.ts
+++ b/packages/core/src/__tests__/posthog.shutdown.spec.ts
@@ -22,19 +22,17 @@ describe('PostHog Core', () => {
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
     })
 
-    it('respects timeout', async () => {
+    it('logs and resolves when shutdown times out', async () => {
       mocks.fetch.mockImplementation(() => new Promise(() => {}))
+      const criticalSpy = jest.spyOn((posthog as any)._logger, 'critical').mockImplementation(() => {})
 
       posthog.capture('test-event')
 
-      await posthog
-        .shutdown(100)
-        .then(() => {
-          throw new Error('Should not resolve')
-        })
-        .catch((e) => {
-          expect(e).toEqual('Timeout while shutting down PostHog. Some events may not have been sent.')
-        })
+      await expect(posthog.shutdown(100)).resolves.toBeUndefined()
+      expect(criticalSpy).toHaveBeenCalledWith(
+        'Timeout while shutting down PostHog. Some events may not have been sent.',
+        { shutdownTimeoutMs: 100 }
+      )
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
     })
 

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -1910,9 +1910,10 @@ export abstract class PostHogCoreStateless {
     }
 
     return raceWithTimeout(doShutdown(), shutdownTimeoutMs, () => {
-      this._logger.error('Timed out while shutting down PostHog')
+      this._logger.critical('Timeout while shutting down PostHog. Some events may not have been sent.', {
+        shutdownTimeoutMs,
+      })
       hasTimedOut = true
-      throw 'Timeout while shutting down PostHog. Some events may not have been sent.'
     })
   }
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -755,7 +755,7 @@ export interface IPostHog {
    *
    * @param shutdownTimeoutMs The shutdown timeout, in milliseconds. Defaults to 30000 (30s).
    */
-  shutdown(shutdownTimeoutMs?: number): void
+  shutdown(shutdownTimeoutMs?: number): Promise<void>
 
   /**
    * @description Waits for local evaluation to be ready, with an optional timeout.


### PR DESCRIPTION
## Problem

A shutdown timeout currently rejects with a bare string. If the caller does not handle the returned promise, Node treats that rejection as unhandled and can terminate the process. PR #4439 improves the rejection value, but an unhandled `Error` rejection can still terminate Node.

Shutdown is a best-effort cleanup boundary. Losing queued analytics events should be reported, but it should not crash the application that is shutting down.

## Changes

- Resolve `shutdown()` after its timeout instead of rejecting.
- Always log a critical diagnostic with the configured timeout and warn that some events may not have been sent.
- Correct `IPostHog.shutdown()` to return `Promise<void>`, matching the implementation and the shared PostHog interface.
- Add regression coverage for both the resolved promise and the diagnostic.

This supersedes #4439.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The implementation was prepared with Pi and reviewed with Pi autoreview. We chose to treat shutdown timeout as a logged cleanup failure instead of converting the rejected string to a rejected `Error`, because either rejection can terminate Node when the promise is left unhandled.
