### PR TITLE
feat(webpack): add event release mode with native debug ids

### DIFF
--- a/.changeset/bump-cli-for-native-debug-ids.md
+++ b/.changeset/bump-cli-for-native-debug-ids.md
@@ -1,0 +1,8 @@
+---
+'@posthog/nextjs-config': patch
+'@posthog/nuxt': patch
+'@posthog/rollup-plugin': patch
+'@posthog/webpack-plugin': patch
+---
+
+Bump `@posthog/cli` to `~0.14.1`, which makes `sourcemap inject --release-mode=event` adopt a bundler-emitted ECMA-426 debug id as the chunk id instead of deriving its own, so the ids webpack stamps into each chunk are the ones the CLI uploads against.

--- a/.changeset/webpack-event-release-mode.md
+++ b/.changeset/webpack-event-release-mode.md
@@ -1,0 +1,6 @@
+---
+'@posthog/webpack-plugin': minor
+'@posthog/nextjs-config': minor
+---
+
+Add experimental `sourcemaps.releaseMode: 'event'` to the webpack plugin and Next.js config. In event mode posthog-cli resolves the release once and injects its id into every chunk on disk, so exceptions report their release directly instead of it being bound to the uploaded symbol sets, and chunk ids are content-derived so a rebuild of unchanged code reuses the symbol set already uploaded. On webpack >= 5.104 the plugin also turns on webpack's own debug ids, which the CLI adopts as chunk ids, so one id identifies a chunk across the whole toolchain. The option defaults to the `POSTHOG_RELEASE_MODE` environment variable and then to `symbol-set`, which behaves exactly as before. Event mode needs a posthog-cli with the `release resolve` command.

--- a/packages/webpack-plugin/src/index.spec.ts
+++ b/packages/webpack-plugin/src/index.spec.ts
@@ -31,6 +31,7 @@ const config: ResolvedPluginConfig = {
     sourcemaps: {
         enabled: true,
         deleteAfterUpload: true,
+        releaseMode: 'symbol-set',
     },
 }
 
@@ -52,6 +53,18 @@ async function exists(filePath: string): Promise<boolean> {
     } catch {
         return false
     }
