### PR TITLE
fix(playground): make vite-surveys dev server start again

### DIFF
--- a/packages/browser/playground/vite-surveys/package.json
+++ b/packages/browser/playground/vite-surveys/package.json
@@ -11,6 +11,7 @@
     "devDependencies": {
         "@babel/plugin-transform-react-jsx-development": "^7.22.5",
         "@preact/preset-vite": "^2.8.2",
+        "preact": "^10.29.3",
         "typescript": "^5.2.2",
         "vite": "^5.2.0"
     }

--- a/packages/browser/playground/vite-surveys/package.json
+++ b/packages/browser/playground/vite-surveys/package.json
@@ -9,6 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
+        "@babel/plugin-transform-react-jsx-development": "^7.22.5",
         "@preact/preset-vite": "^2.8.2",
         "typescript": "^5.2.2",
         "vite": "^5.2.0"

--- a/packages/browser/playground/vite-surveys/pnpm-lock.yaml
+++ b/packages/browser/playground/vite-surveys/pnpm-lock.yaml
@@ -15,7 +15,10 @@ importers:
         version: 7.22.5(@babel/core@7.24.5)
       '@preact/preset-vite':
         specifier: ^2.8.2
-        version: 2.8.2(@babel/core@7.24.5)(preact@10.21.0)(vite@5.2.11)
+        version: 2.8.2(@babel/core@7.24.5)(preact@10.29.8)(vite@5.2.11)
+      preact:
+        specifier: ^10.29.3
+        version: 10.29.8
       typescript:
         specifier: ^5.2.2
         version: 5.4.5
@@ -585,8 +588,13 @@ packages:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact@10.21.0:
-    resolution: {integrity: sha512-aQAIxtzWEwH8ou+OovWVSVNlFImL7xUCwJX3YMqA3U8iKCNC34999fFOnWjYNsylgfPgMexpbk7WYOLtKr/mxg==}
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
@@ -910,12 +918,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@preact/preset-vite@2.8.2(@babel/core@7.24.5)(preact@10.21.0)(vite@5.2.11)':
+  '@preact/preset-vite@2.8.2(@babel/core@7.24.5)(preact@10.29.8)(vite@5.2.11)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.5)
-      '@prefresh/vite': 2.4.5(preact@10.21.0)(vite@5.2.11)
+      '@prefresh/vite': 2.4.5(preact@10.29.8)(vite@5.2.11)
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.24.5)
       debug: 4.3.4
@@ -932,20 +940,20 @@ snapshots:
 
   '@prefresh/babel-plugin@0.5.1': {}
 
-  '@prefresh/core@1.5.2(preact@10.21.0)':
+  '@prefresh/core@1.5.2(preact@10.29.8)':
     dependencies:
-      preact: 10.21.0
+      preact: 10.29.8
 
   '@prefresh/utils@1.2.0': {}
 
-  '@prefresh/vite@2.4.5(preact@10.21.0)(vite@5.2.11)':
+  '@prefresh/vite@2.4.5(preact@10.29.8)(vite@5.2.11)':
     dependencies:
       '@babel/core': 7.24.5
       '@prefresh/babel-plugin': 0.5.1
-      '@prefresh/core': 1.5.2(preact@10.21.0)
+      '@prefresh/core': 1.5.2(preact@10.29.8)
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
-      preact: 10.21.0
+      preact: 10.29.8
       vite: 5.2.11
     transitivePeerDependencies:
       - supports-color
@@ -1170,7 +1178,7 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.2.0
 
-  preact@10.21.0: {}
+  preact@10.29.8: {}
 
   resolve@1.22.8:
     dependencies:

--- a/packages/browser/playground/vite-surveys/pnpm-lock.yaml
+++ b/packages/browser/playground/vite-surveys/pnpm-lock.yaml
@@ -4,12 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-NcJJTOonOQcgxZjsY8Gzw0si+6KaijnvTulC+DTi/NI=
+pnpmfileChecksum: sha256-nEzaO9RZQvokXDp+wY/5HRsIl7TOLEwlqWt5sT6UUbg=
 
 importers:
 
   .:
     devDependencies:
