### PR TITLE
chore(browser): stop publishing dist source maps to npm

### DIFF
--- a/.changeset/no-npm-dist-sourcemaps.md
+++ b/.changeset/no-npm-dist-sourcemaps.md
@@ -1,5 +1,0 @@
----
-'posthog-js': patch
----
-
-Stop publishing the `dist/*.js.map` source maps to npm. They accounted for 28 MB of the package's 43 MB unpacked size and are never loaded at runtime. The maps are still built and still uploaded to the CDN, so snippet users and the `x_google_ignoreList` console attribution are unaffected.

--- a/.changeset/no-npm-dist-sourcemaps.md
+++ b/.changeset/no-npm-dist-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Stop publishing the `dist/*.js.map` source maps to npm. They accounted for 28 MB of the package's 43 MB unpacked size and are never loaded at runtime. The maps are still built and still uploaded to the CDN, so snippet users and the `x_google_ignoreList` console attribution are unaffected.

--- a/.changeset/strip-npm-sourcemap-sources-content.md
+++ b/.changeset/strip-npm-sourcemap-sources-content.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Drop `sourcesContent` from the source maps published to npm. The maps themselves still ship, so downstream source-map chaining and the `//# sourceMappingURL` references are unaffected — only the copy of our TypeScript sources embedded in each map is gone, taking the package from 40.8 MB to 17.4 MB unpacked. CDN artifacts are built separately and keep their inlined sources.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -53,6 +53,7 @@
     "files": [
         "lib/*",
         "dist/*",
+        "!dist/*.map",
         "react/dist/**",
         "react/package.json",
         "react/surveys/package.json",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -17,6 +17,7 @@
         "build": "tsc -b && rollup -c",
         "bundle-size:array": "node scripts/compare-array-bundle-size.mjs",
         "postbuild": "node scripts/strip-lib-package-json.js && node scripts/check-mangled-property-consistency.js && node scripts/check-sourcemap-ignore-list.js",
+        "prepack": "node scripts/strip-sourcemap-sources-content.js",
         "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
         "lint": "eslint src && eslint playwright",
         "lint:fix": "eslint src --fix && eslint playwright --fix",
@@ -53,7 +54,6 @@
     "files": [
         "lib/*",
         "dist/*",
-        "!dist/*.map",
         "react/dist/**",
         "react/package.json",
         "react/surveys/package.json",

--- a/packages/browser/scripts/strip-sourcemap-sources-content.js
+++ b/packages/browser/scripts/strip-sourcemap-sources-content.js
@@ -33,44 +33,60 @@ function findMaps(dir) {
     })
 }
 
