### PR TITLE
feat(rollup): add event release mode

### DIFF
--- a/.changeset/bump-cli-for-release-resolve.md
+++ b/.changeset/bump-cli-for-release-resolve.md
@@ -1,0 +1,8 @@
+---
+'@posthog/nextjs-config': patch
+'@posthog/nuxt': patch
+'@posthog/rollup-plugin': patch
+'@posthog/webpack-plugin': patch
+---
+
+Bump `@posthog/cli` to `~0.13.0`, which ships the `release resolve` command the rollup plugin's event release mode spawns.

--- a/.changeset/rollup-event-release-mode.md
+++ b/.changeset/rollup-event-release-mode.md
@@ -1,0 +1,6 @@
+---
+'@posthog/plugin-utils': minor
+'@posthog/rollup-plugin': minor
+---
+
+Add experimental `sourcemaps.releaseMode: 'event'` to the rollup plugin. In event mode the plugin resolves the release with `posthog-cli release resolve` and injects its id into every chunk, so exceptions report their release directly instead of it being bound to the uploaded symbol sets, and chunk ids are derived from chunk content so a rebuild of unchanged code reuses the symbol set already uploaded. The option defaults to the `POSTHOG_RELEASE_MODE` environment variable and then to `symbol-set`, which behaves exactly as before. Event mode needs a posthog-cli with the `release resolve` command.

--- a/packages/plugin-utils/src/chunk-ids.spec.ts
+++ b/packages/plugin-utils/src/chunk-ids.spec.ts
@@ -1,15 +1,41 @@
-import { createChunkId, createChunkIdComment, createChunkIdSnippet, determineChunkIdFromSource } from './chunk-ids'
+import {
+    createChunkId,
+    createChunkIdComment,
+    createChunkIdSnippet,
+    createStableChunkId,
+    determineChunkIdFromSource,
+} from './chunk-ids'
 
 // Mirrors cli/src/sourcemaps/constant.rs in PostHog/posthog. The CLI de-duplicates
 // and removes injected snippets by exact substring match, so the JS and Rust
 // templates must stay byte-identical — update both sides together.
 const CLI_CODE_SNIPPET_TEMPLATE = `!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="__POSTHOG_CHUNK_ID__")}catch(e){}}();`
+const CLI_CODE_SNIPPET_WITH_RELEASE_TEMPLATE = `!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{};e._posthogReleaseId=e._posthogReleaseId||__POSTHOG_RELEASE_ID__;var n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="__POSTHOG_CHUNK_ID__")}catch(e){}}();`
 const CLI_CHUNKID_COMMENT_PREFIX = '\n//# chunkId=__POSTHOG_CHUNK_ID__'
 const CLI_CHUNKID_PLACEHOLDER = '__POSTHOG_CHUNK_ID__'
