### PR TITLE
ci: upgrade PostHog monorepo dependencies after releases

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -101,16 +101,59 @@ jobs:
                           root_package_spec="@posthog/mcp-analytics@npm:@posthog/mcp@${PACKAGE_VERSION}"
                           pnpm update --recursive "$root_package_spec"
                           ;;
+                      posthog-react-native|@posthog/rollup-plugin)
+                          # These packages are used only by the standalone Desktop workspace.
+                          ;;
                       *)
                           pnpm update --recursive "$root_package_spec"
                           ;;
                   esac
 
-                  # Desktop is a standalone workspace with its own lockfile. Exempt only the package
-                  # released by this workflow and its freshly published internal PostHog dependencies.
-                  pnpm --dir products/desktop \
-                      --config.minimum-release-age-exclude="$PACKAGE_NAME posthog-js posthog-js-lite posthog-node @posthog/*" \
-                      update --recursive "$package_spec"
+                  desktop_manifests_updated=$(node <<'NODE'
+                  const { globSync, readFileSync, writeFileSync } = require('node:fs')
+
+                  const packageName = process.env.PACKAGE_NAME
+                  const packageVersion = process.env.PACKAGE_VERSION
+                  let updated = 0
+
+                  for (const manifestPath of globSync('products/desktop/{apps,packages,tooling,tools}/*/package.json')) {
+                      const manifestText = readFileSync(manifestPath, 'utf8')
+                      const manifest = JSON.parse(manifestText)
+                      let updatedText = manifestText
+
+                      for (const section of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
+                          const currentVersion = manifest[section]?.[packageName]
+                          if (!currentVersion) {
+                              continue
+                          }
+
+                          const prefix = currentVersion.startsWith('^') ? '^' : currentVersion.startsWith('~') ? '~' : ''
+                          const nextVersion = `${prefix}${packageVersion}`
+                          updatedText = updatedText.replace(
+                              `${JSON.stringify(packageName)}: ${JSON.stringify(currentVersion)}`,
+                              `${JSON.stringify(packageName)}: ${JSON.stringify(nextVersion)}`
+                          )
+                      }
+
+                      if (updatedText !== manifestText) {
+                          writeFileSync(manifestPath, updatedText)
+                          updated++
+                      }
+                  }
+
+                  process.stdout.write(String(updated))
+                  NODE
+                  )
+
+                  if [ "$desktop_manifests_updated" -gt 0 ]; then
+                      # Desktop is a standalone workspace with its own lockfile. semver@6.3.1 is
+                      # already locked there, but its npm metadata triggers pnpm's trust downgrade
+                      # check whenever the lockfile is regenerated. Keep the check for every other
+                      # dependency while allowing this existing version.
+                      pnpm --dir products/desktop install --no-frozen-lockfile \
+                          --trust-policy-exclude='semver@6.3.1' \
+                          --config.minimum-release-age-exclude="$PACKAGE_NAME posthog-js posthog-js-lite posthog-node @posthog/*"
+                  fi
 
             - name: Generate pull request details
               id: generate-pr-details

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -9,6 +9,12 @@ on:
                 required: true
                 options:
                     - posthog-js
+                    - '@posthog/react'
+                    - posthog-node
+                    - posthog-js-lite
+                    - posthog-react-native
+                    - '@posthog/mcp'
+                    - '@posthog/rollup-plugin'
             package_version:
                 description: 'Package version to upgrade to'
                 required: true
@@ -77,8 +83,34 @@ jobs:
                   PACKAGE_NAME: ${{ github.event.inputs.package_name }}
                   PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
               run: |
-                  sed -i "s|${PACKAGE_NAME}:.*|${PACKAGE_NAME}: ^${PACKAGE_VERSION}|" pnpm-workspace.yaml
-                  pnpm i --no-frozen-lockfile
+                  set -euo pipefail
+
+                  package_spec="${PACKAGE_NAME}@${PACKAGE_VERSION}"
+                  root_package_spec="$package_spec"
+
+                  case "$PACKAGE_NAME" in
+                      posthog-js)
+                          sed -i "s|    posthog-js:.*|    posthog-js: ^${PACKAGE_VERSION}|" pnpm-workspace.yaml
+                          pnpm install --no-frozen-lockfile
+                          ;;
+                      @posthog/react)
+                          sed -i "s|    '@posthog/react':.*|    '@posthog/react': ^${PACKAGE_VERSION}|" pnpm-workspace.yaml
+                          pnpm install --no-frozen-lockfile
+                          ;;
+                      @posthog/mcp)
+                          root_package_spec="@posthog/mcp-analytics@npm:@posthog/mcp@${PACKAGE_VERSION}"
+                          pnpm update --recursive "$root_package_spec"
+                          ;;
+                      *)
+                          pnpm update --recursive "$root_package_spec"
+                          ;;
+                  esac
+
+                  # Desktop is a standalone workspace with its own lockfile. Exempt only the package
+                  # released by this workflow and its freshly published internal PostHog dependencies.
+                  pnpm --dir products/desktop \
+                      --config.minimum-release-age-exclude="$PACKAGE_NAME posthog-js posthog-js-lite posthog-node @posthog/*" \
+                      update --recursive "$package_spec"
 
             - name: Generate pull request details
               id: generate-pr-details

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -413,14 +413,32 @@ jobs:
                   emoji_reaction: 'x'
 
     # Wait for the full publish matrix so newly bumped workspace dependencies are available on npm.
