### PR TITLE
fix(browser): support legacy exception autocapture loaders

### DIFF
--- a/.changeset/quiet-otters-capture.md
+++ b/.changeset/quiet-otters-capture.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Restore exception autocapture compatibility for posthog-js clients through version 1.141.0.

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -270,6 +270,15 @@ jobs:
               comment_id: process.env.COMMENT_ID
             })
 
+      - name: Test legacy exception autocapture compatibility
+        run: |
+          COMPAT_VERSION=1.140.1 pnpm exec playwright test \
+            playwright/mocked/error-tracking/legacy-autocapture.spec.ts \
+            --config playwright.config.compat.ts \
+            --project chromium-compat \
+            --reporter=line
+        working-directory: packages/browser
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -118,7 +118,7 @@ jobs:
         id: compat-tests
         continue-on-error: true
         run: |
-          PLAYWRIGHT_JSON_OUTPUT_FILE=compat-results.json pnpm exec playwright test --config playwright.config.compat.ts --project chromium-compat --workers=5 --reporter=json,html
+          PLAYWRIGHT_JSON_OUTPUT_FILE=compat-results.json pnpm exec playwright test --config playwright.config.compat.ts --workers=5 --reporter=json,html
         working-directory: packages/browser
 
       - name: Process compat test results
@@ -269,15 +269,6 @@ jobs:
               repo: context.repo.repo,
               comment_id: process.env.COMMENT_ID
             })
-
-      - name: Test legacy exception autocapture compatibility
-        run: |
-          COMPAT_VERSION=1.140.1 pnpm exec playwright test \
-            playwright/mocked/error-tracking/legacy-autocapture.spec.ts \
-            --config playwright.config.compat.ts \
-            --project chromium-compat \
-            --reporter=line
-        working-directory: packages/browser
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}

