### PR TITLE
fix(mcp): preserve the tools/list response envelope

### DIFF
--- a/.changeset/mcp-tools-list-envelope.md
+++ b/.changeset/mcp-tools-list-envelope.md
@@ -1,0 +1,7 @@
+---
+'@posthog/mcp': patch
+---
+
+Preserve the `tools/list` response envelope, so instrumenting a paginated tool catalogue no longer hides its later pages.
+
+The listing wrapper rebuilt the response as `{ tools }`, discarding every other field the application's handler had set — on both SDK majors. Most visibly `nextCursor`: a client stops enumerating when the cursor is absent, so tools on later pages became undiscoverable the moment `instrument()` was applied, with no error on either side. The wrapper now spreads the response and replaces only `tools`, which also preserves the 2026-07-28 caching directives `ttlMs` / `cacheScope` and result `_meta`. `$mcp_tools_list` captures the response as sent, envelope included.

--- a/packages/mcp/src/__tests__/tools-list-envelope.test.ts
+++ b/packages/mcp/src/__tests__/tools-list-envelope.test.ts
@@ -1,0 +1,230 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import {
+  CallToolRequestSchema,
+  CallToolResultSchema,
+  ListToolsRequestSchema,
+  ListToolsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js'
+import { instrument } from '../index'
+import { MCPAnalyticsEventType } from '../extensions/event-types'
+import { EventCapture, fakePostHog } from './test-utils'
+
+/**
+ * `tools/list` responses must reach the wire as the application built them.
+ * Rebuilding them as `{ tools }` drops `nextCursor`, so a paginated catalogue's
+ * later pages become unreachable the moment `instrument()` is applied — the SDK
+ * removing behaviour the customer's server produced.
+ */
+
+const PAGE_ONE = [{ name: 'page_one_tool', description: 'On page one', inputSchema: { type: 'object' as const } }]
+const PAGE_TWO = [{ name: 'page_two_tool', description: 'On page two', inputSchema: { type: 'object' as const } }]
+
+/** A paginated catalogue: page one advertises a cursor, page two ends the enumeration. */
+function setupPaginatedServer(listResponses?: { firstPage?: Record<string, unknown> }) {
+  const server = new Server({ name: 'paginated test', version: '1.0.0' }, { capabilities: { tools: {} } })
+
+  server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+    if (request.params?.cursor === 'page-2') {
+      return { tools: PAGE_TWO }
+    }
+    return listResponses?.firstPage ?? { tools: PAGE_ONE, nextCursor: 'page-2' }
+  })
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => ({
+    content: [{ type: 'text' as const, text: `called: ${request.params?.name}` }],
+  }))
+
+  const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: {} })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+  return {
+    server,
+    client,
+    async connect() {
+      await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+    },
+    async cleanup() {
+      await clientTransport.close?.()
+      await serverTransport.close?.()
+    },
+  }
+}
+
+describe('tools/list response envelope', () => {
+  let eventCapture: EventCapture
+
+  beforeEach(async () => {
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+  })
+
+  afterEach(async () => {
+    await eventCapture.stop()
+  })
+
+  it('keeps nextCursor, so the client can reach page two through an instrumented server', async () => {
+    const { server, client, connect, cleanup } = await setupPaginatedServer()
+    try {
+      instrument(server, fakePostHog(), { reportMissing: false })
+      await connect()
+
+      const firstPage = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+      expect(firstPage.nextCursor).toBe('page-2')
+
+      const secondPage = await client.request(
+        { method: 'tools/list', params: { cursor: firstPage.nextCursor } },
+        ListToolsResultSchema
+      )
+      expect(secondPage.tools.map((tool) => tool.name)).toEqual(['page_two_tool'])
+      expect(secondPage.nextCursor).toBeUndefined()
+
+      // Enumeration is only worth anything if the tools it reaches are callable.
+      const result = await client.request(
+        { method: 'tools/call', params: { name: 'page_two_tool', arguments: { context: 'reaching page two' } } },
+        CallToolResultSchema
+      )
+      expect((result.content as { text: string }[])[0].text).toBe('called: page_two_tool')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('keeps the 2026-07-28 cache directives and result _meta', async () => {
+    const { server, client, connect, cleanup } = await setupPaginatedServer({
+      firstPage: {
+        tools: PAGE_ONE,
+        nextCursor: 'page-2',
+        ttlMs: 60_000,
+        cacheScope: 'public',
+        _meta: { 'io.modelcontextprotocol/custom': { keep: true } },
+      },
+    })
+    try {
+      instrument(server, fakePostHog(), { reportMissing: false })
+      await connect()
+
+      const page = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+
+      expect(page.ttlMs).toBe(60_000)
+      expect(page.cacheScope).toBe('public')
+      expect(page._meta).toEqual({ 'io.modelcontextprotocol/custom': { keep: true } })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('still injects the analytics parameters into the tools it passes through', async () => {
+    const { server, client, connect, cleanup } = await setupPaginatedServer()
+    try {
+      instrument(server, fakePostHog(), { reportMissing: false, enableConversationId: true })
+      await connect()
+
+      const page = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+
+      expect(page.nextCursor).toBe('page-2')
+      expect(page.tools[0].inputSchema.properties?.context).toBeDefined()
+      expect(page.tools[0].inputSchema.properties?.conversation_id).toBeDefined()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('keeps the envelope on an empty page, which is the exit point that captures an error', async () => {
+    const { server, client, connect, cleanup } = await setupPaginatedServer({
+      firstPage: { tools: [], nextCursor: 'page-2' },
+    })
+    try {
+      instrument(server, fakePostHog(), { reportMissing: false })
+      await connect()
+
+      const page = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+
+      expect(page.tools).toEqual([])
+      expect(page.nextCursor).toBe('page-2')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  /**
+   * A real paginated catalogue, not a two-tool stand-in: 100 tools over two pages.
+   * The oversized row pushes `$mcp_response` past the 100KB event cap, so it pins
+   * that the truncation ladder sheds tool contents and keeps the envelope — the
+   * pagination facts have to survive on exactly the large catalogues that need them.
+   */
+  it.each([
+    ['a realistic catalogue', 300],
+    ['a catalogue past the 100KB event cap', 4000],
+  ])('paginates 100 tools over two pages — %s', async (_label, descriptionChars) => {
+    const page = (offset: number) =>
+      Array.from({ length: 50 }, (_, i) => ({
+        name: `tool_${offset + i}`,
+        description: 'x'.repeat(descriptionChars),
+        inputSchema: { type: 'object' as const, properties: { alpha: { type: 'string' } } },
+      }))
+
+    const server = new Server({ name: 'big catalogue', version: '1.0.0' }, { capabilities: { tools: {} } })
+    server.setRequestHandler(ListToolsRequestSchema, async (request) =>
+      request.params?.cursor === 'page-2'
+        ? { tools: page(50) }
+        : { tools: page(0), nextCursor: 'page-2', ttlMs: 60_000, cacheScope: 'public' }
+    )
+    instrument(server, fakePostHog(), { reportMissing: false })
+
+    const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: {} })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+    try {
+      const firstPage = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+      const secondPage = await client.request(
+        { method: 'tools/list', params: { cursor: firstPage.nextCursor } },
+        ListToolsResultSchema
+      )
+
+      expect(firstPage.tools).toHaveLength(50)
+      expect(firstPage.nextCursor).toBe('page-2')
+      expect(secondPage.tools.at(-1)?.name).toBe('tool_99')
+      // Every tool on every page, which a single-tool page cannot distinguish.
+      expect(firstPage.tools.every((tool) => tool.inputSchema.properties?.context)).toBe(true)
+      expect(secondPage.tools.every((tool) => tool.inputSchema.properties?.context)).toBe(true)
+
+      const event = eventCapture.findEventByType(MCPAnalyticsEventType.mcpToolsList)
+      const response = event?.response as { nextCursor?: string; ttlMs?: number; cacheScope?: string }
+      expect(response.nextCursor).toBe('page-2')
+      expect(response.ttlMs).toBe(60_000)
+      expect(response.cacheScope).toBe('public')
+      expect(event?.listedToolNames).toHaveLength(50)
+    } finally {
+      await clientTransport.close?.()
+      await serverTransport.close?.()
+    }
+  })
+
+  it('captures the response as sent, envelope included', async () => {
+    const { server, client, connect, cleanup } = await setupPaginatedServer({
+      firstPage: { tools: PAGE_ONE, nextCursor: 'page-2', ttlMs: 60_000, cacheScope: 'public' },
+    })
+    try {
+      instrument(server, fakePostHog(), { reportMissing: false })
+      await connect()
+
+      await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+
+      const event = eventCapture.findEventByType(MCPAnalyticsEventType.mcpToolsList)
+      const response = event?.response as {
+        tools: unknown[]
+        nextCursor?: string
+        ttlMs?: number
+        cacheScope?: string
+      }
+      expect(response.nextCursor).toBe('page-2')
+      expect(response.ttlMs).toBe(60_000)
+      expect(response.cacheScope).toBe('public')
+      expect(response.tools).toHaveLength(1)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -530,7 +530,7 @@ export async function handleListToolsRequest(
   request: MCPRequestLike,
   extra: CompatibleRequestHandlerExtra | undefined,
   logger: LoggerFn
-): Promise<{ tools: CompatibleToolsListLike['tools'] }> {
+): Promise<CompatibleToolsListLike> {
   const data = getServerTrackingData(server)
   const startTime = new Date()
   const sessionId = getSessionId(server, extra)
@@ -550,7 +550,7 @@ export async function handleListToolsRequest(
     await applyResolvedMetadata(event, data, request, extra)
   }
 
-  const tools = await getTracedToolsList(
+  const response = await getTracedToolsList(
     server,
     originalListToolsHandler,
     request,
@@ -559,12 +559,13 @@ export async function handleListToolsRequest(
     logger,
     requestAttribution
   )
+  const tools = response.tools
 
   if (!data) {
     logger(
       'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called instrument(server, options) before using tool calls.'
     )
-    return { tools }
+    return response
   }
 
   if (tools.length === 0) {
@@ -575,15 +576,15 @@ export async function handleListToolsRequest(
     event.isError = true
     event.duration = Date.now() - startTime.getTime()
     captureEvent(server, event, data.logger, requestAttribution)
-    return { tools }
+    return response
   }
 
-  event.response = { tools }
+  event.response = response
   event.listedToolNames = collectListedToolNames(tools)
   event.isError = false
   event.duration = Date.now() - startTime.getTime()
   captureEvent(server, event, data.logger, requestAttribution)
-  return { tools }
+  return response
 }
 
 function cacheToolAnalyticsParameterOwnership(
@@ -614,7 +615,7 @@ async function getTracedToolsList(
   event: McpEvent,
   logger: LoggerFn,
   requestAttribution: SessionInfo
-): Promise<CompatibleToolsListLike['tools']> {
+): Promise<CompatibleToolsListLike> {
   try {
     const data = getServerTrackingData(server)
     const originalResponse = (await originalListToolsHandler(request, extra)) as CompatibleToolsListLike
@@ -656,7 +657,8 @@ async function getTracedToolsList(
       cacheToolCategories(data.toolCategories, tools)
     }
 
-    return tools
+    // Spread, never enumerate — fields later revisions add survive by default.
+    return { ...originalResponse, tools }
   } catch (error) {
     logger(
       `Warning: Original list tools handler failed, this suggests an error PostHog MCP analytics did not cause - ${error}`


### PR DESCRIPTION
## The issue

`handleListToolsRequest` injects the analytics parameters into the advertised schemas, and returned a freshly built `{ tools }` — discarding every other field the application's handler had set.

Most visibly `nextCursor`. A client stops enumerating `tools/list` when the cursor is absent, so a paginated catalogue advertised page one and **every tool on a later page became undiscoverable the moment `instrument()` was applied**, with no error on either side. `ttlMs` / `cacheScope` and result `_meta` were dropped the same way.

## The fix

```ts
return { ...originalResponse, tools }
```

Spread rather than enumerate, so fields later revisions add survive by default. `getTracedToolsList` now returns the whole response and all three exit points hand it back. `$mcp_tools_list` captures it as sent, envelope included.

## What we tested

A two-page catalogue served through an instrumented server: the client has to follow the cursor to page two and call a tool that lives there.

| Configuration | Where |
|---|---|
| **SDK v1**, low-level `Server`, in-memory, legacy era | unit tests + testbed |
| **SDK v2**, low-level `Server`, per-request instance, raw JSON-RPC on `2026-07-28` | testbed |
| 100 tools over 2 pages, including past the 100KB event cap | unit tests |

No high-level (`McpServer`) row: both paths share `handleListToolsRequest`, and the high-level built-in handler emits no cursor or envelope fields, so there is nothing to drop. An app that does paginate registers its own handler — the low-level path above. It is still covered as a no-regression check by the harness run.

Both fixtures fail on the parent build, so neither is green by construction:

| | parent | this PR |
|---|---|---|
| pagination probe (testbed) | **2/8** | **8/8** |
| `tools-list-envelope.test.ts` | **0/7** | **7/7** |
| package unit suite | — | **643 passed** |

Full harness re-run clean: dual-era matrix (v1/v2 × high/low × both eras) unchanged, probes 9/9 and 3/3, NestJS acceptance 16/16 (v1) and 35/37 (v2) on both instrument paths. **No v1 row moved.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
