### PR TITLE
fix: drop events when beforeSend hooks throw

### DIFF
--- a/.changeset/fail-closed-before-send.md
+++ b/.changeset/fail-closed-before-send.md
@@ -1,0 +1,7 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+'@posthog/convex': patch
+---
+
+Drop events when a before-send hook throws instead of sending the unmodified event.

--- a/.changeset/fail-closed-before-send.md
+++ b/.changeset/fail-closed-before-send.md
@@ -2,6 +2,10 @@
 '@posthog/core': patch
 'posthog-js': patch
 '@posthog/convex': patch
+'posthog-node': patch
+'posthog-react-native': patch
+'@posthog/next': patch
+'@posthog/nuxt': patch
 ---
 
 Drop events when a before-send hook throws instead of sending the unmodified event.

--- a/packages/browser/src/__tests__/posthog-core.beforeSend.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.beforeSend.test.ts
@@ -120,20 +120,20 @@ describe('posthog core - before send', () => {
     it('can take an array of fns', () => {
         const posthog = posthogWith({
             before_send: [
-                (cr) => {
-                    cr.properties = { ...cr.properties, edited_one: true }
-                    return cr
-                },
+                (cr) => ({ ...cr, properties: { ...cr.properties, edited_one: true } }),
                 (cr) => {
                     if (cr.event === 'to reject') {
                         return null
                     }
-                    return cr
+                    return {
+                        ...cr,
+                        properties: {
+                            ...cr.properties,
+                            second_saw_first: cr.properties.edited_one === true,
+                        },
+                    }
                 },
-                (cr) => {
-                    cr.properties = { ...cr.properties, edited_two: true }
-                    return cr
-                },
+                (cr) => ({ ...cr, properties: { ...cr.properties, edited_two: true } }),
             ],
         })
         ;(posthog._send_request as jest.Mock).mockClear()
@@ -142,7 +142,8 @@ describe('posthog core - before send', () => {
 
         expect(capturedData.filter((cd) => !!cd)).toHaveLength(1)
         expect(capturedData[0]).toHaveProperty(['properties', 'edited_one'], true)
-        expect(capturedData[0]).toHaveProperty(['properties', 'edited_one'], true)
+        expect(capturedData[0]).toHaveProperty(['properties', 'second_saw_first'], true)
+        expect(capturedData[0]).toHaveProperty(['properties', 'edited_two'], true)
         expect(posthog._send_request).toHaveBeenCalledWith({
             batchKey: undefined,
             callback: expect.any(Function),
@@ -152,6 +153,31 @@ describe('posthog core - before send', () => {
             timestampMode: 'capture-body',
             url: 'https://us.i.posthog.com/e/',
         })
+    })
+
+    it('fails closed when a before_send function throws', () => {
+        const error = new Error('before_send failed')
+        const sentinel = jest.fn((event: CaptureResult) => event)
+        const posthog = posthogWith({
+            before_send: [
+                (event) => ({ ...event, properties: { ...event.properties, transformed: true } }),
+                () => {
+                    throw error
+                },
+                sentinel,
+            ],
+        })
+        ;(posthog._send_request as jest.Mock).mockClear()
+        let capturedData: CaptureResult | undefined
+
+        expect(() => {
+            capturedData = posthog.capture(eventName, {}, {})
+        }).not.toThrow()
+
+        expect(capturedData).toBeUndefined()
+        expect(sentinel).not.toHaveBeenCalled()
+        expect(posthog._send_request).not.toHaveBeenCalled()
+        expect(mockLogger.error).toHaveBeenCalledWith(`Error in beforeSend function for event '${eventName}':`, error)
     })
 
     it('can sanitize $set event', () => {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -4579,20 +4579,25 @@ export class PostHog implements PostHogInterface {
         const fns = isArray(this.config.before_send) ? this.config.before_send : [this.config.before_send]
         let beforeSendResult: CaptureResult | null = data
         for (const fn of fns) {
-            beforeSendResult = fn(beforeSendResult)
-            if (isNullish(beforeSendResult)) {
-                const logMessage = `Event '${data.event}' was rejected in beforeSend function`
-                if (isKnownUnsafeEditableEvent(data.event)) {
-                    logger.warn(`${logMessage}. This can cause unexpected behavior.`)
-                } else {
-                    logger.info(logMessage)
+            try {
+                beforeSendResult = fn(beforeSendResult)
+                if (isNullish(beforeSendResult)) {
+                    const logMessage = `Event '${data.event}' was rejected in beforeSend function`
+                    if (isKnownUnsafeEditableEvent(data.event)) {
+                        logger.warn(`${logMessage}. This can cause unexpected behavior.`)
+                    } else {
+                        logger.info(logMessage)
+                    }
+                    return null
                 }
+                if (!beforeSendResult.properties || isEmptyObject(beforeSendResult.properties)) {
+                    logger.warn(
+                        `Event '${data.event}' has no properties after beforeSend function, this is likely an error.`
+                    )
+                }
+            } catch (e) {
+                logger.error(`Error in beforeSend function for event '${data.event}':`, e)
                 return null
-            }
-            if (!beforeSendResult.properties || isEmptyObject(beforeSendResult.properties)) {
-                logger.warn(
-                    `Event '${data.event}' has no properties after beforeSend function, this is likely an error.`
-                )
             }
         }
         // If a beforeSend hook removed a property the event needs to be ingested

--- a/packages/convex/src/client/index.test.ts
+++ b/packages/convex/src/client/index.test.ts
@@ -478,6 +478,35 @@ describe('beforeSend', () => {
     expect(fn2).not.toHaveBeenCalled()
   })
 
+  test('fails closed when a beforeSend function throws', async () => {
+    const component = { lib: { capture: 'capture_ref' } }
+    const error = new Error('beforeSend failed')
+    const sentinel: BeforeSendFn = jest.fn((event: Parameters<BeforeSendFn>[0]) => event)
+    const posthog = new PostHog(component as never, {
+      beforeSend: [
+        (event) => ({ ...event, properties: { ...event.properties, transformed: true } }),
+        () => {
+          throw error
+        },
+        sentinel,
+      ],
+    })
+    const ctx = mockSchedulerCtx()
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(
+      posthog.capture(ctx as never, {
+        distinctId: 'user-1',
+        event: 'test',
+      })
+    ).resolves.toBeUndefined()
+
+    expect(sentinel).not.toHaveBeenCalled()
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith("[PostHog] Error in beforeSend function for event 'test':", error)
+    warnSpy.mockRestore()
+  })
+
   test('applies beforeSend to identify events', async () => {
     const component = { lib: { identify: 'identify_ref' } }
     const beforeSend: BeforeSendFn = (event) => {

--- a/packages/convex/src/client/index.ts
+++ b/packages/convex/src/client/index.ts
@@ -119,8 +119,13 @@ export class PostHog {
     const fns = Array.isArray(this.beforeSend) ? this.beforeSend : [this.beforeSend]
     let result: PostHogEvent | null = event
     for (const fn of fns) {
-      result = fn(result)
-      if (!result) return null
+      try {
+        result = fn(result)
+        if (!result) return null
+      } catch (e) {
+        console.warn(`[PostHog] Error in beforeSend function for event '${event.event}':`, e)
+        return null
+      }
     }
     return result
   }

--- a/packages/core/src/__tests__/posthog.capture.spec.ts
+++ b/packages/core/src/__tests__/posthog.capture.spec.ts
@@ -279,6 +279,34 @@ describe('PostHog Core', () => {
       expect(mocks.fetch).not.toHaveBeenCalled()
     })
 
+    it('should fail closed when a before_send function throws', async () => {
+      const error = new Error('before_send failed')
+      const sentinel = jest.fn((event: CaptureEvent | null) => event)
+      const captureListener = jest.fn()
+      ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
+        flushAt: 1,
+        before_send: [
+          (event) => event && { ...event, properties: { ...event.properties, transformed: true } },
+          () => {
+            throw error
+          },
+          sentinel,
+        ],
+      })
+      const errorSpy = jest.spyOn((posthog as any)._logger, 'error').mockImplementation(() => {})
+      posthog.on('capture', captureListener)
+
+      expect(() => posthog.capture('custom-event')).not.toThrow()
+      await waitForPromises()
+
+      expect(sentinel).not.toHaveBeenCalled()
+      expect(captureListener).not.toHaveBeenCalled()
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.Queue)).toBeUndefined()
+      expect(mocks.fetch).not.toHaveBeenCalled()
+      expect(errorSpy).toHaveBeenCalledWith("Error in before_send function for event 'custom-event':", error)
+      errorSpy.mockRestore()
+    })
+
     it('should pass timestamp and uuid through before_send', async () => {
       const customDate = new Date('2023-06-15')
       const customUuid = uuidv7()

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -1739,6 +1739,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
         }
       } catch (e) {
         this._logger.error(`Error in before_send function for event '${captureEvent.event}':`, e)
+        return null
       }
     }
 

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -758,6 +758,32 @@ describe('PostHog Node.js', () => {
       expect(mockedFetch).not.toHaveBeenCalledWith('http://example.com/batch/', expect.anything())
     })
 
+    it('should fail closed when a before_send function throws', async () => {
+      const error = new Error('before_send failed')
+      const sentinel = jest.fn((event) => event)
+      const ph = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        fetchRetryCount: 0,
+        disableCompression: true,
+        before_send: [
+          (event) => ({ ...event, properties: { ...event.properties, transformed: true } }),
+          () => {
+            throw error
+          },
+          sentinel,
+        ],
+      })
+      const loggerSpy = jest.spyOn((ph as any)._logger, 'error').mockImplementation(() => {})
+
+      ph.capture({ distinctId: '123', event: 'test-event', properties: { foo: 'bar' } })
+      await waitForFlushTimer()
+
+      expect(sentinel).not.toHaveBeenCalled()
+      expect(loggerSpy).toHaveBeenCalledWith("Error in before_send function for event 'test-event':", error)
+      expect(mockedFetch).not.toHaveBeenCalledWith('http://example.com/batch/', expect.anything())
+      loggerSpy.mockRestore()
+    })
+
     it('should work with captureImmediate', async () => {
       const beforeSendFn = jest.fn((event) => ({ ...event, event: 'modified-event' }))
       const ph = new PostHog('TEST_API_KEY', {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -3057,14 +3057,19 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     let result: EventMessage | null = eventMessage
 
     for (const fn of fns) {
-      result = fn(result)
-      if (!result) {
-        this._logger.info(`Event '${eventMessage.event}' was rejected in beforeSend function`)
+      try {
+        result = fn(result)
+        if (!result) {
+          this._logger.info(`Event '${eventMessage.event}' was rejected in beforeSend function`)
+          return null
+        }
+        if (!result.properties || Object.keys(result.properties).length === 0) {
+          const message = `Event '${result.event}' has no properties after beforeSend function, this is likely an error.`
+          this._logger.warn(message)
+        }
+      } catch (error) {
+        this._logger.error(`Error in before_send function for event '${eventMessage.event}':`, error)
         return null
-      }
-      if (!result.properties || Object.keys(result.properties).length === 0) {
-        const message = `Event '${result.event}' has no properties after beforeSend function, this is likely an error.`
-        this._logger.warn(message)
       }
     }
 


### PR DESCRIPTION
## Problem

When a `beforeSend` or `before_send` hook throws, the browser, core, Node, and Convex clients could continue with the previous event value or rely on an outer rejected-promise handler. This could send an event that the hook was expected to inspect or redact, or log only a bare stack trace.

## Changes

- Catch errors from each before-send hook and log them through the SDK logger.
- Stop the remaining hook chain and drop the event when a hook throws.
- Keep passing each successful hook's returned event to the next hook.
- Add regression tests that verify thrown hooks do not enqueue, schedule, or send events.
- Add direct release notes for Node, React Native, Next, and Nuxt because they expose or route through the affected clients.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [x] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

`@posthog/core` also receives a patch release and is not listed in the checklist above.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The Pi coding agent used the PR and autoreview skills. The implementation follows the shared fail-closed contract: a thrown hook is contained and logged, later hooks do not run, and the event is not queued or sent. Focused tests and production builds were run for Core, Browser, Convex, and Node. Reviewer feedback prompted the Node coverage and expanded release notes. The final isolated autoreview found no actionable issues.
