### PR TITLE
fix(ci): support pnpm 10 in the release toolbar build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -649,11 +649,14 @@ jobs:
               with:
                   node-version: 24
 
+            # Unlike the rest of this repo, this step installs the pnpm that
+            # posthog/posthog pins (currently 10.x), because that is the
+            # checkout above. pnpm/setup only installs v11 and newer.
             - name: Setup pnpm
-              uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+              uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
               with:
                   cache: false
-                  install: false
+                  run_install: false
 
             - name: Install frontend dependencies
               run: pnpm --filter=@posthog/frontend... install --frozen-lockfile


### PR DESCRIPTION
## Problem

A release that includes a new posthog-js version now publishes to npm and then fails before anything reaches the CDN.

`build-toolbar` builds the toolbar from a checkout of `posthog/posthog`, which pins `pnpm@10.29.3`. #4539 bumped that job's setup step to `pnpm/setup@v2.0.2`, which refuses anything older than v11:

```
Error: The requested pnpm version "10.29.3" resolved to 10.29.3, but this action only installs pnpm v11 or newer.
To install older pnpm, use the pnpm/action-setup action instead.
```

Both matrix regions fail at `Setup pnpm`, so `upload-s3` then fails at `Download toolbar artifact` and the run ends on `Notify Slack - Partial Release (npm only)`.

| Release run | Toolbar build | Note |
| --- | --- | --- |
| [32104720836](https://github.com/PostHog/posthog-js/actions/runs/32104720836) (08-18 05:54Z) | success | before #4539 |
| [32147793501](https://github.com/PostHog/posthog-js/actions/runs/32147793501) (08-18 14:21Z) | failure (us and eu) | after #4539, npm published, S3 upload did not |

## Change

That one step moves to `pnpm/action-setup`, which is what the error message asks for. The input rename (`install` to `run_install`) matches the same swap #4550 made in `posthog-upgrade.yml`.

`upload-s3` deliberately keeps `pnpm/setup`: it checks out posthog-js, which pins `pnpm@11.7.0`, and its own `Setup pnpm` step passed in the failed run above.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