-const distDir = path.join(PACKAGE_ROOT, 'dist')
-if (!fs.existsSync(distDir)) {
-    console.error('FAIL: dist/ is missing — run `pnpm build` before packing')
-    process.exit(1)
-}
-
-// Every directory in `files` that carries maps. `react/dist` is npm-only (the S3 upload takes
-// `dist/*.js{,.map}` and nothing else), so it's safe to strip here too.
-const maps = [distDir, path.join(PACKAGE_ROOT, 'lib'), path.join(PACKAGE_ROOT, 'react', 'dist')].flatMap(findMaps)
-
-if (maps.length === 0) {
-    console.warn('warn: no source maps found in dist/, lib/ or react/dist/ — nothing to strip')
-    process.exit(0)
-}
-
-let stripped = 0
-let bytesBefore = 0
-let bytesAfter = 0
-
-for (const mapPath of maps) {
-    const raw = fs.readFileSync(mapPath, 'utf8')
-    const map = JSON.parse(raw)
-    bytesBefore += Buffer.byteLength(raw)
-
-    if (!map.sourcesContent) {
-        bytesAfter += Buffer.byteLength(raw)
-        continue
+function stripSourceMapSourcesContent(packageRoot) {
+    const distDir = path.join(packageRoot, 'dist')
+    if (!fs.existsSync(distDir)) {
+        throw new Error('dist/ is missing — run `pnpm build` before packing')
     }
 
-    delete map.sourcesContent
-    const output = JSON.stringify(map)
-    fs.writeFileSync(mapPath, output)
-    bytesAfter += Buffer.byteLength(output)
-    stripped++
+    // Every directory in `files` that carries maps. `react/dist` is npm-only (the S3 upload takes
+    // `dist/*.js{,.map}` and nothing else), so it's safe to strip here too.
+    const maps = [distDir, path.join(packageRoot, 'lib'), path.join(packageRoot, 'react', 'dist')].flatMap(findMaps)
+
+    if (maps.length === 0) {
+        throw new Error('no source maps found in dist/, lib/ or react/dist/')
+    }
+
+    let stripped = 0
+    let bytesBefore = 0
+    let bytesAfter = 0
+
+    for (const mapPath of maps) {
+        const raw = fs.readFileSync(mapPath, 'utf8')
+        const map = JSON.parse(raw)
+        bytesBefore += Buffer.byteLength(raw)
+
+        if (!map.sourcesContent) {
+            bytesAfter += Buffer.byteLength(raw)
+            continue
+        }
+
+        delete map.sourcesContent
+        const output = JSON.stringify(map)
+        fs.writeFileSync(mapPath, output)
+        bytesAfter += Buffer.byteLength(output)
+        stripped++
+    }
+
+    return { stripped, total: maps.length, bytesBefore, bytesAfter }
 }
 
 const asMb = (bytes) => `${(bytes / 1024 / 1024).toFixed(1)} MB`
 
-console.log(
-    `OK: stripped sourcesContent from ${stripped}/${maps.length} source map(s), ${asMb(bytesBefore)} -> ${asMb(bytesAfter)}`
-)
+function main() {
+    try {
+        const { stripped, total, bytesBefore, bytesAfter } = stripSourceMapSourcesContent(PACKAGE_ROOT)
+        console.log(
+            `OK: stripped sourcesContent from ${stripped}/${total} source map(s), ${asMb(bytesBefore)} -> ${asMb(bytesAfter)}`
+        )
+    } catch (error) {
+        console.error(`FAIL: ${error.message}`)
+        process.exitCode = 1
+    }
+}
+
+if (require.main === module) {
+    main()
+}
+
+module.exports = { stripSourceMapSourcesContent }

--- a/packages/browser/scripts/strip-sourcemap-sources-content.js
+++ b/packages/browser/scripts/strip-sourcemap-sources-content.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * Pre-pack step: drop `sourcesContent` from the source maps we publish to npm.
+ *
+ * The maps have to stay — downstream bundlers chain through them, and dropping them would
+ * leave every `//# sourceMappingURL` dangling. But the inlined copy of our sources is ~3/4 of
+ * their weight and nothing downstream reads it; positions still resolve without it.
+ *
+ * On `prepack` rather than in the build because the CDN artifacts keep their inlined sources —
+ * the release workflow builds those in a separate job (`build-s3-artifacts`), so pack-time
+ * stripping never reaches them.
+ *
+ * Rewrites in place, so a local `pnpm pack` leaves you without inlined sources until you build
+ * again.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..')
+
+function findMaps(dir) {
+    if (!fs.existsSync(dir)) {
+        return []
+    }
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const entryPath = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+            return findMaps(entryPath)
+        }
+        return entry.name.endsWith('.js.map') ? [entryPath] : []
+    })
+}
+
+const distDir = path.join(PACKAGE_ROOT, 'dist')
+if (!fs.existsSync(distDir)) {
+    console.error('FAIL: dist/ is missing — run `pnpm build` before packing')
+    process.exit(1)
+}
+
+// Every directory in `files` that carries maps. `react/dist` is npm-only (the S3 upload takes
+// `dist/*.js{,.map}` and nothing else), so it's safe to strip here too.
+const maps = [distDir, path.join(PACKAGE_ROOT, 'lib'), path.join(PACKAGE_ROOT, 'react', 'dist')].flatMap(findMaps)
+
+if (maps.length === 0) {
+    console.warn('warn: no source maps found in dist/, lib/ or react/dist/ — nothing to strip')
+    process.exit(0)
+}
+
+let stripped = 0
+let bytesBefore = 0
+let bytesAfter = 0
+
+for (const mapPath of maps) {
+    const raw = fs.readFileSync(mapPath, 'utf8')
+    const map = JSON.parse(raw)
+    bytesBefore += Buffer.byteLength(raw)
+
+    if (!map.sourcesContent) {
+        bytesAfter += Buffer.byteLength(raw)
+        continue
+    }
+
+    delete map.sourcesContent
+    const output = JSON.stringify(map)
+    fs.writeFileSync(mapPath, output)
+    bytesAfter += Buffer.byteLength(output)
+    stripped++
+}
+
+const asMb = (bytes) => `${(bytes / 1024 / 1024).toFixed(1)} MB`
+
+console.log(
+    `OK: stripped sourcesContent from ${stripped}/${maps.length} source map(s), ${asMb(bytesBefore)} -> ${asMb(bytesAfter)}`
+)

