### PR TITLE
fix(error-tracking): recognise Firefox and Safari extension frames

### DIFF
--- a/.changeset/extension-frames-firefox-safari.md
+++ b/.changeset/extension-frames-firefox-safari.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+---
+
+Recognise Firefox and Safari extension frames when filtering extension exceptions, and stop counting Safari's masked `webkit-masked-url://` frames as in-app code.

--- a/packages/browser/src/__tests__/posthog-exceptions.test.ts
+++ b/packages/browser/src/__tests__/posthog-exceptions.test.ts
@@ -223,8 +223,13 @@ describe('PostHogExceptions', () => {
         })
 
         describe('Extension exceptions', () => {
-            it('does not capture exceptions with frames from extensions by default', () => {
-                const frame = { filename: 'chrome-extension://', platform: 'javascript:web' }
+            it.each([
+                ['chrome', 'chrome-extension://abc/content.js'],
+                ['firefox', 'moz-extension://abc/content.js'],
+                ['safari', 'safari-extension:abc/content.js'],
+                ['safari web', 'safari-web-extension:abc/content.js'],
+            ])('does not capture exceptions with frames from %s extensions by default', (_browser, filename) => {
+                const frame = { filename, platform: 'javascript:web' }
                 const exception = { stacktrace: { frames: [frame], type: 'raw' } }
                 exceptions.sendExceptionEvent({ $exception_list: [exception] })
                 expect(captureMock).not.toBeCalledWith(
@@ -232,6 +237,16 @@ describe('PostHogExceptions', () => {
                     { $exception_list: [exception] },
                     expect.anything()
                 )
+            })
+
+            it('captures exceptions from the page even when a filename merely mentions an extension', () => {
+                const frame = {
+                    filename: 'https://example.com/moz-extension://not-really.js',
+                    platform: 'javascript:web',
+                }
+                const exception = { stacktrace: { frames: [frame], type: 'raw' } }
+                exceptions.sendExceptionEvent({ $exception_list: [exception] })
+                expect(captureMock).toBeCalledWith('$exception', { $exception_list: [exception] }, expect.anything())
             })
 
             it('captures extension exceptions when enabled', () => {

--- a/packages/browser/src/posthog-exceptions.ts
+++ b/packages/browser/src/posthog-exceptions.ts
@@ -8,6 +8,11 @@ import { isString, isArray, isObject, ErrorTracking, isNullish } from '@posthog/
 
 const logger = createLogger('[Error tracking]')
 
+// Browser extensions serve their content scripts from these schemes. `safari-extension:` and
+// `safari-web-extension:` are synthesised by the stack parser (see extractSafariExtensionDetails)
+// rather than being real URLs, but they mark the frame just as definitively.
+const EXTENSION_URL_PREFIXES = ['chrome-extension://', 'moz-extension://', 'safari-extension:', 'safari-web-extension:']
+
 export function buildErrorPropertiesBuilder() {
     return new ErrorTracking.ErrorPropertiesBuilder(
         [
@@ -261,7 +266,9 @@ export class PostHogExceptions implements Extension {
 
     private _isExtensionException(exceptionList: ErrorTracking.ExceptionList): boolean {
         const frames = exceptionList.flatMap((e) => e.stacktrace?.frames ?? [])
-        return frames.some((f) => f.filename && f.filename.startsWith('chrome-extension://'))
+        return frames.some(({ filename }) => {
+            return !!filename && EXTENSION_URL_PREFIXES.some((prefix) => filename.startsWith(prefix))
+        })
     }
 
     private _isPostHogException(exceptionList: ErrorTracking.ExceptionList): boolean {

--- a/packages/core/src/error-tracking/parsers/base.spec.ts
+++ b/packages/core/src/error-tracking/parsers/base.spec.ts
@@ -1,0 +1,33 @@
+import { createFrame } from './base'
+
+describe('createFrame', () => {
+  const platform = 'web:javascript'
+
+  it('marks ordinary browser frames as in_app', () => {
+    const frame = createFrame(platform, 'https://example.com/app.js', 'doThing', 1, 2)
+    expect(frame.in_app).toBe(true)
+  })
+
+  it('does not mark frames Safari has masked as in_app', () => {
+    // Safari hides the origin of extension content scripts, and of blob:/eval'd code, behind
+    // this placeholder. None of it is the page's own code.
+    const frame = createFrame(platform, 'webkit-masked-url://hidden/', '_classCallCheck', 1, 2)
+    expect(frame.in_app).toBe(false)
+  })
+
+  it('keeps the masked frame rather than discarding it', () => {
+    const frame = createFrame(platform, 'webkit-masked-url://hidden/', 'someFn', 3, 4)
+    expect(frame).toMatchObject({
+      filename: 'webkit-masked-url://hidden/',
+      function: 'someFn',
+      lineno: 3,
+      colno: 4,
+    })
+  })
+
+  it('falls back to in_app when the parser could not determine a filename', () => {
+    // Regex capture groups that do not participate arrive here as undefined despite the type
+    const frame = createFrame(platform, undefined as unknown as string, 'doThing')
+    expect(frame.in_app).toBe(true)
+  })
+})

--- a/packages/core/src/error-tracking/parsers/base.ts
+++ b/packages/core/src/error-tracking/parsers/base.ts
@@ -7,6 +7,13 @@ import { StackFrame } from '../types'
 
 export const UNKNOWN_FUNCTION = '?'
 
+// Safari replaces the URL of scripts it will not attribute to the page with this placeholder.
+// Web extension content scripts are the common source, but blob:, eval'd and injected code can
+// be masked the same way, so the filename alone cannot tell us which one we are looking at.
+// Either way it is not the page's own code, so keep the frame -- it is still useful context --
+// but do not let it count as in_app and pull the issue into the site's own stack.
+const MASKED_URL_PREFIX = 'webkit-masked-url://'
+
 export function createFrame(
   platform: StackFrame['platform'],
   filename: string,
@@ -19,7 +26,8 @@ export function createFrame(
     platform,
     filename,
     function: func === '<anonymous>' ? UNKNOWN_FUNCTION : func,
-    in_app: true, // All browser frames are considered in_app
+    // Browser frames are considered in_app unless the runtime has masked their origin
+    in_app: !filename?.startsWith(MASKED_URL_PREFIX),
   }
 
   if (!isUndefined(lineno)) {


### PR DESCRIPTION
## Problem

An issue on posthog.com (`TypeError: Cannot call a class as a function`, Safari-only, single frame with filename `webkit-masked-url://hidden/`) is reported as if it were the site's own code. Two separate gaps let it through.

**1. Extension filtering is Chrome-only.** `_isExtensionException` tested only `chrome-extension://`, so Firefox (`moz-extension://`) and Safari extension frames were captured and reported against the site.

Worth noting: `safari-extension:` / `safari-web-extension:` are *already* synthesised by `extractSafariExtensionDetails` in the stack parser specifically to mark these frames — the drop check just never looked at them. Including them here is slightly beyond "add Firefox", but leaving them out would ship a fix that still misses the browser in the original report. Happy to split them out if reviewers would rather keep this minimal.

**2. Every browser frame is hardcoded `in_app: true`.** `createFrame` marked all frames as the site's own, so even non-app code pulled issues into the site's stack.

## What this does not do

`webkit-masked-url://` is **not** treated as an extension and is **not** dropped. Safari uses that placeholder for any script it will not attribute to the page — extension content scripts are the common case, but `blob:`, `eval`'d and injected code are masked identically, and the filename alone cannot distinguish them.

That matters because `_isExtensionException` uses `.some()`: adding the masked prefix to the drop list would discard the *entire* exception whenever one masked frame appears anywhere in the stack, including a genuine first-party bug where an extension has monkey-patched `fetch` mid-stack. Silently dropping real customer errors is a worse failure than the noise it removes.

So masked frames are marked `in_app: false` instead — the exception is still captured, it just stops counting as the site's own code.

## Note on the original diagnosis

The report that prompted this claimed the throwing bundle must be third-party because "posthog-js is compiled by TypeScript, which never emits `_classCallCheck`". That premise is wrong: the browser bundle runs through `@rollup/plugin-babel` with `@babel/preset-env` (`rollup.config.mjs:79-99`), and **both** targets downlevel `class` to ES5. Running the repo's exact config:

| `loose` | class → ES5 | emits `_classCallCheck` |
|---|---|---|
| `true` (current) | yes | no |
| `false` | yes | **yes** |

We don't emit that string today only because of `loose: true` on line 81 — one flag away from flipping. The "not ours" conclusion still holds (vendored rrweb, `lib/` and preact are all clean), just not for the stated reason. Flagging it so nobody re-derives the same false premise later.

## Testing

- New `packages/core/src/error-tracking/parsers/base.spec.ts` covers in-app, masked, and undefined-filename frames.
- Existing extension test in `posthog-exceptions.test.ts` becomes an `it.each` across all four schemes, plus a negative case ensuring a page URL that merely *contains* `moz-extension://` is still captured.
- Both changes mutation-tested: reverting each source change fails exactly the intended tests (1 and 3 respectively) and nothing else.
- `jest` (48 core + 31 browser), `eslint` and `prettier` clean. The one `tsc` error (`moduleResolution=node10` deprecation) is pre-existing and reproduces on a clean tree.

`filename` is typed `string` but arrives `undefined` at runtime from non-participating regex groups, so the new check is optional-chained — an unknown filename keeps the previous `in_app: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
