### PR TITLE
fix(react-native): lazily initialize feature flag result

### DIFF
--- a/.changeset/lazy-rn-feature-flag-hooks.md
+++ b/.changeset/lazy-rn-feature-flag-hooks.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Avoid rereading cached feature flag results on unrelated React Native component rerenders.

--- a/packages/react-native/src/hooks/useFeatureFlagResult.ts
+++ b/packages/react-native/src/hooks/useFeatureFlagResult.ts
@@ -5,7 +5,7 @@ import { PostHog } from '../posthog-rn'
 
 export function useFeatureFlagResult(flag: string, client?: PostHog): FeatureFlagResult | undefined {
   const posthog = useOverridablePostHog(client, 'useFeatureFlagResult')
-  const [result, setResult] = useState<FeatureFlagResult | undefined>(posthog?.getFeatureFlagResult(flag))
+  const [result, setResult] = useState<FeatureFlagResult | undefined>(() => posthog?.getFeatureFlagResult(flag))
 
   useEffect(() => {
     setResult(posthog?.getFeatureFlagResult(flag))

--- a/packages/react-native/test/useFeatureFlagResult.spec.ts
+++ b/packages/react-native/test/useFeatureFlagResult.spec.ts
@@ -98,6 +98,15 @@ describe('useFeatureFlagResult', () => {
     expect(result.current).toEqual(updated)
   })
 
+  it('does not reread the feature flag result on an unrelated rerender', () => {
+    const { rerender } = renderHook(() => useFeatureFlagResult('test-flag'), { wrapper })
+    ;(mockPostHog.getFeatureFlagResult as jest.Mock).mockClear()
+
+    rerender()
+
+    expect(mockPostHog.getFeatureFlagResult).not.toHaveBeenCalled()
+  })
+
   it('should unsubscribe on cleanup', () => {
     const unsubscribe = jest.fn()
     ;(mockPostHog.onFeatureFlags as jest.Mock).mockReturnValue(unsubscribe)


### PR DESCRIPTION
## Problem

The merged fix in #4526 made `useFeatureFlags` and `useFeatureFlag` use lazy state initializers. A broader audit found the sibling `useFeatureFlagResult` hook still eagerly calls `getFeatureFlagResult(flag)` on every render, repeatedly normalizing cached flag details even though React discards the value after mount.

Follow-up to #4526 and #4525. Supersedes #4527, whose branch was rewritten after #4526 merged.

## Changes

- Lazily initialize `useFeatureFlagResult`
- Add a regression test proving unrelated rerenders do not reread the flag result
- Add a patch changeset for `posthog-react-native`

## Validation

- 13 focused hook tests pass
- Full `posthog-react-native` lint passes
- Dependency-aware `posthog-react-native` Turbo build passes

## Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR is based on merged `main` and intentionally contains only the remaining sibling hook discovered in the audit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*