### PR TITLE
fix(replay): guard lazy recorder startup after teardown

### DIFF
--- a/.changeset/gentle-otters-record.md
+++ b/.changeset/gentle-otters-record.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Prevent stale session recorders from initializing after consent or session teardown, and dispose of recorders when switching to cookieless mode.

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -314,7 +314,10 @@ describe('cookieless', () => {
             const { posthog, beforeSendMock } = await setup({
                 cookieless_mode: 'on_reject',
             })
+            const detachedSessionRecording = posthog.sessionRecording!
+            const detachedRemoteConfig = jest.spyOn(detachedSessionRecording, 'onRemoteConfig')
             posthog.opt_out_capturing()
+            expect(posthog['_extensions']).not.toContain(detachedSessionRecording)
             posthog.register({ test: 'test' })
             posthog.capture(eventName, eventProperties)
             expect(beforeSendMock).toBeCalledTimes(2)
@@ -335,6 +338,43 @@ describe('cookieless', () => {
             expect(beforeSendMock.mock.calls[3][0].properties.$window_id).toMatch(uuidV7Pattern)
             expect(beforeSendMock.mock.calls[3][0].properties.$cookieless_mode).toEqual(undefined)
             expect(posthog.sessionRecording).toBeTruthy()
+
+            posthog._onRemoteConfig({ ok: false })
+            expect(detachedRemoteConfig).not.toHaveBeenCalled()
+        })
+
+        it('disposes the detached recorder when consent changes before opting in', async () => {
+            const { posthog } = await setup({
+                cookieless_mode: 'on_reject',
+            })
+            posthog.opt_in_capturing()
+            const detachedSessionRecording = posthog.sessionRecording!
+            const identityBeforeReplacement = {
+                distinctId: posthog.get_distinct_id(),
+                sessionId: posthog.get_session_id(),
+            }
+            let identityAtDisposal: typeof identityBeforeReplacement | undefined
+            const originalDispose = detachedSessionRecording.dispose.bind(detachedSessionRecording)
+            const disposeSessionRecording = jest
+                .spyOn(detachedSessionRecording, 'dispose')
+                .mockImplementation((options) => {
+                    identityAtDisposal = {
+                        distinctId: posthog.get_distinct_id(),
+                        sessionId: posthog.get_session_id(),
+                    }
+                    originalDispose(options)
+                })
+
+            // Consent persistence is shared across tabs and can change without this instance receiving opt_out_capturing().
+            posthog.consent.optInOut(false)
+            posthog.opt_in_capturing()
+
+            expect(disposeSessionRecording).toHaveBeenCalledWith({ discardBufferedEvents: true })
+            expect(identityAtDisposal).toEqual(identityBeforeReplacement)
+            expect(posthog.get_distinct_id()).not.toBe(identityBeforeReplacement.distinctId)
+            expect(posthog.get_session_id()).not.toBe(identityBeforeReplacement.sessionId)
+            expect(posthog.sessionRecording).not.toBe(detachedSessionRecording)
+            expect(posthog['_extensions']).not.toContain(detachedSessionRecording)
         })
 
         it('should reset when switching consent mode from opt in to opt out', async () => {
@@ -348,9 +388,25 @@ describe('cookieless', () => {
             expect(beforeSendMock).toBeCalledTimes(3)
             expect(beforeSendMock.mock.calls[2][0].properties.test).toBe('test')
 
+            const identityBeforeOptOut = {
+                distinctId: posthog.get_distinct_id(),
+                sessionId: posthog.get_session_id(),
+            }
+            let identityAtDisposal: typeof identityBeforeOptOut | undefined
+            const sessionRecording = posthog.sessionRecording!
+            const originalDispose = sessionRecording.dispose.bind(sessionRecording)
+            const disposeSessionRecording = jest.spyOn(sessionRecording, 'dispose').mockImplementation((options) => {
+                identityAtDisposal = {
+                    distinctId: posthog.get_distinct_id(),
+                    sessionId: posthog.get_session_id(),
+                }
+                originalDispose(options)
+            })
             posthog.opt_out_capturing()
             posthog.capture(eventName, eventProperties)
 
+            expect(disposeSessionRecording).toHaveBeenCalledWith({ discardBufferedEvents: true })
+            expect(identityAtDisposal).toEqual(identityBeforeOptOut)
             expect(beforeSendMock).toBeCalledTimes(4)
             expect(beforeSendMock.mock.calls[3][0].event).toBe(eventName)
             expect(beforeSendMock.mock.calls[3][0].properties.test).toBe(undefined)

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording-compression.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording-compression.test.ts
@@ -245,6 +245,55 @@ describe('LazyLoadedSessionRecording compression paths', () => {
         )
     })
 
+    it('discards in-flight async compression without a deferred flush', async () => {
+        let releaseCompression: () => void = () => {}
+        const compressionGate = new Promise<void>((resolve) => {
+            releaseCompression = resolve
+        })
+        const gzipCompress = jest.fn(async (input: string) => {
+            await compressionGate
+            return new Blob([gzipSync(strToU8(input))])
+        })
+
+        const { emit, posthog, lazyLoadedSessionRecording, stopRrweb } = await setupLazyLoadedSessionRecording({
+            gzipSupported: true,
+            gzipCompress,
+        })
+
+        emit(createFullSnapshot({ content: 'discard pending compression' }))
+        const compressionQueue = lazyLoadedSessionRecording['_compressionQueue']
+        lazyLoadedSessionRecording.discard({ discardProducerEvents: true })
+
+        expect(stopRrweb).toHaveBeenCalled()
+        expect(posthog.capture).not.toHaveBeenCalled()
+
+        releaseCompression()
+        await compressionQueue
+        await Promise.resolve()
+
+        expect(posthog.capture).not.toHaveBeenCalled()
+    })
+
+    it('discards events emitted synchronously while rrweb stops', async () => {
+        const { emit, posthog, lazyLoadedSessionRecording, stopRrweb } = await setupLazyLoadedSessionRecording({
+            gzipSupported: false,
+        })
+        stopRrweb.mockImplementation(() => {
+            emit(createFullSnapshot({ content: 'rrweb teardown emission' }))
+        })
+        emit(createFullSnapshot({ content: 'existing buffered snapshot' }))
+        lazyLoadedSessionRecording['_buffer'].sessionId = 'stale-session-id'
+        expect(lazyLoadedSessionRecording['_buffer'].data.length).toBeGreaterThan(0)
+
+        lazyLoadedSessionRecording.discard({ discardProducerEvents: true })
+
+        expect(lazyLoadedSessionRecording['_buffer'].data).toEqual([])
+        expect(lazyLoadedSessionRecording['_flushBufferTimer']).toBeUndefined()
+
+        lazyLoadedSessionRecording['_flushBuffer']()
+        expect(posthog.capture).not.toHaveBeenCalled()
+    })
+
     it('synchronously drains pending async compression on beforeunload', async () => {
         let releaseCompression: () => void = () => {}
         const compressionGate = new Promise<void>((resolve) => {

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -5023,6 +5023,24 @@ describe('Lazy SessionRecording', () => {
             expect(lazyRecorderStop).toHaveBeenCalledTimes(1)
         })
 
+        it('discards an active recorder when disposed without flushing buffered events', () => {
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                    },
+                })
+            )
+            const lazyRecorder = sessionRecording['_lazyLoadedSessionRecording']!
+            const lazyRecorderStop = jest.spyOn(lazyRecorder, 'stop')
+            const lazyRecorderDiscard = jest.spyOn(lazyRecorder, 'discard')
+
+            sessionRecording.dispose({ discardBufferedEvents: true })
+
+            expect(lazyRecorderDiscard).toHaveBeenCalledWith({ discardProducerEvents: true })
+            expect(lazyRecorderStop).not.toHaveBeenCalled()
+        })
+
         it('does not start a recorder when its script loads after disposal', () => {
             let completeScriptLoad: (() => void) | undefined
             loadScriptMock.mockImplementation((_ph, _path, callback) => {

--- a/packages/browser/src/__tests__/extensions/replay/sessionRecording-onRemoteConfig.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/sessionRecording-onRemoteConfig.test.ts
@@ -137,6 +137,7 @@ describe('SessionRecording', () => {
             config: config,
             capture: jest.fn(),
             persistence: postHogPersistence,
+            register: jest.fn(),
             onFeatureFlags: (): (() => void) => {
                 return () => {}
             },
@@ -171,6 +172,10 @@ describe('SessionRecording', () => {
     })
 
     afterEach(() => {
+        posthog.sessionManager?.destroy()
+        if (posthog.sessionManager !== sessionManager) {
+            sessionManager.destroy()
+        }
         // @ts-expect-error this is a test, it's safe to write to location like this
         window!.location = originalLocation
     })
@@ -218,6 +223,44 @@ describe('SessionRecording', () => {
             expect(registerForSessionMock).toHaveBeenCalledWith({
                 [SDK_DEBUG_RECORDING_SCRIPT_NOT_LOADED]: true,
             })
+        })
+
+        it('does not flag the session when a stale recorder script load fails', () => {
+            let finishLoading: ((error?: string) => void) | undefined
+            loadScriptMock.mockImplementation((_ph, _path, callback) => {
+                finishLoading = callback
+            })
+
+            sessionRecording.onRemoteConfig(makeFlagsResponse({ sessionRecording: { endpoint: '/s/' } }))
+            posthog.sessionManager = undefined
+            finishLoading?.('blocked')
+
+            expect(registerForSessionMock).not.toHaveBeenCalled()
+            expect(sessionRecording.status).toBe('disabled')
+        })
+
+        it.each([
+            ['consent is opted out', () => jest.spyOn(posthog.consent, 'isOptedOut').mockReturnValue(true)],
+            ['the session manager is unavailable', () => (posthog.sessionManager = undefined)],
+            ['the session manager is replaced', () => (posthog.sessionManager = new SessionIdManager(posthog))],
+        ])('does not initialize after %s while the recorder script is loading', (_condition, disableRecording) => {
+            let finishLoading: (() => void) | undefined
+            loadScriptMock.mockImplementation((_ph, _path, callback) => {
+                finishLoading = callback
+            })
+            const initSessionRecording = jest.fn(() => new LazyLoadedSessionRecording(posthog))
+            assignableWindow.__PosthogExtensions__.initSessionRecording = initSessionRecording
+
+            sessionRecording.onRemoteConfig(makeFlagsResponse({ sessionRecording: { endpoint: '/s/' } }))
+            expect(finishLoading).toBeDefined()
+
+            disableRecording()
+            addRRwebToWindow()
+
+            expect(() => finishLoading?.()).not.toThrow()
+            expect(initSessionRecording).not.toHaveBeenCalled()
+            expect(sessionRecording['_lazyLoadedSessionRecording']).toBeUndefined()
+            expect(sessionRecording.status).toBe('disabled')
         })
 
         it('uses anyMatchSessionRecordingStatus when triggerMatching is "any"', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1523,7 +1523,13 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         this._scheduleFlushBuffer()
     }
 
-    discard() {
+    discard({ discardProducerEvents = false }: { discardProducerEvents?: boolean } = {}) {
+        if (discardProducerEvents) {
+            // rrweb teardown can synchronously emit deferred stylesheet mutations.
+            // Clear first so those emissions cannot flush existing data, then clear them below too.
+            this._clearBuffer()
+            this._stopRecordingProducers()
+        }
         this._clearBuffer()
         this._teardown()
         logger.info('discarded')

--- a/packages/browser/src/extensions/replay/session-recording.ts
+++ b/packages/browser/src/extensions/replay/session-recording.ts
@@ -105,10 +105,14 @@ export class SessionRecording implements Extension {
         this.startIfEnabledOrStop()
     }
 
-    dispose(): void {
+    dispose({ discardBufferedEvents = false }: { discardBufferedEvents?: boolean } = {}): void {
         this._sessionRecordingDisposed = true
         document?.removeEventListener?.('visibilitychange', this._onVisibilityChange)
-        this.stopRecording()
+        if (discardBufferedEvents) {
+            this._discardRecording(true)
+        } else {
+            this.stopRecording()
+        }
     }
 
     private get _isRecordingEnabled() {
@@ -170,10 +174,21 @@ export class SessionRecording implements Extension {
             !assignableWindow?.__PosthogExtensions__?.rrweb?.record ||
             !assignableWindow.__PosthogExtensions__?.initSessionRecording
         ) {
+            // Consent and session state can change while the recorder chunk is loading.
+            // Only the recorder that initiated this load may finish starting with its manager.
+            const sessionManager = this._instance.sessionManager
             assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(
                 this._instance,
                 this._scriptName,
                 (err) => {
+                    if (
+                        this._sessionRecordingDisposed ||
+                        !this._isRecordingEnabled ||
+                        this._instance.sessionManager !== sessionManager
+                    ) {
+                        this._recordingStatus = DISABLED
+                        return
+                    }
                     if (err) {
                         // most often this is an ad blocker matching the `/static/<script>.js` path.
                         // flag it on the session so a blocked recorder is visible in analytics
@@ -197,10 +212,10 @@ export class SessionRecording implements Extension {
         this._lazyLoadedSessionRecording?.stop()
     }
 
-    private _discardRecording() {
+    private _discardRecording(discardProducerEvents = false) {
         this._persistFlagsOnSessionListener?.()
         this._persistFlagsOnSessionListener = undefined
-        this._lazyLoadedSessionRecording?.discard()
+        this._lazyLoadedSessionRecording?.discard({ discardProducerEvents })
     }
 
     private _resetSampling() {
@@ -342,7 +357,8 @@ export class SessionRecording implements Extension {
     }
 
     private _onScriptLoaded(startReason?: SessionStartReason) {
-        if (this._sessionRecordingDisposed) {
+        if (this._sessionRecordingDisposed || !this._isRecordingEnabled || !this._instance.sessionManager) {
+            this._recordingStatus = DISABLED
             return
         }
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -473,13 +473,18 @@ export class PostHog implements PostHogInterface {
     private _browserClientAdapter: BrowserClientAdapter | undefined
     private _featureFlagsReloadingUnsubscribe: (() => void) | undefined
 
-    private _replaceExtension<T extends Extension>(oldExt: T | undefined, newExt: T): T {
-        if (oldExt) {
-            const idx = this._extensions.indexOf(oldExt)
-            if (idx !== -1) {
-                this._extensions.splice(idx, 1)
-            }
+    private _removeExtension<T extends Extension>(extension: T | undefined): void {
+        if (!extension) {
+            return
         }
+        const idx = this._extensions.indexOf(extension)
+        if (idx !== -1) {
+            this._extensions.splice(idx, 1)
+        }
+    }
+
+    private _replaceExtension<T extends Extension>(oldExt: T | undefined, newExt: T): T {
+        this._removeExtension(oldExt)
         this._extensions.push(newExt)
         newExt.initialize?.()
         return newExt
@@ -4286,6 +4291,8 @@ export class PostHog implements PostHogInterface {
             return
         }
         if (this._inCookielessMode()) {
+            // Identity changes must not let queued recorder work flush under the replacement identity.
+            this.sessionRecording?.dispose({ discardBufferedEvents: true })
             // If the user was being treated as rejected in on_reject mode (either explicitly opted out, or opted out by default via opt_out_capturing_by_default), then before we can start sending regular non-cookieless events
             // we need to reset the instance to ensure that there is no leaking of state or data between the cookieless and regular events
             this._reset(true, true)
@@ -4360,6 +4367,11 @@ export class PostHog implements PostHogInterface {
             return
         }
 
+        const sessionRecording =
+            this.config.cookieless_mode === COOKIELESS_ON_REJECT ? this.sessionRecording : undefined
+        // Identity changes must not let queued recorder work flush under the cookieless identity.
+        sessionRecording?.dispose({ discardBufferedEvents: true })
+
         if (this.config.cookieless_mode === COOKIELESS_ON_REJECT && this.consent.isOptedIn()) {
             // If the user has opted in, we need to reset the instance to ensure that there is no leaking of state or data between the cookieless and regular events
             this._reset(true, true)
@@ -4374,8 +4386,8 @@ export class PostHog implements PostHogInterface {
                 distinct_id: COOKIELESS_SENTINEL_VALUE,
                 $device_id: null,
             })
-            // tear down rrweb observers before sessionManager goes away — late events would throw
-            this.sessionRecording?.stopRecording()
+            // Detach the recorder before sessionManager goes away so pending work cannot outlive it.
+            this._removeExtension(sessionRecording)
             this.sessionRecording = undefined
             this.sessionManager?.destroy()
             this.pageViewManager?.destroy()

--- a/packages/browser/src/utils/globals.ts
+++ b/packages/browser/src/utils/globals.ts
@@ -209,7 +209,7 @@ export type PostHogExtensionKind =
 export interface LazyLoadedSessionRecordingInterface {
     start: (startReason?: SessionStartReason) => void
     stop: () => void
-    discard: () => void
+    discard: (options?: { discardProducerEvents?: boolean }) => void
     sessionId: string
     status: SessionRecordingStatus
     onRRwebEmit: (rawEvent: eventWithTime) => void

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -594,6 +594,7 @@
         "_remove",
         "_removeAllTriggerListeners",
         "_removeEventTriggerCaptureHook",
+        "_removeExtension",
         "_removeListeners",
         "_removePageViewCaptureHook",
         "_removeSurveyFromDom",


### PR DESCRIPTION
## Summary

- ignore lazy recorder callbacks when recording is no longer allowed or the session manager has changed
- dispose and detach recorders before cookieless identity changes, discarding pending producer and compression work
- add regression coverage for manager replacement, shared consent changes, and synchronous or deferred teardown events

## Why

Session recording downloads its recorder code asynchronously. A user can opt out
while that download is still in progress. In `cookieless_mode: 'on_reject'`,
opt-out removes session recording and destroys its session manager.

When the delayed download callback runs, it can still try to create a recorder.
Without a session manager, that constructor throws:

`[SessionRecording] must be started with a valid sessionManager.`

A quick opt-out followed by opt-in creates a second case: the old callback can see
the new session manager and start a detached recorder beside the replacement.
This change ties each callback to the manager that started it, rechecks whether
recording is still allowed, and disposes the old recorder before either identity
transition. Final disposal also invalidates pending compression and clears events
emitted while rrweb stops, so detached work cannot flush under a replacement identity.

GitHits helped find and verify this bug.[^investigation]

[^investigation]: **GitHits helped find and verify this bug.** Starting from the reported runtime error, GitHits' version-pinned source search resolved `posthog-js@1.418.1` to commit `16b9d0a0a4da0eb6aad314bf8e330fc555d8e8dd`. It showed that replay eligibility is checked before the asynchronous recorder download ([load path](https://github.com/PostHog/posthog-js/blob/16b9d0a0a4da0eb6aad314bf8e330fc555d8e8dd/packages/browser/src/extensions/replay/session-recording.ts#L153-L179)), but the completion callback initializes the recorder without rechecking consent or `sessionManager` ([callback](https://github.com/PostHog/posthog-js/blob/16b9d0a0a4da0eb6aad314bf8e330fc555d8e8dd/packages/browser/src/extensions/replay/session-recording.ts#L336-L355)). During cookieless opt-out, PostHog removes replay and then destroys and clears the manager ([teardown](https://github.com/PostHog/posthog-js/blob/16b9d0a0a4da0eb6aad314bf8e330fc555d8e8dd/packages/browser/src/posthog-core.ts#L4324-L4335)); a delayed callback can therefore construct the lazy recorder after teardown, whose constructor immediately reads the manager ([constructor](https://github.com/PostHog/posthog-js/blob/16b9d0a0a4da0eb6aad314bf8e330fc555d8e8dd/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts#L607-L616)) and throws the reported error when it is missing ([guard](https://github.com/PostHog/posthog-js/blob/16b9d0a0a4da0eb6aad314bf8e330fc555d8e8dd/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts#L575-L581)). The earlier fix in [#3544](https://github.com/PostHog/posthog-js/pull/3544) covered late recorder events after teardown, but not this pending download callback.

## Validation

- 420 focused replay and cookieless unit tests passed across 4 suites
- 1 replay snapshot passed
- browser TypeScript typecheck passed
- targeted ESLint and diff checks passed