### PR TITLE
feat(react-native): record automatic exception steps

### DIFF
--- a/.changeset/automatic-exception-steps-react-native.md
+++ b/.changeset/automatic-exception-steps-react-native.md
@@ -6,3 +6,5 @@
 Add automatic exception steps to React Native, so a captured exception carries a timeline even where nobody called `addExceptionStep`. Set `errorTracking.exceptionSteps.automatic` to `true`, or to an object, to record a step for a screen change (`navigation`), an autocaptured tap (`taps`), or an app lifecycle transition (`lifecycle`). Every signal stays off by default, because each step adds bytes to every captured exception.
 
 Automatic steps carry `$type`, which the error tracking timeline already renders, and they share the byte-bounded buffer and the native forwarding that manual steps use. A manual step stays untyped. An event that `before_send` dropped leaves no step.
+
+`reset()` now clears the exception-step buffer, for automatic and manual steps alike. Exception steps are user-session state, so on a shared device the previous user's screen names and tap labels must not reach the next user's exception. The buffer still survives a capture, so every exception in one session carries the same steps.

--- a/.changeset/automatic-exception-steps-react-native.md
+++ b/.changeset/automatic-exception-steps-react-native.md
@@ -3,7 +3,7 @@
 'posthog-react-native': minor
 ---
 
-Add automatic exception steps to React Native, so a captured exception carries a timeline even where nobody called `addExceptionStep`. Set `errorTracking.exceptionSteps.automatic` to `true`, or to an object, to record a step for a screen change (`navigation`), an autocaptured tap (`taps`), or an app lifecycle transition (`lifecycle`). Every signal stays off by default, because each step adds bytes to every captured exception.
+Add automatic exception steps to React Native, so a captured exception carries a timeline even where nobody called `addExceptionStep`. Set `errorTracking.exceptionSteps.automatic` to `true`, or to an object, to record a step for a screen change (`navigation`), an autocaptured tap or React Native Web click (`taps`), or an app lifecycle transition (`lifecycle`). Every signal stays off by default, because each step adds bytes to every captured exception.
 
 Automatic steps carry `$type`, which the error tracking timeline already renders, and they share the byte-bounded buffer and the native forwarding that manual steps use. A manual step stays untyped. An event that `before_send` dropped leaves no step.
 

--- a/.changeset/automatic-exception-steps-react-native.md
+++ b/.changeset/automatic-exception-steps-react-native.md
@@ -1,0 +1,8 @@
+---
+'@posthog/core': minor
+'posthog-react-native': minor
+---
+
+Add automatic exception steps to React Native, so a captured exception carries a timeline even where nobody called `addExceptionStep`. Set `errorTracking.exceptionSteps.automatic` to `true`, or to an object, to record a step for a screen change (`navigation`), an autocaptured tap (`taps`), or an app lifecycle transition (`lifecycle`). Every signal stays off by default, because each step adds bytes to every captured exception.
+
+Automatic steps carry `$type`, which the error tracking timeline already renders, and they share the byte-bounded buffer and the native forwarding that manual steps use. A manual step stays untyped. An event that `before_send` dropped leaves no step.

--- a/.changeset/automatic-exception-steps-react-native.md
+++ b/.changeset/automatic-exception-steps-react-native.md
@@ -7,4 +7,4 @@ Add automatic exception steps to React Native, so a captured exception carries a
 
 Automatic steps carry `$type`, which the error tracking timeline already renders, and they share the byte-bounded buffer and the native forwarding that manual steps use. A manual step stays untyped. An event that `before_send` dropped leaves no step.
 
-`reset()` now clears the exception-step buffer, for automatic and manual steps alike. Exception steps are user-session state, so on a shared device the previous user's screen names and tap labels must not reach the next user's exception. The buffer still survives a capture, so every exception in one session carries the same steps.
+The buffer keeps its existing lifetime. A capture keeps the steps, and `reset()` keeps them too, because steps scope to the app session rather than to the user session.

--- a/.changeset/automatic-exception-steps-react-native.md
+++ b/.changeset/automatic-exception-steps-react-native.md
@@ -3,8 +3,8 @@
 'posthog-react-native': minor
 ---
 
-Add automatic exception steps to React Native, so a captured exception carries a timeline even where nobody called `addExceptionStep`. Set `errorTracking.exceptionSteps.automatic` to `true`, or to an object, to record a step for a screen change (`navigation`), an autocaptured tap or React Native Web click (`taps`), or an app lifecycle transition (`lifecycle`). Every signal stays off by default, because each step adds bytes to every captured exception.
+Add automatic exception steps to React Native, so a captured exception carries a timeline even where nobody called `addExceptionStep`. Set `errorTracking.exceptionSteps.automatic` to `true`, or to an object, to record a step for a screen change (`navigation`), an autocaptured tap or React Native Web click (`taps`), an app lifecycle transition (`lifecycle`), or an identity change (`identity`). Every signal stays off by default, because each step adds bytes to every captured exception.
 
 Automatic steps carry `$type`, which the error tracking timeline already renders, and they share the byte-bounded buffer and the native forwarding that manual steps use. A manual step stays untyped. An event that `before_send` dropped leaves no step.
 
-The buffer keeps its existing lifetime. A capture keeps the steps, and `reset()` keeps them too, because steps scope to the app session rather than to the user session.
+The buffer keeps its existing lifetime. A capture keeps the steps, and `reset()` keeps them too, because steps scope to the app session rather than to the user session. The `identity` signal marks that boundary instead of erasing it: it records a `User changed` step at `reset()`, so the previous user's steps do not read as the next user's. The step carries no distinct ID.

--- a/examples/example-expo-57/app/(tabs)/error-tracking.tsx
+++ b/examples/example-expo-57/app/(tabs)/error-tracking.tsx
@@ -112,6 +112,10 @@ export default function ErrorTrackingScreen() {
                     Record breadcrumb-style steps with addExceptionStep. Buffered steps attach to every captured
                     $exception as $exception_steps — including the manual captures above and the native crash below.
                 </ThemedText>
+                <ThemedText>
+                    This example also sets errorTracking.exceptionSteps.automatic, so switching tabs, tapping a button
+                    and backgrounding the app each leave their own step. Those steps carry a $type.
+                </ThemedText>
                 {EXCEPTION_STEPS.map(({ label, message, properties }) => (
                     <Button
                         key={label}

--- a/examples/example-expo-57/posthog.ts
+++ b/examples/example-expo-57/posthog.ts
@@ -36,6 +36,11 @@ export const posthog = new PostHog(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_API_K
             // `uploadNativeSymbols` option in app.json).
             nativeCrashes: true,
         },
+        exceptionSteps: {
+            // Record a step for every screen change, autocaptured tap and lifecycle transition, so a
+            // captured exception carries a timeline without an addExceptionStep call at each site.
+            automatic: true,
+        },
     },
     // Inject X-POSTHOG-DISTINCT-ID and X-POSTHOG-SESSION-ID on outgoing fetch
     // requests to these hostnames. Used by the Tracing Headers screen to verify

--- a/examples/example-expo-57/posthog.ts
+++ b/examples/example-expo-57/posthog.ts
@@ -37,8 +37,9 @@ export const posthog = new PostHog(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_API_K
             nativeCrashes: true,
         },
         exceptionSteps: {
-            // Record a step for every screen change, autocaptured tap and lifecycle transition, so a
-            // captured exception carries a timeline without an addExceptionStep call at each site.
+            // Record a step for every screen change, autocaptured tap, lifecycle transition and
+            // identity change, so a captured exception carries a timeline without an
+            // addExceptionStep call at each site.
             automatic: true,
         },
     },

--- a/packages/core/src/error-tracking/exception-steps.spec.ts
+++ b/packages/core/src/error-tracking/exception-steps.spec.ts
@@ -3,7 +3,6 @@ import {
   ExceptionStep,
   ExceptionStepsBuffer,
   getUtf8ByteLength,
-  resolveAutomaticExceptionStepsConfig,
   resolveExceptionStepsConfig,
   stripReservedExceptionStepFields,
 } from './exception-steps'
@@ -25,34 +24,6 @@ describe('exception steps', () => {
     })
   })
 