-    # The posthog-js tag points at this release commit only when this run published a new browser SDK version.
+    # A package tag points at this release commit only when this run published that package.
     dispatch-posthog-upgrade:
-        name: Dispatch PostHog upgrade
+        name: Dispatch ${{ matrix.package.name }} upgrade
         needs: [version-bump, publish]
         runs-on: ubuntu-latest
         permissions:
             contents: read
             actions: write
+        strategy:
+            fail-fast: false
+            matrix:
+                package:
+                    - name: posthog-js
+                      path: packages/browser
+                    - name: '@posthog/react'
+                      path: packages/react
+                    - name: posthog-node
+                      path: packages/node
+                    - name: posthog-js-lite
+                      path: packages/web
+                    - name: posthog-react-native
+                      path: packages/react-native
+                    - name: '@posthog/mcp'
+                      path: packages/mcp
+                    - name: '@posthog/rollup-plugin'
+                      path: packages/rollup-plugin
         steps:
             - name: Checkout repository
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -428,16 +446,18 @@ jobs:
                   ref: ${{ needs.version-bump.outputs.commit-hash }}
                   fetch-depth: 1
 
-            - name: Check whether posthog-js was published by this release
+            - name: Check whether ${{ matrix.package.name }} was published by this release
               id: release-metadata
               env:
+                  PACKAGE_NAME: ${{ matrix.package.name }}
+                  PACKAGE_PATH: ${{ matrix.package.path }}
                   RELEASE_SHA: ${{ needs.version-bump.outputs.commit-hash }}
               run: |
                   set -euo pipefail
 
-                  package_version=$(jq -r '.version' packages/browser/package.json)
-                  package_ref="posthog-js@v$package_version"
-                  tag_sha=$(git ls-remote --tags origin "refs/tags/posthog-js@$package_version" | awk 'NR == 1 { print $1 }')
+                  package_version=$(jq -r '.version' "$PACKAGE_PATH/package.json")
+                  package_ref="$PACKAGE_NAME@$package_version"
+                  tag_sha=$(git ls-remote --tags origin "refs/tags/$package_ref" | awk 'NR == 1 { print $1 }')
 
                   was_published=false
                   if [ "$tag_sha" = "$RELEASE_SHA" ]; then
@@ -458,6 +478,7 @@ jobs:
               continue-on-error: true
               if: steps.release-metadata.outputs.was_published == 'true'
               env:
+                  PACKAGE_NAME: ${{ matrix.package.name }}
                   PACKAGE_VERSION: ${{ steps.release-metadata.outputs.package_version }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
@@ -467,7 +488,7 @@ jobs:
                        https://api.github.com/repos/posthog/posthog-js/actions/workflows/posthog-upgrade.yml/dispatches \
                        -d "$(jq -n \
                          --arg ref "main" \
-                         --arg package_name "posthog-js" \
+                         --arg package_name "$PACKAGE_NAME" \
                          --arg package_version "$PACKAGE_VERSION" \
                          '{ref: $ref, inputs: {package_name: $package_name, package_version: $package_version}}' \
                        )"
@@ -488,7 +509,7 @@ jobs:
                         "repository": "${{ github.repository }}",
                         "sdk": "posthog-js",
                         "jobName": "dispatch-posthog-upgrade",
-                        "packageName": "posthog-js",
+                        "packageName": "${{ matrix.package.name }}",
                         "packageVersion": "${{ steps.release-metadata.outputs.package_version || 'unknown' }}",
                         "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                         "failedStepName": "dispatch-posthog-upgrade",


### PR DESCRIPTION
## Problem

The release workflow only opens a downstream dependency upgrade PR for `posthog-js`. Other packages released from this repository and used by `PostHog/posthog` can remain outdated until someone upgrades them manually.

## Changes

- Dispatch the downstream upgrade workflow for `posthog-js`, `@posthog/react`, `posthog-node`, `posthog-js-lite`, `posthog-react-native`, `@posthog/mcp`, and `@posthog/rollup-plugin` when their release tag points at the current release commit.
- Update catalog and direct dependencies in the main PostHog workspace.
- Update matching dependency entries in Desktop package manifests while preserving exact, caret, and tilde version ranges.
- Refresh Desktop's standalone lockfile only when that workspace uses the released package.
- Handle the `@posthog/mcp-analytics` npm alias without changing its dependency structure.
- Keep pnpm's trust policy enabled while allowing Desktop's existing `semver@6.3.1` lock entry.

Each package upgrade path was run locally against a clean `PostHog/posthog` worktree using Node.js 24 and pnpm 10.29.3. All seven commands completed and changed only their expected manifests and lockfiles.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and validated with the Pi coding agent. The original recursive Desktop update failed against a clean checkout because pnpm rechecked an existing trust downgrade. The final approach updates matching manifests first, then regenerates the standalone lockfile with a precise exception for the already-locked dependency while retaining trust checks for everything else.
