### PR TITLE
fix(mcp): attribute tool calls and handshakes to their own client

### DIFF
--- a/.changeset/mcp-stamp-before-identify.md
+++ b/.changeset/mcp-stamp-before-identify.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': patch
+---
+
+Attribute `$mcp_tool_call` and `$mcp_initialize` to the client that made the request. Both stamped client identity after awaiting the `identify` callback, so a handshake arriving on the same server instance meanwhile could rename the event; `$mcp_initialize` additionally read the previously handshaked client rather than the one in its own request body.

--- a/packages/mcp/src/__tests__/concurrent-attribution.test.ts
+++ b/packages/mcp/src/__tests__/concurrent-attribution.test.ts
@@ -71,6 +71,13 @@ function invokeInitialize(
   return handler(request, extra)
 }
 
+function handshake(name: string, version: string): MCPRequestLike {
+  return {
+    method: 'initialize',
+    params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name, version } },
+  }
+}
+
 function setFakeTransport(server: MCPServerLike, transport: unknown): void {
   ;(server as unknown as { _transport?: unknown })._transport = transport
 }
@@ -177,6 +184,90 @@ describe('concurrent request attribution', () => {
       $mcp_client_name: 'client-b',
       $mcp_client_version: '2.0.0',
       $mcp_protocol_version: '2025-06-18',
+    })
+  })
+
+  it('stamps the calling client before a slow identify lets another handshake replace it', async () => {
+    const identifyCallStarted = deferred()
+    const releaseIdentifyCall = deferred()
+    const server = createServer({
+      identify: async (request) => {
+        if (request.method === 'tools/call') {
+          identifyCallStarted.resolve()
+          await releaseIdentifyCall.promise
+        }
+        return { distinctId: 'user-a' }
+      },
+    })
+
+    // client-a completes the handshake, so `getClientVersion()` — the last link of
+    // the identity chain, and the only one a legacy-era request ever reaches —
+    // answers 'client-a'.
+    await invokeInitialize(server, handshake('client-a', '1.0.0'), { requestInfo: { headers: {} } })
+
+    // A legacy-era call: nothing in `_meta`, no envelope, no protocol header.
+    const callRequest = invokeTool(server, 'A', { requestInfo: { headers: {} } })
+    await identifyCallStarted.promise
+
+    // client-b handshakes on the same instance while the identify callback is still
+    // in flight, replacing what the accessor answers.
+    await invokeInitialize(server, handshake('client-b', '2.0.0'), { requestInfo: { headers: {} } })
+
+    releaseIdentifyCall.resolve()
+    await callRequest
+    await flushCaptures()
+
+    const toolCalls = capture.findCapturesByEvent('$mcp_tool_call')
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0].properties).toMatchObject({
+      $mcp_client_name: 'client-a',
+      $mcp_client_version: '1.0.0',
+    })
+  })
+
+  it('attributes each handshake to the client that sent it, not the one before it', async () => {
+    const server = createServer({})
+
+    await invokeInitialize(server, handshake('client-a', '1.0.0'), { requestInfo: { headers: {} } })
+    await invokeInitialize(server, handshake('client-b', '2.0.0'), { requestInfo: { headers: {} } })
+    await flushCaptures()
+
+    // `getClientVersion()` still names client-a while client-b's handshake is being
+    // instrumented — the SDK only records the new client further downstream — so
+    // the body each request carries has to outrank it.
+    const initializes = capture.findCapturesByEvent('$mcp_initialize')
+    expect(initializes.map((event) => event.properties.$mcp_client_name)).toEqual(['client-a', 'client-b'])
+    expect(initializes.map((event) => event.properties.$mcp_client_version)).toEqual(['1.0.0', '2.0.0'])
+  })
+
+  it('stamps the handshaking client before a slow identify lets another handshake replace it', async () => {
+    const identifyBStarted = deferred()
+    const releaseIdentifyB = deferred()
+    const server = createServer({
+      identify: async (request) => {
+        const clientName = (request.params?.clientInfo as { name?: string } | undefined)?.name
+        if (clientName === 'client-b') {
+          identifyBStarted.resolve()
+          await releaseIdentifyB.promise
+        }
+        return { distinctId: `user-${clientName}` }
+      },
+    })
+
+    await invokeInitialize(server, handshake('client-a', '1.0.0'), { requestInfo: { headers: {} } })
+
+    const initializeB = invokeInitialize(server, handshake('client-b', '2.0.0'), { requestInfo: { headers: {} } })
+    await identifyBStarted.promise
+    await invokeInitialize(server, handshake('client-c', '3.0.0'), { requestInfo: { headers: {} } })
+    releaseIdentifyB.resolve()
+    await initializeB
+    await flushCaptures()
+
+    const initializes = capture.findCapturesByEvent('$mcp_initialize')
+    const captureB = initializes.find((event) => event.distinct_id === 'user-client-b')
+    expect(captureB?.properties).toMatchObject({
+      $mcp_client_name: 'client-b',
+      $mcp_client_version: '2.0.0',
     })
   })
 

