### PR TITLE
ci: Remove auto-merge from PostHog upgrade workflow

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -228,15 +228,6 @@ jobs:
                       --title "$PR_TITLE" \
                       --body "$PR_BODY"
 
-            - name: Enable automerge
-              env:
-                  GH_TOKEN: ${{ steps.upgrader.outputs.token }}
-                  PR_NUMBER: ${{ steps.main-repo-pr.outputs.pull-request-number }}
-              run: |
-                  if [ "$(gh pr view "$PR_NUMBER" --repo PostHog/posthog --json autoMergeRequest --jq '.autoMergeRequest != null')" = "false" ]; then
-                      gh pr merge "$PR_NUMBER" --repo PostHog/posthog --auto --squash
-                  fi
-
             - name: Assign reviewers
               env:
                   GH_TOKEN: ${{ steps.upgrader.outputs.token }}


### PR DESCRIPTION
## Problem

The PostHog upgrade workflow fails after creating or updating the downstream `PostHog/posthog` pull request. It calls `gh pr merge --auto`, but auto-merge is disabled for that repository. The command exits with an error and prevents the workflow from assigning reviewers.

Failed run: https://github.com/PostHog/posthog-js/actions/runs/31726088656/job/94534700762

## Changes

Remove the step that enables auto-merge on the downstream pull request. The workflow can now continue to assign reviewers after it creates or updates the pull request.

Validated the workflow with `actionlint` and a YAML parser.

## Release info Sub-libraries affected

### Libraries affected

No SDK libraries require a version bump.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with the Pi coding agent. We removed the auto-merge step instead of adding a repository capability check because auto-merge is disabled across the organization and the step no longer provides useful behavior. No SDK code or release artifacts changed.
