### PR TITLE
fix(ci): support pnpm 10 in PostHog upgrade workflow

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -49,10 +49,10 @@ jobs:
                   node-version: 24
 
             - name: Setup pnpm
-              uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
               with:
                   cache: false
-                  install: false
+                  run_install: false
 
             - name: Wait for package to become available on npm
               shell: bash


### PR DESCRIPTION
## Problem

The PostHog upgrade workflow checks out the `PostHog/posthog` repository, which uses pnpm 10. The recent upgrade to `pnpm/setup@v2` made the workflow fail during setup because that action only supports pnpm 11 or newer.

Failed run: https://github.com/PostHog/posthog-js/actions/runs/32130685267/job/95713128259

## Changes

Use `pnpm/action-setup@v6.0.10` for this workflow. This is the action recommended for pnpm 10. The action remains pinned to a full commit SHA and continues to read the pnpm version from the checked-out repository.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi inspected the failed GitHub Actions job and made the workflow-only change. The workflow was validated with `actionlint`, with ShellCheck disabled because the file has a pre-existing style warning in an unrelated step. `git diff --check` also passed.
