### PR TITLE
feat(node): fall back for requested flags missing locally

### DIFF
--- a/.changeset/calm-flags-fallback.md
+++ b/.changeset/calm-flags-fallback.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+Fall back to remote evaluation when a requested flag is missing from loaded local definitions.

--- a/.changeset/calm-flags-fallback.md
+++ b/.changeset/calm-flags-fallback.md
@@ -1,5 +1,6 @@
 ---
-'posthog-node': patch
+'posthog-node': minor
 ---
 
-Fall back to remote evaluation when a requested flag is missing from loaded local definitions.
+Fall back to remote evaluation when a requested flag is missing from loaded local definitions. This
+changes scoped calls that previously omitted the flag without making a request.

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -484,7 +484,7 @@
         },
         {
           "category": "Feature flags",
-          "description": "Evaluate all feature flags for a user in a single call and return a  snapshot. Branch on `.isEnabled()` / `.getFlag()`, then pass the same snapshot to `capture()` via the `flags` option so the captured event carries the exact flag values the code branched on.\nPrefer this over repeated `isFeatureEnabled()` / `getFeatureFlag()` calls and over `capture({ sendFeatureFlags: true })` — it consolidates flag evaluation into a single `/flags` request per incoming request.\n**Local evaluation is transparent.** When the poller can resolve a flag from cached definitions, no network call is made and the snapshot's `$feature_flag_called` events are tagged `locally_evaluated: true`.\n**Trim the request.** Pass `flagKeys` to scope the underlying `/flags` request to a subset of flags — useful when you only need a few flags and want to reduce the response payload.\n**Trim the event payload.** Use `flags.only([...])` or `flags.onlyAccessed()` to filter which flags get attached to a captured event without re-fetching.",
+          "description": "Evaluate all feature flags for a user in a single call and return a  snapshot. Branch on `.isEnabled()` / `.getFlag()`, then pass the same snapshot to `capture()` via the `flags` option so the captured event carries the exact flag values the code branched on.\nPrefer this over repeated `isFeatureEnabled()` / `getFeatureFlag()` calls and over `capture({ sendFeatureFlags: true })` — it consolidates flag evaluation into a single `/flags` request per incoming request.\n**Local evaluation is transparent.** When the poller can resolve a flag from cached definitions, no network call is made and the snapshot's `$feature_flag_called` events are tagged `locally_evaluated: true`. A requested key missing from local definitions is included in a `/flags` fallback unless `onlyEvaluateLocally` is true. Locally resolved values remain authoritative when remote results are merged.\n**Trim the request.** Pass `flagKeys` to scope local evaluation, the underlying `/flags` request, and the returned snapshot to a subset of flags. Remote evaluation responses are not cached, so a key missing both locally and remotely costs one `/flags` request per `evaluateFlags()` call.\n**Trim the event payload.** Use `flags.only([...])` or `flags.onlyAccessed()` to filter which flags get attached to a captured event without re-fetching.",
           "details": null,
           "id": "evaluateFlags",
           "showDocs": true,
@@ -514,7 +514,7 @@
           "releaseTag": "public",
           "params": [
             {
-              "description": "Optional configuration for flag evaluation. Supports the same fields as `getAllFlags()`, including `flagKeys` to scope the `/flags` request.",
+              "description": "Optional configuration for flag evaluation. Supports the same fields as `getAllFlags()`. `flagKeys` scopes local evaluation, the `/flags` request, and the returned snapshot. `onlyEvaluateLocally` prevents fallback and leaves unresolved keys absent.",
               "isOptional": true,
               "type": "AllFlagsOptions",
               "name": "options"
@@ -1713,6 +1713,7 @@
           "name": "groupProperties"
         },
         {
+          "description": "Skip remote fallback and omit flags that local definitions cannot resolve.",
           "type": "boolean",
           "name": "onlyEvaluateLocally"
         },
@@ -1721,6 +1722,7 @@
           "name": "disableGeoip"
         },
         {
+          "description": "Restrict local evaluation, the `/flags` request, and the returned snapshot to these keys.\n`evaluateFlags()` falls back remotely when a requested key is missing from local definitions\nunless `onlyEvaluateLocally` is true. Remote evaluation responses are not cached, so a key\nmissing both locally and remotely costs one `/flags` request per `evaluateFlags()` call.",
           "type": "string[]",
           "name": "flagKeys"
         }
@@ -1763,6 +1765,7 @@
           "name": "groupProperties"
         },
         {
+          "description": "Skip remote fallback and omit flags that local definitions cannot resolve.",
           "type": "boolean",
           "name": "onlyEvaluateLocally"
         },
