### PR TITLE
fix(surveys): don't snapshot the whole page when closing a survey

### DIFF
--- a/.changeset/survey-close-viewport-snapshot-crash.md
+++ b/.changeset/survey-close-viewport-snapshot-crash.md
@@ -1,0 +1,9 @@
+---
+'posthog-js': patch
+---
+
+Fix a Chrome renderer crash (grey "Aw, Snap" tab, "Error code: 5") that could still occur when closing an in-app survey on a heavy page such as a large dashboard.
+
+Closing a survey animated the fade-out with `document.startViewTransition`, which snapshots the entire page viewport. The survey applied no `view-transition-name` scoping, so on a heavy host page capturing that whole-page snapshot could exhaust renderer memory and crash the tab. A previous fix addressed a related crash (a snapshot pointing at a removed node) but left the document-level transition — and its whole-page snapshot cost — in place.
+
+The survey renders in an isolated shadow root, so it never needed a document-level transition. The close now fades the popup out with a plain CSS opacity transition scoped to the survey's own container, then unmounts it once the fade has run. No whole-page snapshot, no crash, same fade-out UX.

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -262,7 +262,7 @@ describe('usePopupVisibility', () => {
     })
 })
 
-describe('usePopupVisibility view-transition close path', () => {
+describe('usePopupVisibility close animation path', () => {
     const mockSurvey: Survey = {
         id: 'testSurvey1',
         name: 'Test survey 1',
@@ -299,158 +299,102 @@ describe('usePopupVisibility view-transition close path', () => {
     })
     const removeSurvey = jest.fn()
 
-    // Installs a controllable mock for document.startViewTransition. Returns
-    // helpers to resolve/reject the transition.finished promise so tests can
-    // drive the async settle path deterministically.
-    const installViewTransitionMock = () => {
-        let resolveFinished: () => void
-        let rejectFinished: (reason?: any) => void
-        const finished = new Promise<void>((resolve, reject) => {
-            resolveFinished = resolve
-            rejectFinished = reject
-        })
-        const updateCallback = jest.fn()
-        const skipTransition = jest.fn()
-        const startViewTransition = jest.fn((cb: () => void) => {
-            // Mimic the browser: run the update callback synchronously.
-            cb()
-            return { finished, updateCallbackDone: finished, ready: Promise.resolve(), skipTransition }
-        })
-        Object.defineProperty(document, 'startViewTransition', {
-            configurable: true,
-            writable: true,
-            value: startViewTransition,
-        })
-        return {
-            startViewTransition,
-            updateCallback,
-            skipTransition,
-            // Call the stored resolver, then return a promise that resolves on the
-            // next microtask so callers can `await` inside act() and let the
-            // transition.finished .then(finish) callback flush before asserting.
-            resolve: () => {
-                resolveFinished()
-                return Promise.resolve()
-            },
-            reject: (reason?: any) => {
-                rejectFinished(reason)
-                return Promise.resolve()
-            },
-        }
+    const renderWithContainer = (container?: HTMLElement) =>
+        renderHook(() =>
+            usePopupVisibility(
+                mockSurvey,
+                mockPostHog,
+                0,
+                false,
+                removeSurvey,
+                true,
+                container ? ({ current: container } as any) : undefined
+            )
+        )
+
+    const attachedContainer = () => {
+        const container = document.createElement('div')
+        document.body.appendChild(container)
+        return container
     }
 
     beforeEach(() => {
         removeSurvey.mockClear()
+        jest.useFakeTimers()
     })
 
-    afterAll(() => {
-        // jsdom has no startViewTransition; restore that state.
-        // @ts-expect-error - deleting a property that may have been added by a test
-        delete document.startViewTransition
+    afterEach(() => {
+        jest.useRealTimers()
     })
 
-    test('hides the popup synchronously when startViewTransition is unavailable', () => {
-        // @ts-expect-error - jsdom does not define startViewTransition
-        delete document.startViewTransition
-        expect(document.startViewTransition).toBeUndefined()
-
-        const { result } = renderHook(() => usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true))
+    test('tears down synchronously when there is no container ref to animate', () => {
+        const { result } = renderWithContainer()
         expect(result.current.isPopupVisible).toBe(true)
 
         act(() => {
-            result.current.hidePopupWithViewTransition()
+            result.current.hidePopupWithAnimation()
         })
 
         expect(result.current.isPopupVisible).toBe(false)
         expect(removeSurvey).toHaveBeenCalledTimes(1)
     })
 
-    test('does not remove the survey container inside the transition callback', () => {
-        const vt = installViewTransitionMock()
-        const container = document.createElement('div')
-        document.body.appendChild(container)
-
-        const { result } = renderHook(() =>
-            usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true, {
-                current: container,
-            } as any)
-        )
+    test('fades the container out without removing it, then unmounts once the fade has run', () => {
+        const container = attachedContainer()
+        const { result } = renderWithContainer(container)
 
         act(() => {
-            result.current.hidePopupWithViewTransition()
+            result.current.hidePopupWithAnimation()
         })
 
-        // The transition ran...
-        expect(vt.startViewTransition).toHaveBeenCalledTimes(1)
-        // ...but the callback only faded the container out, it did NOT remove it.
+        // The container is faded out via a scoped opacity transition — NOT removed,
+        // and the popup stays mounted until the fade has had time to run.
         expect(container.parentNode).not.toBeNull()
         expect(container.style.opacity).toBe('0')
-        // And the popup is still "visible" until the transition settles.
+        expect(container.style.transition).toContain('opacity')
         expect(result.current.isPopupVisible).toBe(true)
         expect(removeSurvey).not.toHaveBeenCalled()
 
-        // Settling the transition tears the DOM down via the React path.
-        return act(async () => {
-            await vt.resolve()
-        }).then(() => {
-            expect(result.current.isPopupVisible).toBe(false)
-            expect(removeSurvey).toHaveBeenCalledTimes(1)
-        })
-    })
-
-    test('settles the popup state even if the transition is interrupted (finished rejects)', () => {
-        const vt = installViewTransitionMock()
-
-        const { result } = renderHook(() => usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true))
-
         act(() => {
-            result.current.hidePopupWithViewTransition()
-        })
-        expect(result.current.isPopupVisible).toBe(true)
-
-        // An interrupted/skipped transition rejects transition.finished.
-        return act(async () => {
-            await vt.reject(new Error('transition skipped'))
-        }).then(() => {
-            // The popup must still end up hidden — no stale visible state.
-            expect(result.current.isPopupVisible).toBe(false)
-            expect(removeSurvey).toHaveBeenCalledTimes(1)
-        })
-    })
-
-    test('does not start a second transition on repeated close calls', () => {
-        const vt = installViewTransitionMock()
-        const container = document.createElement('div')
-        document.body.appendChild(container)
-
-        const { result } = renderHook(() =>
-            usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true, {
-                current: container,
-            } as any)
-        )
-
-        act(() => {
-            result.current.hidePopupWithViewTransition()
-            // A second close while the first transition is still animating.
-            result.current.hidePopupWithViewTransition()
-        })
-
-        expect(vt.startViewTransition).toHaveBeenCalledTimes(1)
-    })
-
-    test('falls back to a plain remove if startViewTransition throws', () => {
-        const vt = installViewTransitionMock()
-        vt.startViewTransition.mockImplementation(() => {
-            throw new Error('not allowed in this document state')
-        })
-
-        const { result } = renderHook(() => usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey, true))
-
-        act(() => {
-            result.current.hidePopupWithViewTransition()
+            jest.advanceTimersByTime(1000)
         })
 
         expect(result.current.isPopupVisible).toBe(false)
+        expect(removeSurvey).toHaveBeenCalledTimes(1)
+    })
+
+    test('never calls document.startViewTransition (no full-page snapshot on heavy pages)', () => {
+        const startViewTransition = jest.fn()
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            writable: true,
+            value: startViewTransition,
+        })
+
+        const { result } = renderWithContainer(attachedContainer())
+        act(() => {
+            result.current.hidePopupWithAnimation()
+            jest.advanceTimersByTime(1000)
+        })
+
+        // The whole point of the fix: closing a survey must not snapshot the page.
+        expect(startViewTransition).not.toHaveBeenCalled()
+        expect(result.current.isPopupVisible).toBe(false)
+
+        // @ts-expect-error - clean up the property we added
+        delete document.startViewTransition
+    })
+
+    test('does not tear down twice on repeated close calls', () => {
+        const { result } = renderWithContainer(attachedContainer())
+
+        act(() => {
+            result.current.hidePopupWithAnimation()
+            // A second close while the first is still animating.
+            result.current.hidePopupWithAnimation()
+            jest.advanceTimersByTime(1000)
+        })
+
         expect(removeSurvey).toHaveBeenCalledTimes(1)
     })
 })

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -397,6 +397,32 @@ describe('usePopupVisibility close animation path', () => {
 
         expect(removeSurvey).toHaveBeenCalledTimes(1)
     })
+
+    test('a no-container close does not leave the close guard stuck for a later close', () => {
+        // The no-container path tears down synchronously with no settle timer, so it
+        // must not raise the in-flight guard — otherwise a popup that is shown again
+        // (e.g. a tab widget re-shown on a URL match) can never be closed a second time.
+        const { result } = renderWithContainer()
+
+        act(() => {
+            result.current.hidePopupWithAnimation()
+        })
+        expect(result.current.isPopupVisible).toBe(false)
+        expect(removeSurvey).toHaveBeenCalledTimes(1)
+
+        // The same hook instance shows the popup again.
+        act(() => {
+            result.current.setIsPopupVisible(true)
+        })
+        expect(result.current.isPopupVisible).toBe(true)
+
+        // The second close must still tear down — the guard was not left stuck.
+        act(() => {
+            result.current.hidePopupWithAnimation()
+        })
+        expect(result.current.isPopupVisible).toBe(false)
+        expect(removeSurvey).toHaveBeenCalledTimes(2)
+    })
 })
 
 describe('SurveyManager', () => {

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1128,6 +1128,10 @@ export function useHideSurveyOnURLChange({
     }, [isPreviewMode, survey, removeSurveyFromFocus, setSurveyVisible, posthog])
 }
 
+// Duration of the survey close fade-out, in milliseconds. Kept short so the popup
+// disappears promptly; also the window the fallback settle timer waits on.
+const CLOSE_ANIMATION_DURATION_MS = 200
+
 export function usePopupVisibility(
     survey: Survey,
     posthog: PostHog | undefined,
@@ -1144,13 +1148,12 @@ export function usePopupVisibility(
     )
     const [isSurveySent, setIsSurveySent] = useState(false)
 
-    // Tracks whether a view transition is already in flight so a second close
-    // (e.g. Enter + button click, or a dismiss fired while the thank-you screen
-    // is animating out) doesn't start an overlapping transition. Overlapping
-    // transitions on the same document are a known source of renderer crashes.
-    const isTransitionInFlightRef = useRef(false)
+    // Tracks whether a close is already animating so a second close (e.g. Enter +
+    // button click, or a dismiss fired while the thank-you screen is animating out)
+    // doesn't start a second animation or tear the popup down twice.
+    const isClosingRef = useRef(false)
 
-    const hidePopupWithViewTransition = () => {
+    const hidePopupWithAnimation = () => {
         const removeDOMAndHidePopup = () => {
             if (isPopup) {
                 removeSurveyFromFocus(survey)
@@ -1158,58 +1161,45 @@ export function usePopupVisibility(
             setIsPopupVisible(false)
         }
 
-        // No View Transitions API (jsdom, older browsers): tear down synchronously.
-        if (typeof document === 'undefined' || !document.startViewTransition) {
+        // A close is already animating. Don't start a second one — the in-flight
+        // close settles the popup when it finishes.
+        if (isClosingRef.current) {
+            return
+        }
+        isClosingRef.current = true
+
+        // No element to animate (jsdom, or the ref never attached): tear down now.
+        const container = surveyContainerRef?.current
+        if (!container) {
             removeDOMAndHidePopup()
             return
         }
 
-        // A transition is already animating the close. Don't start a second one —
-        // overlapping transitions on the same document are themselves a renderer
-        // crash risk. The in-flight transition's `finish` will hide the popup.
-        if (isTransitionInFlightRef.current) {
-            return
-        }
+        // Fade the popup out with a plain CSS opacity transition scoped to the
+        // survey's own container, which lives in an isolated shadow root. We
+        // deliberately do NOT use document.startViewTransition: that API snapshots
+        // the ENTIRE page viewport, and on a heavy host page (e.g. a large dashboard)
+        // capturing that snapshot can exhaust renderer memory and crash the tab (grey
+        // "Aw, Snap"). A scoped opacity transition costs nothing on the rest of the page.
+        container.style.transition = `opacity ${CLOSE_ANIMATION_DURATION_MS}ms ease-out`
+        container.style.opacity = '0'
 
-        isTransitionInFlightRef.current = true
-
-        const finish = () => {
-            isTransitionInFlightRef.current = false
+        // Unmount once the fade has had time to run. This uses a timer rather than a
+        // `transitionend` listener because transitionend never fires for a cancelled or
+        // zero-duration transition (backgrounded tab, reduced motion), so a timer would
+        // have to back it up regardless — and settling a few ms later than strictly
+        // necessary is imperceptible for an element that is already fully transparent.
+        setTimeout(() => {
+            isClosingRef.current = false
             removeDOMAndHidePopup()
-        }
-
-        try {
-            // The transition callback only animates the fade-out of the survey
-            // container. It must NOT own the DOM teardown — removing the element
-            // inside the callback (the previous behaviour) is what triggered a
-            // Chromium renderer crash (grey "Aw, Snap" tab) on heavy SPAs, because
-            // the transition's captured snapshot ended up pointing at a removed
-            // node. React unmounts the container via setIsPopupVisible(false) +
-            // removeSurveyFromFocus once the transition settles.
-            const transition = document.startViewTransition(() => {
-                if (surveyContainerRef?.current) {
-                    surveyContainerRef.current.style.opacity = '0'
-                }
-            })
-
-            // `transition.finished` rejects if the transition is skipped or
-            // interrupted (e.g. tab backgrounded, reduced motion, another transition
-            // supersedes it). Always settle the state so the popup is never left
-            // visible with a stale ref.
-            transition.finished.then(finish, finish)
-        } catch (error) {
-            // startViewTransition can throw if the document is not in a state that
-            // allows a transition (e.g. during unload). Fall back to a plain remove.
-            logger.warn('View transition failed, removing survey without animation:', error)
-            finish()
-        }
+        }, CLOSE_ANIMATION_DURATION_MS + 50)
     }
 
     const handleSurveyClosed = (event: CustomEvent) => {
         if (event.detail.surveyId !== survey.id) {
             return
         }
-        hidePopupWithViewTransition()
+        hidePopupWithAnimation()
     }
 
     useEffect(() => {
@@ -1226,12 +1216,12 @@ export function usePopupVisibility(
                 return
             }
             if (!survey.appearance?.displayThankYouMessage) {
-                return hidePopupWithViewTransition()
+                return hidePopupWithAnimation()
             }
             setIsSurveySent(true)
             if (survey.appearance?.autoDisappear) {
                 setTimeout(() => {
-                    hidePopupWithViewTransition()
+                    hidePopupWithAnimation()
                 }, 5000)
             }
         }
@@ -1290,7 +1280,7 @@ export function usePopupVisibility(
         posthog,
     })
 
-    return { isPopupVisible, isSurveySent, setIsPopupVisible, hidePopupWithViewTransition }
+    return { isPopupVisible, isSurveySent, setIsPopupVisible, hidePopupWithAnimation }
 }
 
 interface SurveyPopupProps {
@@ -1358,7 +1348,7 @@ export function SurveyPopup({
     const surveyPopupDelayMilliseconds = survey.appearance?.surveyPopupDelaySeconds
         ? survey.appearance.surveyPopupDelaySeconds * 1000
         : 0
-    const { isPopupVisible, isSurveySent, hidePopupWithViewTransition } = usePopupVisibility(
+    const { isPopupVisible, isSurveySent, hidePopupWithAnimation } = usePopupVisibility(
         survey,
         posthog,
         surveyPopupDelayMilliseconds,
@@ -1452,7 +1442,7 @@ export function SurveyPopup({
                         contentType={survey.appearance?.thankYouMessageDescriptionContentType}
                         appearance={survey.appearance || defaultSurveyAppearance}
                         onClose={() => {
-                            hidePopupWithViewTransition()
+                            hidePopupWithAnimation()
                             onCloseConfirmationMessage()
                         }}
                     />

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1166,14 +1166,20 @@ export function usePopupVisibility(
         if (isClosingRef.current) {
             return
         }
-        isClosingRef.current = true
 
         // No element to animate (jsdom, or the ref never attached): tear down now.
+        // Do this before raising isClosingRef so the guard is only ever set for a real
+        // in-flight animation — this early return has no timer to clear it, so setting
+        // the flag here would leave it stuck and block every later close.
         const container = surveyContainerRef?.current
         if (!container) {
             removeDOMAndHidePopup()
             return
         }
+
+        // Committing to the fade now — raise the guard so a second close can't start
+        // another animation; the settle timer below clears it.
+        isClosingRef.current = true
 
         // Fade the popup out with a plain CSS opacity transition scoped to the
         // survey's own container, which lives in an isolated shadow root. We


### PR DESCRIPTION
## Problem

Closing an in-app survey popup could crash the Chrome tab — the grey "Aw, Snap!" page with `Error code: 5` (a renderer out-of-memory kill). It was reproducible on a heavy page such as a large dashboard, and took the whole tab down rather than just dismissing the survey.

Root cause: the close path animated the fade-out with `document.startViewTransition`, which snapshots the **entire page viewport**. The survey applied no `view-transition-name` scoping, so nothing limited that snapshot to the popup itself. On a heavy host page, capturing the whole-page snapshot could exhaust renderer memory and kill the tab.

[#4497](https://github.com/PostHog/posthog-js/pull/4497) fixed a *related* crash on this path (the transition's captured snapshot pointing at an already-removed node), but it kept the document-level view transition — so the whole-page snapshot cost, which is what OOMs on heavy pages, was still there. The crash was still reproducing on a build that already contained that fix.

## Changes

The survey renders into an isolated shadow root, so it never needed a document-level transition in the first place.

- Fade the popup out with a plain CSS opacity transition scoped to the survey's own container, then let React unmount it once the fade has run. No page snapshot, same fade-out UX.
- Use a timer rather than a `transitionend` listener. `transitionend` never fires for a cancelled or zero-duration transition (backgrounded tab, reduced motion), so a timer has to back it up regardless — and settling a few ms later than strictly necessary is imperceptible for an element that is already fully transparent. Dropping the listener also removes the double-settle guard and descendant-event filtering it would otherwise need.
- Keep the existing guard against a second close while one is animating.

Net **-66 lines**, and the replaced code path is simpler than what it replaces.

Tests cover the fade not removing the container, the unmount after the fade, repeated closes tearing down exactly once, and an explicit assertion that `document.startViewTransition` is never called — so this can't silently regress.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a report that closing a survey popup crashed the tab on a dashboard page. Tools used: PostHog MCP (`execute-sql`, `surveys-get-all`) and the `debugging-surveys` skill, plus local git/grep/jest.

Decisions along the way:

- The `debugging-surveys` playbook steers most survey reports toward eligibility gates. Ruled that out early — the symptom was a renderer crash on dismiss, not a survey failing to show — and treated it as a rendering bug instead.
- Confirmed this was **not** a stale-SDK problem before writing any code: the crashing session ran `posthog-js` 1.417.1, that version is what the app serves fleet-wide, and 1.417.1 already contains [#4497](https://github.com/PostHog/posthog-js/pull/4497) (verified with `git merge-base --is-ancestor`). That ruled out "just upgrade" and established the earlier fix was incomplete rather than un-deployed.
- First implementation kept a `transitionend` listener with a fallback timer, a settle mutex, descendant filtering, and a forced reflow. On self-review that was strictly worse: the fallback timer must exist anyway, so the listener bought ~50ms on an already-invisible element while adding an `eslint-disable`, a forward-declared variable, and a lint violation against the repo's `addEventListener` helper rule. Cut it to the timer alone and dropped the reflow (unnecessary — the element has been painted at opacity 1 for a while).
- Considered dropping the close animation entirely, which would be the smallest possible diff, but that regresses the fade-out UX that this code path has had; kept the fade.

Verified: all 518 survey unit tests pass, plus typecheck and lint clean on the changed files. **Not** manually verified in a browser against a real heavy dashboard — the crash needs a real Chromium renderer under memory pressure, which I could not reproduce in this environment. Worth a manual check before release.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787074502515409?thread_ts=1787074502.515409&cid=C0ACRAMJUAG)*