+}
+
+function createCompiler(version: string | undefined): {
+    compiler: webpack.Compiler
+    sourceMapDevToolPlugin: jest.Mock
+} {
+    const sourceMapDevToolPlugin = jest.fn().mockImplementation(() => ({ apply: jest.fn() }))
+    const compiler = {
+        webpack: { SourceMapDevToolPlugin: sourceMapDevToolPlugin, version },
+        hooks: { done: { tapAsync: jest.fn() } },
+    } as unknown as webpack.Compiler
+    return { compiler, sourceMapDevToolPlugin }
 }
 
 describe('PosthogWebpackPlugin', () => {
@@ -101,6 +114,62 @@ describe('PosthogWebpackPlugin', () => {
         await plugin.processSourceMaps(compilation, testConfig)
 
         expect(await exists(cssSourceMap)).toBe(expectedExists)
+    })
+
+    it.each<{ releaseMode: 'event' | 'symbol-set'; version: string | undefined; expected: boolean; label: string }>([
+        {
+            releaseMode: 'event',
+            version: '5.108.1',
+            expected: true,
+            label: 'enables webpack debug ids in event release mode on webpack >= 5.104',
+        },
+        {
+            releaseMode: 'event',
+            version: '6.0.0',
+            expected: true,
+            label: 'enables webpack debug ids in event release mode on webpack 6',
+        },
+        {
+            releaseMode: 'event',
+            version: '5.103.9',
+            expected: false,
+            label: 'skips debug ids on webpacks that mishandle them with hidden source maps',
+        },
+        {
+            releaseMode: 'event',
+            version: undefined,
+            expected: false,
+            label: 'skips debug ids when the compiler reports no webpack version',
+        },
+        {
+            releaseMode: 'event',
+            version: 'nightly',
+            expected: false,
+            label: 'skips debug ids when the webpack version is unparsable',
+        },
+        {
+            releaseMode: 'symbol-set',
+            version: '5.108.1',
+            expected: false,
+            label: 'does not enable debug ids in symbol-set release mode',
+        },
+    ])('$label', ({ releaseMode, version, expected }) => {
+        const testConfig = {
+            ...config,
+            sourcemaps: { ...config.sourcemaps, releaseMode },
+        }
+        const { compiler, sourceMapDevToolPlugin } = createCompiler(version)
+
+        new PosthogWebpackPlugin(testConfig, true).apply(compiler)
+
+        expect(sourceMapDevToolPlugin).toHaveBeenCalledTimes(1)
+        const options = sourceMapDevToolPlugin.mock.calls[0][0]
+        if (expected) {
+            expect(options.debugIds).toBe(true)
+        } else {
+            // Absent rather than false: webpacks predating the option reject unknown keys.
+            expect(options).not.toHaveProperty('debugIds')
+        }
     })
 
     it('continues deleting CSS source maps and logs each deletion failure', async () => {

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -7,6 +7,21 @@ import fs from 'fs/promises'
 
 export * from './config'
 
+// webpack validates SourceMapDevToolPlugin options against its schema, so passing `debugIds` to a
+// webpack that predates the option fails the build outright. 5.97.0 added it; 5.104.0 fixed its
+// interplay with builds that suppress the sourceMappingURL comment (`append: false`, the
+// deleteAfterUpload default), so that's the floor.
+const DEBUG_IDS_MIN_MAJOR = 5
+const DEBUG_IDS_MIN_MINOR = 104
+
+function webpackSupportsDebugIds(version: string | undefined): boolean {
+    if (!version) {
+        return false
+    }
+    const [major = NaN, minor = NaN] = version.split('.').map((part) => Number.parseInt(part, 10))
+    return major > DEBUG_IDS_MIN_MAJOR || (major === DEBUG_IDS_MIN_MAJOR && minor >= DEBUG_IDS_MIN_MINOR)
+}
+
 export class PosthogWebpackPlugin {
     resolvedConfig: ResolvedPluginConfig
     logger: Logger
@@ -22,11 +37,18 @@ export class PosthogWebpackPlugin {
 
     apply(compiler: webpack.Compiler): void {
         if (this.resolvedConfig.sourcemaps.enabled) {
+            // In event release mode webpack stamps an ECMA-426 debug id into each chunk at
+            // compile time, and posthog-cli adopts it as the chunk id instead of deriving its
+            // own, so one id identifies the chunk across the whole toolchain. On webpacks
+            // without the option the CLI falls back to content-derived ids, which are equally
+            // stable — just not shared with other tooling.
+            const eventReleaseMode = this.resolvedConfig.sourcemaps.releaseMode === 'event'
             new compiler.webpack.SourceMapDevToolPlugin({
                 filename: '[file].map',
                 noSources: false,
                 moduleFilenameTemplate: '[resource-path]',
                 append: this.resolvedConfig.sourcemaps.deleteAfterUpload ? false : undefined,
+                ...(eventReleaseMode && webpackSupportsDebugIds(compiler.webpack.version) ? { debugIds: true } : {}),
             }).apply(compiler)
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^7.27.1
       version: 7.28.5
     '@posthog/cli':
-      specifier: ~0.13.0
-      version: 0.13.0
+      specifier: ~0.14.1
+      version: 0.14.1
     '@rslib/core':
       specifier: 0.10.6
       version: 0.10.6
@@ -708,7 +708,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.13.0
+        version: 0.14.1
       '@posthog/plugin-utils':
         specifier: workspace:^
         version: link:../plugin-utils
@@ -785,7 +785,7 @@ importers:
         version: 4.1.3(magicast@0.5.3)
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.13.0
+        version: 0.14.1
       '@posthog/core':
         specifier: workspace:^
         version: link:../core
@@ -1127,7 +1127,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.13.0
+        version: 0.14.1
       '@posthog/plugin-utils':
         specifier: workspace:^
         version: link:../plugin-utils
@@ -1680,7 +1680,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.13.0
+        version: 0.14.1
       '@posthog/core':
         specifier: workspace:^
         version: link:../core
@@ -5665,8 +5665,8 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@posthog/cli@0.13.0':
-    resolution: {integrity: sha512-ZP7ZLmFyjLakGjkDzm3/Eu5XvonY4pFD1SOtMc5TjkwYS6TmihuuLp0iDp+X7Pd9xFI0eLtBpfV/G9HI/XRZbg==}
+  '@posthog/cli@0.14.1':
+    resolution: {integrity: sha512-gTzcKpl9TZLf0LrlLHEjChlPc9LIK1gdQG0alMnX6+b+W1mTD+6nTN0W/MeEzjT4DiKDeK8FPhc1n7dT1tWKFw==}
     engines: {node: '>=14.14', npm: '>=6'}
     hasBin: true
 
@@ -10289,6 +10289,7 @@ packages:
   eslint@9.37.0:
     resolution: {integrity: sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -24247,7 +24248,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@posthog/cli@0.13.0':
+  '@posthog/cli@0.14.1':
     dependencies:
       detect-libc: 2.1.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@babel/preset-env': ^7.27.1
   '@babel/preset-react': ^7.27.1
   '@babel/preset-typescript': ^7.27.1
-  '@posthog/cli': ~0.13.0
+  '@posthog/cli': ~0.14.1
   '@rslib/core': 0.10.6
   '@testing-library/dom': ^10.4.1
   '@testing-library/jest-dom': ^6.9.1


### PR DESCRIPTION
In this PR we add support for the new releases mode to rely on webpack generated debug ids.

It needs this PR first https://github.com/PostHog/posthog/pull/85307 - it has been tested in that PR.