### PR TITLE
fix(core): detect LinkedIn, Twitter, TikTok, WeChat, Line in-app browsers; narrow Pinterest bot filter

### DIFF
--- a/packages/core/src/utils/bot-detection.ts
+++ b/packages/core/src/utils/bot-detection.ts
@@ -28,7 +28,7 @@ export const DEFAULT_BLOCKED_UA_STRS = [
   'msnbot',
   'nessus',
   'petalbot',
-  'pinterest',
+  'pinterestbot',
   'prerender',
   'rogerbot',
   'screaming frog',

--- a/packages/core/src/utils/user-agent-utils.ts
+++ b/packages/core/src/utils/user-agent-utils.ts
@@ -58,6 +58,11 @@ const PALE_MOON = 'Pale Moon'
 const WATERFOX = 'Waterfox'
 const BRAVE = 'Brave'
 const GOOGLE_SEARCH_APP = 'Google Search App'
+const LINKEDIN = 'LinkedIn'
+const TWITTER = 'Twitter'
+const TIKTOK = 'TikTok'
+const WECHAT = 'WeChat'
+const LINE = 'Line'
 
 const BROWSER_VERSION_REGEX_SUFFIX = '(\\d+(\\.\\d+)?)'
 const DEFAULT_BROWSER_VERSION_REGEX = new RegExp('Version/' + BROWSER_VERSION_REGEX_SUFFIX)
@@ -193,6 +198,20 @@ export const detectBrowser = function (
     return DUCKDUCKGO
   } else if (includes(user_agent, 'FBIOS')) {
     return FACEBOOK + ' ' + MOBILE
+  } else if (includes(user_agent, 'FBAN') || includes(user_agent, 'FB_IAB')) {
+    return FACEBOOK + ' ' + MOBILE
+  } else if (includes(user_agent, 'Instagram')) {
+    return 'Instagram'
+  } else if (includes(user_agent, 'LinkedInApp') || includes(user_agent, '[LinkedInApp]')) {
+    return LINKEDIN
+  } else if (includes(user_agent, 'Twitter for')) {
+    return TWITTER
+  } else if (includes(user_agent, 'musical_ly')) {
+    return TIKTOK
+  } else if (includes(user_agent, 'MicroMessenger/')) {
+    return WECHAT
+  } else if (includes(user_agent, 'Line/')) {
+    return LINE
   } else if (includes(user_agent, 'UCWEB') || includes(user_agent, 'UCBrowser')) {
     return 'UC Browser'
   } else if (includes(user_agent, 'CriOS')) {


### PR DESCRIPTION
`detectBrowser` in user-agent-utils.ts matched only Facebook iOS (`FBIOS`)
and the Google Search App (`GSA/`). All other in-app browsers fell through
to the platform webview (Chrome or Mobile Safari), making in-app traffic
impossible to segment, exclude from experiments, or even count.

This commit adds detection for:
- Facebook Android (`FBAN`/`FB_IAB`)
- Instagram
- LinkedIn (`LinkedInApp` / `[LinkedInApp]`)
- Twitter/X (`Twitter for`)
- TikTok (`musical_ly`)
- WeChat (`MicroMessenger/`)
- Line (`Line/`)

Also narrows the `pinterest` bot blocklist entry to `pinterestbot` so that
Pinterest's in-app browser (`[Pinterest/iOS]`) is not incorrectly dropped
as bot traffic.

Refs: PostHog/posthog#83413