--- a/packages/browser/src/__tests__/strip-sourcemap-sources-content.test.ts
+++ b/packages/browser/src/__tests__/strip-sourcemap-sources-content.test.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { stripSourceMapSourcesContent } from '../../scripts/strip-sourcemap-sources-content'
+
+describe('stripSourceMapSourcesContent', () => {
+    let packageRoot: string
+
+    beforeEach(() => {
+        packageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-strip-sourcemaps-'))
+        fs.mkdirSync(path.join(packageRoot, 'dist'))
+    })
+
+    afterEach(() => {
+        fs.rmSync(packageRoot, { recursive: true, force: true })
+    })
+
+    it('fails packing when no source maps are present', () => {
+        const scriptsDir = path.join(packageRoot, 'scripts')
+        const scriptPath = path.join(scriptsDir, 'strip-sourcemap-sources-content.js')
+        fs.mkdirSync(scriptsDir)
+        fs.copyFileSync(path.resolve(__dirname, '../../scripts/strip-sourcemap-sources-content.js'), scriptPath)
+
+        const result = spawnSync(process.execPath, [scriptPath], { encoding: 'utf8' })
+
+        expect(result.status).toBe(1)
+        expect(result.stderr).toContain('FAIL: no source maps found in dist/, lib/ or react/dist/')
+    })
+
+    it('retains source maps while removing sourcesContent', () => {
+        const mapPath = path.join(packageRoot, 'dist', 'main.js.map')
+        fs.writeFileSync(
+            mapPath,
+            JSON.stringify({
+                version: 3,
+                sources: ['main.ts'],
+                sourcesContent: ['export const value = 1'],
+                names: [],
+                mappings: '',
+            })
+        )
+
+        expect(stripSourceMapSourcesContent(packageRoot)).toMatchObject({ stripped: 1, total: 1 })
+        expect(fs.existsSync(mapPath)).toBe(true)
+        expect(JSON.parse(fs.readFileSync(mapPath, 'utf8'))).not.toHaveProperty('sourcesContent')
+    })
+})


### PR DESCRIPTION
## Problem

Closes #3205.

`posthog-js` unpacks to ~41 MB, and 28 MB of that is `dist/*.js.map` — 41 bundles' worth of maps with their sources inlined. Nothing loads them at runtime, but every install pays for them: CI caches, Docker images that ship production `node_modules`, disk on every machine with the SDK in a lockfile.

To answer the question on the issue: no, they don't reach anyone's bundle output. That's exactly why this is cheap to fix and still worth fixing.

## Changes

One line in `files`: `"!dist/*.map"`.

The maps are still built and the CDN still gets them — the `upload-s3` job reads `packages/browser/dist/*.js.map` from its own build, never from the npm tarball. So the `x_google_ignoreList` console attribution from #4299 is untouched for snippet users, and `check-sourcemap-ignore-list.js` still guards it.

Left alone on purpose: the 2.4 MB of `lib/**/*.js.map` (negation in `files` doesn't reach files pulled in by a directory match, so `"!lib/**/*.map"` is a no-op on the pnpm we pin — better fixed via `sourceMap` in the `tsc` config), and `lib/*` itself, which is 6 MB of unreachable output but has real deep importers like `posthog-js/lib/src/constants`.

## Testing

Packed the real `posthog-js@1.416.1` file tree both ways with the pinned pnpm, so the globs ran against actual filenames:

| | before | after |
|---|---|---|
| unpacked | 40.8 MB | 12.4 MB |
| tarball | 10.9 MB | 3.3 MB |
| files | 766 | 725 |

Diffed the file lists: exactly 41 files dropped, all `dist/*.js.map`, nothing else. All 41 bundles, all 154 `.d.ts`, `react/dist/**` and the subpath shims still ship.

The bundles keep their `//# sourceMappingURL` comments. esbuild — what Vite prebundles deps with — resolves a missing map silently. A `source-map-loader` walking `node_modules` is the one setup likely to warn.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. I asked why the package was so heavy; it traced the build and release pipeline and established the split this rests on — the tarball maps are dead weight, the CDN ones are load-bearing.

Two things it tried that I dropped: negating the `lib/` maps (silently a no-op on the pinned pnpm, several spellings checked) and removing `lib/*` outright (breaks deep imports). Numbers above come from packing the real published tree, not estimates.
