### PR TITLE
fix(error-tracking): skip frames for onerror reports with no position

### DIFF
--- a/.changeset/skip-locationless-onerror-frames.md
+++ b/.changeset/skip-locationless-onerror-frames.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+---
+
+Stop building a stack frame for a `window.onerror` report that carries no code position, such as the `ResizeObserver` loop warning. The frame named the document URL rather than a script, so no source map could resolve it. These exceptions now arrive with no stack trace.

--- a/packages/core/src/error-tracking/coercers/error-event-coercer.spec.ts
+++ b/packages/core/src/error-tracking/coercers/error-event-coercer.spec.ts
@@ -91,7 +91,8 @@ describe('ErrorEventCoercer', () => {
   it.each([
     { name: 'a zeroed position', lineno: 0, colno: 0 },
     { name: 'no position at all', lineno: undefined, colno: undefined },
-  ])('reports no stack trace when the browser sends $name', ({ lineno, colno }) => {
+    { name: 'a column but no line', lineno: 0, colno: 13 },
+  ])('reports no stack trace for $name', ({ lineno, colno }) => {
     const exception = buildException(
       new FakeErrorEvent({
         message: 'ResizeObserver loop completed with undelivered notifications.',

--- a/packages/core/src/error-tracking/coercers/error-event-coercer.spec.ts
+++ b/packages/core/src/error-tracking/coercers/error-event-coercer.spec.ts
@@ -88,6 +88,38 @@ describe('ErrorEventCoercer', () => {
     })
   })
 
+  it.each([
+    { name: 'a zeroed position', lineno: 0, colno: 0 },
+    { name: 'no position at all', lineno: undefined, colno: undefined },
+  ])('reports no stack trace when the browser sends $name', ({ lineno, colno }) => {
+    const exception = buildException(
+      new FakeErrorEvent({
+        message: 'ResizeObserver loop completed with undelivered notifications.',
+        filename: 'https://example.com/dashboard/1',
+        lineno,
+        colno,
+      })
+    )
+
+    expect(exception.stacktrace).toBeUndefined()
+    expect(exception).toMatchObject({ value: 'ResizeObserver loop completed with undelivered notifications.' })
+  })
+
+  it('keeps a frame when only the column is zero', () => {
+    const exception = buildException(
+      new FakeErrorEvent({
+        message: 'Uncaught TypeError: x is not a function',
+        filename: 'https://example.com/app.js',
+        lineno: 42,
+        colno: 0,
+      })
+    )
+
+    expect(exception.stacktrace?.frames).toEqual([
+      expect.objectContaining({ filename: 'https://example.com/app.js', lineno: 42, colno: 0 }),
+    ])
+  })
+
   it('does not parse frame-shaped lines from a multiline message', () => {
     const exception = buildException(
       new FakeErrorEvent({

--- a/packages/core/src/error-tracking/coercers/error-event-coercer.ts
+++ b/packages/core/src/error-tracking/coercers/error-event-coercer.ts
@@ -51,11 +51,11 @@ export class ErrorEventCoercer implements ErrorTrackingCoercer<ErrorEventLike> {
     if (!isString(location.filename) || location.filename.length === 0) {
       return undefined
     }
-    // Stack lines are 1-indexed, so a fully zeroed position means the browser reported none. It
-    // pairs that with the document URL as `filename`, and a frame built from the two names a page
-    // rather than a script, which no source map can resolve. Leaving the exception frameless says
-    // the same thing without inviting a lookup that cannot succeed.
-    if (lineno === 0 && colno === 0) {
+    // Stack lines are 1-indexed, so a zero line means the report carries no code position. The
+    // browser pairs that with the document URL as `filename`, and a frame built from the two names
+    // a page rather than a script, which no source map can resolve. Leaving the exception frameless
+    // says the same thing without inviting a lookup that cannot succeed.
+    if (lineno === 0) {
       return undefined
     }
     // The message stays in `value`, which prevents multiline messages from being parsed as extra frames.

--- a/packages/core/src/error-tracking/coercers/error-event-coercer.ts
+++ b/packages/core/src/error-tracking/coercers/error-event-coercer.ts
@@ -46,12 +46,19 @@ export class ErrorEventCoercer implements ErrorTrackingCoercer<ErrorEventLike> {
 
   private _buildLocationStack(err: ErrorEventLike): string | undefined {
     const location = err as ErrorEventLike & ErrorEventLocation
-    if (isString(location.filename) && location.filename.length > 0) {
-      const lineno = location.lineno ?? 0
-      const colno = location.colno ?? 0
-      // The message stays in `value`, which prevents multiline messages from being parsed as extra frames.
-      return `Error\n    at ${location.filename}:${lineno}:${colno}`
+    const lineno = location.lineno ?? 0
+    const colno = location.colno ?? 0
+    if (!isString(location.filename) || location.filename.length === 0) {
+      return undefined
     }
-    return undefined
+    // Stack lines are 1-indexed, so a fully zeroed position means the browser reported none. It
+    // pairs that with the document URL as `filename`, and a frame built from the two names a page
+    // rather than a script, which no source map can resolve. Leaving the exception frameless says
+    // the same thing without inviting a lookup that cannot succeed.
+    if (lineno === 0 && colno === 0) {
+      return undefined
+    }
+    // The message stays in `value`, which prevents multiline messages from being parsed as extra frames.
+    return `Error\n    at ${location.filename}:${lineno}:${colno}`
   }
 }


### PR DESCRIPTION
## Problem

An error the browser reports through `window.onerror` without a code position produces a stack frame that names the page, not a script. Nothing can resolve it, and the reader sees a URL where a filename belongs.

The `ResizeObserver` loop warning is the common source. Chrome reports it with the document URL as `source` and zero for both `lineno` and `colno`.

- `resolveOnErrorInput` rebuilds an `ErrorEvent` from the positional arguments whenever `source` is a non-empty string. It does not look at the position.
- `ErrorEventCoercer._buildLocationStack` then guards on `filename` only, and defaults a missing `lineno` and `colno` to 0.
- The result is a frame at `<document URL>:0:0`. Stack lines are 1-indexed, so 0 is not a position any source map can be queried at, and the document is not a script that has one.

Downstream this is worse than an empty stack. Symbolication treats the URL as a script and fetches it, which for a single-page app returns the HTML fallback with a 200, and that gets stored as a failed lookup against a reference that can never resolve.

## Changes

- An `ErrorEvent` with a zero line number now produces no stack trace, rather than a frame naming the document.
- A real line with a zero column still produces a frame, so only a missing line counts as no position.

`_buildLocationStack` already returned `undefined` for a missing filename, and `coerce` falls back to `exceptionLike.stack` for that case. The `onerror` hint passes no `syntheticException`, so the fallback is also undefined and the exception simply arrives frameless. No SDK-internal frames are exposed by this path.

The function is unchanged when the browser does supply a position, which is the case #4235 added it for.

## How did you test this code?

Added two tests to `error-event-coercer.spec.ts`:

- A parameterized case covering a zeroed position, an absent one, and a column with no line. It fails if the guard is dropped, or narrowed back to a fully zeroed pair. Either puts the document URL in the filename slot of an unresolvable frame.
- A case pinning a real line with a zero column as still frame-worthy. It fails if the guard widens to any zero, which would discard genuine frames.

Ran the `@posthog/core` error-tracking suite and the browser `exception-autocapture` and `posthog-exceptions` suites locally. Lint is clean on the changed files.

Not checked: no browser or E2E run, and nothing was exercised against a real page.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, with the `/writing-pr-descriptions` skill.

Review feedback widened the guard. It first rejected only a fully zeroed position, and now rejects any zero line.

This came out of an investigation in the main repo into unresolved JavaScript frames, where these fabricated frames were the largest single cause. PostHog/posthog#86313 handles the same shape from the other side, for events already ingested and for SDKs that still send them. This change stops new ones being produced.

The alternative considered was guarding in `resolveOnErrorInput` instead. `_buildLocationStack` is the better place, because `ErrorEventCoercer` also handles real `ErrorEvent` objects a page dispatches itself, not only the ones rebuilt from `onerror` arguments.

Public artifact: no customer conversation, ticket, or log fed this PR. The test fixtures are invented and use a reserved domain.

