### PR TITLE
fix(node): return undefined instead of null variant in getFeatureFlagResult

### DIFF
--- a/.changeset/node-null-variant.md
+++ b/.changeset/node-null-variant.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+fix getFeatureFlagResult returning null variant instead of undefined when remotely evaluated

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -355,6 +355,7 @@ describe('Lazy SessionRecording', () => {
     })
 
     afterEach(() => {
+        sessionRecording.stopRecording()
         // @ts-expect-error this is a test, it's safe to write to location like this
         window!.location = originalLocation
     })

--- a/packages/node/src/__tests__/feature-flags.flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.flags.spec.ts
@@ -730,6 +730,39 @@ describe('getFeatureFlagResult', () => {
     expect(result?.payload).toBeUndefined()
   })
 
+  it('normalizes null variant from the API to undefined', async () => {
+    const flagsResponse: PostHogV2FlagsResponse = {
+      flags: {
+        'boolean-flag': {
+          key: 'boolean-flag',
+          enabled: true,
+          // The flags API serializes missing variants as null
+          variant: null as unknown as undefined,
+          reason: undefined,
+          metadata: undefined,
+        },
+      },
+      errorsWhileComputingFlags: false,
+      requestId: '0152a345-295f-4fba-adac-2e6ea9c91082',
+      evaluatedAt: 1640995200000,
+    }
+    mockedFetch.mockImplementation(apiImplementationV4(flagsResponse))
+
+    const posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      ...posthogImmediateResolveOptions,
+    })
+
+    const result = await posthog.getFeatureFlagResult('boolean-flag', 'some-distinct-id')
+
+    expect(result).toEqual({
+      key: 'boolean-flag',
+      enabled: true,
+      variant: undefined,
+      payload: undefined,
+    })
+  })
+
   it('returns disabled result when conditions do not match', async () => {
     const flagsResponse: PostHogV2FlagsResponse = {
       flags: {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1347,7 +1347,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
           result = {
             key,
             enabled: flagDetail.enabled,
-            variant: flagDetail.variant,
+            // The flags API serializes missing variants as null
+            variant: flagDetail.variant ?? undefined,
             payload: parsedPayload,
           }
         }


### PR DESCRIPTION
## Problem

The remote evaluation path in `_getFeatureFlagResult` copies `flagDetail.variant` straight from the parsed `/flags` response, where missing variants are serialized as `null`. `FeatureFlagResult.variant` is typed `string | undefined`, so consumers that serialize or validate the result get a value the type says cannot exist. We hit this caching the result with a zod schema written against the type: every cached entry failed validation. The override and local evaluation paths already normalize to `undefined`.

## Changes

- Normalize `null` variant to `undefined` in the remote evaluation path
- Regression test (fails without the fix: `null` does not `toEqual` `undefined`)