--- a/packages/browser/playwright.config.compat.ts
+++ b/packages/browser/playwright.config.compat.ts
@@ -24,11 +24,23 @@ export default defineConfig({
     projects: [
         {
             name: 'chromium-compat',
+            testIgnore: '**/error-tracking/legacy-autocapture.spec.ts',
             use: {
                 ...devices['Desktop Chrome'],
                 staticOverrides: {
                     'array.js': 'array.npm-latest.js',
                     'array.full.js': 'array.full.npm-latest.js',
+                },
+            },
+        },
+        {
+            name: 'chromium-legacy-exception-autocapture',
+            testMatch: '**/error-tracking/legacy-autocapture.spec.ts',
+            use: {
+                ...devices['Desktop Chrome'],
+                staticOverrides: {
+                    'array.js': 'array.npm-legacy-exception-autocapture.js',
+                    'array.full.js': 'array.full.npm-legacy-exception-autocapture.js',
                 },
             },
         },

--- a/packages/browser/playwright.config.ts
+++ b/packages/browser/playwright.config.ts
@@ -13,6 +13,8 @@ import { defineConfig, devices } from '@playwright/test'
  */
 export default defineConfig({
     testDir: './playwright/mocked',
+    /* This spec requires the pinned core configured by playwright.config.compat.ts. */
+    testIgnore: '**/error-tracking/legacy-autocapture.spec.ts',
     /* Run tests in files in parallel */
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/packages/browser/playwright/fixtures/network.ts
+++ b/packages/browser/playwright/fixtures/network.ts
@@ -84,13 +84,15 @@ export class NetworkPage {
             ...flagsOverrides,
         }
 
-        await this.page.route('**/flags/*', async (route) => {
-            await route.fulfill({
-                status: 200,
-                contentType: 'application/json',
-                body: JSON.stringify(flagsResponse),
+        for (const routePattern of ['**/flags/*', '**/decide/*']) {
+            await this.page.route(routePattern, async (route) => {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify(flagsResponse),
+                })
             })
-        })
+        }
 
         // Mock the remote config endpoint to return the same config data.
         // RemoteConfig is now the sole config loading mechanism.

--- a/packages/browser/playwright/global-setup-compat.ts
+++ b/packages/browser/playwright/global-setup-compat.ts
@@ -5,6 +5,12 @@ import path from 'path'
 const DIST_DIR = path.join(__dirname, '../dist')
 const NPM_ARRAY_FILE = path.join(DIST_DIR, 'array.npm-latest.js')
 const NPM_ARRAY_FULL_FILE = path.join(DIST_DIR, 'array.full.npm-latest.js')
+const LEGACY_EXCEPTION_AUTOCAPTURE_VERSION = '1.140.1'
+const LEGACY_EXCEPTION_AUTOCAPTURE_ARRAY_FILE = path.join(DIST_DIR, 'array.npm-legacy-exception-autocapture.js')
+const LEGACY_EXCEPTION_AUTOCAPTURE_ARRAY_FULL_FILE = path.join(
+    DIST_DIR,
+    'array.full.npm-legacy-exception-autocapture.js'
+)
 
 async function downloadFile(url: string, dest: string): Promise<void> {
     const response = await fetch(url, { redirect: 'follow' })
@@ -30,11 +36,21 @@ async function downloadNpmVersion(): Promise<void> {
     process.env.COMPAT_VERSION = version
 
     // eslint-disable-next-line no-console
-    console.log(`Compat tests using posthog-js@${version} from NPM`)
+    console.log(
+        `Compat tests using posthog-js@${version} and posthog-js@${LEGACY_EXCEPTION_AUTOCAPTURE_VERSION} from NPM`
+    )
 
     await Promise.all([
         downloadFile(`https://unpkg.com/posthog-js@${version}/dist/array.js`, NPM_ARRAY_FILE),
         downloadFile(`https://unpkg.com/posthog-js@${version}/dist/array.full.js`, NPM_ARRAY_FULL_FILE),
+        downloadFile(
+            `https://unpkg.com/posthog-js@${LEGACY_EXCEPTION_AUTOCAPTURE_VERSION}/dist/array.js`,
+            LEGACY_EXCEPTION_AUTOCAPTURE_ARRAY_FILE
+        ),
+        downloadFile(
+            `https://unpkg.com/posthog-js@${LEGACY_EXCEPTION_AUTOCAPTURE_VERSION}/dist/array.full.js`,
+            LEGACY_EXCEPTION_AUTOCAPTURE_ARRAY_FULL_FILE
+        ),
     ])
 }
 

--- a/packages/browser/playwright/mocked/error-tracking/legacy-autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/legacy-autocapture.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from '../utils/posthog-playwright-test-base'
+import { test } from '../../fixtures'
+
+test.use({ url: '/playground/cypress/index.html' })
+
+test('captures exceptions with the posthog-js 1.140.1 core', async ({ posthog, page, network }) => {
+    await network.mockFlags({ autocaptureExceptions: true })
+    await posthog.init()
+
+    await page.waitForFunction(() => {
+        const win = window as any
+        return (
+            win.extendPostHogWithExceptionAutoCapture &&
+            win.extendPostHogWithExceptionAutoCapture === win.extendPostHogWithExceptionAutocapture &&
+            win.onerror?.__POSTHOG_INSTRUMENTED__ === true
+        )
+    })
+
+    await page.evaluate(() => {
+        const win = window as any
+        const originalCapture = win.posthog.capture
+        win.__legacyCapturedEvents = []
+        win.posthog.capture = function (event: string, ...args: any[]) {
+            win.__legacyCapturedEvents.push(event)
+            return originalCapture.call(this, event, ...args)
+        }
+    })
+
+    await page.click('[data-cy-button-throws-error]')
+
+    await expect.poll(() => page.evaluate(() => (window as any).__legacyCapturedEvents)).toContain('$exception')
+})

--- a/packages/browser/playwright/mocked/error-tracking/legacy-autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/legacy-autocapture.spec.ts
@@ -21,6 +21,40 @@ test('captures exceptions with the posthog-js 1.140.1 core', async ({ posthog, p
         const originalCapture = win.posthog.capture
         win.__legacyCapturedEvents = []
         win.posthog.capture = function (event: string, ...args: any[]) {
+            win.__legacyCapturedEvents.push({ event, options: args[1] })
+            return originalCapture.call(this, event, ...args)
+        }
+    })
+
+    await page.click('[data-cy-button-throws-error]')
+
+    await expect
+        .poll(() =>
+            page.evaluate(() =>
+                (window as any).__legacyCapturedEvents.find(({ event }: { event: string }) => event === '$exception')
+            )
+        )
+        .toEqual({
+            event: '$exception',
+            options: expect.objectContaining({ _noHeatmaps: true }),
+        })
+})
+
+test('respects legacy exception exclusion rules', async ({ posthog, page, network }) => {
+    await network.mockFlags({
+        autocaptureExceptions: {
+            errors_to_ignore: ['^This is an error$'],
+        },
+    })
+    await posthog.init()
+
+    await page.waitForFunction(() => (window as any).onerror?.__POSTHOG_INSTRUMENTED__ === true)
+
+    await page.evaluate(() => {
+        const win = window as any
+        const originalCapture = win.posthog.capture
+        win.__legacyCapturedEvents = []
+        win.posthog.capture = function (event: string, ...args: any[]) {
             win.__legacyCapturedEvents.push(event)
             return originalCapture.call(this, event, ...args)
         }
@@ -28,5 +62,5 @@ test('captures exceptions with the posthog-js 1.140.1 core', async ({ posthog, p
 
     await page.click('[data-cy-button-throws-error]')
 
-    await expect.poll(() => page.evaluate(() => (window as any).__legacyCapturedEvents)).toContain('$exception')
+    expect(await page.evaluate(() => (window as any).__legacyCapturedEvents)).not.toContain('$exception')
 })

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -171,6 +171,9 @@ const plugins = (es5, noExternal, preserveCrossBundleProperties) => [
                               '_noTruncate',
                               '_onCapture',
 
+                              // passed from the exception extension bundle to legacy cores
+                              '_noHeatmaps',
+
                               // used in surveys, however, this shouldn't be needed
                               // TODO: figure out how to remove them
                               '_posthog',

--- a/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
@@ -1,0 +1,50 @@
+import '../../entrypoints/exception-autocapture'
+import { assignableWindow, window } from '../../utils/globals'
+
+describe('exception-autocapture entrypoint', () => {
+    const originalOnError = window?.onerror
+    const originalOnUnhandledRejection = window?.onunhandledrejection
+
+    afterEach(() => {
+        if (window) {
+            window.onerror = originalOnError
+            window.onunhandledrejection = originalOnUnhandledRejection
+        }
+    })
+
+    it('exposes both exception autocapture names used by posthog-js <= 1.141.0', () => {
+        expect(assignableWindow.extendPostHogWithExceptionAutoCapture).toBe(
+            assignableWindow.extendPostHogWithExceptionAutocapture
+        )
+    })
+
+    it('captures errors for legacy clients', () => {
+        const capture = jest.fn()
+
+        assignableWindow.extendPostHogWithExceptionAutocapture({ capture })
+        window?.onerror?.('message', 'source', 1, 2, new Error('legacy error'))
+
+        expect(capture).toHaveBeenCalledWith(
+            '$exception',
+            expect.objectContaining({
+                $exception_list: [expect.objectContaining({ type: 'Error', value: 'legacy error' })],
+            }),
+            { _noTruncate: true, _batchKey: 'exceptionEvent' }
+        )
+    })
+
+    it('captures unhandled rejections for legacy clients', () => {
+        const capture = jest.fn()
+
+        assignableWindow.extendPostHogWithExceptionAutocapture({ capture })
+        window?.onunhandledrejection?.({ reason: new Error('legacy rejection') } as PromiseRejectionEvent)
+
+        expect(capture).toHaveBeenCalledWith(
+            '$exception',
+            expect.objectContaining({
+                $exception_list: [expect.objectContaining({ value: 'legacy rejection' })],
+            }),
+            { _noTruncate: true, _batchKey: 'exceptionEvent' }
+        )
+    })
+})

--- a/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
@@ -29,7 +29,47 @@ describe('exception-autocapture entrypoint', () => {
             expect.objectContaining({
                 $exception_list: [expect.objectContaining({ type: 'Error', value: 'legacy error' })],
             }),
-            { _noTruncate: true, _batchKey: 'exceptionEvent' }
+            { _noTruncate: true, _batchKey: 'exceptionEvent', _noHeatmaps: true }
+        )
+    })
+
+    it('still calls the original error handler when legacy capture throws', () => {
+        const originalErrorHandler = jest.fn(() => true)
+        const capture = jest.fn(() => {
+            throw new Error('capture failed')
+        })
+        if (!window) {
+            throw new Error('window is required for this test')
+        }
+        window.onerror = originalErrorHandler
+
+        assignableWindow.extendPostHogWithExceptionAutocapture({ capture })
+
+        expect(() => window.onerror?.('message', 'source', 1, 2, new Error('legacy error'))).not.toThrow()
+        expect(originalErrorHandler).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not capture errors matching legacy exclusion rules', () => {
+        const capture = jest.fn()
+
+        assignableWindow.extendPostHogWithExceptionAutocapture(
+            { capture },
+            {
+                autocaptureExceptions: {
+                    errors_to_ignore: ['^ignored error$'],
+                },
+            }
+        )
+        window?.onerror?.('ignored error', 'source', 1, 2, new Error('ignored error'))
+        window?.onerror?.('reported error', 'source', 1, 2, new Error('reported error'))
+
+        expect(capture).toHaveBeenCalledTimes(1)
+        expect(capture).toHaveBeenCalledWith(
+            '$exception',
+            expect.objectContaining({
+                $exception_list: [expect.objectContaining({ value: 'reported error' })],
+            }),
+            { _noTruncate: true, _batchKey: 'exceptionEvent', _noHeatmaps: true }
         )
     })
 
@@ -44,7 +84,7 @@ describe('exception-autocapture entrypoint', () => {
             expect.objectContaining({
                 $exception_list: [expect.objectContaining({ value: 'legacy rejection' })],
             }),
-            { _noTruncate: true, _batchKey: 'exceptionEvent' }
+            { _noTruncate: true, _batchKey: 'exceptionEvent', _noHeatmaps: true }
         )
     })
 })

--- a/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
@@ -95,8 +95,11 @@ describe('exception-autocapture entrypoint', () => {
         const capture = jest.fn()
 
         assignableWindow.extendPostHogWithExceptionAutocapture({ capture })
-        window?.onunhandledrejection?.({ reason: new Error('legacy rejection') } as PromiseRejectionEvent)
+        const handled = window?.onunhandledrejection?.({
+            reason: new Error('legacy rejection'),
+        } as PromiseRejectionEvent)
 
+        expect(handled).toBe(true)
         expect(capture).toHaveBeenCalledWith(
             '$exception',
             expect.objectContaining({

--- a/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
@@ -73,6 +73,30 @@ describe('exception-autocapture entrypoint', () => {
         )
     })
 
+    it('does not apply legacy error exclusion rules to unhandled rejections', () => {
+        const capture = jest.fn()
+
+        assignableWindow.extendPostHogWithExceptionAutocapture(
+            { capture },
+            {
+                autocaptureExceptions: {
+                    errors_to_ignore: ['^ignored error$'],
+                },
+            }
+        )
+        window?.onunhandledrejection?.({
+            reason: new Error('ignored error'),
+        } as PromiseRejectionEvent)
+
+        expect(capture).toHaveBeenCalledWith(
+            '$exception',
+            expect.objectContaining({
+                $exception_list: [expect.objectContaining({ value: 'ignored error' })],
+            }),
+            { _noTruncate: true, _batchKey: 'exceptionEvent', _noHeatmaps: true }
+        )
+    })
+
     it('captures errors when a legacy exclusion rule is invalid', () => {
         const capture = jest.fn()
 

--- a/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
@@ -73,6 +73,24 @@ describe('exception-autocapture entrypoint', () => {
         )
     })
 
+    it('captures errors when a legacy exclusion rule is invalid', () => {
+        const capture = jest.fn()
+
+        expect(() =>
+            assignableWindow.extendPostHogWithExceptionAutocapture(
+                { capture },
+                {
+                    autocaptureExceptions: {
+                        errors_to_ignore: ['['],
+                    },
+                }
+            )
+        ).not.toThrow()
+        window?.onerror?.('reported error', 'source', 1, 2, new Error('reported error'))
+
+        expect(capture).toHaveBeenCalledTimes(1)
+    })
+
     it('captures unhandled rejections for legacy clients', () => {
         const capture = jest.fn()
 

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -45,7 +45,10 @@ const wrapOnError = (captureFn: (props: ErrorTracking.ErrorProperties) => void) 
     }
 }
 
-const wrapUnhandledRejection = (captureFn: (props: ErrorTracking.ErrorProperties) => void) => {
+const wrapUnhandledRejection = (
+    captureFn: (props: ErrorTracking.ErrorProperties) => void,
+    defaultReturnValue = false
+) => {
     const win = window as any
     if (!win) {
         logger.info('window not available, cannot wrap onUnhandledRejection')
@@ -58,7 +61,9 @@ const wrapUnhandledRejection = (captureFn: (props: ErrorTracking.ErrorProperties
             mechanism: { handled: false },
         })
         captureFn(errorProperties)
-        return isFunction(originalOnUnhandledRejection) ? (originalOnUnhandledRejection(ev) ?? false) : false
+        return isFunction(originalOnUnhandledRejection)
+            ? (originalOnUnhandledRejection(ev) ?? false)
+            : defaultReturnValue
     }
     win.onunhandledrejection.__POSTHOG_INSTRUMENTED__ = true
 
@@ -168,7 +173,7 @@ const extendPostHogWithExceptionAutocapture = (instance?: LegacyPostHogInstance,
     }
 
     wrapOnError(captureException)
-    wrapUnhandledRejection(captureException)
+    wrapUnhandledRejection(captureException, true)
 }
 
 assignableWindow.extendPostHogWithExceptionAutoCapture = extendPostHogWithExceptionAutocapture

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -2,7 +2,7 @@ import { window } from '@posthog/browser-common/utils/globals'
 import { assignableWindow } from '../utils/globals'
 import { ErrorEventArgs } from '../types'
 import { createLogger } from '@posthog/browser-common/utils/logger'
-import { isFunction, isString, type ErrorTracking } from '@posthog/core'
+import { isArray, isFunction, isNull, isString, type ErrorTracking } from '@posthog/core'
 import { buildErrorPropertiesBuilder } from '../posthog-exceptions'
 
 const logger = createLogger('[ExceptionAutocapture]')
@@ -124,16 +124,40 @@ assignableWindow.posthogErrorWrappingFunctions = posthogErrorWrappingFunctions
 type LegacyPostHogInstance = {
     capture?: (event: string, properties: Record<string, any>, options?: Record<string, any>) => unknown
 }
-const extendPostHogWithExceptionAutocapture = (instance?: LegacyPostHogInstance) => {
+type LegacyDecideResponse = {
+    autocaptureExceptions?: boolean | { errors_to_ignore?: string[] }
+}
+const extendPostHogWithExceptionAutocapture = (instance?: LegacyPostHogInstance, response?: LegacyDecideResponse) => {
     if (!isFunction(instance?.capture)) {
         return
     }
 
+    const autocaptureExceptions = response?.autocaptureExceptions
+    const errorsToIgnore =
+        !isNull(autocaptureExceptions) &&
+        typeof autocaptureExceptions === 'object' &&
+        isArray(autocaptureExceptions.errors_to_ignore)
+            ? autocaptureExceptions.errors_to_ignore.map((rule) => new RegExp(rule))
+            : []
+
     const captureException = (properties: ErrorTracking.ErrorProperties) => {
-        instance.capture?.('$exception', properties as Record<string, any>, {
-            _noTruncate: true,
-            _batchKey: 'exceptionEvent',
-        })
+        if (
+            errorsToIgnore.some((regex) =>
+                properties.$exception_list.some((exception) => regex.test(exception.value || ''))
+            )
+        ) {
+            return
+        }
+
+        try {
+            instance.capture?.('$exception', properties as Record<string, any>, {
+                _noTruncate: true,
+                _batchKey: 'exceptionEvent',
+                _noHeatmaps: true,
+            })
+        } catch (error) {
+            logger.error('Failed to capture exception for a legacy client', error)
+        }
     }
 
     wrapOnError(captureException)

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -118,4 +118,29 @@ assignableWindow.__PosthogExtensions__.errorWrappingFunctions = posthogErrorWrap
 // when 1.161.1 is the oldest version seen in production we can remove this
 assignableWindow.posthogErrorWrappingFunctions = posthogErrorWrappingFunctions
 
+// posthog-js <= 1.141.0 checked the first spelling after loading this bundle,
+// but called the second spelling. Keep both aliases because the unversioned
+// extension bundle can be loaded by those pinned clients.
+type LegacyPostHogInstance = {
+    capture?: (event: string, properties: Record<string, any>, options?: Record<string, any>) => unknown
+}
+const extendPostHogWithExceptionAutocapture = (instance?: LegacyPostHogInstance) => {
+    if (!isFunction(instance?.capture)) {
+        return
+    }
+
+    const captureException = (properties: ErrorTracking.ErrorProperties) => {
+        instance.capture?.('$exception', properties as Record<string, any>, {
+            _noTruncate: true,
+            _batchKey: 'exceptionEvent',
+        })
+    }
+
+    wrapOnError(captureException)
+    wrapUnhandledRejection(captureException)
+}
+
+assignableWindow.extendPostHogWithExceptionAutoCapture = extendPostHogWithExceptionAutocapture
+assignableWindow.extendPostHogWithExceptionAutocapture = extendPostHogWithExceptionAutocapture
+
 export default posthogErrorWrappingFunctions

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -152,15 +152,7 @@ const extendPostHogWithExceptionAutocapture = (instance?: LegacyPostHogInstance,
               }, [])
             : []
 
-    const captureException = (properties: ErrorTracking.ErrorProperties) => {
-        if (
-            errorsToIgnore.some((regex) =>
-                properties.$exception_list.some((exception) => regex.test(exception.value || ''))
-            )
-        ) {
-            return
-        }
-
+    const sendExceptionEvent = (properties: ErrorTracking.ErrorProperties) => {
         try {
             instance.capture?.('$exception', properties as Record<string, any>, {
                 _noTruncate: true,
@@ -172,8 +164,20 @@ const extendPostHogWithExceptionAutocapture = (instance?: LegacyPostHogInstance,
         }
     }
 
+    const captureException = (properties: ErrorTracking.ErrorProperties) => {
+        if (
+            errorsToIgnore.some((regex) =>
+                properties.$exception_list.some((exception) => regex.test(exception.value || ''))
+            )
+        ) {
+            return
+        }
+
+        sendExceptionEvent(properties)
+    }
+
     wrapOnError(captureException)
-    wrapUnhandledRejection(captureException, true)
+    wrapUnhandledRejection(sendExceptionEvent, true)
 }
 
 assignableWindow.extendPostHogWithExceptionAutoCapture = extendPostHogWithExceptionAutocapture

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -137,7 +137,14 @@ const extendPostHogWithExceptionAutocapture = (instance?: LegacyPostHogInstance,
         !isNull(autocaptureExceptions) &&
         typeof autocaptureExceptions === 'object' &&
         isArray(autocaptureExceptions.errors_to_ignore)
-            ? autocaptureExceptions.errors_to_ignore.map((rule) => new RegExp(rule))
+            ? autocaptureExceptions.errors_to_ignore.reduce<RegExp[]>((rules, rule) => {
+                  try {
+                      rules.push(new RegExp(rule))
+                  } catch (error) {
+                      logger.error('Ignoring invalid legacy exception exclusion rule', rule, error)
+                  }
+                  return rules
+              }, [])
             : []
 
     const captureException = (properties: ErrorTracking.ErrorProperties) => {

--- a/packages/browser/src/utils/globals.ts
+++ b/packages/browser/src/utils/globals.ts
@@ -83,6 +83,17 @@ export type AssignableWindow = Window &
         posthogErrorWrappingFunctions: any
 
         /**
+         * Legacy exception autocapture entrypoint names used by posthog-js <= 1.141.0.
+         * Both spellings are required because those clients checked one and called the other.
+         *
+         * See entrypoints/exception-autocapture.ts
+         *
+         * @deprecated use `__PosthogExtensions__.errorWrappingFunctions` instead
+         */
+        extendPostHogWithExceptionAutoCapture: any
+        extendPostHogWithExceptionAutocapture: any
+
+        /**
          * This is a legacy way to expose these functions, but we still need to support it for backwards compatibility
          * Can be removed once we drop support for 1.161.1
          *


### PR DESCRIPTION
## Problem

`posthog-js` versions through 1.141.0 check for `window.extendPostHogWithExceptionAutoCapture` after loading the exception autocapture bundle, but call `window.extendPostHogWithExceptionAutocapture`. The current unversioned bundle exposes neither name, so pinned clients can throw a `TypeError` when exception autocapture is enabled.

Closes #1904.

## Changes

- Expose the legacy exception autocapture adapter under both spellings expected by older clients.
- Route captured errors and unhandled rejections through the legacy client's `capture` method while preserving exclusion rules and `_noHeatmaps` behavior.
- Keep malformed exclusion rules and capture failures from breaking legacy error handlers, and preserve the old unhandled-rejection return value.
- Add unit coverage for both global names, both capture paths, exclusions, and failure handling.
- Extend the general backward-compatibility Playwright suite with a project that runs the current lazy bundle against `posthog-js@1.140.1`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and reviewed with Pi. The compatibility adapter deliberately exposes both historical spellings because old clients check one name and call the other. It retains the old core's exclusion and heatmap options while using the current `$exception_list` shape. The general compatibility suite downloads the published 1.140.1 core and runs focused capture and exclusion tests as a separate Playwright project alongside the latest-core tests.
