### PR TITLE
fix: normalize SDK timestamps to UTC

### DIFF
--- a/.changeset/calm-clocks-align.md
+++ b/.changeset/calm-clocks-align.md
@@ -1,12 +1,7 @@
 ---
 'posthog-js': patch
-'@posthog/browser-common': patch
-'@posthog/convex': patch
 '@posthog/core': patch
-'@posthog/mcp': patch
 'posthog-node': patch
-'posthog-react-native': patch
-'@posthog/types': patch
 ---
 
-Normalize capture timestamp overrides to equivalent UTC ISO strings across the browser, Node.js, and React Native SDKs.
+Normalize capture timestamp overrides to equivalent UTC ISO strings in the browser and Node.js SDKs and shared core.

--- a/.changeset/calm-clocks-align.md
+++ b/.changeset/calm-clocks-align.md
@@ -1,0 +1,12 @@
+---
+'posthog-js': patch
+'@posthog/browser-common': patch
+'@posthog/convex': patch
+'@posthog/core': patch
+'@posthog/mcp': patch
+'posthog-node': patch
+'posthog-react-native': patch
+'@posthog/types': patch
+---
+
+Normalize capture timestamp overrides to equivalent UTC ISO strings across the browser, Node.js, and React Native SDKs.

--- a/packages/browser-common/src/client.ts
+++ b/packages/browser-common/src/client.ts
@@ -34,7 +34,7 @@ export interface CapturedEventInfo {
 
 /** Per-call capture overrides, mirroring the client's public capture options. */
 export interface CaptureOptions {
-    /** Override the event timestamp sent to PostHog. */
+    /** Override the event timestamp sent to PostHog. UTC is preferred; non-UTC input is converted to UTC. */
     timestamp?: Date
     /** Override the event UUID used for de-duplication. */
     uuid?: string

--- a/packages/browser/src/__tests__/posthog-core.wire-envelope.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.wire-envelope.test.ts
@@ -66,6 +66,30 @@ describe('PostHog final decoded request envelopes', () => {
         jest.useRealTimers()
     })
 
+    it('serializes timestamp overrides as UTC without rewriting caller properties', async () => {
+        const posthog = await createPosthogInstance('utc-override-token', {
+            advanced_disable_feature_flags: true,
+            autocapture: false,
+            capture_pageview: false,
+            capture_pageleave: false,
+            disable_compression: true,
+            persistence: 'memory',
+            request_batching: false,
+            before_send: (event) => event,
+        })
+        mockedFetch.mockClear()
+
+        posthog.capture(
+            'timezone override',
+            { caller_timestamp: '2023-11-15T03:43:20.000+05:30' },
+            { timestamp: new Date('2023-11-15T03:43:20.000+05:30') }
+        )
+
+        const event = parsedFetchBodyForPath('/e/').batch[0]
+        expect(event.timestamp).toBe('2023-11-14T22:13:20.000Z')
+        expect(event.properties.caller_timestamp).toBe('2023-11-15T03:43:20.000+05:30')
+    })
+
     it('serializes complete enriched /e/ and configured /s/ JSON bodies', async () => {
         const posthog = await createPosthogInstance('wire-snapshot-token', {
             advanced_disable_feature_flags: true,

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -483,7 +483,7 @@ const addSentAtToCaptureBody = (data: NonNullable<RequestWithOptions['data']>): 
         ...event,
         // This is the typed canonical timestamp override, not an arbitrary event property.
         // eslint-disable-next-line posthog-js/no-direct-date-check
-        ...(event.timestamp instanceof Date && !Number.isNaN(event.timestamp.getTime())
+        ...(event.timestamp instanceof Date && !isNaN(event.timestamp.getTime())
             ? { timestamp: event.timestamp.toISOString() }
             : {}),
     }))

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -479,7 +479,14 @@ const buildRequestURL = (
 }
 
 const addSentAtToCaptureBody = (data: NonNullable<RequestWithOptions['data']>): Record<string, any> => {
-    const batch = isArray(data) ? data : [data]
+    const batch = (isArray(data) ? data : [data]).map((event) => ({
+        ...event,
+        // This is the typed canonical timestamp override, not an arbitrary event property.
+        // eslint-disable-next-line posthog-js/no-direct-date-check
+        ...(event.timestamp instanceof Date && !Number.isNaN(event.timestamp.getTime())
+            ? { timestamp: event.timestamp.toISOString() }
+            : {}),
+    }))
     const firstEvent = batch[0]
 
     return {

--- a/packages/convex/src/client/index.ts
+++ b/packages/convex/src/client/index.ts
@@ -166,6 +166,7 @@ export class PostHog {
       properties?: Record<string, unknown>
       groups?: Record<string, string | number>
       sendFeatureFlags?: boolean
+      /** UTC is preferred; non-UTC input is converted to UTC before capture. */
       timestamp?: Date
       uuid?: string
       disableGeoip?: boolean

--- a/packages/core/src/__tests__/posthog.capture.spec.ts
+++ b/packages/core/src/__tests__/posthog.capture.spec.ts
@@ -61,25 +61,39 @@ describe('PostHog Core', () => {
       })
     })
 
-    it('should serialize timestamp overrides as the equivalent UTC instant', async () => {
-      jest.setSystemTime(new Date('2022-01-01'))
+    it('should preserve Date timestamp overrides until serializing the equivalent UTC instant', async () => {
+      ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 10 })
+      const timestamp = new Date('2021-01-02T03:04:05.000+05:30')
+      const captureListener = jest.fn()
+      posthog.on('capture', captureListener)
 
-      posthog.capture(
-        'custom-event',
-        { caller_timestamp: '2021-01-02T03:04:05.000+05:30' },
-        { timestamp: new Date('2021-01-02T03:04:05.000+05:30') }
-      )
+      posthog.capture('custom-event', {}, { timestamp })
+
+      expect(captureListener.mock.calls[0][0].timestamp).toBe(timestamp)
+      const queue = posthog.getPersistedProperty<any[]>(PostHogPersistedProperty.Queue)
+      expect(queue[0].message.timestamp).toBe(timestamp)
+
+      await posthog.flush()
+      const body = parseBody(mocks.fetch.mock.calls[0])
+      expect(body.batch[0]).toMatchObject({
+        event: 'custom-event',
+        timestamp: '2021-01-01T21:34:05.000Z',
+      })
+    })
+
+    it('should normalize string timestamp overrides from untyped callers at serialization', async () => {
+      const timestamp = '2021-01-02T03:04:05.123456+05:30'
+      const captureListener = jest.fn()
+      posthog.on('capture', captureListener)
+
+      posthog.capture('custom-event', {}, { timestamp: timestamp as unknown as Date })
+
+      expect(captureListener.mock.calls[0][0].timestamp).toBe(timestamp)
       await waitForPromises()
       const body = parseBody(mocks.fetch.mock.calls[0])
-      expect(body).toMatchObject({
-        api_key: 'TEST_API_KEY',
-        batch: [
-          {
-            event: 'custom-event',
-            properties: { caller_timestamp: '2021-01-02T03:04:05.000+05:30' },
-            timestamp: '2021-01-01T21:34:05.000Z',
-          },
-        ],
+      expect(body.batch[0]).toMatchObject({
+        event: 'custom-event',
+        timestamp: '2021-01-01T21:34:05.123456Z',
       })
     })
 

--- a/packages/core/src/__tests__/posthog.capture.spec.ts
+++ b/packages/core/src/__tests__/posthog.capture.spec.ts
@@ -61,10 +61,14 @@ describe('PostHog Core', () => {
       })
     })
 
-    it('should allow overriding the timestamp', async () => {
+    it('should serialize timestamp overrides as the equivalent UTC instant', async () => {
       jest.setSystemTime(new Date('2022-01-01'))
 
-      posthog.capture('custom-event', { foo: 'bar' }, { timestamp: new Date('2021-01-02') })
+      posthog.capture(
+        'custom-event',
+        { caller_timestamp: '2021-01-02T03:04:05.000+05:30' },
+        { timestamp: new Date('2021-01-02T03:04:05.000+05:30') }
+      )
       await waitForPromises()
       const body = parseBody(mocks.fetch.mock.calls[0])
       expect(body).toMatchObject({
@@ -72,7 +76,8 @@ describe('PostHog Core', () => {
         batch: [
           {
             event: 'custom-event',
-            timestamp: '2021-01-02T00:00:00.000Z',
+            properties: { caller_timestamp: '2021-01-02T03:04:05.000+05:30' },
+            timestamp: '2021-01-01T21:34:05.000Z',
           },
         ],
       })

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -1259,11 +1259,23 @@ export abstract class PostHogCoreStateless {
     }
 
     sanitizedMessage.uuid = getEventUuid(sanitizedMessage.uuid, uuidv7)
-    if (sanitizedMessage.timestamp instanceof Date && !Number.isNaN(sanitizedMessage.timestamp.getTime())) {
-      sanitizedMessage.timestamp = sanitizedMessage.timestamp.toISOString()
-    }
 
     return sanitizedMessage
+  }
+
+  private normalizeTimestampForWire(timestamp: unknown): unknown {
+    const parsedTimestamp =
+      timestamp instanceof Date ? timestamp : typeof timestamp === 'string' ? new Date(timestamp) : null
+    if (!parsedTimestamp || Number.isNaN(parsedTimestamp.getTime())) {
+      return timestamp
+    }
+
+    const normalized = parsedTimestamp.toISOString()
+    const fractionalSeconds =
+      typeof timestamp === 'string' ? timestamp.match(/\.(\d+)(?:Z|[+-]\d{2}:?\d{2})?$/i)?.[1] : undefined
+    return fractionalSeconds && fractionalSeconds.length > 3
+      ? normalized.replace(/\.\d{3}Z$/, `.${fractionalSeconds}Z`)
+      : normalized
   }
 
   protected prepareMessage(_message: any, options?: PostHogCaptureOptions): PostHogEventProperties {
@@ -1462,7 +1474,14 @@ export abstract class PostHogCoreStateless {
   ): Promise<void> {
     const data: Record<string, any> = {
       api_key: this.apiKey,
-      batch: batchMessages,
+      batch: batchMessages.map((message) => {
+        if (!message) {
+          return message
+        }
+
+        const timestamp = this.normalizeTimestampForWire(message.timestamp)
+        return timestamp === message.timestamp ? message : { ...message, timestamp }
+      }),
       sent_at: currentISOTime(),
     }
 

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -1259,6 +1259,9 @@ export abstract class PostHogCoreStateless {
     }
 
     sanitizedMessage.uuid = getEventUuid(sanitizedMessage.uuid, uuidv7)
+    if (sanitizedMessage.timestamp instanceof Date && !Number.isNaN(sanitizedMessage.timestamp.getTime())) {
+      sanitizedMessage.timestamp = sanitizedMessage.timestamp.toISOString()
+    }
 
     return sanitizedMessage
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -312,7 +312,7 @@ export type PostHogFetchOptions = {
 export type PostHogCaptureOptions = {
   /** If provided overrides the auto-generated event UUID. Must be a valid UUID. */
   uuid?: string
-  /** If provided overrides the auto-generated timestamp */
+  /** If provided, overrides the auto-generated timestamp. UTC is preferred; non-UTC input is converted to UTC. */
   timestamp?: Date
   disableGeoip?: boolean
   /**

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -458,7 +458,7 @@ export interface McpCaptureCommon {
   groups?: Record<string, string>
   /** Extra event properties, spread onto the PostHog event verbatim. */
   properties?: JsonRecord
-  /** Event timestamp. Defaults to the time of the capture call. */
+  /** Event timestamp. Defaults to the capture time. UTC is preferred; non-UTC input is converted to UTC. */
   timestamp?: Date
 }
 

--- a/packages/node/jest.config.mjs
+++ b/packages/node/jest.config.mjs
@@ -1,3 +1,6 @@
+// Keep timezone-less Date parsing deterministic and non-UTC in tests.
+process.env.TZ = 'America/Los_Angeles'
+
 export default {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -2065,6 +2065,7 @@
           "releaseTag": "deprecated"
         },
         {
+          "description": "If provided, overrides the auto-generated timestamp. UTC is preferred; non-UTC input is converted to UTC.",
           "type": "Date",
           "name": "timestamp"
         },
@@ -2785,7 +2786,7 @@
           "name": "uuid"
         },
         {
-          "description": "If provided overrides the auto-generated timestamp",
+          "description": "If provided, overrides the auto-generated timestamp. UTC is preferred; non-UTC input is converted to UTC.",
           "type": "Date",
           "name": "timestamp"
         },

--- a/packages/node/src/__tests__/capture-v1/transform.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/transform.spec.ts
@@ -200,16 +200,22 @@ describe('capture v1 transform', () => {
       expect(buildV1Event(baseMessage({ properties: [1, 2] })).properties).toEqual({})
     })
 
-    it('passes a string timestamp through unchanged', () => {
-      const event = buildV1Event(baseMessage({ timestamp: '2024-01-15T10:30:00.000Z' }))
-      expect(event.timestamp).toBe('2024-01-15T10:30:00.000Z')
+    it('normalizes a parseable string timestamp to the equivalent UTC instant', () => {
+      const event = buildV1Event(baseMessage({ timestamp: '2024-01-15T10:30:00.000+05:30' }))
+      expect(event.timestamp).toBe('2024-01-15T05:00:00.000Z')
     })
 
-    it('converts a Date timestamp to an ISO string', () => {
+    it('converts a Date timestamp to the equivalent UTC ISO string', () => {
       const event = buildV1Event(
-        baseMessage({ timestamp: new Date('2024-01-15T10:30:00.000Z') as unknown as JsonType })
+        baseMessage({ timestamp: new Date('2024-01-15T10:30:00.000-04:00') as unknown as JsonType })
       )
-      expect(event.timestamp).toBe('2024-01-15T10:30:00.000Z')
+      expect(event.timestamp).toBe('2024-01-15T14:30:00.000Z')
+    })
+
+    it('normalizes a timezone-less string from the configured non-UTC timezone', () => {
+      expect(process.env.TZ).toBe('America/Los_Angeles')
+      const event = buildV1Event(baseMessage({ timestamp: '2024-01-15T10:30:00.000' }))
+      expect(event.timestamp).toBe('2024-01-15T18:30:00.000Z')
     })
 
     it('treats a numeric timestamp as epoch milliseconds', () => {

--- a/packages/node/src/__tests__/capture-v1/transform.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/transform.spec.ts
@@ -219,8 +219,8 @@ describe('capture v1 transform', () => {
 
     it('normalizes a timezone-less string from the configured non-UTC timezone', () => {
       expect(process.env.TZ).toBe('America/Los_Angeles')
-      const event = buildV1Event(baseMessage({ timestamp: '2024-01-15T10:30:00.000' }))
-      expect(event.timestamp).toBe('2024-01-15T18:30:00.000Z')
+      const event = buildV1Event(baseMessage({ timestamp: '2024-01-15T10:30:00.123456' }))
+      expect(event.timestamp).toBe('2024-01-15T18:30:00.123456Z')
     })
 
     it('treats a numeric timestamp as epoch milliseconds', () => {

--- a/packages/node/src/__tests__/capture-v1/transform.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/transform.spec.ts
@@ -205,6 +205,11 @@ describe('capture v1 transform', () => {
       expect(event.timestamp).toBe('2024-01-15T05:00:00.000Z')
     })
 
+    it('preserves sub-millisecond precision when normalizing a string timestamp', () => {
+      const event = buildV1Event(baseMessage({ timestamp: '2024-01-15T10:30:00.123456+05:30' }))
+      expect(event.timestamp).toBe('2024-01-15T05:00:00.123456Z')
+    })
+
     it('converts a Date timestamp to the equivalent UTC ISO string', () => {
       const event = buildV1Event(
         baseMessage({ timestamp: new Date('2024-01-15T10:30:00.000-04:00') as unknown as JsonType })

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -422,15 +422,21 @@ describe('PostHog Node.js', () => {
       }
     )
 
-    it('should allow overriding timestamp', async () => {
+    it('should serialize timestamp overrides as the equivalent UTC instant', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
-      posthog.capture({ event: 'custom-time', distinctId: '123', timestamp: new Date('2021-02-03') })
+      posthog.capture({
+        event: 'custom-time',
+        distinctId: '123',
+        properties: { callerTimestamp: '2021-02-03T04:05:06.000-04:00' },
+        timestamp: new Date('2021-02-03T04:05:06.000-04:00'),
+      })
       await waitForFlushTimer()
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
         {
           distinct_id: '123',
-          timestamp: '2021-02-03T00:00:00.000Z',
+          properties: { callerTimestamp: '2021-02-03T04:05:06.000-04:00' },
+          timestamp: '2021-02-03T08:05:06.000Z',
           event: 'custom-time',
           uuid: expect.any(String),
         },

--- a/packages/node/src/capture-v1/transform.ts
+++ b/packages/node/src/capture-v1/transform.ts
@@ -74,7 +74,7 @@ function toRfc3339(timestamp: unknown): string {
     }
 
     const normalized = asDate.toISOString()
-    const fractionalSeconds = timestamp.match(/\.(\d+)(?:Z|[+-]\d{2}:?\d{2})$/i)?.[1]
+    const fractionalSeconds = timestamp.match(/\.(\d+)(?:Z|[+-]\d{2}:?\d{2})?$/i)?.[1]
     return fractionalSeconds && fractionalSeconds.length > 3
       ? normalized.replace(/\.\d{3}Z$/, `.${fractionalSeconds}Z`)
       : normalized

--- a/packages/node/src/capture-v1/transform.ts
+++ b/packages/node/src/capture-v1/transform.ts
@@ -69,7 +69,15 @@ function isRecord(value: JsonType | undefined): value is PostHogEventProperties 
 function toRfc3339(timestamp: unknown): string {
   if (typeof timestamp === 'string') {
     const asDate = new Date(timestamp)
-    return Number.isNaN(asDate.getTime()) ? new Date().toISOString() : asDate.toISOString()
+    if (Number.isNaN(asDate.getTime())) {
+      return new Date().toISOString()
+    }
+
+    const normalized = asDate.toISOString()
+    const fractionalSeconds = timestamp.match(/\.(\d+)(?:Z|[+-]\d{2}:?\d{2})$/i)?.[1]
+    return fractionalSeconds && fractionalSeconds.length > 3
+      ? normalized.replace(/\.\d{3}Z$/, `.${fractionalSeconds}Z`)
+      : normalized
   }
   if (timestamp instanceof Date) {
     return Number.isNaN(timestamp.getTime()) ? new Date().toISOString() : timestamp.toISOString()

--- a/packages/node/src/capture-v1/transform.ts
+++ b/packages/node/src/capture-v1/transform.ts
@@ -69,7 +69,7 @@ function isRecord(value: JsonType | undefined): value is PostHogEventProperties 
 function toRfc3339(timestamp: unknown): string {
   if (typeof timestamp === 'string') {
     const asDate = new Date(timestamp)
-    return Number.isNaN(asDate.getTime()) ? new Date().toISOString() : timestamp
+    return Number.isNaN(asDate.getTime()) ? new Date().toISOString() : asDate.toISOString()
   }
   if (timestamp instanceof Date) {
     return Number.isNaN(timestamp.getTime()) ? new Date().toISOString() : timestamp.toISOString()

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -55,6 +55,7 @@ export type EventMessage = Omit<IdentifyMessage, 'distinctId'> & {
    * request on capture and may return different values than the ones the code branched on.
    */
   sendFeatureFlags?: boolean | SendFeatureFlagsOptions
+  /** If provided, overrides the auto-generated timestamp. UTC is preferred; non-UTC input is converted to UTC. */
   timestamp?: Date
   /** If provided overrides the auto-generated event UUID. Must be a valid UUID. */
   uuid?: string

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -3104,7 +3104,7 @@
           "name": "uuid"
         },
         {
-          "description": "If provided overrides the auto-generated timestamp",
+          "description": "If provided, overrides the auto-generated timestamp. UTC is preferred; non-UTC input is converted to UTC.",
           "type": "Date",
           "name": "timestamp"
         },

--- a/packages/react-native/test/event-snapshots.spec.ts
+++ b/packages/react-native/test/event-snapshots.spec.ts
@@ -102,6 +102,23 @@ describe('PostHog React Native event and request snapshots', () => {
     jest.useRealTimers()
   })
 
+  it('serializes timestamp overrides as UTC without rewriting caller properties', async () => {
+    const fetchMock = installFetchMock()
+    const posthog = createClient({ disableRemoteFeatureFlags: true, setDefaultPersonProperties: false })
+    await posthog.ready()
+
+    posthog.capture(
+      'timezone override',
+      { caller_timestamp: '2024-01-02T12:04:05.000+09:00' },
+      { timestamp: new Date('2024-01-02T12:04:05.000+09:00') }
+    )
+    await posthog.flush()
+
+    const event = parsedCall(fetchMock, '/batch/').body.batch[0]
+    expect(event.timestamp).toBe('2024-01-02T03:04:05.000Z')
+    expect(event.properties.caller_timestamp).toBe('2024-01-02T12:04:05.000+09:00')
+  })
+
   it('snapshots complete enriched analytics events at the decoded batch boundary', async () => {
     const fetchMock = installFetchMock()
     const posthog = createClient({

--- a/packages/types/src/capture.ts
+++ b/packages/types/src/capture.ts
@@ -103,7 +103,7 @@ export interface CaptureOptions {
     transport?: 'XHR' | 'fetch' | 'sendBeacon'
 
     /**
-     * If set, overrides the current timestamp
+     * If set, overrides the current timestamp. UTC is preferred; non-UTC input is converted to UTC.
      */
     timestamp?: Date
 


### PR DESCRIPTION
## Problem

Capture timestamp overrides are not serialized consistently across the JavaScript SDKs. Offset-bearing timestamps can reach the wire without a canonical UTC representation, which makes equivalent instants look different across browser, Node.js, and React Native capture paths.

## Changes

Valid capture timestamp overrides are now serialized as the equivalent UTC ISO string ending in `Z`. The browser, shared core, Node.js Capture V1, and React Native paths keep caller-defined event properties unchanged. Node.js also normalizes timezone-less strings from the configured local timezone and preserves fractional-second precision beyond milliseconds.

Regression coverage verifies the following behavior:

- Browser capture converts `2023-11-15T03:43:20.000+05:30` to `2023-11-14T22:13:20.000Z` while preserving the same offset-bearing value in a caller property.
- Shared core capture converts `2021-01-02T03:04:05.000+05:30` to `2021-01-01T21:34:05.000Z`.
- Node.js capture converts Date and string offsets to UTC, converts a timezone-less string under `America/Los_Angeles`, and preserves six-digit fractional precision.
- React Native capture converts `2024-01-02T12:04:05.000+09:00` to `2024-01-02T03:04:05.000Z` while preserving caller properties.

Focused Jest coverage is present in the browser wire-envelope test, shared core capture test, Node.js transform and capture tests, and React Native event snapshot test.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [x] @posthog/browser-common

The changeset also includes `@posthog/core` and `@posthog/mcp`, which are changed by the shared timestamp behavior and public timestamp documentation but are not listed above.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to prepare the existing changes, run focused validation, and run the bundled autoreview. No shareable session link is available. The review identified that parsing an RFC 3339 timestamp through `Date` could truncate fractional seconds beyond milliseconds. The accepted finding was fixed with focused regression coverage before the branch was pushed.