+const CLI_RELEASE_ID_PLACEHOLDER = '__POSTHOG_RELEASE_ID__'
 
 describe('chunk-ids', () => {
     it('emits the snippet byte-identical to the posthog-cli template', () => {
         expect(createChunkIdSnippet(CLI_CHUNKID_PLACEHOLDER)).toBe(CLI_CODE_SNIPPET_TEMPLATE)
+    })
+
+    it('emits the release snippet byte-identical to the posthog-cli template', () => {
+        // The CLI substitutes __POSTHOG_RELEASE_ID__ with a JSON-encoded string, which brings its
+        // own quotes, so rendering the placeholder as an id yields the template with it quoted.
+        const expected = CLI_CODE_SNIPPET_WITH_RELEASE_TEMPLATE.replace(
+            CLI_RELEASE_ID_PLACEHOLDER,
+            `"${CLI_RELEASE_ID_PLACEHOLDER}"`
+        )
+
+        expect(createChunkIdSnippet(CLI_CHUNKID_PLACEHOLDER, CLI_RELEASE_ID_PLACEHOLDER)).toBe(expected)
+    })
+
+    it('derives a chunk id from content with the same namespace as posthog-cli', () => {
+        // Golden vector cross-checked against the CLI: injecting a chunk whose bytes are exactly
+        // `code();\n` writes this id. A different namespace or digest silently gives every chunk a
+        // new id on the next build, so the symbol sets stop deduplicating.
+        expect(createStableChunkId('code();\n')).toBe('58a7864c-f7b3-5a2e-ba91-18655350fd89')
     })
 
     it('emits the chunk id comment byte-identical to the posthog-cli template', () => {

--- a/packages/plugin-utils/src/chunk-ids.ts
+++ b/packages/plugin-utils/src/chunk-ids.ts
@@ -2,15 +2,24 @@ import * as crypto from 'crypto'
 
 /**
  * Returns the minified chunk-id IIFE the SDK reads at runtime to map an
- * error's stack back to a chunk id.
+ * error's stack back to a chunk id. With `releaseId`, the snippet also pins
+ * `_posthogReleaseId` on the global so the SDK emits the release on every
+ * exception (first write wins, so the first loaded chunk decides).
  *
- * Byte-for-byte contract with posthog-cli (`CODE_SNIPPET_TEMPLATE` in
- * cli/src/sourcemaps/constant.rs): the CLI recognizes and removes previously
- * injected snippets by exact substring match, so any change here must ship in
- * the CLI constants too. Covered by a parity test in chunk-ids.spec.ts.
+ * Byte-for-byte contract with posthog-cli (`CODE_SNIPPET_TEMPLATE` and
+ * `CODE_SNIPPET_WITH_RELEASE_TEMPLATE` in cli/src/sourcemaps/constant.rs): the
+ * CLI recognizes and removes previously injected snippets by exact substring
+ * match, so any change here must ship in the CLI constants too. Ids are
+ * JSON-encoded for the same reason the CLI encodes them: an id carrying a quote
+ * would otherwise break out of the string literal. Covered by a parity test in
+ * chunk-ids.spec.ts.
  */
-export function createChunkIdSnippet(chunkId: string): string {
-    return `!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="${chunkId}")}catch(e){}}();`
+export function createChunkIdSnippet(chunkId: string, releaseId?: string): string {
+    const chunk = JSON.stringify(chunkId)
+    if (releaseId === undefined) {
+        return `!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]=${chunk})}catch(e){}}();`
+    }
+    return `!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{};e._posthogReleaseId=e._posthogReleaseId||${JSON.stringify(releaseId)};var n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]=${chunk})}catch(e){}}();`
 }
 
 /**
@@ -27,6 +36,33 @@ export function createChunkIdComment(chunkId: string): string {
  */
 export function createChunkId(): string {
     return crypto.randomUUID()
+}
+
+// Fixed namespace for content-addressed chunk ids, matching `CHUNK_ID_NAMESPACE` in
+// cli/src/sourcemaps/constant.rs. Both sides must derive ids from the same namespace, or a
+// dist processed by one tool and re-processed by the other would upload the same code twice.
+const CHUNK_ID_NAMESPACE = '0e9b3c7a-5d1f-42a8-b6c4-e2d0f8a17593'
+
+/**
+ * Derives a chunk id from the chunk's own bytes (UUIDv5), so identical code keeps its id across
+ * rebuilds and re-uploads dedupe against the symbol set already stored. Used in event release
+ * mode, where the release travels inside the chunk instead of being bound to the symbol set, so
+ * a per-build random id would create a fresh symbol set on every build.
+ *
+ * The id is content-addressed over what `renderChunk` sees. posthog-cli derives its own ids from
+ * the file on disk, which by then also carries the trailing `sourceMappingURL` comment, so the
+ * same chunk gets a different (but equally stable) id depending on which tool injected it.
+ */
+export function createStableChunkId(code: string): string {
+    const namespace = Buffer.from(CHUNK_ID_NAMESPACE.replace(/-/g, ''), 'hex')
+    const hash = crypto.createHash('sha1').update(namespace).update(code, 'utf8').digest()
+
+    // RFC 4122: version in the high nibble of byte 6, variant in the top two bits of byte 8.
+    hash[6] = (hash[6] & 0x0f) | 0x50
+    hash[8] = (hash[8] & 0x3f) | 0x80
+
+    const hex = hash.subarray(0, 16).toString('hex')
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`
 }
 
 // Anchored with a bounded quantifier and only ever run against a fixed-size

--- a/packages/plugin-utils/src/cli.spec.ts
+++ b/packages/plugin-utils/src/cli.spec.ts
@@ -21,6 +21,23 @@ describe('buildSourcemapCliArgs', () => {
         expect(args).not.toContain('--delete-after')
     })
 
+    it.each([
+        { releaseMode: 'symbol-set' as const, expected: false },
+        { releaseMode: 'event' as const, expected: true },
+    ])('passes --release-mode only in event mode ($releaseMode)', ({ releaseMode, expected }) => {
+        // Symbol-set builds must stay compatible with a posthog-cli predating the flag, and an
+        // event build that loses it binds its symbol sets to a release after all.
+        const withMode = resolveConfig({
+            personalApiKey: 'phx_test',
+            projectId: '1',
+            sourcemaps: { releaseMode },
+        })
+
+        const args = buildSourcemapCliArgs(withMode, { directory: 'dist' }, 'upload')
+
+        expect(args.includes('--release-mode')).toBe(expected)
+    })
+
     it('keeps release args on upload', () => {
         const withRelease = resolveConfig({
             personalApiKey: 'phx_test',

--- a/packages/plugin-utils/src/cli.spec.ts
+++ b/packages/plugin-utils/src/cli.spec.ts
@@ -1,9 +1,35 @@
-import { buildSourcemapCliArgs } from './cli'
+import { buildCliEnv, buildSourcemapCliArgs } from './cli'
 import { resolveConfig } from './config'
 
 const config = resolveConfig({
     personalApiKey: 'phx_test',
     projectId: '1',
+})
+
+describe('buildCliEnv', () => {
+    const originalEnv = process.env.POSTHOG_RELEASE_MODE
+
+    afterEach(() => {
+        if (originalEnv === undefined) {
+            delete process.env.POSTHOG_RELEASE_MODE
+        } else {
+            process.env.POSTHOG_RELEASE_MODE = originalEnv
+        }
+    })
+
+    it('pins the release mode the plugin resolved, so an inherited value cannot flip the CLI', () => {
+        // posthog-cli binds --release-mode to POSTHOG_RELEASE_MODE, so forwarding an inherited
+        // 'event' would upload in event mode while the plugin injected symbol-set chunks, and the
+        // build would end up with a release at neither end.
+        process.env.POSTHOG_RELEASE_MODE = 'event'
+        const symbolSet = resolveConfig({
+            personalApiKey: 'phx_test',
+            projectId: '1',
+            sourcemaps: { releaseMode: 'symbol-set' },
+        })
+
+        expect(buildCliEnv(symbolSet).POSTHOG_RELEASE_MODE).toBe('symbol-set')
+    })
 })
 
 describe('buildSourcemapCliArgs', () => {

--- a/packages/plugin-utils/src/cli.ts
+++ b/packages/plugin-utils/src/cli.ts
@@ -80,6 +80,9 @@ export function buildCliEnv(config: ResolvedPluginConfig): NodeJS.ProcessEnv {
         POSTHOG_CLI_HOST: config.host,
         POSTHOG_CLI_API_KEY: config.personalApiKey,
         POSTHOG_CLI_PROJECT_ID: config.projectId,
+        // The CLI reads this variable itself, so an inherited value would decide the release mode
+        // of the spawned command while the plugin injected chunks for the mode it resolved.
+        POSTHOG_RELEASE_MODE: config.sourcemaps.releaseMode,
     }
 }
 

--- a/packages/plugin-utils/src/cli.ts
+++ b/packages/plugin-utils/src/cli.ts
@@ -1,5 +1,5 @@
 import { ResolvedPluginConfig } from './config'
-import { spawnLocal } from './spawn-local'
+import { spawnLocal, spawnLocalCapture } from './spawn-local'
 
 /**
  * `process` injects chunk ids into the built files on disk and uploads them.
@@ -7,6 +7,28 @@ import { spawnLocal } from './spawn-local'
  * (e.g. injected in-memory by a bundler plugin before the files were written).
  */
 export type SourcemapCliCommand = 'process' | 'upload'
+
+/**
+ * The flags identifying which release this build belongs to. Shared by every command that
+ * resolves one, so `release resolve` lands on the same release row the upload would have.
+ */
+function buildReleaseArgs(config: ResolvedPluginConfig): string[] {
+    const args: string[] = []
+
+    if (config.sourcemaps.releaseName) {
+        args.push('--release-name', config.sourcemaps.releaseName)
+    }
+
+    if (config.sourcemaps.releaseVersion) {
+        args.push('--release-version', config.sourcemaps.releaseVersion)
+    }
+
+    if (config.sourcemaps.build !== undefined && config.sourcemaps.build !== '') {
+        args.push('--build', config.sourcemaps.build)
+    }
+
+    return args
+}
 
 /**
  * Build CLI arguments for `posthog-cli sourcemap <command>`.
@@ -24,16 +46,12 @@ export function buildSourcemapCliArgs(
         args.push('--directory', mode.directory)
     }
 
-    if (config.sourcemaps.releaseName) {
-        args.push('--release-name', config.sourcemaps.releaseName)
-    }
+    args.push(...buildReleaseArgs(config))
 
-    if (config.sourcemaps.releaseVersion) {
-        args.push('--release-version', config.sourcemaps.releaseVersion)
-    }
-
-    if (config.sourcemaps.build !== undefined && config.sourcemaps.build !== '') {
-        args.push('--build', config.sourcemaps.build)
+    // Only passed in event mode, so a symbol-set build keeps working against a posthog-cli
+    // predating the flag.
+    if (config.sourcemaps.releaseMode === 'event') {
+        args.push('--release-mode', 'event')
     }
 
     // On `upload` the caller owns map deletion: `--delete-after` also rewrites
@@ -87,4 +105,36 @@ export async function runSourcemapCli(
     }
 
     await spawnLocal(config.cliBinaryPath, args, spawnOptions)
+}
+
+/**
+ * Resolves the release this build belongs to, creating it if it doesn't exist yet, and returns its
+ * id for injection into the chunks. Returns undefined when nothing identifies a release: the CLI
+ * prints nothing and exits zero for a build with no release name/version and no git or CI
+ * metadata to derive them from, which is a build that ships without a release rather than a
+ * failure.
+ */
+export async function resolveReleaseId(config: ResolvedPluginConfig): Promise<string | undefined> {
+    const args = ['release', 'resolve', ...buildReleaseArgs(config)]
+    const { code, stdout, stderr } = await spawnLocalCapture(config.cliBinaryPath, args, {
+        cwd: process.cwd(),
+        env: buildCliEnv(config),
+    })
+
+    if (code !== 0) {
+        // `release resolve` shipped after `sourcemap upload`, so an older binary on the PATH
+        // fails here rather than at upload time, where the message would make more sense.
+        const hint = /unrecognized subcommand|unexpected argument/.test(stderr)
+            ? ` Event release mode needs a posthog-cli with 'release resolve' (${config.cliBinaryPath}).`
+            : ''
+        throw new Error(`posthog-cli release resolve failed with code ${code}.${hint}\n${stderr.trim()}`)
+    }
+
+    // The CLI logs to stderr and prints only the id to stdout, so forward its warnings rather
+    // than swallowing them with the captured stream.
+    if (stderr.trim()) {
+        process.stderr.write(stderr)
+    }
+
+    return stdout.trim() || undefined
 }

--- a/packages/plugin-utils/src/config.spec.ts
+++ b/packages/plugin-utils/src/config.spec.ts
@@ -31,6 +31,60 @@ describe('resolveConfig', () => {
         expect(config.host).toBe(expectedHost)
     })
 
+    describe('releaseMode', () => {
+        const originalEnv = process.env.POSTHOG_RELEASE_MODE
+
+        afterEach(() => {
+            if (originalEnv === undefined) {
+                delete process.env.POSTHOG_RELEASE_MODE
+            } else {
+                process.env.POSTHOG_RELEASE_MODE = originalEnv
+            }
+        })
+
+        it.each([
+            { name: 'defaults to symbol-set', option: undefined, env: undefined, expected: 'symbol-set' },
+            { name: 'reads POSTHOG_RELEASE_MODE', option: undefined, env: 'event', expected: 'event' },
+            { name: 'prefers the explicit option', option: 'symbol-set', env: 'event', expected: 'symbol-set' },
+            {
+                name: 'takes the explicit option without an env var',
+                option: 'event',
+                env: undefined,
+                expected: 'event',
+            },
+        ])('$name', ({ option, env, expected }) => {
+            if (env === undefined) {
+                delete process.env.POSTHOG_RELEASE_MODE
+            } else {
+                process.env.POSTHOG_RELEASE_MODE = env
+            }
+
+            const config = resolveConfig(
+                {
+                    personalApiKey: 'phx_personal_key',
+                    projectId: 'project-id',
+                    cliBinaryPath: '/tmp/posthog-cli',
+                    sourcemaps: { releaseMode: option as 'symbol-set' | 'event' | undefined },
+                },
+                { defaultEnabled: false }
+            )
+
+            expect(config.sourcemaps.releaseMode).toBe(expected)
+        })
+
+        it('rejects an unknown release mode instead of silently binding to a release', () => {
+            process.env.POSTHOG_RELEASE_MODE = 'events'
+
+            expect(() =>
+                resolveConfig({
+                    personalApiKey: 'phx_personal_key',
+                    projectId: 'project-id',
+                    cliBinaryPath: '/tmp/posthog-cli',
+                })
+            ).toThrow('sourcemaps.releaseMode must be one of symbol-set, event')
+        })
+    })
+
     it('rejects a blank personalApiKey after trimming whitespace when sourcemaps are enabled', () => {
         expect(() =>
             resolveConfig({

--- a/packages/plugin-utils/src/config.ts
+++ b/packages/plugin-utils/src/config.ts
@@ -13,6 +13,26 @@ function normalizeHost(value?: unknown): string {
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'
 
+/**
+ * How an exception gets associated with a release, mirroring posthog-cli's `--release-mode`.
+ *
+ * `symbol-set` binds the uploaded symbol sets to a release. `event` leaves them unbound and
+ * injects the release id into each chunk instead, so the release is resolved per exception.
+ */
+export type ReleaseMode = 'symbol-set' | 'event'
+
+const RELEASE_MODES: ReleaseMode[] = ['symbol-set', 'event']
+
+function normalizeReleaseMode(value: string | undefined): ReleaseMode {
+    if (value === undefined || value === '') {
+        return 'symbol-set'
+    }
+    if (!(RELEASE_MODES as string[]).includes(value)) {
+        throw new Error(`sourcemaps.releaseMode must be one of ${RELEASE_MODES.join(', ')}, got '${value}'`)
+    }
+    return value as ReleaseMode
+}
+
 export interface PluginConfig {
     personalApiKey: string
     /** @deprecated Use projectId instead */
@@ -32,6 +52,12 @@ export interface PluginConfig {
         build?: string | number
         deleteAfterUpload?: boolean
         batchSize?: number
+        /**
+         * EXPERIMENTAL. Defaults to the `POSTHOG_RELEASE_MODE` env var, the same one posthog-cli
+         * reads, then to `symbol-set`. Event mode needs a posthog-cli that supports
+         * `release resolve` and `--release-mode`.
+         */
+        releaseMode?: ReleaseMode
     }
 }
 
@@ -47,6 +73,7 @@ export interface ResolvedPluginConfig extends Omit<PluginConfig, 'envId' | 'proj
         build?: string
         deleteAfterUpload: boolean
         batchSize?: number
+        releaseMode: ReleaseMode
     }
 }
 
@@ -96,6 +123,7 @@ export function resolveConfig(options: PluginConfig, resolveOptions?: ResolveCon
             build: userSourcemaps.build !== undefined ? String(userSourcemaps.build) : undefined,
             deleteAfterUpload: userSourcemaps.deleteAfterUpload ?? true,
             batchSize: userSourcemaps.batchSize,
+            releaseMode: normalizeReleaseMode(userSourcemaps.releaseMode ?? process.env.POSTHOG_RELEASE_MODE),
         },
     }
 }

--- a/packages/plugin-utils/src/spawn-local.ts
+++ b/packages/plugin-utils/src/spawn-local.ts
@@ -1,5 +1,45 @@
 import { spawn } from 'cross-spawn'
 
+export interface CapturedRun {
+    code: number | null
+    stdout: string
+    stderr: string
+}
+
+/**
+ * Runs a command and captures both streams instead of inheriting them, for commands whose stdout
+ * is a value the caller needs rather than build output. Resolves with a non-zero `code` rather
+ * than rejecting, so the caller can shape the error from what the command wrote to stderr.
+ */
+export async function spawnLocalCapture(
+    executable: string,
+    args: string[],
+    options: {
+        env: NodeJS.ProcessEnv
+        cwd: string
+    }
+): Promise<CapturedRun> {
+    const child = spawn(executable, [...args], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: options.env,
+        cwd: options.cwd,
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString()
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString()
+    })
+
+    return await new Promise<CapturedRun>((resolve, reject) => {
+        child.on('close', (code) => resolve({ code, stdout, stderr }))
+        child.on('error', (error) => reject(error))
+    })
+}
+
 export async function spawnLocal(
     executable: string,
     args: string[],

--- a/packages/rollup-plugin/src/index.spec.ts
+++ b/packages/rollup-plugin/src/index.spec.ts
@@ -3,6 +3,7 @@ import {
     createChunkIdComment,
     createChunkIdSnippet,
     determineChunkIdFromSource,
+    resolveReleaseId,
     runSourcemapCli,
 } from '@posthog/plugin-utils'
 import posthogRollupPlugin from './index.js'
@@ -13,6 +14,7 @@ import os from 'node:os'
 jest.mock('@posthog/plugin-utils', () => ({
     ...jest.requireActual('@posthog/plugin-utils'),
     runSourcemapCli: jest.fn().mockResolvedValue(undefined),
+    resolveReleaseId: jest.fn().mockResolvedValue('release-id-1'),
 }))
 
 const options = {
@@ -24,6 +26,7 @@ type RenderChunkResult = { code: string; map: unknown } | null
 
 type TestPlugin = {
     config: () => { build: { sourcemap: 'hidden' | true } } | undefined
+    buildStart: () => void
     outputOptions: {
         handler: (options: OutputOptions) => OutputOptions
     }
@@ -146,6 +149,71 @@ describe('posthogRollupPlugin', () => {
             })
 
             expect(result!.code.startsWith('"use client";\n"use strict";\n!function(){try{')).toBe(true)
+        })
+
+        describe('event release mode', () => {
+            const eventOptions = { ...options, sourcemaps: { releaseMode: 'event' as const } }
+
+            beforeEach(() => {
+                jest.mocked(resolveReleaseId).mockResolvedValue('release-id-1')
+            })
+
+            it('injects the resolved release id so exceptions carry it', async () => {
+                const plugin = testPlugin(eventOptions)
+
+                const result = await plugin.renderChunk.handler(code, { fileName: 'index.js' })
+
+                expect(result!.code).toContain('e._posthogReleaseId=e._posthogReleaseId||"release-id-1"')
+            })
+
+            it('derives the chunk id from content, so rebuilds reuse the symbol set', async () => {
+                const plugin = testPlugin(eventOptions)
+
+                const first = await plugin.renderChunk.handler(code, { fileName: 'index.js' })
+                const rebuilt = await testPlugin(eventOptions).renderChunk.handler(code, { fileName: 'index.js' })
+                const other = await plugin.renderChunk.handler(`${code}more();`, { fileName: 'other.js' })
+
+                expect(determineChunkIdFromSource(rebuilt!.code)).toBe(determineChunkIdFromSource(first!.code))
+                expect(determineChunkIdFromSource(other!.code)).not.toBe(determineChunkIdFromSource(first!.code))
+            })
+
+            it('resolves the release once per build, not once per chunk', async () => {
+                const plugin = testPlugin(eventOptions)
+
+                await plugin.renderChunk.handler(code, { fileName: 'a.js' })
+                await plugin.renderChunk.handler(`${code}more();`, { fileName: 'b.js' })
+
+                expect(resolveReleaseId).toHaveBeenCalledTimes(1)
+
+                // A watch-mode rebuild can land on a new commit, so the next build resolves again.
+                plugin.buildStart()
+                await plugin.renderChunk.handler(code, { fileName: 'a.js' })
+
+                expect(resolveReleaseId).toHaveBeenCalledTimes(2)
+            })
+
+            it('still injects chunk ids when no release can be resolved', async () => {
+                // Chunk ids alone still symbolicate, so a build with no identifiable release warns
+                // instead of failing, the way posthog-cli does.
+                jest.mocked(resolveReleaseId).mockResolvedValue(undefined)
+                const plugin = testPlugin(eventOptions)
+                const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+                const result = await plugin.renderChunk.handler(code, { fileName: 'index.js' })
+
+                expect(result!.code).not.toContain('_posthogReleaseId')
+                expect(determineChunkIdFromSource(result!.code)).toBeDefined()
+                expect(warn).toHaveBeenCalledWith(expect.stringContaining('no release could be resolved'))
+                warn.mockRestore()
+            })
+
+            it('does not resolve a release in symbol-set mode', async () => {
+                const plugin = testPlugin(options)
+
+                await plugin.renderChunk.handler(code, { fileName: 'index.js' })
+
+                expect(resolveReleaseId).not.toHaveBeenCalled()
+            })
         })
 
         it('skips non-js chunks and disabled sourcemaps', () => {

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -3,7 +3,9 @@ import {
     PluginConfig,
     resolveConfig,
     runSourcemapCli,
+    resolveReleaseId,
     createChunkId,
+    createStableChunkId,
     createChunkIdSnippet,
     createChunkIdComment,
     determineChunkIdFromSource,
@@ -37,8 +39,32 @@ const PROLOGUE_REGEX =
 
 export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOptions): Plugin {
     const posthogOptions = resolveConfig(userOptions)
+    const eventReleaseMode = posthogOptions.sourcemaps.releaseMode === 'event'
+
+    // Resolved once per build and shared by every output, so all chunks of one build carry the
+    // same release. Cleared in buildStart because a watch-mode rebuild can land on a new commit,
+    // which is a different release.
+    let releaseIdPromise: Promise<string | undefined> | undefined
+    let warnedAboutMissingRelease = false
+
+    function injectChunkId(code: string, chunkId: string, releaseId?: string) {
+        const magicString = new MagicString(code)
+        magicString.appendLeft(code.match(PROLOGUE_REGEX)?.[0].length ?? 0, createChunkIdSnippet(chunkId, releaseId))
+        magicString.append(createChunkIdComment(chunkId))
+
+        return {
+            code: magicString.toString(),
+            map: magicString.generateMap({ hires: 'boundary' }),
+        }
+    }
+
     const plugin: PostHogRollupPlugin = {
         name: 'posthog-rollup-plugin',
+
+        buildStart() {
+            releaseIdPromise = undefined
+            warnedAboutMissingRelease = false
+        },
 
         config() {
             if (!posthogOptions.sourcemaps.enabled) return
@@ -72,17 +98,36 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
                 if (!posthogOptions.sourcemaps.enabled) return null
                 if (!JS_CHUNK_REGEX.test(chunk.fileName)) return null
                 // Already carries an id (watch-mode re-render, another tool)
-                if (determineChunkIdFromSource(code)) return null
-
-                const chunkId = createChunkId()
-                const magicString = new MagicString(code)
-                magicString.appendLeft(code.match(PROLOGUE_REGEX)?.[0].length ?? 0, createChunkIdSnippet(chunkId))
-                magicString.append(createChunkIdComment(chunkId))
-
-                return {
-                    code: magicString.toString(),
-                    map: magicString.generateMap({ hires: 'boundary' }),
+                if (determineChunkIdFromSource(code)) {
+                    if (eventReleaseMode) {
+                        console.warn(
+                            `PostHog: ${chunk.fileName} already carries a chunk id, so no release id was injected — its exceptions will report no release`
+                        )
+                    }
+                    return null
                 }
+
+                if (!eventReleaseMode) {
+                    return injectChunkId(code, createChunkId())
+                }
+
+                // Event mode carries the release inside the chunk, which means resolving it before
+                // the snippet is built. The id is content-addressed so an unchanged chunk keeps its
+                // id (and its symbol set) across rebuilds.
+                releaseIdPromise ??= resolveReleaseId(posthogOptions)
+                const chunkId = createStableChunkId(code)
+                return releaseIdPromise.then((releaseId) => {
+                    // A build that identifies no release still symbolicates from its chunk ids, so
+                    // this warns rather than failing, matching what posthog-cli does in the same
+                    // situation.
+                    if (!releaseId && !warnedAboutMissingRelease) {
+                        warnedAboutMissingRelease = true
+                        console.warn(
+                            '[posthog-rollup-plugin] no release could be resolved, injecting chunk ids only, so exceptions from this build will report no release. Set sourcemaps.releaseName and sourcemaps.releaseVersion, or build from a git repository or a supported CI environment.'
+                        )
+                    }
+                    return injectChunkId(code, chunkId, releaseId)
+                })
             },
         },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^7.27.1
       version: 7.28.5
     '@posthog/cli':
-      specifier: ~0.11.1
-      version: 0.11.1
+      specifier: ~0.13.0
+      version: 0.13.0
     '@rslib/core':
       specifier: 0.10.6
       version: 0.10.6
@@ -708,7 +708,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.13.0
       '@posthog/plugin-utils':
         specifier: workspace:^
         version: link:../plugin-utils
@@ -785,7 +785,7 @@ importers:
         version: 4.1.3(magicast@0.5.3)
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.13.0
       '@posthog/core':
         specifier: workspace:^
         version: link:../core
@@ -1127,7 +1127,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.13.0
       '@posthog/plugin-utils':
         specifier: workspace:^
         version: link:../plugin-utils
@@ -1680,7 +1680,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.13.0
       '@posthog/core':
         specifier: workspace:^
         version: link:../core
@@ -5665,8 +5665,8 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@posthog/cli@0.11.1':
-    resolution: {integrity: sha512-v1Ry3Ej6pltN5F1VahtrzpFdhgBAT6vwBRcC2A5P2k/CQjPVB1dWzYFA9yD1hjwpAw+cmWhJlyZm4QccX/DQnw==}
+  '@posthog/cli@0.13.0':
+    resolution: {integrity: sha512-ZP7ZLmFyjLakGjkDzm3/Eu5XvonY4pFD1SOtMc5TjkwYS6TmihuuLp0iDp+X7Pd9xFI0eLtBpfV/G9HI/XRZbg==}
     engines: {node: '>=14.14', npm: '>=6'}
     hasBin: true
 
@@ -24247,7 +24247,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@posthog/cli@0.11.1':
+  '@posthog/cli@0.13.0':
     dependencies:
       detect-libc: 2.1.2
 
@@ -27131,7 +27131,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.22':
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@vue/shared': 3.5.22
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -27791,8 +27791,8 @@ snapshots:
 
   babel-plugin-jest-hoist@26.6.2:
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
       '@types/babel__core': 7.1.18
       '@types/babel__traverse': 7.14.2
 
@@ -34953,8 +34953,8 @@ snapshots:
   metro-transform-plugins@0.80.12:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/template': 7.27.2
+      '@babel/generator': 7.29.8
+      '@babel/template': 7.29.7
       '@babel/traverse': 7.28.5
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
@@ -34996,9 +34996,9 @@ snapshots:
   metro-transform-worker@0.80.12:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       metro: 0.80.12
       metro-babel-transformer: 0.80.12
@@ -35037,11 +35037,11 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.27.2
+      '@babel/generator': 7.29.8
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       absolute-path: 0.0.0
       accepts: 1.3.8
       async: 3.2.6
@@ -37547,10 +37547,8 @@ snapshots:
       which: 2.0.2
       yargs: 17.7.2
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
       - typescript
-      - utf-8-validate
 
   react-native-codegen@0.69.2(@babel/preset-env@7.28.5(@babel/core@7.28.5)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@babel/preset-env': ^7.27.1
   '@babel/preset-react': ^7.27.1
   '@babel/preset-typescript': ^7.27.1
-  '@posthog/cli': ~0.11.1
+  '@posthog/cli': ~0.13.0
   '@rslib/core': 0.10.6
   '@testing-library/dom': ^10.4.1
   '@testing-library/jest-dom': ^6.9.1


### PR DESCRIPTION
## Problem

Someone using the rollup plugin cannot get a release onto their exceptions the way `posthog-cli --release-mode=event` does. Three reasons, in order:

- The release can only be bound to the uploaded symbol set, so exceptions resolve a release indirectly or not at all.
- The plugin injects chunk ids in memory in `renderChunk` and then calls `sourcemap upload`, so the CLI's inject step never runs, and nothing writes a release id into a chunk.
- Chunk ids are random per build, so a rebuild of unchanged code uploads a second symbol set for the same bytes.

## Changes

- `sourcemaps.releaseMode: 'event'` turns on the new path. The default, `symbol-set`, behaves exactly as before.
- The plugin resolves the release once per build with `posthog-cli release resolve` and injects its id into every chunk, so each exception reports `$release_id` itself.
- Chunk ids in event mode are derived from the chunk's own bytes, using the CLI's UUIDv5 namespace. An unchanged chunk keeps its id, so the symbol set already uploaded is reused.
- The upload passes `--release-mode=event`, which leaves the symbol sets unbound. That flag is only passed in event mode, so a symbol-set build still works against a posthog-cli that predates it.
- The option falls back to `POSTHOG_RELEASE_MODE`, the same environment variable the CLI reads.
- A build that identifies no release warns and injects chunk ids only. That matches what posthog-cli does in the same situation, where chunk ids alone still symbolicate.
- The release is re-resolved on a watch-mode rebuild, because a rebuild can land on a new commit.

Two things a reviewer should not have to derive from the diff:

- Ids derived here differ from the ids posthog-cli derives for the same chunk. The CLI hashes the file on disk, which by then carries the trailing `sourceMappingURL` comment, and `renderChunk` code does not. Both are stable and content-addressed, and every consumer reads the id back from the injected comment.
- Injection stays in `renderChunk` rather than moving to `sourcemap process`. `process` rewrites the files on disk, which would invalidate SRI hashes and content-hashed file names, the reason in-memory injection exists.

Event mode needs a posthog-cli with `release resolve`, which is not released yet ([PostHog/posthog#83231](https://github.com/PostHog/posthog/pull/83231)).

## Testing

| Old approach (still works) | New approach |
|--------|--------|
| <img width="1229" height="874" alt="CleanShot 2026-08-18 at 12 06 12" src="https://github.com/user-attachments/assets/38815816-8fde-41f3-87f5-64f4627b9257" /> | <img width="1229" height="874" alt="CleanShot 2026-08-18 at 12 06 34" src="https://github.com/user-attachments/assets/9aeb353d-762a-4085-8d5d-2998b3f6616c" /> | 

| New approach (existing release) | New approach (new release) |
|--------|--------|
| <img width="1670" height="226" alt="CleanShot 2026-08-18 at 12 07 58@2x" src="https://github.com/user-attachments/assets/ab8a9b20-cf04-4115-be35-8541fb6ce6a3" /> | <img width="1960" height="226" alt="CleanShot 2026-08-18 at 12 08 30@2x" src="https://github.com/user-attachments/assets/a0f92baa-fbb9-4169-9566-c92b786ae571" /> | 

Unit tests cover the parts that break silently: byte parity of the release snippet against the CLI template, a UUIDv5 golden vector cross-checked against the CLI, `--release-mode` reaching the upload in event mode only, one release resolution per build rather than per chunk, and the no-release fallback.

I also ran it end to end against a local PostHog, using the node-rollup app in error-tracking-examples:

- The build resolved the release, and `dist/index.js` carried `_posthogReleaseId` next to the chunk id.
- The captured `$exception` arrived with that `$release_id`.
- The stored symbol set had `release: null` and `has_uploaded_file: true`, and its `last_used` moved when the exception symbolicated.
- A second build of identical code under a new release version created the new release, kept the same chunk id, and reported `1 skipped (1 already present)` instead of uploading again.

Not run: the repo's full CI matrix, and any webpack plugin path, which this leaves untouched.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [x] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

`@posthog/plugin-utils` is bumped too, by the changeset in this PR.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

I (actually Claude) wrote this change, driven by @ablaszkiewicz.
