### PR TITLE
ci: upgrade React Native plugin in PostHog after releases

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -13,6 +13,7 @@ on:
                     - posthog-node
                     - posthog-js-lite
                     - posthog-react-native
+                    - '@posthog/react-native-plugin'
                     - '@posthog/mcp'
                     - '@posthog/rollup-plugin'
             package_version:
@@ -101,7 +102,7 @@ jobs:
                           root_package_spec="@posthog/mcp-analytics@npm:@posthog/mcp@${PACKAGE_VERSION}"
                           pnpm update --recursive "$root_package_spec"
                           ;;
-                      posthog-react-native|@posthog/rollup-plugin)
+                      posthog-react-native|@posthog/react-native-plugin|@posthog/rollup-plugin)
                           # These packages are used only by the standalone Desktop workspace.
                           ;;
                       *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,6 +435,8 @@ jobs:
                       path: packages/web
                     - name: posthog-react-native
                       path: packages/react-native
+                    - name: '@posthog/react-native-plugin'
+                      path: packages/react-native-plugin
                     - name: '@posthog/mcp'
                       path: packages/mcp
                     - name: '@posthog/rollup-plugin'


### PR DESCRIPTION
## Problem

The release workflow does not start a downstream dependency upgrade when `@posthog/react-native-plugin` is published. The PostHog Desktop mobile app can therefore remain on an older plugin version after a release.

## Changes

- Dispatch the PostHog upgrade workflow when an `@posthog/react-native-plugin` release tag points at the current release commit.
- Add the package to the manual upgrade workflow options.
- Update the package only in Desktop manifests before refreshing Desktop's standalone lockfile.

The workflow files pass YAML parsing and `actionlint`. A clean downstream dry run updated the mobile app from `@posthog/react-native-plugin` 2.3.1 to 2.4.0 and refreshed the matching lockfile entry. Current PostHog master has unrelated pnpm trust downgrade failures, so the local lockfile dry run disabled the trust policy.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The Pi coding agent implemented and validated this follow-up in a dedicated worktree. The change reuses the Desktop-only dependency update path added in the earlier downstream upgrade PR.
