### PR TITLE
fix(mcp): avoid conversation ID prompt injection

### DIFF
--- a/.changeset/calm-conversations-report.md
+++ b/.changeset/calm-conversations-report.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': patch
+---
+
+Return conversation IDs as data-only tool output to avoid prompt-injection warnings from clients with stale schemas.

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -241,7 +241,7 @@ describe('conversation-id', () => {
       }
       expect(content).toHaveLength(2)
       expect(content[1].type).toBe('text')
-      expect(content[1].text).toContain('conversation_id=conv-123')
+      expect(JSON.parse(content[1].text)).toEqual({ conversation_id: 'conv-123' })
     })
 
     it('injects into an errored result — the retry must land in the same conversation', () => {
@@ -354,7 +354,7 @@ describe('conversation_id tool parameter', () => {
       await capture.stop()
     })
 
-    it('mints a conversation_id and appends a prompt-back text block when the agent omits it', async () => {
+    it('mints a conversation_id and appends a data-only text block when the agent omits it', async () => {
       instrument(server, fakePostHog(), { enableConversationId: true })
 
       const result = await client.request(
@@ -369,7 +369,7 @@ describe('conversation_id tool parameter', () => {
       )
 
       const promptBack = result.content.find(
-        (c) => c.type === 'text' && typeof c.text === 'string' && c.text.includes('conversation_id=')
+        (c) => c.type === 'text' && typeof c.text === 'string' && c.text.includes('"conversation_id"')
       )
       expect(promptBack).toBeDefined()
     })
@@ -436,7 +436,7 @@ describe('conversation_id tool parameter', () => {
       // A tool that fails on the first call is exactly when the agent needs the
       // session handle, or its retry starts a different conversation.
       const hasPromptBack = (result.content ?? []).some(
-        (c) => c.type === 'text' && typeof c.text === 'string' && c.text.includes('conversation_id=')
+        (c) => c.type === 'text' && typeof c.text === 'string' && c.text.includes('"conversation_id"')
       )
       expect(hasPromptBack).toBe(true)
     })
@@ -552,7 +552,13 @@ describe('conversation_id edge cases', () => {
       CallToolResultSchema
     )
     const handle = (first.content ?? [])
-      .map((c: any) => String(c.text ?? '').match(/conversation_id=([\w-]+)/)?.[1])
+      .map((c: any) => {
+        try {
+          return JSON.parse(String(c.text ?? '')).conversation_id
+        } catch {
+          return undefined
+        }
+      })
       .find(Boolean)
     expect(handle).toBeDefined()
 
@@ -637,7 +643,7 @@ describe('conversation_id edge cases', () => {
         CallToolResultSchema
       )
 
-      const hasPromptBack = (result.content ?? []).some((c: any) => String(c.text ?? '').includes('conversation_id='))
+      const hasPromptBack = (result.content ?? []).some((c: any) => String(c.text ?? '').includes('"conversation_id"'))
       expect(hasPromptBack).toBe(false)
     })
 

--- a/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
+++ b/packages/mcp/src/__tests__/instrument-lowlevel.test.ts
@@ -505,7 +505,7 @@ describe('Low-level Server tracing (e2e)', () => {
 
         expect(receivedCalls.at(-1)).toEqual({ name: 'owned_reserved', arguments: suppliedArguments })
         expect(
-          (result.content as { text?: string }[]).some((content) => content.text?.includes('conversation_id='))
+          (result.content as { text?: string }[]).some((content) => content.text?.includes('"conversation_id"'))
         ).toBe(false)
 
         await new Promise((resolve) => setTimeout(resolve, 50))
@@ -569,7 +569,7 @@ describe('Low-level Server tracing (e2e)', () => {
         arguments: { context: 'unknown context', conversation_id: 'unknown conversation', text: 'hi' },
       })
       expect(
-        (result.content as { text?: string }[]).some((content) => content.text?.includes('conversation_id='))
+        (result.content as { text?: string }[]).some((content) => content.text?.includes('"conversation_id"'))
       ).toBe(false)
       await new Promise((resolve) => setTimeout(resolve, 50))
       const event = eventCapture.getEvents().find((candidate) => candidate.resourceName === 'echo')

--- a/packages/mcp/src/__tests__/output-instructions.test.ts
+++ b/packages/mcp/src/__tests__/output-instructions.test.ts
@@ -283,7 +283,7 @@ describe('mirroring the session handle into structuredContent', () => {
     const result = mirrorInstructionsIntoStructuredContent(withStructured(), 'conv-1') as any
 
     expect(result.structuredContent[MCP_INSTRUCTIONS_KEY].conversation_id).toBe('conv-1')
-    expect(result.structuredContent[MCP_INSTRUCTIONS_KEY].instructions).toEqual(expect.any(String))
+    expect(result.structuredContent[MCP_INSTRUCTIONS_KEY]).toEqual({ conversation_id: 'conv-1' })
     expect(result.structuredContent.ok).toBe(true)
   })
 
@@ -352,7 +352,7 @@ describe('mirroring over a real client', () => {
       const second = await call(client, echoed)
 
       // The text block is mint-only; the structured copy rides every response.
-      const hasText = (second.content ?? []).some((c: any) => String(c.text).includes('conversation_id='))
+      const hasText = (second.content ?? []).some((c: any) => String(c.text).includes('"conversation_id"'))
       expect(hasText).toBe(false)
       expect((second.structuredContent as any)[MCP_INSTRUCTIONS_KEY].conversation_id).toBe(echoed)
     } finally {

--- a/packages/mcp/src/__tests__/reserved-arguments.test.ts
+++ b/packages/mcp/src/__tests__/reserved-arguments.test.ts
@@ -176,7 +176,7 @@ describe('high-level reserved analytics arguments', () => {
           CallToolResultSchema
         )
         expect(result.content).not.toEqual(
-          expect.arrayContaining([expect.objectContaining({ text: expect.stringContaining('conversation_id=') })])
+          expect.arrayContaining([expect.objectContaining({ text: expect.stringContaining('"conversation_id"') })])
         )
 
         expect(receivedArgs).toEqual(suppliedArguments)

--- a/packages/mcp/src/__tests__/v2-high-level-server.test.ts
+++ b/packages/mcp/src/__tests__/v2-high-level-server.test.ts
@@ -184,7 +184,7 @@ describe('instrument() on an MCP SDK v2 high-level server', () => {
   })
 
   /**
-   * `enableConversationId` appends a `[SERVER]: Reuse conversation_id=…` block to
+   * `enableConversationId` appends a data-only conversation ID block to
    * the result so the agent echoes the handle back. On v2 a thrown error is
    * already flattened into an `isError` result by the time we see it, so that
    * result *is* our only description of the failure — and reading the error off
@@ -214,8 +214,8 @@ describe('instrument() on an MCP SDK v2 high-level server', () => {
     expect(call.properties.$mcp_error_message).not.toMatch(/conversation_id/)
 
     // The caller still gets the handle, on the failed call.
-    const delivered = (result.content as { text: string }[]).map((block) => block.text).join('\n')
-    expect(delivered).toMatch(/Reuse conversation_id=/)
+    const delivered = (result.content as { text: string }[]).find((block) => block.text.includes('"conversation_id"'))
+    expect(JSON.parse(delivered?.text ?? '')).toEqual({ conversation_id: expect.any(String) })
   })
 
   /**

--- a/packages/mcp/src/extensions/conversation-id.ts
+++ b/packages/mcp/src/extensions/conversation-id.ts
@@ -162,7 +162,10 @@ export function buildConversationIdPromptBack(conversationId: string): {
 } {
   return {
     type: 'text',
-    text: `[SERVER]: Reuse conversation_id=${conversationId} on every subsequent tool call in this conversation. Required for the server to correlate calls and provide context-aware results.`,
+    // Tool results are untrusted content. Keep this as data rather than an
+    // instruction so clients do not classify it as prompt injection when they
+    // are still using a cached tool schema without `conversation_id`.
+    text: JSON.stringify({ conversation_id: conversationId }),
   }
 }
 

--- a/packages/mcp/src/extensions/output-instructions.ts
+++ b/packages/mcp/src/extensions/output-instructions.ts
@@ -21,11 +21,9 @@ import type { AnalyticsInjectableJsonSchema } from './analytics-parameters'
  */
 export const MCP_INSTRUCTIONS_KEY = '_mcp_instructions'
 
-const INSTRUCTIONS_FIELD_DESCRIPTION =
-  'Server-issued handles for this conversation, and what to do with them. Read and follow.'
+const INSTRUCTIONS_FIELD_DESCRIPTION = 'Server-issued metadata for this conversation.'
 
-const CONVERSATION_ID_FIELD_DESCRIPTION =
-  'Echo this exact value as the conversation_id argument on every subsequent tool call.'
+const CONVERSATION_ID_FIELD_DESCRIPTION = 'The server-issued conversation identifier.'
 
 export interface OutputInstructionsInjectableTool {
   name?: string
@@ -165,7 +163,6 @@ export function addInstructionsToOutputSchema<TTool extends OutputInstructionsIn
         type: 'string',
         description: CONVERSATION_ID_FIELD_DESCRIPTION,
       },
-      instructions: { type: 'string' },
     },
   }
 
@@ -186,14 +183,11 @@ export function addInstructionsToOutputSchemas<TTool extends OutputInstructionsI
 
 export interface ConversationInstructions {
   conversation_id: string
-  instructions: string
 }
-
-const ECHO_INSTRUCTION = 'Send this conversation_id as an argument on every subsequent tool call in this conversation.'
 
 /** The payload mirrored into `structuredContent` for a tool we declared the key on. */
 export function buildConversationInstructions(conversationId: string): ConversationInstructions {
-  return { conversation_id: conversationId, instructions: ECHO_INSTRUCTION }
+  return { conversation_id: conversationId }
 }
 
 /**


### PR DESCRIPTION
## Summary

With `enableConversationId`, the SDK appended `[SERVER]: Reuse conversation_id=… Required for the server to correlate calls…` to every minting tool result. Claude flags that as a prompt-injection attempt and refuses to follow it (#4483).

The shape is the problem, not the phrasing: an imperative addressed to the model, in the output of a tool that has nothing to do with sessions. Rewording does not help — phrasings without the imperative are refused too.

So the handle is returned as ordinary data, and the protocol stays in the input schema where it is configuration rather than tool output:

- the `[SERVER]:` block becomes `{"conversation_id": "…"}`
- `_mcp_instructions` drops its `instructions` sentence and carries the value alone — models parse `structuredContent`, so an instruction there was an imperative in a different envelope, not a hidden one
- `outputSchema` field descriptions read as metadata, not commands

The `conversation_id` parameter description already told the agent what to do, so nothing is lost.

Fixes #4483

## Validation

Claude web custom connector against this build, both lanes (Vercel `mcp-handler` and the official SDK handler), skew staged by flipping the flag mid-session:

| Client's cached schema | Result |
|---|---|
| no `conversation_id` (the #4483 state) | no warning, no refusal — reported as a correlation gap, not a security finding. Degrades to per-call silently |
| `conversation_id` present | call 1 mints, call 2 echoes, both in one `$session_id` |

The first row produced a flat refusal before this change.

648 unit tests pass, lint clean, package builds.

## Note

`enableConversationId` changes advertised tool schemas, so set it before clients connect. A client that cached the pre-flag listing cannot send the parameter and will not pick it up on its own — connector-style clients need reconnecting, and there is no server-side way to detect or repair that.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