+      '@babel/plugin-transform-react-jsx-development':
+        specifier: ^7.22.5
+        version: 7.22.5(@babel/core@7.24.5)
       '@preact/preset-vite':
         specifier: ^2.8.2
         version: 2.8.2(@babel/core@7.24.5)(preact@10.21.0)(vite@5.2.11)
@@ -277,23 +280,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@jridgewell/gen-mapping@0.3.5':
-    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@preact/preset-vite@2.8.2':
     resolution: {integrity: sha512-m3tl+M8IO8jgiHnk+7LSTFl8axdPXloewi7iGVLdmCwf34XOzEUur0bZVewW4DUbUipFjTS2CXu27+5f/oexBA==}
@@ -346,46 +347,55 @@ packages:
     resolution: {integrity: sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.17.2':
     resolution: {integrity: sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.17.2':
     resolution: {integrity: sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.17.2':
     resolution: {integrity: sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.17.2':
     resolution: {integrity: sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.17.2':
     resolution: {integrity: sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.17.2':
     resolution: {integrity: sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.17.2':
     resolution: {integrity: sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.17.2':
     resolution: {integrity: sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.17.2':
     resolution: {integrity: sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==}
@@ -661,8 +671,8 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@babel/code-frame@7.24.2':
     dependencies:
@@ -694,8 +704,8 @@ snapshots:
   '@babel/generator@7.24.5':
     dependencies:
       '@babel/types': 7.24.5
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 2.5.2
 
   '@babel/helper-annotate-as-pure@7.22.5':
@@ -884,22 +894,21 @@ snapshots:
   '@esbuild/win32-x64@0.20.2':
     optional: true
 
-  '@jridgewell/gen-mapping@0.3.5':
+  '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/set-array@1.2.1': {}
-
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
-  '@jridgewell/trace-mapping@0.3.25':
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@preact/preset-vite@2.8.2(@babel/core@7.24.5)(preact@10.21.0)(vite@5.2.11)':
     dependencies:

--- a/packages/browser/playground/vite-surveys/pnpm-workspace.yaml
+++ b/packages/browser/playground/vite-surveys/pnpm-workspace.yaml
@@ -1,5 +1,17 @@
 pnpmfile: ../.pnpmfile.cjs
+
+# @preact/preset-vite loads its babel plugins by bare name from the project root,
+# so they have to be flat in node_modules.
+nodeLinker: hoisted
 minimumReleaseAge: 10080
 
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+
+# Same exclusion the root workspace makes: these are old transitive versions,
+# not downgrades of anything we depend on directly.
+trustPolicyExclude:
+  - semver@6.3.1
+
+allowBuilds:
+  esbuild: true

--- a/packages/browser/playground/vite-surveys/src/list.tsx
+++ b/packages/browser/playground/vite-surveys/src/list.tsx
@@ -161,12 +161,15 @@ const surveys = [
     },
 ]
 
+const fakePosthog = { capture: () => {} } as any
+
 export function List() {
     return (
         <div style={{ width: '100%', paddingLeft: '40px', paddingRight: '40px', display: 'flex', flexWrap: 'wrap' }}>
             {surveys.map((survey) => (
                 <div style={{ width: '33%', paddingTop: '40px' }}>
                     <SurveyPopup
+                        posthog={fakePosthog}
                         readOnly={true}
                         style={{
                             position: 'relative',

--- a/packages/browser/playground/vite-surveys/src/main.tsx
+++ b/packages/browser/playground/vite-surveys/src/main.tsx
@@ -1,7 +1,8 @@
 import { render } from 'preact'
 
-import { createShadow, style } from '../../../src/extensions/surveys/surveys-utils.tsx'
+import { retrieveSurveyShadow } from '../../../src/extensions/surveys/surveys-extension-utils.tsx'
+import { SurveyType } from '../../../src/posthog-surveys-types'
 import { List } from './list.tsx'
 
-const shadow = createShadow(style({}), 'some_id')
+const { shadow } = retrieveSurveyShadow({ id: 'playground', type: SurveyType.Popover, appearance: {} })
 render(<List />, shadow)

--- a/packages/browser/playground/vite-surveys/vite.config.ts
+++ b/packages/browser/playground/vite-surveys/vite.config.ts
@@ -3,7 +3,23 @@ import preact from '@preact/preset-vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [preact()],
+    plugins: [
+        {
+            // The SDK's rollup build turns `import styles from './survey.css'` into a
+            // JS string default export; vite only does that with the ?inline suffix.
+            name: 'sdk-css-as-string',
+            enforce: 'pre',
+            async resolveId(source, importer, options) {
+                if (source.endsWith('.css') && importer?.includes('/packages/browser/src/')) {
+                    const resolved = await this.resolve(source, importer, { skipSelf: true, ...options })
+                    if (resolved) {
+                        return resolved.id + '?inline'
+                    }
+                }
+            },
+        },
+        preact(),
+    ],
     resolve: {
         // The SDK source imported via ../../src must use this workspace's preact,
         // not the repo root's copy — two preact instances break hooks.

--- a/packages/browser/playground/vite-surveys/vite.config.ts
+++ b/packages/browser/playground/vite-surveys/vite.config.ts
@@ -4,4 +4,9 @@ import preact from '@preact/preset-vite'
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [preact()],
+    resolve: {
+        // The SDK source imported via ../../src must use this workspace's preact,
+        // not the repo root's copy — two preact instances break hooks.
+        dedupe: ['preact'],
+    },
 })


### PR DESCRIPTION
## TL;DR

The surveys playground had been broken for a while. `pnpm dev` printed a wall of "could not resolve" errors and never rendered. Six unrelated things were wrong; this fixes all six — `pnpm dev` now serves a page with all seven demo surveys working.

## What changed

**`src/main.tsx` imported a file that no longer exists.** It pulled `createShadow` and `style` from `surveys-utils.tsx`. That file was renamed to `surveys-extension-utils.tsx` and both exports are gone. Now uses `retrieveSurveyShadow`.

**Babel plugins were not resolvable.** `@preact/preset-vite` loads its plugins by bare name from the project root, and pnpm's strict node_modules layout does not put them there. Babel failed on `@babel/plugin-transform-react-jsx-development`, then on `babel-plugin-transform-hook-names`. Set `nodeLinker: hoisted`, and add the jsx-development plugin as a direct devDependency pinned to the 7.x line to match the babel core in use.

**The lockfile failed the `no-downgrade` trust policy** on `semver@6.3.1`, so `pnpm install` refused to run. The root workspace already excludes that entry; this adds the same exclusion here. Also allows `esbuild` to run its install script, which vite needs.

**Two preact copies.** With `nodeLinker: hoisted` the playground gets its own preact (peer of `@preact/preset-vite`), while SDK source imported via `../../src` resolves preact from the repo root install. Two instances break hooks at runtime — and when the root install is broken, resolution fails outright (`preact/hooks` "could not be resolved"). Pin `preact` here to match `packages/browser` and `resolve.dedupe` it in vite so everything uses the playground's single copy, independent of root-install state.

**SDK css imports threw at runtime.** The SDK's rollup build turns `import styles from './survey.css'` into a string default export; vite only does that with `?inline`. A small resolve plugin appends `?inline` to css imported from SDK source. Module-graph crawls miss this one: the transform returns 200, the throw happens in the browser.

**`SurveyPopup` renders nothing without a `posthog` instance.** The read-only list now passes a stub.

## Not covered here

Running the playground still needs `@posthog/core` and `@posthog/browser-common` built at the repo root (their `exports` point at `dist/`). Separately, `pnpm install` at the root exits 1 because `sharp` has no prebuilt binary and its source build fails. Linking completes, but the non-zero exit makes pnpm treat the install as incomplete, so every later `pnpm run` retries it and fails again. Both are worth fixing, neither is in scope here.

## Testing

Ran `pnpm dev` and loaded the page in Chrome via playwright: all 7 surveys render inside the shadow root, closing a survey removes it, no console or page errors (only a benign favicon 404).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*