@@ -2352,6 +2355,7 @@
           "name": "groupProperties"
         },
         {
+          "description": "Skip remote fallback and omit flags that local definitions cannot resolve.",
           "type": "boolean",
           "name": "onlyEvaluateLocally"
         },

--- a/packages/node/src/__tests__/evaluate-flags.spec.ts
+++ b/packages/node/src/__tests__/evaluate-flags.spec.ts
@@ -11,6 +11,7 @@ const mockedFetch = jest.spyOn(globalThis, 'fetch').mockImplementation()
 
 const posthogImmediateResolveOptions: PostHogOptions = {
   fetchRetryCount: 0,
+  featureFlagsPollingInterval: 3_600_000,
 }
 
 const flagsResponseFixture = (): PostHogV2FlagsResponse => ({
@@ -718,6 +719,38 @@ describe('evaluateFlags', () => {
       expect(remoteFlagCalls).toHaveLength(1)
       const [, init] = remoteFlagCalls[0]
       expect(JSON.parse((init as any).body as string).flag_keys_to_evaluate).toEqual(['local-flag', 'remote-only'])
+    })
+
+    it('falls back once per evaluation when the requested key is also missing remotely', async () => {
+      await posthog.shutdown()
+      mockedFetch.mockClear()
+
+      const remoteResponse = flagsResponseFixture()
+      remoteResponse.flags = {}
+      const localApi = apiImplementation({ localFlags: localFlagsFixture() })
+      const remoteApi = apiImplementationV4(remoteResponse)
+      mockedFetch.mockImplementation((url) =>
+        String(url).includes('flags/definitions') ? localApi(url) : remoteApi(url)
+      )
+      setup({ personalApiKey: 'TEST_PERSONAL_API_KEY' })
+
+      for (let i = 0; i < 2; i++) {
+        const flags = await posthog.evaluateFlags('user-1', {
+          flagKeys: ['local-flag', 'typo-flag'],
+        })
+
+        expect(flags.keys).toEqual(['local-flag'])
+        expect(flags.getFlag('local-flag')).toBe(true)
+        expect(flags.getFlag('typo-flag')).toBeUndefined()
+      }
+
+      // Node does not cache evaluateFlags() responses across calls. Each call still makes at most
+      // one scoped fallback and keeps the local value when the server cannot resolve the typo.
+      const remoteFlagCalls = mockedFetch.mock.calls.filter((call) => String(call[0]).includes('/flags/?v=2'))
+      expect(remoteFlagCalls).toHaveLength(2)
+      for (const [, init] of remoteFlagCalls) {
+        expect(JSON.parse((init as any).body as string).flag_keys_to_evaluate).toEqual(['local-flag', 'typo-flag'])
+      }
     })
 
     it('does not fall back for a missing requested flag in local-only mode', async () => {

--- a/packages/node/src/__tests__/evaluate-flags.spec.ts
+++ b/packages/node/src/__tests__/evaluate-flags.spec.ts
@@ -683,6 +683,56 @@ describe('evaluateFlags', () => {
       expect(remoteFlagCalls).toHaveLength(0)
     })
 
+    it('falls back once when a requested flag is missing from local definitions', async () => {
+      await posthog.shutdown()
+      mockedFetch.mockClear()
+
+      const remoteResponse = flagsResponseFixture()
+      remoteResponse.flags = {
+        ...remoteResponse.flags,
+        'local-flag': {
+          ...remoteResponse.flags['disabled-flag'],
+          key: 'local-flag',
+        },
+        'remote-only': {
+          ...remoteResponse.flags['boolean-flag'],
+          key: 'remote-only',
+        },
+      }
+      const localApi = apiImplementation({ localFlags: localFlagsFixture() })
+      const remoteApi = apiImplementationV4(remoteResponse)
+      mockedFetch.mockImplementation((url) =>
+        String(url).includes('flags/definitions') ? localApi(url) : remoteApi(url)
+      )
+      setup({ personalApiKey: 'TEST_PERSONAL_API_KEY' })
+
+      const flags = await posthog.evaluateFlags('user-1', {
+        flagKeys: ['local-flag', 'remote-only'],
+      })
+
+      expect(flags.keys.sort()).toEqual(['local-flag', 'remote-only'])
+      expect(flags.getFlag('local-flag')).toBe(true)
+      expect(flags.getFlag('remote-only')).toBe(true)
+
+      const remoteFlagCalls = mockedFetch.mock.calls.filter((call) => String(call[0]).includes('/flags/?v=2'))
+      expect(remoteFlagCalls).toHaveLength(1)
+      const [, init] = remoteFlagCalls[0]
+      expect(JSON.parse((init as any).body as string).flag_keys_to_evaluate).toEqual(['local-flag', 'remote-only'])
+    })
+
+    it('does not fall back for a missing requested flag in local-only mode', async () => {
+      const flags = await posthog.evaluateFlags('user-1', {
+        flagKeys: ['local-flag', 'remote-only'],
+        onlyEvaluateLocally: true,
+      })
+
+      expect(flags.keys).toEqual(['local-flag'])
+      expect(flags.getFlag('local-flag')).toBe(true)
+      expect(flags.getFlag('remote-only')).toBeUndefined()
+      const remoteFlagCalls = mockedFetch.mock.calls.filter((call) => String(call[0]).includes('/flags/?v=2'))
+      expect(remoteFlagCalls).toHaveLength(0)
+    })
+
     it('attaches $feature_flag_definitions_loaded_at on locally-evaluated $feature_flag_called events', async () => {
       const flags = await posthog.evaluateFlags('user-1')
       flags.isEnabled('local-flag')

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2047,6 +2047,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       onlyEvaluateLocally = this.options.strictLocalEvaluation ?? false
     }
 
+    const requestedFlagKeys = flagKeys ? new Set(flagKeys) : undefined
     const records: Record<string, EvaluatedFlagRecord> = {}
     let requestId: string | undefined = undefined
     let evaluatedAt: number | undefined = undefined
@@ -2080,7 +2081,10 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     // Fall back to remote evaluation for any flags the poller couldn't resolve locally.
     // We use the detail-shaped endpoint so the resulting records carry id/version/reason
     // and fired $feature_flag_called events match what isFeatureEnabled()/getFeatureFlag() emit.
-    const fallbackToFlags = localResult ? localResult.fallbackToFlags : true
+    const requestedFlagMissingLocally =
+      requestedFlagKeys !== undefined &&
+      Array.from(requestedFlagKeys).some((key) => this.featureFlagsPoller?.featureFlagsByKey[key] === undefined)
+    const fallbackToFlags = localResult ? localResult.fallbackToFlags || requestedFlagMissingLocally : true
     if (fallbackToFlags && !onlyEvaluateLocally) {
       const details = await super.getFeatureFlagDetailsStateless(
         evaluationContext.distinctId,
@@ -2149,6 +2153,14 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         const existing = records[key]
         if (existing) {
           records[key] = { ...existing, payload }
+        }
+      }
+    }
+
+    if (requestedFlagKeys !== undefined) {
+      for (const key of Object.keys(records)) {
+        if (!requestedFlagKeys.has(key)) {
+          delete records[key]
         }
       }
     }

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1940,11 +1940,14 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    *
    * **Local evaluation is transparent.** When the poller can resolve a flag from
    * cached definitions, no network call is made and the snapshot's `$feature_flag_called`
-   * events are tagged `locally_evaluated: true`.
+   * events are tagged `locally_evaluated: true`. A requested key missing from local
+   * definitions is included in a `/flags` fallback unless `onlyEvaluateLocally` is true.
+   * Locally resolved values remain authoritative when remote results are merged.
    *
-   * **Trim the request.** Pass `flagKeys` to scope the underlying `/flags` request
-   * to a subset of flags — useful when you only need a few flags and want to reduce
-   * the response payload.
+   * **Trim the request.** Pass `flagKeys` to scope local evaluation, the underlying
+   * `/flags` request, and the returned snapshot to a subset of flags. Remote evaluation
+   * responses are not cached, so a key missing both locally and remotely costs one
+   * `/flags` request per `evaluateFlags()` call.
    *
    * **Trim the event payload.** Use `flags.only([...])` or `flags.onlyAccessed()`
    * to filter which flags get attached to a captured event without re-fetching.
@@ -1991,7 +1994,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * {@label Feature flags}
    *
    * @param distinctIdOrOptions - The user's distinct ID, or options when the distinctId comes from `withContext()`
-   * @param options - Optional configuration for flag evaluation. Supports the same fields as `getAllFlags()`, including `flagKeys` to scope the `/flags` request.
+   * @param options - Optional configuration for flag evaluation. Supports the same fields as `getAllFlags()`. `flagKeys` scopes local evaluation, the `/flags` request, and the returned snapshot. `onlyEvaluateLocally` prevents fallback and leaves unresolved keys absent.
    * @returns Promise that resolves to a `FeatureFlagEvaluations` snapshot
    */
   async evaluateFlags(options?: AllFlagsOptions): Promise<FeatureFlagEvaluations>

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -110,6 +110,7 @@ export type BaseFlagEvaluationOptions = {
   groups?: Record<string, string>
   personProperties?: Properties
   groupProperties?: Record<string, Properties>
+  /** Skip remote fallback and omit flags that local definitions cannot resolve. */
   onlyEvaluateLocally?: boolean
   disableGeoip?: boolean
 }
@@ -118,6 +119,12 @@ export type FlagEvaluationOptions = BaseFlagEvaluationOptions & {
 }
 
 export type AllFlagsOptions = BaseFlagEvaluationOptions & {
+  /**
+   * Restrict local evaluation, the `/flags` request, and the returned snapshot to these keys.
+   * `evaluateFlags()` falls back remotely when a requested key is missing from local definitions
+   * unless `onlyEvaluateLocally` is true. Remote evaluation responses are not cached, so a key
+   * missing both locally and remotely costs one `/flags` request per `evaluateFlags()` call.
+   */
   flagKeys?: string[]
 }
 
@@ -695,14 +702,14 @@ export interface IPostHog {
    * posthog.capture({ distinctId: 'user_123', event: 'page_viewed', flags })
    * ```
    *
-   * @param options - Optional configuration for flag evaluation. Pass `flagKeys` to scope the underlying `/flags` request to a subset of flags.
+   * @param options - Optional configuration for flag evaluation. `flagKeys` scopes local evaluation, the `/flags` request, and the returned snapshot. Missing local keys trigger fallback unless `onlyEvaluateLocally` is true.
    */
   evaluateFlags(options?: AllFlagsOptions): Promise<FeatureFlagEvaluations>
   /**
    * @description Evaluate all feature flags for a specific user.
    *
    * @param distinctId - The user's distinct ID
-   * @param options - Optional configuration for flag evaluation. Pass `flagKeys` to scope the underlying `/flags` request to a subset of flags.
+   * @param options - Optional configuration for flag evaluation. `flagKeys` scopes local evaluation, the `/flags` request, and the returned snapshot. Missing local keys trigger fallback unless `onlyEvaluateLocally` is true.
    */
   evaluateFlags(distinctId: string, options?: AllFlagsOptions): Promise<FeatureFlagEvaluations>
 


### PR DESCRIPTION
## Problem

When local feature flag definitions were loaded, `evaluateFlags()` did not fall back to `/flags` if an explicitly requested key was missing from those definitions. The missing flag was silently absent even though callers had not requested local-only evaluation.

This follows the cross-SDK decision in [PostHog/posthog-android#678](https://github.com/PostHog/posthog-android/pull/678#issuecomment-5341879578) and the contract proposed in [PostHog/sdk-specs#44](https://github.com/PostHog/sdk-specs/pull/44).

## Changes

- Treat a requested key missing from loaded local definitions as requiring remote fallback.
- Keep local-only evaluation free of remote requests and leave unresolved keys absent.
- Forward the caller's original requested key list and keep locally resolved values authoritative.
- Filter the final snapshot to the requested keys, even if `/flags` returns additional flags.
- Document that Node does not cache `evaluateFlags()` responses. A key missing both locally and remotely therefore costs one scoped `/flags` request per evaluation call.
- Use a minor changeset because scoped calls now make a request where they previously omitted the key without network I/O.
- Keep the test poll interval away from request-count assertions.
- Regenerate the checked-in Node API reference after updating public documentation.

## How did you test this code?

- `pnpm --filter posthog-node test:unit -- evaluate-flags.spec.ts --runInBand` - 43 tests passed
- `pnpm --filter posthog-node lint`
- `pnpm turbo --filter=posthog-node... build`
- `pnpm exec changeset status`
- `pnpm generate-references`
- `pnpm check:public-api`
- Autoreview against `origin/main` at `49f302983` found no actionable issues

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a minor changeset for `posthog-node`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and audited with the Pi coding agent under @marandaneto's direction. The audit compared this implementation with the reviewed Android behavior and kept Node's existing no-cache evaluation architecture explicit rather than adding a broader cache.