--- a/packages/mcp/src/extensions/instrumentation.ts
+++ b/packages/mcp/src/extensions/instrumentation.ts
@@ -225,16 +225,6 @@ async function prepareToolCallEvent(
     // Snapshot token/client/protocol metadata synchronously, before identify or
     // metadata callbacks can yield and let another request replace shared state.
     const sessionInfo = getSessionInfo(server, data, sessionId)
-    const identity = await handleIdentify(
-      server,
-      data,
-      sessionId,
-      request,
-      sessionInfo,
-      extra,
-      !!conversation.conversationId
-    )
-    const requestAttribution = withIdentity(sessionInfo, identity)
 
     const toolName = request.params?.name
     const event: McpEvent = {
@@ -249,11 +239,27 @@ async function prepareToolCallEvent(
     }
     // Modern (stateless) clients carry client name/version + protocol version in
     // `_meta` on every request rather than at `initialize`; stamp them onto this
-    // event now so concurrent requests can't cross-attribute it.
+    // event now so concurrent requests can't cross-attribute it. Stamped before
+    // the identify await below for the same reason the snapshot is: the chain's
+    // last link is the server's own `getClientVersion()`, which a concurrent
+    // `initialize` can replace while an identify callback is in flight — and
+    // `captureEvent` prefers a stamped value over `sessionInfo`, so a late stamp
+    // would win with the wrong client's name.
     stampClientIdentity(event, request, extra, server)
     // Which *surface* of the client made this call lives only in the request
     // headers (HTTP transports); `clientInfo` can't tell a vendor's products apart.
     stampTransportIdentity(event, extra)
+
+    const identity = await handleIdentify(
+      server,
+      data,
+      sessionId,
+      request,
+      sessionInfo,
+      extra,
+      !!conversation.conversationId
+    )
+    const requestAttribution = withIdentity(sessionInfo, identity)
 
     await applyResolvedMetadata(event, data, request, extra)
     setEventIntent(event, await resolveToolCallIntent(data, request, canCaptureContextIntent, extra))
@@ -858,9 +864,6 @@ export async function handleInitializeRequest(
     clientName: initializeClientInfo?.name ?? sessionInfo.clientName,
     clientVersion: initializeClientInfo?.version ?? sessionInfo.clientVersion,
   }
-  const identity = await handleIdentify(server, data, sessionId, request, requestSessionInfo, extra)
-  const requestAttribution = withIdentity(requestSessionInfo, identity)
-
   const event: McpEvent = {
     sessionId,
     resourceName: request.params?.name || 'Unknown Tool Name',
@@ -868,11 +871,29 @@ export async function handleInitializeRequest(
     parameters: buildCapturedMcpParameters(request),
     timestamp: new Date(),
   }
-  // Harmless for a legacy `initialize` (client info rides the body there, and the
-  // negotiated protocol version below overrides any `_meta` one); picks up client
-  // info if a client also sends it in `_meta`.
+  // Picks up client info if a client also sends it in `_meta` (the negotiated
+  // protocol version below overrides any `_meta` one). Stamped before the
+  // identify await for the same reason the snapshot is taken there: the chain's
+  // last link is the server's own `getClientVersion()`, which a concurrent
+  // `initialize` can replace while an identify callback is in flight.
   stampClientIdentity(event, request, extra, server)
+  // A legacy `initialize` carries its client in the request body, which is the
+  // one place the chain does not read. That body is this request's own answer,
+  // so it outranks the accessor — which on a server that already handshaked
+  // still names the *previous* client, because the SDK only records this one
+  // when its handler runs further below. Without this, the second and every
+  // later handshake on a shared instance reports the first client's name, since
+  // `captureEvent` prefers a stamped value over `requestSessionInfo`.
+  if (initializeClientInfo?.name) {
+    event.clientName = initializeClientInfo.name
+  }
+  if (initializeClientInfo?.version) {
+    event.clientVersion = initializeClientInfo.version
+  }
   stampTransportIdentity(event, extra)
+
+  const identity = await handleIdentify(server, data, sessionId, request, requestSessionInfo, extra)
+  const requestAttribution = withIdentity(requestSessionInfo, identity)
 
   await applyResolvedMetadata(event, data, request, extra)
 


### PR DESCRIPTION
Follow-up to #4504, which fixed this ordering on `tools/list` after review. The same window existed on the other two instrumented paths.

`stampClientIdentity` ran *after* `await handleIdentify(...)` in both `prepareToolCallEvent` and `handleInitializeRequest`. The identity chain's last link is the server's own `getClientVersion()`, which a concurrent `initialize` can replace while an identify callback is in flight — and `captureEvent` prefers a stamped value over the pre-await `sessionInfo` snapshot, so a late stamp won with the wrong client's name. Both now stamp before the await, as `tools/list` does.

While testing that, `initialize` turned out to have a second, deterministic version of the same problem: it never read the client out of its own request body, so the stamp fell through to the accessor — which still names the *previously* handshaked client, because the SDK only records the new one when its handler runs further downstream. On a shared server instance, every handshake after the first was reported as the first client. A two-handshake test on `main` captures `[client-a, client-a]`. The request body now outranks the accessor, field by field, the same way `requestSessionInfo` already builds attribution.

Both are attribution-only: no tool ever behaves differently, only what the event says about who called.

## Testing

- Three new cases in `concurrent-attribution.test.ts` — the tool-call race, the initialize race, and the deterministic two-handshake regression. All three fail on `main`.
- Full package suite: 646 passed, 45 suites. No existing case changed.
- Lint and typecheck clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)