### PR TITLE
fix(error-tracking): stop counting Chromium <anonymous> frames as in_app

### DIFF
--- a/.changeset/anonymous-frames-not-in-app.md
+++ b/.changeset/anonymous-frames-not-in-app.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+---
+
+Stop counting Chromium `<anonymous>` stack frames (extension-injected, devtools or string-evaluated code) as in-app code.

--- a/packages/core/src/error-tracking/parsers/base.spec.ts
+++ b/packages/core/src/error-tracking/parsers/base.spec.ts
@@ -1,4 +1,5 @@
 import { createFrame } from './base'
+import { createDefaultStackParser } from './index'
 
 describe('createFrame', () => {
   const platform = 'web:javascript'
@@ -25,9 +26,42 @@ describe('createFrame', () => {
     })
   })
 
+  it('does not mark Chromium <anonymous> frames as in_app', () => {
+    // Chromium reports scripts that have no URL (extension-injected code, devtools, string eval)
+    // as `<anonymous>`. They can never be symbolicated and are not attributable to the page.
+    const frame = createFrame(platform, '<anonymous>', '?', 1, 394)
+    expect(frame.in_app).toBe(false)
+    expect(frame).toMatchObject({ filename: '<anonymous>', function: '?', lineno: 1, colno: 394 })
+  })
+
   it('falls back to in_app when the parser could not determine a filename', () => {
     // Regex capture groups that do not participate arrive here as undefined despite the type
     const frame = createFrame(platform, undefined as unknown as string, 'doThing')
     expect(frame.in_app).toBe(true)
+  })
+})
+
+describe('createDefaultStackParser in_app classification', () => {
+  const parse = createDefaultStackParser()
+
+  it('demotes a bare <anonymous> frame from injected code', () => {
+    const frames = parse("SyntaxError: Failed to execute 'appendChild' on 'Node': boom\n    at <anonymous>:1:394")
+    expect(frames).toEqual([
+      { platform: 'web:javascript', filename: '<anonymous>', function: '?', in_app: false, lineno: 1, colno: 394 },
+    ])
+  })
+
+  it("keeps the page's own eval'd code as in_app", () => {
+    // V8 attributes eval'd code to the script that called eval; the chrome parser already
+    // rewrites these frames to that URL, so they must not be caught by the <anonymous> rule.
+    const frames = parse(
+      'Error: boom\n' +
+        '    at eval (eval at <anonymous> (https://example.com/app.js:10:5), <anonymous>:1:394)\n' +
+        '    at https://example.com/app.js:10:5'
+    )
+    expect(frames.map((f) => [f.filename, f.in_app])).toEqual([
+      ['https://example.com/app.js', true],
+      ['https://example.com/app.js', true],
+    ])
   })
 })

--- a/packages/core/src/error-tracking/parsers/base.ts
+++ b/packages/core/src/error-tracking/parsers/base.ts
@@ -14,6 +14,14 @@ export const UNKNOWN_FUNCTION = '?'
 // but do not let it count as in_app and pull the issue into the site's own stack.
 const MASKED_URL_PREFIX = 'webkit-masked-url://'
 
+// Chromium's counterpart: a script with no URL at all -- code injected by an extension
+// (`chrome.scripting.executeScript`), pasted into devtools, or evaluated from a string -- shows
+// up as a bare `<anonymous>:line:col` frame. The page's own eval'd code is *not* affected: V8
+// reports it as `eval at <anonymous> (https://site/app.js:1:2)` and the chrome parser already
+// rewrites that to the site URL. A bare `<anonymous>` can never be symbolicated, so treating it
+// as in_app only ever pulled an unresolvable frame into the site's own stack.
+const ANONYMOUS_FILENAME = '<anonymous>'
+
 export function createFrame(
   platform: StackFrame['platform'],
   filename: string,
@@ -26,8 +34,8 @@ export function createFrame(
     platform,
     filename,
     function: func === '<anonymous>' ? UNKNOWN_FUNCTION : func,
-    // Browser frames are considered in_app unless the runtime has masked their origin
-    in_app: !filename?.startsWith(MASKED_URL_PREFIX),
+    // Browser frames are considered in_app unless the runtime has masked or dropped their origin
+    in_app: !filename?.startsWith(MASKED_URL_PREFIX) && filename !== ANONYMOUS_FILENAME,
   }
 
   if (!isUndefined(lineno)) {


### PR DESCRIPTION
## Problem

An issue on posthog.com (`SyntaxError: Failed to execute 'appendChild' ...`, one Edge user, same error following them across posthog.com, us.posthog.com and eu.posthog.com) is reported as if it were the site's own code. The stack is a single frame:

```
filename: "<anonymous>", function: "?", lineno: 1, colno: 394   (symbolication: resolve_failure)
```

That is the frame Chromium produces for a top-level statement in a script with **no URL** — code injected by an extension (`chrome.scripting.executeScript({func})`), pasted into devtools, or evaluated from a string. Cross-origin persistence for a single user points at an extension, but the SDK can only act on the frame shape, and the frame shape means "no source file" regardless of who injected it.

`createFrame` marked every browser frame `in_app: true` except Safari's `webkit-masked-url://` placeholder (#4549). Chromium's equivalent, `<anonymous>`, fell through, so an extension-only stack landed as application code with no usable frames.

Our own script loading is ruled out: `external-scripts-loader.ts` only ever sets `scriptTag.src`, never inline text.

## Change

Treat `<anonymous>` exactly like the masked-URL case: **keep the frame, mark it `in_app: false`**. One condition in `createFrame`, mirroring #4549.

```ts
in_app: !filename?.startsWith(MASKED_URL_PREFIX) && filename !== ANONYMOUS_FILENAME,
```

This is also what the backend already says it wants — cymbal's `js.rs` has "If this is a source_url: <anonymous> frame, we always assume it's not in_app" — but only applies on the no-location path. A `<anonymous>:1:394` frame has a location, so it goes down the resolve-failure path and keeps whatever `in_app` the SDK sent. A matching cymbal change for that path would cover older SDK versions too; this PR is the SDK half.

## What this does not do

- **Not dropped.** Unlike `chrome-extension://`, `<anonymous>` does not prove an extension — devtools and string-eval produce the same frame — so it must not join `_isExtensionException`'s drop list (`.some()` would discard whole exceptions on one injected frame mid-stack). Demote, not drop.
- **The issue is still created.** Fingerprinting falls back to the first frame when nothing is in_app, so a single-frame stack groups identically. This fixes the first-party attribution and presentation, not "lands in error tracking". The lever for "make it go away" remains a suppression rule.
- **The page's own eval'd code is unaffected.** V8 reports it as `eval at <anonymous> (https://site/app.js:10:5), <anonymous>:1:394` and `chromeEvalRegex` already rewrites those frames to the site URL (covered by a test).

## Caveat

For multi-frame stacks mixing `<anonymous>` and real frames, demotion changes which frames feed the v1 fingerprint, so some existing issues could re-group. Same trade-off #4549 accepted for Safari.

## Testing

- `base.spec.ts`: new `createFrame` case for `<anonymous>`, plus two end-to-end `createDefaultStackParser` cases — bare `<anonymous>:1:394` (the exact reported frame) comes out `in_app: false`; `eval at <anonymous> (url)` frames stay on the site URL and `in_app: true`.
- Mutation-tested: swapping `base.ts` back to `main` fails exactly the two new tests and nothing else.
- `jest` (52 core error-tracking + 68 browser exception tests), `eslint`, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