-  describe('resolveAutomaticExceptionStepsConfig', () => {
-    const allOff = { navigation: false, taps: false, lifecycle: false }
-    const allOn = { navigation: true, taps: true, lifecycle: true }
-
-    it('disables every signal when no config is passed', () => {
-      expect(resolveAutomaticExceptionStepsConfig()).toEqual(allOff)
-      expect(resolveAutomaticExceptionStepsConfig(false)).toEqual(allOff)
-      expect(resolveAutomaticExceptionStepsConfig(null)).toEqual(allOff)
-    })
-
-    it('enables every signal for true', () => {
-      expect(resolveAutomaticExceptionStepsConfig(true)).toEqual(allOn)
-    })
-
-    it('enables only the signals the object sets', () => {
-      expect(resolveAutomaticExceptionStepsConfig({ navigation: true })).toEqual({ ...allOff, navigation: true })
-      expect(resolveAutomaticExceptionStepsConfig({ taps: true, lifecycle: true })).toEqual({
-        ...allOn,
-        navigation: false,
-      })
-    })
-
-    it('ignores a value that is neither a boolean nor an object', () => {
-      expect(resolveAutomaticExceptionStepsConfig('yes' as any)).toEqual(allOff)
-      expect(resolveAutomaticExceptionStepsConfig([] as any)).toEqual(allOff)
-    })
-  })
-
   describe('stripReservedExceptionStepFields', () => {
     it('strips reserved fields and keeps custom properties', () => {
       const result = stripReservedExceptionStepFields({
@@ -67,14 +38,13 @@ describe('exception steps', () => {
       })
     })
 
-    it('keeps a caller-provided $type and $level, which the SDK does not own', () => {
+    it('keeps a caller-provided $type, which the SDK does not own', () => {
       const result = stripReservedExceptionStepFields({
         [EXCEPTION_STEP_INTERNAL_FIELDS.TYPE]: 'checkout',
-        [EXCEPTION_STEP_INTERNAL_FIELDS.LEVEL]: 'warning',
       })
 
       expect(result).toEqual({
-        sanitizedProperties: { $type: 'checkout', $level: 'warning' },
+        sanitizedProperties: { $type: 'checkout' },
         droppedKeys: [],
       })
     })

--- a/packages/core/src/error-tracking/exception-steps.spec.ts
+++ b/packages/core/src/error-tracking/exception-steps.spec.ts
@@ -3,6 +3,7 @@ import {
   ExceptionStep,
   ExceptionStepsBuffer,
   getUtf8ByteLength,
+  resolveAutomaticExceptionStepsConfig,
   resolveExceptionStepsConfig,
   stripReservedExceptionStepFields,
 } from './exception-steps'
@@ -24,6 +25,34 @@ describe('exception steps', () => {
     })
   })
 
+  describe('resolveAutomaticExceptionStepsConfig', () => {
+    const allOff = { navigation: false, taps: false, lifecycle: false }
+    const allOn = { navigation: true, taps: true, lifecycle: true }
+
+    it('disables every signal when no config is passed', () => {
+      expect(resolveAutomaticExceptionStepsConfig()).toEqual(allOff)
+      expect(resolveAutomaticExceptionStepsConfig(false)).toEqual(allOff)
+      expect(resolveAutomaticExceptionStepsConfig(null)).toEqual(allOff)
+    })
+
+    it('enables every signal for true', () => {
+      expect(resolveAutomaticExceptionStepsConfig(true)).toEqual(allOn)
+    })
+
+    it('enables only the signals the object sets', () => {
+      expect(resolveAutomaticExceptionStepsConfig({ navigation: true })).toEqual({ ...allOff, navigation: true })
+      expect(resolveAutomaticExceptionStepsConfig({ taps: true, lifecycle: true })).toEqual({
+        ...allOn,
+        navigation: false,
+      })
+    })
+
+    it('ignores a value that is neither a boolean nor an object', () => {
+      expect(resolveAutomaticExceptionStepsConfig('yes' as any)).toEqual(allOff)
+      expect(resolveAutomaticExceptionStepsConfig([] as any)).toEqual(allOff)
+    })
+  })
+
   describe('stripReservedExceptionStepFields', () => {
     it('strips reserved fields and keeps custom properties', () => {
       const result = stripReservedExceptionStepFields({
@@ -35,6 +64,18 @@ describe('exception steps', () => {
       expect(result).toEqual({
         sanitizedProperties: { custom: true },
         droppedKeys: [EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE, EXCEPTION_STEP_INTERNAL_FIELDS.TIMESTAMP],
+      })
+    })
+
+    it('keeps a caller-provided $type and $level, which the SDK does not own', () => {
+      const result = stripReservedExceptionStepFields({
+        [EXCEPTION_STEP_INTERNAL_FIELDS.TYPE]: 'checkout',
+        [EXCEPTION_STEP_INTERNAL_FIELDS.LEVEL]: 'warning',
+      })
+
+      expect(result).toEqual({
+        sanitizedProperties: { $type: 'checkout', $level: 'warning' },
+        droppedKeys: [],
       })
     })
   })

--- a/packages/core/src/error-tracking/exception-steps.ts
+++ b/packages/core/src/error-tracking/exception-steps.ts
@@ -1,14 +1,33 @@
 import { isArray, isNumber, isObject, isString, safeJsonStringify } from '@/utils'
 
 export const EXCEPTION_STEP_INTERNAL_FIELDS = {
+  TYPE: '$type',
   MESSAGE: '$message',
+  LEVEL: '$level',
   TIMESTAMP: '$timestamp',
 } as const
 
+/**
+ * Only `$message` and `$timestamp` are reserved: the SDK owns their canonical values, so a caller
+ * cannot spoof them. `$type` and `$level` stay writable by callers who want to categorise their own
+ * steps, and the SDK sets `$type` itself only on automatic steps.
+ */
 const RESERVED_EXCEPTION_STEP_KEYS = new Set<string>([
   EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE,
   EXCEPTION_STEP_INTERNAL_FIELDS.TIMESTAMP,
 ])
+
+/**
+ * `$type` values the SDK sets on automatic steps. Every SDK uses these exact strings, so the error
+ * tracking timeline labels an automatic step the same way on web and on mobile.
+ */
+export const EXCEPTION_STEP_TYPES = {
+  NAVIGATION: 'navigation',
+  TAP: 'tap',
+  LIFECYCLE: 'lifecycle',
+} as const
+
+export type ExceptionStepType = (typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEPTION_STEP_TYPES]
 
 export type ExceptionStep = {
   [EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE]: string
@@ -30,6 +49,62 @@ export type ResolvedExceptionStepsConfig = {
 export const DEFAULT_EXCEPTION_STEPS_CONFIG: ResolvedExceptionStepsConfig = {
   enabled: true,
   max_bytes: 32768, // ~32KB
+}
+
+/**
+ * Which app signals the SDK turns into automatic steps. Every signal is opt-in, because a step adds
+ * bytes to each captured exception and the buffer already carries whatever the caller added by hand.
+ *
+ * NOTE: The SDK reads these signals from its own platform. A platform that cannot observe a signal
+ * ignores the flag rather than failing.
+ */
+export type AutomaticExceptionStepsConfig = {
+  /** Screen or route changes. @default false */
+  navigation?: boolean
+  /** Taps and clicks the SDK already autocaptures. @default false */
+  taps?: boolean
+  /** App lifecycle transitions such as open, foreground and background. @default false */
+  lifecycle?: boolean
+}
+
+export type ResolvedAutomaticExceptionStepsConfig = {
+  navigation: boolean
+  taps: boolean
+  lifecycle: boolean
+}
+
+export const DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG: ResolvedAutomaticExceptionStepsConfig = {
+  navigation: false,
+  taps: false,
+  lifecycle: false,
+}
+
+const ALL_AUTOMATIC_EXCEPTION_STEPS_CONFIG: ResolvedAutomaticExceptionStepsConfig = {
+  navigation: true,
+  taps: true,
+  lifecycle: true,
+}
+
+/**
+ * Resolves the automatic-steps config. `true` enables every signal, `false` and `undefined` disable
+ * every signal, and an object enables only the signals it sets.
+ */
+export function resolveAutomaticExceptionStepsConfig(
+  config?: boolean | AutomaticExceptionStepsConfig | null
+): ResolvedAutomaticExceptionStepsConfig {
+  if (config === true) {
+    return { ...ALL_AUTOMATIC_EXCEPTION_STEPS_CONFIG }
+  }
+
+  if (!config || !isObject(config)) {
+    return { ...DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG }
+  }
+
+  return {
+    navigation: config.navigation ?? DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG.navigation,
+    taps: config.taps ?? DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG.taps,
+    lifecycle: config.lifecycle ?? DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG.lifecycle,
+  }
 }
 
 export function resolveExceptionStepsConfig(config?: ExceptionStepsConfig | null): ResolvedExceptionStepsConfig {

--- a/packages/core/src/error-tracking/exception-steps.ts
+++ b/packages/core/src/error-tracking/exception-steps.ts
@@ -3,31 +3,18 @@ import { isArray, isNumber, isObject, isString, safeJsonStringify } from '@/util
 export const EXCEPTION_STEP_INTERNAL_FIELDS = {
   TYPE: '$type',
   MESSAGE: '$message',
-  LEVEL: '$level',
   TIMESTAMP: '$timestamp',
 } as const
 
 /**
  * Only `$message` and `$timestamp` are reserved: the SDK owns their canonical values, so a caller
- * cannot spoof them. `$type` and `$level` stay writable by callers who want to categorise their own
- * steps, and the SDK sets `$type` itself only on automatic steps.
+ * cannot spoof them. `$type` stays writable by a caller who wants to categorise their own steps, and
+ * an SDK sets it itself only on a step the SDK records without the caller asking.
  */
 const RESERVED_EXCEPTION_STEP_KEYS = new Set<string>([
   EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE,
   EXCEPTION_STEP_INTERNAL_FIELDS.TIMESTAMP,
 ])
-
-/**
- * `$type` values the SDK sets on automatic steps. Every SDK uses these exact strings, so the error
- * tracking timeline labels an automatic step the same way on web and on mobile.
- */
-export const EXCEPTION_STEP_TYPES = {
-  NAVIGATION: 'navigation',
-  TAP: 'tap',
-  LIFECYCLE: 'lifecycle',
-} as const
-
-export type ExceptionStepType = (typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEPTION_STEP_TYPES]
 
 export type ExceptionStep = {
   [EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE]: string
@@ -49,62 +36,6 @@ export type ResolvedExceptionStepsConfig = {
 export const DEFAULT_EXCEPTION_STEPS_CONFIG: ResolvedExceptionStepsConfig = {
   enabled: true,
   max_bytes: 32768, // ~32KB
-}
-
-/**
- * Which app signals the SDK turns into automatic steps. Every signal is opt-in, because a step adds
- * bytes to each captured exception and the buffer already carries whatever the caller added by hand.
- *
- * NOTE: The SDK reads these signals from its own platform. A platform that cannot observe a signal
- * ignores the flag rather than failing.
- */
-export type AutomaticExceptionStepsConfig = {
-  /** Screen or route changes. @default false */
-  navigation?: boolean
-  /** Taps and clicks the SDK already autocaptures. @default false */
-  taps?: boolean
-  /** App lifecycle transitions such as open, foreground and background. @default false */
-  lifecycle?: boolean
-}
-
-export type ResolvedAutomaticExceptionStepsConfig = {
-  navigation: boolean
-  taps: boolean
-  lifecycle: boolean
-}
-
-export const DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG: ResolvedAutomaticExceptionStepsConfig = {
-  navigation: false,
-  taps: false,
-  lifecycle: false,
-}
-
-const ALL_AUTOMATIC_EXCEPTION_STEPS_CONFIG: ResolvedAutomaticExceptionStepsConfig = {
-  navigation: true,
-  taps: true,
-  lifecycle: true,
-}
-
-/**
- * Resolves the automatic-steps config. `true` enables every signal, `false` and `undefined` disable
- * every signal, and an object enables only the signals it sets.
- */
-export function resolveAutomaticExceptionStepsConfig(
-  config?: boolean | AutomaticExceptionStepsConfig | null
-): ResolvedAutomaticExceptionStepsConfig {
-  if (config === true) {
-    return { ...ALL_AUTOMATIC_EXCEPTION_STEPS_CONFIG }
-  }
-
-  if (!config || !isObject(config)) {
-    return { ...DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG }
-  }
-
-  return {
-    navigation: config.navigation ?? DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG.navigation,
-    taps: config.taps ?? DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG.taps,
-    lifecycle: config.lifecycle ?? DEFAULT_AUTOMATIC_EXCEPTION_STEPS_CONFIG.lifecycle,
-  }
 }
 
 export function resolveExceptionStepsConfig(config?: ExceptionStepsConfig | null): ResolvedExceptionStepsConfig {

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -1730,6 +1730,28 @@
       "path": "src/types.ts"
     },
     {
+      "id": "AutomaticExceptionStepsConfig",
+      "name": "AutomaticExceptionStepsConfig",
+      "properties": [
+        {
+          "description": "Screen or route changes.",
+          "type": "boolean",
+          "name": "navigation"
+        },
+        {
+          "description": "Taps and clicks the SDK already autocaptures.",
+          "type": "boolean",
+          "name": "taps"
+        },
+        {
+          "description": "App lifecycle transitions such as open, foreground and background.",
+          "type": "boolean",
+          "name": "lifecycle"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
+    },
+    {
       "id": "BaseException",
       "name": "BaseException",
       "properties": [
@@ -2177,6 +2199,13 @@
         }
       ],
       "path": "../core/src/error-tracking/exception-steps.ts"
+    },
+    {
+      "id": "ExceptionStepType",
+      "name": "ExceptionStepType",
+      "properties": [],
+      "path": "../core/src/error-tracking/exception-steps.ts",
+      "example": "(typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEPTION_STEP_TYPES]"
     },
     {
       "id": "ExpressErrorMiddleware",
@@ -3916,6 +3945,25 @@
       "properties": [],
       "path": "../core/src/error-tracking/coercers/promise-rejection-event.ts",
       "example": "PromiseRejectionEventLike | EventWithDetailReason"
+    },
+    {
+      "id": "ResolvedAutomaticExceptionStepsConfig",
+      "name": "ResolvedAutomaticExceptionStepsConfig",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "navigation"
+        },
+        {
+          "type": "boolean",
+          "name": "taps"
+        },
+        {
+          "type": "boolean",
+          "name": "lifecycle"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ResolvedExceptionStepsConfig",

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -1730,28 +1730,6 @@
       "path": "src/types.ts"
     },
     {
-      "id": "AutomaticExceptionStepsConfig",
-      "name": "AutomaticExceptionStepsConfig",
-      "properties": [
-        {
-          "description": "Screen or route changes.",
-          "type": "boolean",
-          "name": "navigation"
-        },
-        {
-          "description": "Taps and clicks the SDK already autocaptures.",
-          "type": "boolean",
-          "name": "taps"
-        },
-        {
-          "description": "App lifecycle transitions such as open, foreground and background.",
-          "type": "boolean",
-          "name": "lifecycle"
-        }
-      ],
-      "path": "../core/src/error-tracking/exception-steps.ts"
-    },
-    {
       "id": "BaseException",
       "name": "BaseException",
       "properties": [
@@ -2199,13 +2177,6 @@
         }
       ],
       "path": "../core/src/error-tracking/exception-steps.ts"
-    },
-    {
-      "id": "ExceptionStepType",
-      "name": "ExceptionStepType",
-      "properties": [],
-      "path": "../core/src/error-tracking/exception-steps.ts",
-      "example": "(typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEPTION_STEP_TYPES]"
     },
     {
       "id": "ExpressErrorMiddleware",
@@ -3945,25 +3916,6 @@
       "properties": [],
       "path": "../core/src/error-tracking/coercers/promise-rejection-event.ts",
       "example": "PromiseRejectionEventLike | EventWithDetailReason"
-    },
-    {
-      "id": "ResolvedAutomaticExceptionStepsConfig",
-      "name": "ResolvedAutomaticExceptionStepsConfig",
-      "properties": [
-        {
-          "type": "boolean",
-          "name": "navigation"
-        },
-        {
-          "type": "boolean",
-          "name": "taps"
-        },
-        {
-          "type": "boolean",
-          "name": "lifecycle"
-        }
-      ],
-      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ResolvedExceptionStepsConfig",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2240,6 +2240,28 @@
       "path": "dist/error-tracking/index.d.ts"
     },
     {
+      "id": "AutomaticExceptionStepsConfig",
+      "name": "AutomaticExceptionStepsConfig",
+      "properties": [
+        {
+          "description": "Screen or route changes.",
+          "type": "boolean",
+          "name": "navigation"
+        },
+        {
+          "description": "Taps and clicks the SDK already autocaptures.",
+          "type": "boolean",
+          "name": "taps"
+        },
+        {
+          "description": "App lifecycle transitions such as open, foreground and background.",
+          "type": "boolean",
+          "name": "lifecycle"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
+    },
+    {
       "id": "BaseException",
       "name": "BaseException",
       "properties": [
@@ -2594,6 +2616,11 @@
       "name": "ExceptionStepsOptions",
       "properties": [
         {
+          "description": "Records steps for app signals the SDK already observes, so an exception carries a timeline even where nobody called `addExceptionStep`. Every signal is off by default, because each step adds bytes to every captured exception.\nPass `true` to enable every signal, or an object to enable single signals.\nfalse",
+          "type": "boolean | CoreErrorTracking.AutomaticExceptionStepsConfig",
+          "name": "automatic"
+        },
+        {
           "description": "Whether exception steps are recorded and attached.   true",
           "type": "boolean",
           "name": "enabled"
@@ -2605,6 +2632,13 @@
         }
       ],
       "path": "dist/error-tracking/index.d.ts"
+    },
+    {
+      "id": "ExceptionStepType",
+      "name": "ExceptionStepType",
+      "properties": [],
+      "path": "../core/src/error-tracking/exception-steps.ts",
+      "example": "(typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEPTION_STEP_TYPES]"
     },
     {
       "id": "FeatureFlagDetail",
@@ -4389,6 +4423,25 @@
       "properties": [],
       "path": "../core/src/error-tracking/coercers/promise-rejection-event.ts",
       "example": "PromiseRejectionEventLike | EventWithDetailReason"
+    },
+    {
+      "id": "ResolvedAutomaticExceptionStepsConfig",
+      "name": "ResolvedAutomaticExceptionStepsConfig",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "navigation"
+        },
+        {
+          "type": "boolean",
+          "name": "taps"
+        },
+        {
+          "type": "boolean",
+          "name": "lifecycle"
+        }
+      ],
+      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ResolvedExceptionStepsConfig",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2240,16 +2240,16 @@
       "path": "dist/error-tracking/index.d.ts"
     },
     {
-      "id": "AutomaticExceptionStepsConfig",
-      "name": "AutomaticExceptionStepsConfig",
+      "id": "AutomaticExceptionStepsOptions",
+      "name": "AutomaticExceptionStepsOptions",
       "properties": [
         {
-          "description": "Screen or route changes.",
+          "description": "Screen changes.",
           "type": "boolean",
           "name": "navigation"
         },
         {
-          "description": "Taps and clicks the SDK already autocaptures.",
+          "description": "Taps the SDK already autocaptures.",
           "type": "boolean",
           "name": "taps"
         },
@@ -2259,7 +2259,7 @@
           "name": "lifecycle"
         }
       ],
-      "path": "../core/src/error-tracking/exception-steps.ts"
+      "path": "dist/error-tracking/automatic-steps.d.ts"
     },
     {
       "id": "BaseException",
@@ -2617,7 +2617,7 @@
       "properties": [
         {
           "description": "Records steps for app signals the SDK already observes, so an exception carries a timeline even where nobody called `addExceptionStep`. Every signal is off by default, because each step adds bytes to every captured exception.\nPass `true` to enable every signal, or an object to enable single signals.\nfalse",
-          "type": "boolean | CoreErrorTracking.AutomaticExceptionStepsConfig",
+          "type": "boolean | AutomaticExceptionStepsOptions",
           "name": "automatic"
         },
         {
@@ -2632,13 +2632,6 @@
         }
       ],
       "path": "dist/error-tracking/index.d.ts"
-    },
-    {
-      "id": "ExceptionStepType",
-      "name": "ExceptionStepType",
-      "properties": [],
-      "path": "../core/src/error-tracking/exception-steps.ts",
-      "example": "(typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEPTION_STEP_TYPES]"
     },
     {
       "id": "FeatureFlagDetail",
@@ -4423,25 +4416,6 @@
       "properties": [],
       "path": "../core/src/error-tracking/coercers/promise-rejection-event.ts",
       "example": "PromiseRejectionEventLike | EventWithDetailReason"
-    },
-    {
-      "id": "ResolvedAutomaticExceptionStepsConfig",
-      "name": "ResolvedAutomaticExceptionStepsConfig",
-      "properties": [
-        {
-          "type": "boolean",
-          "name": "navigation"
-        },
-        {
-          "type": "boolean",
-          "name": "taps"
-        },
-        {
-          "type": "boolean",
-          "name": "lifecycle"
-        }
-      ],
-      "path": "../core/src/error-tracking/exception-steps.ts"
     },
     {
       "id": "ResolvedExceptionStepsConfig",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2249,7 +2249,7 @@
           "name": "navigation"
         },
         {
-          "description": "Taps the SDK already autocaptures.",
+          "description": "Taps the SDK already autocaptures, and clicks on React Native Web.",
           "type": "boolean",
           "name": "taps"
         },

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2257,6 +2257,11 @@
           "description": "App lifecycle transitions such as open, foreground and background.",
           "type": "boolean",
           "name": "lifecycle"
+        },
+        {
+          "description": "Identity changes, recorded at `reset()`.",
+          "type": "boolean",
+          "name": "identity"
         }
       ],
       "path": "dist/error-tracking/automatic-steps.d.ts"

--- a/packages/react-native/src/error-tracking/automatic-steps.ts
+++ b/packages/react-native/src/error-tracking/automatic-steps.ts
@@ -20,7 +20,7 @@ export type ExceptionStepType = (typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEP
 export type AutomaticExceptionStepsOptions = {
   /** Screen changes. @default false */
   navigation?: boolean
-  /** Taps the SDK already autocaptures. @default false */
+  /** Taps the SDK already autocaptures, and clicks on React Native Web. @default false */
   taps?: boolean
   /** App lifecycle transitions such as open, foreground and background. @default false */
   lifecycle?: boolean
@@ -78,7 +78,15 @@ const LIFECYCLE_EVENTS = new Set<string>([
   'Application Backgrounded',
 ])
 
-const TOUCH_EVENT_TYPE = 'touch'
+/**
+ * Interaction event types autocapture emits. React Native Web reports a `click` for mouse, trackpad
+ * and keyboard activation, because a browser fires `touchend` only for touch input, so both belong
+ * to the `taps` signal.
+ */
+const INTERACTION_VERBS: Record<string, string> = {
+  touch: 'Tap',
+  click: 'Click',
+}
 
 export type AutomaticExceptionStep = {
   type: ExceptionStepType
@@ -126,21 +134,27 @@ function buildNavigationStep(properties: unknown): AutomaticExceptionStep | unde
 }
 
 /**
- * Only a touch leaves a tap step. The label comes from the innermost autocaptured element, which
- * holds either a `ph-label` or a component display name.
+ * Only an interaction leaves a tap step, so a non-interaction `$autocapture` event records nothing.
+ * The label comes from the innermost autocaptured element, which holds either a `ph-label` or a
+ * component display name.
+ *
+ * A touch and a click share the `tap` type, because they are one signal to the caller who enabled
+ * `taps`, and only the message verb tells them apart.
  *
  * The step never carries `$el_text` or touch coordinates. Element text is user-visible copy and can
  * hold personal data, and an exception timeline does not need the pixel the user hit.
  */
 function buildTapStep(properties: unknown): AutomaticExceptionStep | undefined {
-  if (readStringProperty(properties, '$event_type') !== TOUCH_EVENT_TYPE) {
+  const eventType = readStringProperty(properties, '$event_type')
+  const verb = eventType ? INTERACTION_VERBS[eventType] : undefined
+  if (!verb) {
     return undefined
   }
 
   const label = readTapLabel(properties)
   return {
     type: EXCEPTION_STEP_TYPES.TAP,
-    message: label ? `Tap: ${label}` : 'Tap',
+    message: label ? `${verb}: ${label}` : verb,
   }
 }
 

--- a/packages/react-native/src/error-tracking/automatic-steps.ts
+++ b/packages/react-native/src/error-tracking/automatic-steps.ts
@@ -83,10 +83,10 @@ const LIFECYCLE_EVENTS = new Set<string>([
  * and keyboard activation, because a browser fires `touchend` only for touch input, so both belong
  * to the `taps` signal.
  */
-const INTERACTION_VERBS: Record<string, string> = {
-  touch: 'Tap',
-  click: 'Click',
-}
+const INTERACTION_VERBS = new Map<string, string>([
+  ['touch', 'Tap'],
+  ['click', 'Click'],
+])
 
 export type AutomaticExceptionStep = {
   type: ExceptionStepType
@@ -146,7 +146,9 @@ function buildNavigationStep(properties: unknown): AutomaticExceptionStep | unde
  */
 function buildTapStep(properties: unknown): AutomaticExceptionStep | undefined {
   const eventType = readStringProperty(properties, '$event_type')
-  const verb = eventType ? INTERACTION_VERBS[eventType] : undefined
+  // A Map, not an object literal, so an event type such as `toString` cannot reach Object.prototype
+  // and resolve to a function the message would then stringify.
+  const verb = eventType ? INTERACTION_VERBS.get(eventType) : undefined
   if (!verb) {
     return undefined
   }

--- a/packages/react-native/src/error-tracking/automatic-steps.ts
+++ b/packages/react-native/src/error-tracking/automatic-steps.ts
@@ -1,4 +1,70 @@
-import { ErrorTracking as CoreErrorTracking, isString, isArray, isObject } from '@posthog/core'
+import { isString, isArray, isObject } from '@posthog/core'
+
+/**
+ * `$type` values the SDK sets on an automatic step, so the error tracking timeline labels the step.
+ * The signals are the ones React Native observes, so the vocabulary lives here rather than in
+ * `@posthog/core`, which every SDK shares.
+ */
+export const EXCEPTION_STEP_TYPES = {
+  NAVIGATION: 'navigation',
+  TAP: 'tap',
+  LIFECYCLE: 'lifecycle',
+} as const
+
+export type ExceptionStepType = (typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEPTION_STEP_TYPES]
+
+/**
+ * Which app signals the SDK turns into automatic steps. Every signal is opt-in, because a step adds
+ * bytes to each captured exception and the buffer already carries whatever the caller added by hand.
+ */
+export type AutomaticExceptionStepsOptions = {
+  /** Screen changes. @default false */
+  navigation?: boolean
+  /** Taps the SDK already autocaptures. @default false */
+  taps?: boolean
+  /** App lifecycle transitions such as open, foreground and background. @default false */
+  lifecycle?: boolean
+}
+
+export type ResolvedAutomaticExceptionStepsOptions = {
+  navigation: boolean
+  taps: boolean
+  lifecycle: boolean
+}
+
+const ALL_SIGNALS_OFF: ResolvedAutomaticExceptionStepsOptions = {
+  navigation: false,
+  taps: false,
+  lifecycle: false,
+}
+
+const ALL_SIGNALS_ON: ResolvedAutomaticExceptionStepsOptions = {
+  navigation: true,
+  taps: true,
+  lifecycle: true,
+}
+
+/**
+ * Resolves the automatic-steps options. `true` enables every signal, `false` and `undefined` disable
+ * every signal, and an object enables only the signals it sets.
+ */
+export function resolveAutomaticExceptionStepsOptions(
+  options?: boolean | AutomaticExceptionStepsOptions | null
+): ResolvedAutomaticExceptionStepsOptions {
+  if (options === true) {
+    return { ...ALL_SIGNALS_ON }
+  }
+
+  if (!options || !isObject(options)) {
+    return { ...ALL_SIGNALS_OFF }
+  }
+
+  return {
+    navigation: options.navigation ?? ALL_SIGNALS_OFF.navigation,
+    taps: options.taps ?? ALL_SIGNALS_OFF.taps,
+    lifecycle: options.lifecycle ?? ALL_SIGNALS_OFF.lifecycle,
+  }
+}
 
 /**
  * App lifecycle events the SDK captures in `captureAppLifecycleEvents`. The step message is the
@@ -15,7 +81,7 @@ const LIFECYCLE_EVENTS = new Set<string>([
 const TOUCH_EVENT_TYPE = 'touch'
 
 export type AutomaticExceptionStep = {
-  type: CoreErrorTracking.ExceptionStepType
+  type: ExceptionStepType
   message: string
 }
 
@@ -27,7 +93,7 @@ export type AutomaticExceptionStep = {
  * the capture path without touching the SDK's state.
  */
 export function buildAutomaticExceptionStep(
-  config: CoreErrorTracking.ResolvedAutomaticExceptionStepsConfig,
+  config: ResolvedAutomaticExceptionStepsOptions,
   event: unknown,
   properties: unknown
 ): AutomaticExceptionStep | undefined {
@@ -44,7 +110,7 @@ export function buildAutomaticExceptionStep(
   }
 
   if (config.lifecycle && LIFECYCLE_EVENTS.has(event)) {
-    return { type: CoreErrorTracking.EXCEPTION_STEP_TYPES.LIFECYCLE, message: event }
+    return { type: EXCEPTION_STEP_TYPES.LIFECYCLE, message: event }
   }
 
   return undefined
@@ -56,7 +122,7 @@ function buildNavigationStep(properties: unknown): AutomaticExceptionStep | unde
     return undefined
   }
 
-  return { type: CoreErrorTracking.EXCEPTION_STEP_TYPES.NAVIGATION, message: `Screen: ${screenName}` }
+  return { type: EXCEPTION_STEP_TYPES.NAVIGATION, message: `Screen: ${screenName}` }
 }
 
 /**
@@ -73,7 +139,7 @@ function buildTapStep(properties: unknown): AutomaticExceptionStep | undefined {
 
   const label = readTapLabel(properties)
   return {
-    type: CoreErrorTracking.EXCEPTION_STEP_TYPES.TAP,
+    type: EXCEPTION_STEP_TYPES.TAP,
     message: label ? `Tap: ${label}` : 'Tap',
   }
 }

--- a/packages/react-native/src/error-tracking/automatic-steps.ts
+++ b/packages/react-native/src/error-tracking/automatic-steps.ts
@@ -1,0 +1,102 @@
+import { ErrorTracking as CoreErrorTracking, isString, isArray, isObject } from '@posthog/core'
+
+/**
+ * App lifecycle events the SDK captures in `captureAppLifecycleEvents`. The step message is the
+ * event name itself, so the timeline reads the same as the event list.
+ */
+const LIFECYCLE_EVENTS = new Set<string>([
+  'Application Installed',
+  'Application Updated',
+  'Application Opened',
+  'Application Became Active',
+  'Application Backgrounded',
+])
+
+const TOUCH_EVENT_TYPE = 'touch'
+
+export type AutomaticExceptionStep = {
+  type: CoreErrorTracking.ExceptionStepType
+  message: string
+}
+
+/**
+ * Maps an enqueued event to the automatic exception step it should leave behind, or `undefined` when
+ * the event is not a signal the caller enabled.
+ *
+ * The function is pure and reads only the event name and its properties, so the caller can run it on
+ * the capture path without touching the SDK's state.
+ */
+export function buildAutomaticExceptionStep(
+  config: CoreErrorTracking.ResolvedAutomaticExceptionStepsConfig,
+  event: unknown,
+  properties: unknown
+): AutomaticExceptionStep | undefined {
+  if (!isString(event)) {
+    return undefined
+  }
+
+  if (config.navigation && event === '$screen') {
+    return buildNavigationStep(properties)
+  }
+
+  if (config.taps && event === '$autocapture') {
+    return buildTapStep(properties)
+  }
+
+  if (config.lifecycle && LIFECYCLE_EVENTS.has(event)) {
+    return { type: CoreErrorTracking.EXCEPTION_STEP_TYPES.LIFECYCLE, message: event }
+  }
+
+  return undefined
+}
+
+function buildNavigationStep(properties: unknown): AutomaticExceptionStep | undefined {
+  const screenName = readStringProperty(properties, '$screen_name')
+  if (!screenName) {
+    return undefined
+  }
+
+  return { type: CoreErrorTracking.EXCEPTION_STEP_TYPES.NAVIGATION, message: `Screen: ${screenName}` }
+}
+
+/**
+ * Only a touch leaves a tap step. The label comes from the innermost autocaptured element, which
+ * holds either a `ph-label` or a component display name.
+ *
+ * The step never carries `$el_text` or touch coordinates. Element text is user-visible copy and can
+ * hold personal data, and an exception timeline does not need the pixel the user hit.
+ */
+function buildTapStep(properties: unknown): AutomaticExceptionStep | undefined {
+  if (readStringProperty(properties, '$event_type') !== TOUCH_EVENT_TYPE) {
+    return undefined
+  }
+
+  const label = readTapLabel(properties)
+  return {
+    type: CoreErrorTracking.EXCEPTION_STEP_TYPES.TAP,
+    message: label ? `Tap: ${label}` : 'Tap',
+  }
+}
+
+function readTapLabel(properties: unknown): string | undefined {
+  const elements = isObject(properties) ? (properties as Record<string, unknown>).$elements : undefined
+  if (!isArray(elements) || elements.length === 0) {
+    return undefined
+  }
+
+  // Elements run innermost first, so the first entry is the element the user actually hit.
+  return readStringProperty(elements[0], 'tag_name')
+}
+
+function readStringProperty(source: unknown, key: string): string | undefined {
+  if (!isObject(source)) {
+    return undefined
+  }
+
+  const value = (source as Record<string, unknown>)[key]
+  if (!isString(value) || value.trim().length === 0) {
+    return undefined
+  }
+
+  return value
+}

--- a/packages/react-native/src/error-tracking/automatic-steps.ts
+++ b/packages/react-native/src/error-tracking/automatic-steps.ts
@@ -9,6 +9,7 @@ export const EXCEPTION_STEP_TYPES = {
   NAVIGATION: 'navigation',
   TAP: 'tap',
   LIFECYCLE: 'lifecycle',
+  IDENTITY: 'identity',
 } as const
 
 export type ExceptionStepType = (typeof EXCEPTION_STEP_TYPES)[keyof typeof EXCEPTION_STEP_TYPES]
@@ -24,24 +25,29 @@ export type AutomaticExceptionStepsOptions = {
   taps?: boolean
   /** App lifecycle transitions such as open, foreground and background. @default false */
   lifecycle?: boolean
+  /** Identity changes, recorded at `reset()`. @default false */
+  identity?: boolean
 }
 
 export type ResolvedAutomaticExceptionStepsOptions = {
   navigation: boolean
   taps: boolean
   lifecycle: boolean
+  identity: boolean
 }
 
 const ALL_SIGNALS_OFF: ResolvedAutomaticExceptionStepsOptions = {
   navigation: false,
   taps: false,
   lifecycle: false,
+  identity: false,
 }
 
 const ALL_SIGNALS_ON: ResolvedAutomaticExceptionStepsOptions = {
   navigation: true,
   taps: true,
   lifecycle: true,
+  identity: true,
 }
 
 /**
@@ -63,6 +69,7 @@ export function resolveAutomaticExceptionStepsOptions(
     navigation: options.navigation ?? ALL_SIGNALS_OFF.navigation,
     taps: options.taps ?? ALL_SIGNALS_OFF.taps,
     lifecycle: options.lifecycle ?? ALL_SIGNALS_OFF.lifecycle,
+    identity: options.identity ?? ALL_SIGNALS_OFF.identity,
   }
 }
 
@@ -122,6 +129,28 @@ export function buildAutomaticExceptionStep(
   }
 
   return undefined
+}
+
+/**
+ * Message recorded when the active identity changes. The step marks the boundary and nothing more:
+ * it carries no distinct ID, so it says that the user changed without saying who either user was.
+ */
+export const IDENTITY_STEP_MESSAGE = 'User changed'
+
+/**
+ * Builds the step marking an identity change, or `undefined` when the caller left the signal off.
+ *
+ * No enqueued event maps to this, because `reset()` clears the identity rather than capturing it, so
+ * this sits outside `buildAutomaticExceptionStep` and the reset path calls it directly.
+ */
+export function buildIdentityExceptionStep(
+  config: ResolvedAutomaticExceptionStepsOptions
+): AutomaticExceptionStep | undefined {
+  if (!config.identity) {
+    return undefined
+  }
+
+  return { type: EXCEPTION_STEP_TYPES.IDENTITY, message: IDENTITY_STEP_MESSAGE }
 }
 
 function buildNavigationStep(properties: unknown): AutomaticExceptionStep | undefined {

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -11,6 +11,7 @@ import {
 } from '@posthog/core'
 import { Properties } from '@posthog/types'
 import { trackConsole, trackUncaughtExceptions, trackUnhandledRejections } from './utils'
+import { buildAutomaticExceptionStep } from './automatic-steps'
 import { getRemoteConfigBool } from '../utils'
 import { OptionalReactNativePlugin } from '../optional/OptionalPlugin'
 
@@ -45,6 +46,16 @@ export interface ExceptionStepsOptions {
    * @default 32768
    */
   maxBytes?: number
+  /**
+   * Records steps for app signals the SDK already observes, so an exception carries a timeline even
+   * where nobody called `addExceptionStep`. Every signal is off by default, because each step adds
+   * bytes to every captured exception.
+   *
+   * Pass `true` to enable every signal, or an object to enable single signals.
+   *
+   * @default false
+   */
+  automatic?: boolean | CoreErrorTracking.AutomaticExceptionStepsConfig
 }
 
 export interface ErrorTrackingOptions {
@@ -67,6 +78,7 @@ export class ErrorTracking {
   private logger: Logger
   private options: ResolvedErrorTrackingOptions
   private _exceptionStepsConfig: CoreErrorTracking.ResolvedExceptionStepsConfig
+  private _automaticStepsConfig: CoreErrorTracking.ResolvedAutomaticExceptionStepsConfig
   private _exceptionStepsBuffer: CoreErrorTracking.ExceptionStepsBuffer
   private _nativeForwardingEnabled: boolean = false
 
@@ -89,6 +101,7 @@ export class ErrorTracking {
     this._exceptionStepsConfig = CoreErrorTracking.resolveExceptionStepsConfig(
       exceptionSteps ? { enabled: exceptionSteps.enabled, max_bytes: exceptionSteps.maxBytes } : undefined
     )
+    this._automaticStepsConfig = CoreErrorTracking.resolveAutomaticExceptionStepsConfig(exceptionSteps?.automatic)
     this._exceptionStepsBuffer = new CoreErrorTracking.ExceptionStepsBuffer(this._exceptionStepsConfig)
     this.autocapture(this.options.autocapture)
   }
@@ -132,6 +145,44 @@ export class ErrorTracking {
       this.forwardExceptionStepToNative(message, properties)
     } catch (error) {
       this.logger.error('Failed to add exception step. Ignoring breadcrumb.', error)
+    }
+  }
+
+  /**
+   * True when the caller enabled at least one automatic signal. The capture path checks this first,
+   * so an app that never enabled the feature pays one boolean read per event.
+   */
+  get automaticExceptionStepsEnabled(): boolean {
+    const config = this._automaticStepsConfig
+    return config.navigation || config.taps || config.lifecycle
+  }
+
+  /**
+   * Records the automatic step that an enqueued event maps to, and ignores every event that maps to
+   * no step. The SDK sets `$type` here, so the timeline can tell an automatic step from a manual one.
+   *
+   * This runs on the capture path. It never throws, and it never captures an event of its own.
+   */
+  onEnqueuedEvent(event: unknown, properties: unknown): void {
+    if (!this._exceptionStepsConfig.enabled || !this.automaticExceptionStepsEnabled) {
+      return
+    }
+
+    try {
+      const step = buildAutomaticExceptionStep(this._automaticStepsConfig, event, properties)
+      if (!step) {
+        return
+      }
+
+      const stepProperties = { [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.TYPE]: step.type }
+      this._exceptionStepsBuffer.add({
+        ...stepProperties,
+        [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE]: step.message,
+        [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.TIMESTAMP]: new Date().toISOString(),
+      })
+      this.forwardExceptionStepToNative(step.message, stepProperties)
+    } catch (error) {
+      this.logger.error('Failed to add automatic exception step. Ignoring breadcrumb.', error)
     }
   }
 

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -245,7 +245,9 @@ export class ErrorTracking {
   }
 
   /**
-   * Clears the buffer. Called on SDK close, not on capture or identity changes.
+   * Clears the buffer. The host calls this on SDK close and on `reset()`, which is the logout
+   * boundary, so one user's steps never reach the next user's exception. A capture does not clear the
+   * buffer: the steps stay attached to every exception in the same session.
    */
   clearExceptionSteps(): void {
     this._exceptionStepsBuffer.clear()

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -11,7 +11,12 @@ import {
 } from '@posthog/core'
 import { Properties } from '@posthog/types'
 import { trackConsole, trackUncaughtExceptions, trackUnhandledRejections } from './utils'
-import { buildAutomaticExceptionStep } from './automatic-steps'
+import {
+  AutomaticExceptionStepsOptions,
+  ResolvedAutomaticExceptionStepsOptions,
+  buildAutomaticExceptionStep,
+  resolveAutomaticExceptionStepsOptions,
+} from './automatic-steps'
 import { getRemoteConfigBool } from '../utils'
 import { OptionalReactNativePlugin } from '../optional/OptionalPlugin'
 
@@ -55,7 +60,7 @@ export interface ExceptionStepsOptions {
    *
    * @default false
    */
-  automatic?: boolean | CoreErrorTracking.AutomaticExceptionStepsConfig
+  automatic?: boolean | AutomaticExceptionStepsOptions
 }
 
 export interface ErrorTrackingOptions {
@@ -78,7 +83,7 @@ export class ErrorTracking {
   private logger: Logger
   private options: ResolvedErrorTrackingOptions
   private _exceptionStepsConfig: CoreErrorTracking.ResolvedExceptionStepsConfig
-  private _automaticStepsConfig: CoreErrorTracking.ResolvedAutomaticExceptionStepsConfig
+  private _automaticStepsConfig: ResolvedAutomaticExceptionStepsOptions
   private _exceptionStepsBuffer: CoreErrorTracking.ExceptionStepsBuffer
   private _nativeForwardingEnabled: boolean = false
 
@@ -101,7 +106,7 @@ export class ErrorTracking {
     this._exceptionStepsConfig = CoreErrorTracking.resolveExceptionStepsConfig(
       exceptionSteps ? { enabled: exceptionSteps.enabled, max_bytes: exceptionSteps.maxBytes } : undefined
     )
-    this._automaticStepsConfig = CoreErrorTracking.resolveAutomaticExceptionStepsConfig(exceptionSteps?.automatic)
+    this._automaticStepsConfig = resolveAutomaticExceptionStepsOptions(exceptionSteps?.automatic)
     this._exceptionStepsBuffer = new CoreErrorTracking.ExceptionStepsBuffer(this._exceptionStepsConfig)
     this.autocapture(this.options.autocapture)
   }
@@ -245,9 +250,9 @@ export class ErrorTracking {
   }
 
   /**
-   * Clears the buffer. The host calls this on SDK close and on `reset()`, which is the logout
-   * boundary, so one user's steps never reach the next user's exception. A capture does not clear the
-   * buffer: the steps stay attached to every exception in the same session.
+   * Clears the buffer. The host calls this on SDK close only. A capture keeps the buffer, so every
+   * exception in one app session carries the same steps, and `reset()` keeps it too, because steps
+   * scope to the app session rather than to the user session.
    */
   clearExceptionSteps(): void {
     this._exceptionStepsBuffer.clear()

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -12,9 +12,11 @@ import {
 import { Properties } from '@posthog/types'
 import { trackConsole, trackUncaughtExceptions, trackUnhandledRejections } from './utils'
 import {
+  AutomaticExceptionStep,
   AutomaticExceptionStepsOptions,
   ResolvedAutomaticExceptionStepsOptions,
   buildAutomaticExceptionStep,
+  buildIdentityExceptionStep,
   resolveAutomaticExceptionStepsOptions,
 } from './automatic-steps'
 import { getRemoteConfigBool } from '../utils'
@@ -159,7 +161,7 @@ export class ErrorTracking {
    */
   get automaticExceptionStepsEnabled(): boolean {
     const config = this._automaticStepsConfig
-    return config.navigation || config.taps || config.lifecycle
+    return config.navigation || config.taps || config.lifecycle || config.identity
   }
 
   /**
@@ -175,20 +177,52 @@ export class ErrorTracking {
 
     try {
       const step = buildAutomaticExceptionStep(this._automaticStepsConfig, event, properties)
-      if (!step) {
-        return
+      if (step) {
+        this.recordAutomaticStep(step)
       }
-
-      const stepProperties = { [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.TYPE]: step.type }
-      this._exceptionStepsBuffer.add({
-        ...stepProperties,
-        [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE]: step.message,
-        [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.TIMESTAMP]: new Date().toISOString(),
-      })
-      this.forwardExceptionStepToNative(step.message, stepProperties)
     } catch (error) {
       this.logger.error('Failed to add automatic exception step. Ignoring breadcrumb.', error)
     }
+  }
+
+  /**
+   * Records the step marking an identity change. `reset()` calls this before it clears the identity,
+   * so the step lands on the boundary rather than after it.
+   *
+   * The buffer itself survives `reset()`, because steps scope to the app session rather than to the
+   * user session, and clearing would drop exactly the steps that explain a failure in a login or
+   * logout flow. This step is what keeps the previous user's activity from reading as the next
+   * user's: it marks where one identity ended instead of deleting the history.
+   *
+   * Like every automatic signal it is opt-in, and it never captures an event of its own.
+   */
+  onIdentityReset(): void {
+    if (!this._exceptionStepsConfig.enabled) {
+      return
+    }
+
+    try {
+      const step = buildIdentityExceptionStep(this._automaticStepsConfig)
+      if (step) {
+        this.recordAutomaticStep(step)
+      }
+    } catch (error) {
+      this.logger.error('Failed to add identity exception step. Ignoring breadcrumb.', error)
+    }
+  }
+
+  /**
+   * Buffers an SDK-recorded step and mirrors it to native. The SDK sets `$type` here, so the timeline
+   * can tell an automatic step from a manual one.
+   */
+  private recordAutomaticStep(step: AutomaticExceptionStep): void {
+    const stepProperties = { [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.TYPE]: step.type }
+    this._exceptionStepsBuffer.add({
+      ...stepProperties,
+      [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.MESSAGE]: step.message,
+      [CoreErrorTracking.EXCEPTION_STEP_INTERNAL_FIELDS.TIMESTAMP]: new Date().toISOString(),
+    })
+    this.forwardExceptionStepToNative(step.message, stepProperties)
   }
 
   /**

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -757,11 +757,10 @@ export class PostHog extends PostHogCore {
    * @public
    */
   reset(propertiesToKeep?: PostHogPersistedProperty[]): void {
-    // Exception steps are in-memory user-session state, so they must not cross the logout boundary.
-    // On a shared device the next user can trigger an exception, and the buffer would still hold the
-    // previous user's screen names and tap labels. Clear it first, and outside the wrapped
-    // super.reset() below, so a disabled or not-yet-initialized client still drops the steps.
-    this._errorTracking.clearExceptionSteps()
+    // NOTE: reset() deliberately keeps the exception-step buffer. Steps scope to the app session, not
+    // to the user session, because error tracking explains what the app did rather than what one user
+    // did. Clearing here would drop exactly the steps that explain a failure in a login or logout
+    // flow. Every other SDK keeps them too. See the ExceptionSteps docs before changing this.
 
     // When propertiesToKeep is not explicitly provided, automatically preserve app lifecycle
     // properties and device_id to prevent duplicate "Application Installed" events and

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -757,6 +757,12 @@ export class PostHog extends PostHogCore {
    * @public
    */
   reset(propertiesToKeep?: PostHogPersistedProperty[]): void {
+    // Exception steps are in-memory user-session state, so they must not cross the logout boundary.
+    // On a shared device the next user can trigger an exception, and the buffer would still hold the
+    // previous user's screen names and tap labels. Clear it first, and outside the wrapped
+    // super.reset() below, so a disabled or not-yet-initialized client still drops the steps.
+    this._errorTracking.clearExceptionSteps()
+
     // When propertiesToKeep is not explicitly provided, automatically preserve app lifecycle
     // properties and device_id to prevent duplicate "Application Installed" events and
     // to maintain stable feature flag bucketing across identity changes.

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -2808,6 +2808,16 @@ export class PostHog extends PostHogCore {
     } catch (e) {
       this._logger.error(`Session replay event trigger check failed: ${e}.`)
     }
+    // Only a surviving event leaves an automatic step. An event that `before_send` dropped must not
+    // reappear inside an exception payload, because a caller drops events to keep data out of PostHog.
+    // The guard also covers an event enqueued by the base constructor, before `_errorTracking` exists.
+    try {
+      if (processed) {
+        this._errorTracking?.onEnqueuedEvent(processed['event'], processed['properties'])
+      }
+    } catch (e) {
+      this._logger.error(`Automatic exception step failed: ${e}.`)
+    }
     return processed
   }
 

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -761,6 +761,11 @@ export class PostHog extends PostHogCore {
     // to the user session, because error tracking explains what the app did rather than what one user
     // did. Clearing here would drop exactly the steps that explain a failure in a login or logout
     // flow. Every other SDK keeps them too. See the ExceptionSteps docs before changing this.
+    //
+    // Instead of clearing, mark the boundary: the `identity` automatic signal records a step here, so
+    // a reader can see where one user's activity ended rather than reading it as the next user's.
+    // Recorded before super.reset() so the step sits on the boundary rather than after it.
+    this._errorTracking.onIdentityReset()
 
     // When propertiesToKeep is not explicitly provided, automatically preserve app lifecycle
     // properties and device_id to prevent duplicate "Application Installed" events and

--- a/packages/react-native/test/exception-steps-automatic-capture.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic-capture.spec.ts
@@ -1,0 +1,126 @@
+import { PostHog, PostHogCustomStorage } from '../src'
+import { Linking, AppState } from 'react-native'
+import { wait } from './test-utils'
+
+Linking.getInitialURL = jest.fn(() => Promise.resolve(null))
+AppState.addEventListener = jest.fn()
+
+const captureSpy = (posthog: PostHog): jest.SpyInstance => jest.spyOn(posthog as any, 'capture')
+
+const exceptionSteps = (spy: jest.SpyInstance): any => {
+  const call = spy.mock.calls.find(([event]) => event === '$exception')
+  return call?.[1]?.$exception_steps
+}
+
+const messagesOf = (spy: jest.SpyInstance): string[] => (exceptionSteps(spy) ?? []).map((s: any) => s.$message)
+
+// The automatic path runs inside enqueue, which a disabled client never reaches. So these tests use a
+// live client, await ready(), and let the mocked fetch absorb the flush.
+describe('PostHog React Native automatic exception steps capture', () => {
+  jest.useRealTimers()
+
+  let posthog: PostHog
+  let cache: Record<string, any> = {}
+  let mockStorage: PostHogCustomStorage
+
+  beforeEach(() => {
+    cache = {}
+    mockStorage = {
+      getItem: async (key) => cache[key] || null,
+      setItem: async (key, value) => {
+        cache[key] = value
+      },
+    }
+    ;(globalThis as any).window = (globalThis as any).window ?? {}
+    ;(globalThis as any).window.fetch = jest.fn(async (url: unknown) => ({
+      status: 200,
+      json: () => Promise.resolve(String(url).includes('flags') ? { featureFlags: {} } : { status: 'ok' }),
+    }))
+  })
+
+  afterEach(async () => {
+    await posthog?.shutdown()
+  })
+
+  const newPostHog = async (options: Record<string, unknown> = {}): Promise<PostHog> => {
+    posthog = new PostHog('test-token', {
+      customStorage: mockStorage,
+      flushInterval: 0,
+      // Lifecycle events would add their own steps, so the exact-order tests opt out.
+      captureAppLifecycleEvents: false,
+      ...options,
+    } as any)
+    await posthog.ready()
+    await wait(20)
+    return posthog
+  }
+
+  it('attaches automatic steps for screens and taps, in order, alongside manual steps', async () => {
+    await newPostHog({ errorTracking: { exceptionSteps: { automatic: true } } })
+    const spy = captureSpy(posthog)
+
+    await posthog.screen('Cart')
+    posthog.autocapture('touch', [{ tag_name: 'CheckoutButton' }])
+    posthog.addExceptionStep('Submitting payment')
+    await wait(20)
+
+    posthog.captureException(new Error('boom'))
+
+    expect(messagesOf(spy)).toEqual(['Screen: Cart', 'Tap: CheckoutButton', 'Submitting payment'])
+    expect(exceptionSteps(spy).map((s: any) => s.$type)).toEqual(['navigation', 'tap', undefined])
+  })
+
+  it('records a lifecycle step for an app state change', async () => {
+    await newPostHog({
+      captureAppLifecycleEvents: true,
+      errorTracking: { exceptionSteps: { automatic: { lifecycle: true } } },
+    })
+    const spy = captureSpy(posthog)
+
+    posthog.capture('Application Backgrounded')
+    await wait(20)
+
+    posthog.captureException(new Error('boom'))
+
+    expect(messagesOf(spy)).toContain('Application Backgrounded')
+  })
+
+  it('leaves an ordinary analytics event out of the timeline', async () => {
+    await newPostHog({ errorTracking: { exceptionSteps: { automatic: true } } })
+    const spy = captureSpy(posthog)
+
+    posthog.capture('Order Completed', { total: 12900 })
+    await wait(20)
+
+    posthog.captureException(new Error('boom'))
+
+    expect(exceptionSteps(spy)).toBeUndefined()
+  })
+
+  it('records no automatic step when the caller enabled none', async () => {
+    await newPostHog()
+    const spy = captureSpy(posthog)
+
+    await posthog.screen('Cart')
+    await wait(20)
+
+    posthog.captureException(new Error('boom'))
+
+    expect(exceptionSteps(spy)).toBeUndefined()
+  })
+
+  it('leaves no automatic step for an event that before_send dropped', async () => {
+    await newPostHog({
+      errorTracking: { exceptionSteps: { automatic: true } },
+      before_send: (event: any) => (event.event === '$screen' ? null : event),
+    })
+    const spy = captureSpy(posthog)
+
+    await posthog.screen('Cart')
+    await wait(20)
+
+    posthog.captureException(new Error('boom'))
+
+    expect(exceptionSteps(spy)).toBeUndefined()
+  })
+})

--- a/packages/react-native/test/exception-steps-automatic-capture.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic-capture.spec.ts
@@ -109,6 +109,35 @@ describe('PostHog React Native automatic exception steps capture', () => {
     expect(exceptionSteps(spy)).toBeUndefined()
   })
 
+  it('drops buffered steps on reset, so one user never sees the previous user activity', async () => {
+    await newPostHog({ errorTracking: { exceptionSteps: { automatic: true } } })
+    const spy = captureSpy(posthog)
+
+    await posthog.screen('Cart')
+    posthog.addExceptionStep('Submitting payment')
+    await wait(20)
+
+    posthog.reset()
+
+    posthog.captureException(new Error('boom'))
+
+    expect(exceptionSteps(spy)).toBeUndefined()
+  })
+
+  it('records steps again after a reset', async () => {
+    await newPostHog({ errorTracking: { exceptionSteps: { automatic: true } } })
+    const spy = captureSpy(posthog)
+
+    await posthog.screen('Cart')
+    posthog.reset()
+    await posthog.screen('Login')
+    await wait(20)
+
+    posthog.captureException(new Error('boom'))
+
+    expect(messagesOf(spy)).toEqual(['Screen: Login'])
+  })
+
   it('leaves no automatic step for an event that before_send dropped', async () => {
     await newPostHog({
       errorTracking: { exceptionSteps: { automatic: true } },

--- a/packages/react-native/test/exception-steps-automatic-capture.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic-capture.spec.ts
@@ -109,22 +109,9 @@ describe('PostHog React Native automatic exception steps capture', () => {
     expect(exceptionSteps(spy)).toBeUndefined()
   })
 
-  it('drops buffered steps on reset, so one user never sees the previous user activity', async () => {
-    await newPostHog({ errorTracking: { exceptionSteps: { automatic: true } } })
-    const spy = captureSpy(posthog)
-
-    await posthog.screen('Cart')
-    posthog.addExceptionStep('Submitting payment')
-    await wait(20)
-
-    posthog.reset()
-
-    posthog.captureException(new Error('boom'))
-
-    expect(exceptionSteps(spy)).toBeUndefined()
-  })
-
-  it('records steps again after a reset', async () => {
+  // Steps scope to the app session, not to the user session, so a logout keeps the steps that explain
+  // a failure in the logout flow itself. Every other SDK behaves the same way.
+  it('keeps buffered steps across a reset', async () => {
     await newPostHog({ errorTracking: { exceptionSteps: { automatic: true } } })
     const spy = captureSpy(posthog)
 
@@ -135,7 +122,7 @@ describe('PostHog React Native automatic exception steps capture', () => {
 
     posthog.captureException(new Error('boom'))
 
-    expect(messagesOf(spy)).toEqual(['Screen: Login'])
+    expect(messagesOf(spy)).toEqual(['Screen: Cart', 'Screen: Login'])
   })
 
   it('leaves no automatic step for an event that before_send dropped', async () => {

--- a/packages/react-native/test/exception-steps-automatic-capture.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic-capture.spec.ts
@@ -110,9 +110,25 @@ describe('PostHog React Native automatic exception steps capture', () => {
   })
 
   // Steps scope to the app session, not to the user session, so a logout keeps the steps that explain
-  // a failure in the logout flow itself. Every other SDK behaves the same way.
-  it('keeps buffered steps across a reset', async () => {
+  // a failure in the logout flow itself. Every other SDK behaves the same way. The identity step
+  // marks where one user's activity ended, so keeping the buffer does not leave the previous user's
+  // steps reading as the next user's.
+  it('keeps buffered steps across a reset and marks the boundary', async () => {
     await newPostHog({ errorTracking: { exceptionSteps: { automatic: true } } })
+    const spy = captureSpy(posthog)
+
+    await posthog.screen('Cart')
+    posthog.reset()
+    await posthog.screen('Login')
+    await wait(20)
+
+    posthog.captureException(new Error('boom'))
+
+    expect(messagesOf(spy)).toEqual(['Screen: Cart', 'User changed', 'Screen: Login'])
+  })
+
+  it('keeps buffered steps across a reset without marking it when identity is off', async () => {
+    await newPostHog({ errorTracking: { exceptionSteps: { automatic: { navigation: true } } } })
     const spy = captureSpy(posthog)
 
     await posthog.screen('Cart')

--- a/packages/react-native/test/exception-steps-automatic.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic.spec.ts
@@ -1,6 +1,8 @@
 import { ErrorTracking, ExceptionStepsOptions } from '../src/error-tracking'
-import { buildAutomaticExceptionStep } from '../src/error-tracking/automatic-steps'
-import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import {
+  buildAutomaticExceptionStep,
+  resolveAutomaticExceptionStepsOptions,
+} from '../src/error-tracking/automatic-steps'
 
 // Prevent the autocapture handlers from registering real global handlers.
 jest.mock('../src/error-tracking/utils', () => ({
@@ -18,7 +20,7 @@ import { createMockLogger, createMockPostHog } from './test-utils'
 
 const mockPostHog = createMockPostHog()
 
-const ALL_ON = CoreErrorTracking.resolveAutomaticExceptionStepsConfig(true)
+const ALL_ON = resolveAutomaticExceptionStepsOptions(true)
 
 const touchProperties = (elements: unknown[], extra: Record<string, unknown> = {}): Record<string, unknown> => ({
   $event_type: 'touch',
@@ -107,7 +109,7 @@ describe('buildAutomaticExceptionStep', () => {
   })
 
   it('records only the signals the caller enabled', () => {
-    const navigationOnly = CoreErrorTracking.resolveAutomaticExceptionStepsConfig({ navigation: true })
+    const navigationOnly = resolveAutomaticExceptionStepsOptions({ navigation: true })
 
     expect(buildAutomaticExceptionStep(navigationOnly, '$screen', { $screen_name: 'Cart' })).toBeDefined()
     expect(buildAutomaticExceptionStep(navigationOnly, '$autocapture', touchProperties([]))).toBeUndefined()
@@ -115,7 +117,7 @@ describe('buildAutomaticExceptionStep', () => {
   })
 
   it('records nothing when no signal is enabled', () => {
-    const allOff = CoreErrorTracking.resolveAutomaticExceptionStepsConfig()
+    const allOff = resolveAutomaticExceptionStepsOptions()
 
     expect(buildAutomaticExceptionStep(allOff, '$screen', { $screen_name: 'Cart' })).toBeUndefined()
     expect(buildAutomaticExceptionStep(allOff, '$autocapture', touchProperties([]))).toBeUndefined()

--- a/packages/react-native/test/exception-steps-automatic.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic.spec.ts
@@ -1,0 +1,215 @@
+import { ErrorTracking, ExceptionStepsOptions } from '../src/error-tracking'
+import { buildAutomaticExceptionStep } from '../src/error-tracking/automatic-steps'
+import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+
+// Prevent the autocapture handlers from registering real global handlers.
+jest.mock('../src/error-tracking/utils', () => ({
+  trackUncaughtExceptions: jest.fn(),
+  trackUnhandledRejections: jest.fn(),
+  trackConsole: jest.fn(),
+}))
+
+jest.mock('../src/utils', () => ({
+  isHermes: jest.fn(() => false),
+  getRemoteConfigBool: jest.requireActual('../src/utils').getRemoteConfigBool,
+}))
+
+import { createMockLogger, createMockPostHog } from './test-utils'
+
+const mockPostHog = createMockPostHog()
+
+const ALL_ON = CoreErrorTracking.resolveAutomaticExceptionStepsConfig(true)
+
+const touchProperties = (elements: unknown[], extra: Record<string, unknown> = {}): Record<string, unknown> => ({
+  $event_type: 'touch',
+  $elements: elements,
+  ...extra,
+})
+
+describe('buildAutomaticExceptionStep', () => {
+  it('maps $screen to a navigation step', () => {
+    expect(buildAutomaticExceptionStep(ALL_ON, '$screen', { $screen_name: 'Cart' })).toEqual({
+      type: 'navigation',
+      message: 'Screen: Cart',
+    })
+  })
+
+  it('ignores $screen without a usable screen name', () => {
+    expect(buildAutomaticExceptionStep(ALL_ON, '$screen', {})).toBeUndefined()
+    expect(buildAutomaticExceptionStep(ALL_ON, '$screen', { $screen_name: '  ' })).toBeUndefined()
+    expect(buildAutomaticExceptionStep(ALL_ON, '$screen', { $screen_name: 42 })).toBeUndefined()
+  })
+
+  it('labels a tap from the innermost autocaptured element', () => {
+    const step = buildAutomaticExceptionStep(
+      ALL_ON,
+      '$autocapture',
+      touchProperties([{ tag_name: 'CheckoutButton' }, { tag_name: 'CartScreen' }])
+    )
+
+    expect(step).toEqual({ type: 'tap', message: 'Tap: CheckoutButton' })
+  })
+
+  it('records an unlabelled tap when no element carries a label', () => {
+    expect(buildAutomaticExceptionStep(ALL_ON, '$autocapture', touchProperties([]))).toEqual({
+      type: 'tap',
+      message: 'Tap',
+    })
+    expect(buildAutomaticExceptionStep(ALL_ON, '$autocapture', touchProperties([{ $el_text: 'Pay now' }]))).toEqual({
+      type: 'tap',
+      message: 'Tap',
+    })
+  })
+
+  it('never puts element text or touch coordinates in a tap step', () => {
+    const step = buildAutomaticExceptionStep(
+      ALL_ON,
+      '$autocapture',
+      touchProperties([{ tag_name: 'PayButton', $el_text: 'Pay $129.00' }], { $touch_x: 120, $touch_y: 480 })
+    )
+
+    expect(step).toEqual({ type: 'tap', message: 'Tap: PayButton' })
+    expect(JSON.stringify(step)).not.toContain('129.00')
+    expect(JSON.stringify(step)).not.toContain('120')
+  })
+
+  it('records an unlabelled tap when the element list holds no usable element', () => {
+    expect(buildAutomaticExceptionStep(ALL_ON, '$autocapture', touchProperties([null]))).toEqual({
+      type: 'tap',
+      message: 'Tap',
+    })
+    expect(buildAutomaticExceptionStep(ALL_ON, '$autocapture', { $event_type: 'touch', $elements: 'nope' })).toEqual({
+      type: 'tap',
+      message: 'Tap',
+    })
+  })
+
+  it('ignores an autocaptured event that is not a touch', () => {
+    expect(
+      buildAutomaticExceptionStep(ALL_ON, '$autocapture', { $event_type: 'change', $elements: [{ tag_name: 'Input' }] })
+    ).toBeUndefined()
+  })
+
+  it.each([
+    'Application Installed',
+    'Application Updated',
+    'Application Opened',
+    'Application Became Active',
+    'Application Backgrounded',
+  ])('maps the lifecycle event %s to a lifecycle step', (event) => {
+    expect(buildAutomaticExceptionStep(ALL_ON, event, {})).toEqual({ type: 'lifecycle', message: event })
+  })
+
+  it('ignores an event that maps to no signal', () => {
+    expect(buildAutomaticExceptionStep(ALL_ON, 'Order Completed', { total: 12900 })).toBeUndefined()
+    expect(buildAutomaticExceptionStep(ALL_ON, '$exception', {})).toBeUndefined()
+    expect(buildAutomaticExceptionStep(ALL_ON, undefined, {})).toBeUndefined()
+  })
+
+  it('records only the signals the caller enabled', () => {
+    const navigationOnly = CoreErrorTracking.resolveAutomaticExceptionStepsConfig({ navigation: true })
+
+    expect(buildAutomaticExceptionStep(navigationOnly, '$screen', { $screen_name: 'Cart' })).toBeDefined()
+    expect(buildAutomaticExceptionStep(navigationOnly, '$autocapture', touchProperties([]))).toBeUndefined()
+    expect(buildAutomaticExceptionStep(navigationOnly, 'Application Opened', {})).toBeUndefined()
+  })
+
+  it('records nothing when no signal is enabled', () => {
+    const allOff = CoreErrorTracking.resolveAutomaticExceptionStepsConfig()
+
+    expect(buildAutomaticExceptionStep(allOff, '$screen', { $screen_name: 'Cart' })).toBeUndefined()
+    expect(buildAutomaticExceptionStep(allOff, '$autocapture', touchProperties([]))).toBeUndefined()
+    expect(buildAutomaticExceptionStep(allOff, 'Application Opened', {})).toBeUndefined()
+  })
+})
+
+describe('ErrorTracking automatic exception steps', () => {
+  let logger: ReturnType<typeof createMockLogger>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    logger = createMockLogger()
+  })
+
+  const newErrorTracking = (exceptionSteps?: ExceptionStepsOptions): ErrorTracking =>
+    new ErrorTracking(mockPostHog, { exceptionSteps }, logger as any)
+
+  it('is off by default', () => {
+    const et = newErrorTracking()
+    et.onEnqueuedEvent('$screen', { $screen_name: 'Cart' })
+
+    expect(et.automaticExceptionStepsEnabled).toBe(false)
+    expect(et.getAttachableExceptionSteps()).toEqual([])
+  })
+
+  it('buffers a step with $type, $message and $timestamp', () => {
+    const et = newErrorTracking({ automatic: true })
+    et.onEnqueuedEvent('$screen', { $screen_name: 'Cart' })
+
+    const steps = et.getAttachableExceptionSteps()
+    expect(steps).toHaveLength(1)
+    expect(steps[0].$type).toBe('navigation')
+    expect(steps[0].$message).toBe('Screen: Cart')
+    expect(typeof steps[0].$timestamp).toBe('string')
+  })
+
+  it('keeps automatic and manual steps in one ordered buffer', () => {
+    const et = newErrorTracking({ automatic: true })
+    et.onEnqueuedEvent('Application Opened', {})
+    et.addExceptionStep('Loaded cart')
+    et.onEnqueuedEvent('$screen', { $screen_name: 'Checkout' })
+
+    expect(et.getAttachableExceptionSteps().map((s) => s.$message)).toEqual([
+      'Application Opened',
+      'Loaded cart',
+      'Screen: Checkout',
+    ])
+  })
+
+  it('leaves a manual step untyped so the timeline only labels automatic steps', () => {
+    const et = newErrorTracking({ automatic: true })
+    et.addExceptionStep('Loaded cart')
+
+    expect(et.getAttachableExceptionSteps()[0].$type).toBeUndefined()
+  })
+
+  it('records nothing when exception steps are disabled', () => {
+    const et = newErrorTracking({ enabled: false, automatic: true })
+    et.onEnqueuedEvent('$screen', { $screen_name: 'Cart' })
+
+    expect(et.getAttachableExceptionSteps()).toEqual([])
+  })
+
+  it('enables single signals from an object config', () => {
+    const et = newErrorTracking({ automatic: { taps: true } })
+    et.onEnqueuedEvent('$screen', { $screen_name: 'Cart' })
+    et.onEnqueuedEvent('$autocapture', touchProperties([{ tag_name: 'PayButton' }]))
+
+    expect(et.automaticExceptionStepsEnabled).toBe(true)
+    expect(et.getAttachableExceptionSteps().map((s) => s.$message)).toEqual(['Tap: PayButton'])
+  })
+
+  it('evicts the oldest automatic steps once the byte budget is exceeded', () => {
+    const et = newErrorTracking({ automatic: true, maxBytes: 200 })
+    for (const name of ['One', 'Two', 'Three', 'Four', 'Five', 'Six']) {
+      et.onEnqueuedEvent('$screen', { $screen_name: name })
+    }
+
+    const messages = et.getAttachableExceptionSteps().map((s) => s.$message)
+    expect(messages).toContain('Screen: Six')
+    expect(messages).not.toContain('Screen: One')
+  })
+
+  it('never throws out of the capture path', () => {
+    const et = newErrorTracking({ automatic: true })
+    const throwingProperties = {
+      get $screen_name() {
+        throw new Error('property read failed')
+      },
+    }
+
+    expect(() => et.onEnqueuedEvent('$screen', throwingProperties)).not.toThrow()
+    expect(logger.error).toHaveBeenCalled()
+    expect(et.getAttachableExceptionSteps()).toEqual([])
+  })
+})

--- a/packages/react-native/test/exception-steps-automatic.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic.spec.ts
@@ -86,10 +86,25 @@ describe('buildAutomaticExceptionStep', () => {
     })
   })
 
-  it('ignores an autocaptured event that is not a touch', () => {
+  it('records a React Native Web click under the same taps signal', () => {
+    expect(
+      buildAutomaticExceptionStep(ALL_ON, '$autocapture', {
+        $event_type: 'click',
+        $elements: [{ tag_name: 'CheckoutButton' }],
+      })
+    ).toEqual({ type: 'tap', message: 'Click: CheckoutButton' })
+
+    expect(buildAutomaticExceptionStep(ALL_ON, '$autocapture', { $event_type: 'click', $elements: [] })).toEqual({
+      type: 'tap',
+      message: 'Click',
+    })
+  })
+
+  it('ignores an autocaptured event that is not an interaction', () => {
     expect(
       buildAutomaticExceptionStep(ALL_ON, '$autocapture', { $event_type: 'change', $elements: [{ tag_name: 'Input' }] })
     ).toBeUndefined()
+    expect(buildAutomaticExceptionStep(ALL_ON, '$autocapture', { $elements: [{ tag_name: 'Input' }] })).toBeUndefined()
   })
 
   it.each([

--- a/packages/react-native/test/exception-steps-automatic.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic.spec.ts
@@ -107,6 +107,15 @@ describe('buildAutomaticExceptionStep', () => {
     expect(buildAutomaticExceptionStep(ALL_ON, '$autocapture', { $elements: [{ tag_name: 'Input' }] })).toBeUndefined()
   })
 
+  it.each(['toString', 'constructor', 'valueOf', 'hasOwnProperty', '__proto__'])(
+    'ignores the Object.prototype key %s as an event type',
+    (eventType) => {
+      expect(
+        buildAutomaticExceptionStep(ALL_ON, '$autocapture', { $event_type: eventType, $elements: [] })
+      ).toBeUndefined()
+    }
+  )
+
   it.each([
     'Application Installed',
     'Application Updated',

--- a/packages/react-native/test/exception-steps-automatic.spec.ts
+++ b/packages/react-native/test/exception-steps-automatic.spec.ts
@@ -1,6 +1,7 @@
 import { ErrorTracking, ExceptionStepsOptions } from '../src/error-tracking'
 import {
   buildAutomaticExceptionStep,
+  buildIdentityExceptionStep,
   resolveAutomaticExceptionStepsOptions,
 } from '../src/error-tracking/automatic-steps'
 
@@ -149,6 +150,23 @@ describe('buildAutomaticExceptionStep', () => {
   })
 })
 
+describe('buildIdentityExceptionStep', () => {
+  it('marks the boundary without naming either user', () => {
+    expect(buildIdentityExceptionStep(ALL_ON)).toEqual({ type: 'identity', message: 'User changed' })
+  })
+
+  it('records nothing when the caller left the signal off', () => {
+    expect(buildIdentityExceptionStep(resolveAutomaticExceptionStepsOptions())).toBeUndefined()
+    expect(buildIdentityExceptionStep(resolveAutomaticExceptionStepsOptions({ navigation: true }))).toBeUndefined()
+  })
+
+  // No enqueued event maps to identity, so the reset path is the only thing that can record it.
+  it('is not reachable from the event path', () => {
+    expect(buildAutomaticExceptionStep(ALL_ON, '$identify', {})).toBeUndefined()
+    expect(buildAutomaticExceptionStep(ALL_ON, '$create_alias', {})).toBeUndefined()
+  })
+})
+
 describe('ErrorTracking automatic exception steps', () => {
   let logger: ReturnType<typeof createMockLogger>
 
@@ -213,6 +231,41 @@ describe('ErrorTracking automatic exception steps', () => {
 
     expect(et.automaticExceptionStepsEnabled).toBe(true)
     expect(et.getAttachableExceptionSteps().map((s) => s.$message)).toEqual(['Tap: PayButton'])
+  })
+
+  it('marks an identity change in the buffer instead of clearing it', () => {
+    const et = newErrorTracking({ automatic: true })
+    et.onEnqueuedEvent('$screen', { $screen_name: 'Cart' })
+    et.onIdentityReset()
+    et.onEnqueuedEvent('$screen', { $screen_name: 'Login' })
+
+    const steps = et.getAttachableExceptionSteps()
+    expect(steps.map((s) => s.$message)).toEqual(['Screen: Cart', 'User changed', 'Screen: Login'])
+    expect(steps.map((s) => s.$type)).toEqual(['navigation', 'identity', 'navigation'])
+  })
+
+  it('records no identity step when the caller left the signal off', () => {
+    const et = newErrorTracking({ automatic: { navigation: true } })
+    et.onEnqueuedEvent('$screen', { $screen_name: 'Cart' })
+    et.onIdentityReset()
+
+    expect(et.getAttachableExceptionSteps().map((s) => s.$message)).toEqual(['Screen: Cart'])
+  })
+
+  it('records an identity step with no distinct id attached', () => {
+    const et = newErrorTracking({ automatic: { identity: true } })
+    et.onIdentityReset()
+
+    const [step] = et.getAttachableExceptionSteps()
+    expect(et.automaticExceptionStepsEnabled).toBe(true)
+    expect(Object.keys(step).sort()).toEqual(['$message', '$timestamp', '$type'])
+  })
+
+  it('records no identity step when exception steps are disabled', () => {
+    const et = newErrorTracking({ enabled: false, automatic: true })
+    et.onIdentityReset()
+
+    expect(et.getAttachableExceptionSteps()).toEqual([])
   })
 
   it('evicts the oldest automatic steps once the byte budget is exceeded', () => {


### PR DESCRIPTION
Refs PostHog/posthog#43989, the public request for Sentry-style breadcrumbs. That issue asks for them in the browser SDK, so this does not close it.

## Problem

`addExceptionStep` shipped in `posthog-react-native` 4.50.0 (#3861), and it does what the docs promise. But every step is manual, so an exception carries a timeline only where somebody remembered to add a call. Bugsnag and Sentry leave breadcrumbs for navigation, network requests, taps and lifecycle on their own, so a crash arrives with a trail even in code nobody instrumented.

No PostHog SDK records a step automatically today. I checked `posthog-js`, `posthog-ios`, `posthog-android` and `posthog-flutter`: `addExceptionStep` is a public API in each, and nothing calls it internally.

This came from a React Native customer who asked for the Bugsnag Breadcrumbs equivalent, found the manual API, and said the manual calls feel like the part they would forget.

## What this does

Set `errorTracking.exceptionSteps.automatic` to record a step for a signal the SDK already observes:

```ts
const posthog = new PostHog('<token>', {
  errorTracking: {
    exceptionSteps: {
      automatic: true, // or { navigation: true, taps: true, lifecycle: true }
    },
  },
})
```

| Signal | Source event | Step |
| --- | --- | --- |
| `navigation` | `$screen` | `Screen: Cart`, `$type: navigation` |
| `taps` | `$autocapture` (touch) | `Tap: CheckoutButton`, `$type: tap` |
| `lifecycle` | `Application Opened` and the other four | `Application Backgrounded`, `$type: lifecycle` |

Every signal is off by default. Each step adds bytes to every captured exception, so this is opt-in, which also matches `errorTracking.autocapture`.

## How it works

The recorder hangs off the existing `processBeforeEnqueue` chokepoint in `posthog-rn.ts`, which already sees `$screen`, `$autocapture` and the lifecycle events. Nothing new is patched or wrapped. The mapping itself is a pure function, so it is testable without the SDK.

Automatic steps share the byte-bounded buffer and the native forwarding that manual steps use, so a native crash carries the same timeline.

## Decisions worth a look

1. **`$type` on the wire.** The error tracking UI already reads `$type` and `$level` per step (`frontend/src/lib/components/Errors/exceptionStepsValidation.ts`) and renders `$type` as the secondary line in the session timeline, but no SDK emits either one. This adds both to `EXCEPTION_STEP_INTERNAL_FIELDS` in `@posthog/core` to match that contract. Neither becomes reserved, so a caller can still categorise a manual step by hand.
2. **A manual step stays untyped.** Stamping `$type: 'manual'` would put a new label next to every existing step for every current user, so only automatic steps carry `$type`.
3. **A dropped event leaves no step.** A caller drops an event in `before_send` to keep data out of PostHog. Resurrecting it inside an exception payload would defeat that, so only a surviving event records a step.
4. **A tap step carries neither `$el_text` nor coordinates.** Element text is user-visible copy that can hold personal data, and the label from `tag_name` is either a `ph-label` or a component display name.
5. **The config type and resolver live in `@posthog/core`**, not in the RN package, so iOS, Android and web can adopt the same shape and the same `$type` vocabulary. Only React Native reads it today.

## Not in this PR

- **Network request steps.** Bugsnag's `request` breadcrumb is the notable remaining gap. It needs request interception, and the RN SDK patches only `fetch`, not `XMLHttpRequest`, so an `axios` default would go unrecorded. That deserves its own change.
- **Console steps.** Console output already has two homes in this SDK: `errorTracking.autocapture.console` and the Logs product. A third path would be redundant.
- **Docs.** `posthog.com/docs/error-tracking/capture` needs an automatic-steps section. Happy to follow with that PR once the config shape is settled here.

## Testing

- 41 tests across the exception step specs, 626 across the whole React Native package, all passing.
- New: `exception-steps-automatic.spec.ts` covers the mapping and the buffer wiring; `exception-steps-automatic-capture.spec.ts` drives a live client through `ready()` so the assertions run through the real enqueue path rather than a mocked one.
- `automatic-steps.ts` is at 100% statement coverage.
- Core: `resolveAutomaticExceptionStepsConfig` and the `$type`/`$level` strip behavior are covered; the full core suite passes (845).
- Three failures in the `browser` package (`persistence-key-policy`, `module.test.ts`, and a playwright spec run under jest) reproduce on a clean `main` with these changes stashed, so they are unrelated.
- `errorTracking.exceptionSteps.automatic: true` is wired into `example-expo-53` for manual verification: switch tabs, tap a button, background the app, then capture an exception and read the timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

