### PR TITLE
fix(logs): encode OTLP attributes in the canonical spec shapes

### DIFF
--- a/.changeset/otlp-int64-string.md
+++ b/.changeset/otlp-int64-string.md
@@ -1,0 +1,11 @@
+---
+'posthog-js': patch
+'posthog-react-native': patch
+'posthog-node': patch
+'@posthog/core': patch
+'@posthog/types': patch
+---
+
+Fix logs and metrics being silently dropped when an attribute holds a very large integer, a function, a symbol, a sparse array, or a truncated emoji.
+Cap log and metric attributes at 20 levels of nesting, 1,000 entries per object and 10,000 values in total, marking anything beyond as `[Truncated]`.
+Type `OtlpAnyValue.intValue` as `string | number` — code reading that field must handle both.

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -119,7 +119,7 @@ export class PostHogLogs {
     // Build before deferring so attributes reflect state at capture time, not
     // at drain time (identity/session changes between capture and drain must
     // not corrupt recorded attributes).
-    const record = buildOtlpLogRecord(filtered, this._getContext())
+    const record = buildOtlpLogRecord(filtered, this._getContext(), this._logger)
     const entry: BufferedLogEntry = { record }
 
     this._onReady(() => this._enqueue(entry))

--- a/packages/core/src/logs/logs-utils.spec.ts
+++ b/packages/core/src/logs/logs-utils.spec.ts
@@ -1,4 +1,4 @@
-import type { CaptureLogOptions, LogSeverityLevel } from '@posthog/types'
+import type { CaptureLogOptions, LogAttributeValue, LogSeverityLevel } from '@posthog/types'
 import type { LogSdkContext } from './types'
 import {
   buildOtlpLogRecord,
@@ -69,10 +69,36 @@ describe('logs-utils', () => {
       expect(toOtlpAnyValue('hello')).toEqual({ stringValue: 'hello' })
     })
 
-    it('converts integers', () => {
-      expect(toOtlpAnyValue(42)).toEqual({ intValue: 42 })
-      expect(toOtlpAnyValue(0)).toEqual({ intValue: 0 })
-      expect(toOtlpAnyValue(-7)).toEqual({ intValue: -7 })
+    it('converts integers to decimal strings', () => {
+      expect(toOtlpAnyValue(42)).toEqual({ intValue: '42' })
+      expect(toOtlpAnyValue(0)).toEqual({ intValue: '0' })
+      expect(toOtlpAnyValue(-7)).toEqual({ intValue: '-7' })
+    })
+
+    // Spec: outside int64 it is a stringValue, never an intValue.
+    it('converts integers outside int64 to stringValue', () => {
+      expect(toOtlpAnyValue(2 ** 63)).toEqual({ stringValue: '9223372036854775808' })
+      expect(toOtlpAnyValue(-(2 ** 64))).toEqual({ stringValue: '-18446744073709551616' })
+      expect(toOtlpAnyValue(1e21)).toEqual({ stringValue: '1000000000000000000000' })
+    })
+
+    it('logs a debug line when an integer falls outside int64', () => {
+      const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), critical: jest.fn() }
+      toOtlpAnyValue(2 ** 63, logger as any)
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('outside the int64 range'))
+    })
+
+    it('keeps int64 min as intValue', () => {
+      // In range, but `String` renders it 192 below int64 min, so the decimal
+      // has to come from BigInt.
+      expect(toOtlpAnyValue(-(2 ** 63))).toEqual({ intValue: '-9223372036854775808' })
+    })
+
+    it('keeps large in-range integers exact', () => {
+      expect(toOtlpAnyValue(Number.MAX_SAFE_INTEGER)).toEqual({ intValue: '9007199254740991' })
+      // The largest double below 2^63 — no double exists between the two.
+      expect(toOtlpAnyValue(9223372036854774784)).toEqual({ intValue: '9223372036854774784' })
+      expect(toOtlpAnyValue(2 ** 62)).toEqual({ intValue: '4611686018427387904' })
     })
 
     it('converts floats to doubleValue', () => {
@@ -108,15 +134,279 @@ describe('logs-utils', () => {
     it('converts mixed primitive arrays recursively', () => {
       expect(toOtlpAnyValue([1, 'x', true])).toEqual({
         arrayValue: {
-          values: [{ intValue: 1 }, { stringValue: 'x' }, { boolValue: true }],
+          values: [{ intValue: '1' }, { stringValue: 'x' }, { boolValue: true }],
         },
       })
     })
 
-    it('JSON-stringifies plain objects', () => {
+    it('converts plain objects to kvlistValue', () => {
       expect(toOtlpAnyValue({ a: 1, b: 'two' })).toEqual({
-        stringValue: '{"a":1,"b":"two"}',
+        kvlistValue: {
+          values: [
+            { key: 'a', value: { intValue: '1' } },
+            { key: 'b', value: { stringValue: 'two' } },
+          ],
+        },
       })
+    })
+
+    it('converts nested objects recursively', () => {
+      expect(toOtlpAnyValue({ outer: { inner: 1 } })).toEqual({
+        kvlistValue: {
+          values: [
+            {
+              key: 'outer',
+              value: { kvlistValue: { values: [{ key: 'inner', value: { intValue: '1' } }] } },
+            },
+          ],
+        },
+      })
+    })
+
+    it('drops null and undefined keys inside objects', () => {
+      expect(toOtlpAnyValue({ kept: 1, gone: null, alsoGone: undefined })).toEqual({
+        kvlistValue: { values: [{ key: 'kept', value: { intValue: '1' } }] },
+      })
+    })
+
+    // Not in LogAttributeValue, but reachable at runtime from untyped callers.
+    it('encodes Dates as ISO strings', () => {
+      expect(toOtlpAnyValue(new Date('2026-08-20T10:00:00.000Z') as unknown as LogAttributeValue)).toEqual({
+        stringValue: '2026-08-20T10:00:00.000Z',
+      })
+    })
+
+    it('marks circular references instead of recursing', () => {
+      const cyclic: Record<string, unknown> = { name: 'root' }
+      cyclic.self = cyclic
+      expect(toOtlpAnyValue(cyclic)).toEqual({
+        kvlistValue: {
+          values: [
+            { key: 'name', value: { stringValue: 'root' } },
+            { key: 'self', value: { stringValue: '[Circular]' } },
+          ],
+        },
+      })
+    })
+
+    // An escaping error would surface in the caller's application code.
+    it('does not throw on an object nested past the depth cap', () => {
+      let deep: Record<string, unknown> = { end: true }
+      for (let i = 0; i < 25000; i++) {
+        deep = { next: deep }
+      }
+      expect(() => toOtlpAnyValue(deep)).not.toThrow()
+    })
+
+    it('truncates at exactly 20 levels instead of recursing', () => {
+      let deep: Record<string, unknown> = { end: true }
+      for (let i = 0; i < 25; i++) {
+        deep = { next: deep }
+      }
+      const encoded = JSON.stringify(toOtlpAnyValue(deep))
+      expect(encoded).toContain('[Truncated]')
+      expect(encoded.split('"next"').length - 1).toBe(20)
+    })
+
+    it('marks a throwing getter without losing the rest of the object', () => {
+      const attrs = {
+        ok: 1,
+        get bad(): number {
+          throw new Error('getter blew up')
+        },
+      }
+      expect(() => toOtlpKeyValueList(attrs)).not.toThrow()
+      expect(toOtlpKeyValueList(attrs)).toEqual([
+        { key: 'ok', value: { intValue: '1' } },
+        { key: 'bad', value: { stringValue: '[Unserializable]' } },
+      ])
+    })
+
+    // for...in walks the prototype chain once own keys are exhausted.
+    it('ignores inherited enumerable properties', () => {
+      const inherited: Record<string, unknown> = Object.create({ fromPrototype: 'leaked' })
+      inherited.own = 1
+      expect(toOtlpAnyValue(inherited)).toEqual({
+        kvlistValue: { values: [{ key: 'own', value: { intValue: '1' } }] },
+      })
+    })
+
+    // `String(fn)` would put the function's source text on the wire.
+    it('marks function and symbol values instead of stringifying them', () => {
+      expect(toOtlpAnyValue({ handler: () => 1, retries: 2 } as unknown as LogAttributeValue)).toEqual({
+        kvlistValue: {
+          values: [
+            { key: 'handler', value: { stringValue: '[Function]' } },
+            { key: 'retries', value: { intValue: '2' } },
+          ],
+        },
+      })
+      expect(toOtlpAnyValue({ sym: Symbol('x') } as unknown as LogAttributeValue)).toEqual({
+        kvlistValue: { values: [{ key: 'sym', value: { stringValue: 'Symbol(x)' } }] },
+      })
+    })
+
+    // dayjs, Decimal, ORM documents.
+    it('honours toJSON', () => {
+      const wrapped = { toJSON: () => ({ amount: 5 }) }
+      expect(toOtlpAnyValue(wrapped as unknown as LogAttributeValue)).toEqual({
+        kvlistValue: { values: [{ key: 'amount', value: { intValue: '5' } }] },
+      })
+    })
+
+    it('falls back to the plain walk when toJSON throws', () => {
+      const wrapped = {
+        kept: 1,
+        toJSON: () => {
+          throw new Error('nope')
+        },
+      }
+      expect(toOtlpAnyValue(wrapped as unknown as LogAttributeValue)).toEqual({
+        kvlistValue: {
+          values: [
+            { key: 'kept', value: { intValue: '1' } },
+            { key: 'toJSON', value: { stringValue: '[Function]' } },
+          ],
+        },
+      })
+    })
+
+    // A toJSON returning its own object is a cycle like any other.
+    it('marks a cycle that runs through toJSON', () => {
+      const cyclic: Record<string, unknown> = {}
+      cyclic.toJSON = () => ({ inner: cyclic })
+      expect(toOtlpAnyValue(cyclic)).toEqual({
+        kvlistValue: { values: [{ key: 'inner', value: { stringValue: '[Circular]' } }] },
+      })
+    })
+
+    // Both `null` and `{}` here are rejected for the whole request; iOS and
+    // Android drop them too.
+    it('drops holes and nullish elements from arrays', () => {
+      // eslint-disable-next-line no-sparse-arrays
+      expect(toOtlpAnyValue([1, , 3])).toEqual({
+        arrayValue: { values: [{ intValue: '1' }, { intValue: '3' }] },
+      })
+      expect(toOtlpAnyValue([1, null, undefined, 3])).toEqual({
+        arrayValue: { values: [{ intValue: '1' }, { intValue: '3' }] },
+      })
+    })
+
+    it('stops encoding array items once the node budget is spent', () => {
+      const row: Record<string, number> = {}
+      for (let i = 0; i < 20; i++) {
+        row[`k${i}`] = i
+      }
+      const wide = Array.from({ length: 1000 }, () => ({ ...row }))
+      const values = toOtlpAnyValue(wide).arrayValue!.values
+      expect(values[values.length - 1]).toEqual({ stringValue: '[Truncated]' })
+      // One marker, not one per unencodable item.
+      expect(values.filter((v) => v.stringValue === '[Truncated]')).toHaveLength(1)
+    })
+
+    it('caps a shared object graph instead of expanding it', () => {
+      let graph: Record<string, unknown> = { leaf: true }
+      for (let i = 0; i < 20; i++) {
+        graph = { a: graph, b: graph }
+      }
+      const encoded = JSON.stringify(toOtlpAnyValue(graph))
+      expect(encoded).toContain('[Truncated]')
+      expect(encoded.length).toBeLessThan(1_000_000)
+    })
+
+    it('caps a very wide object without inventing an attribute key', () => {
+      const wide: Record<string, number> = {}
+      for (let i = 0; i < 5000; i++) {
+        wide[`k${i}`] = i
+      }
+      const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), critical: jest.fn() }
+      const values = toOtlpAnyValue(wide, logger as any).kvlistValue!.values
+      expect(values).toHaveLength(1000)
+      expect(values.every((v) => v.key.startsWith('k'))).toBe(true)
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('truncated'))
+    })
+
+    // Why the encoder does not delegate to toJsonSafeValue: that maps them to null.
+    it('keeps non-finite floats as strings inside nested objects', () => {
+      expect(toOtlpAnyValue({ nested: { ratio: NaN } })).toEqual({
+        kvlistValue: {
+          values: [
+            {
+              key: 'nested',
+              value: { kvlistValue: { values: [{ key: 'ratio', value: { stringValue: 'NaN' } }] } },
+            },
+          ],
+        },
+      })
+    })
+
+    // A lone surrogate survives JSON.stringify as a \uD800 escape, which the
+    // server rejects for the whole request.
+    it('replaces unpaired surrogates in values and keys', () => {
+      expect(toOtlpAnyValue('ok\ud83d')).toEqual({ stringValue: 'ok\ufffd' })
+      expect(toOtlpAnyValue({ nested: 'ok\ud83d' })).toEqual({
+        kvlistValue: { values: [{ key: 'nested', value: { stringValue: 'ok\ufffd' } }] },
+      })
+      expect(toOtlpKeyValueList({ 'key\ud83d': 1 })).toEqual([{ key: 'key\ufffd', value: { intValue: '1' } }])
+    })
+
+    it('encodes empty containers with an explicit values array', () => {
+      expect(toOtlpAnyValue({})).toEqual({ kvlistValue: { values: [] } })
+      expect(toOtlpAnyValue([])).toEqual({ arrayValue: { values: [] } })
+    })
+
+    it('keeps a Date whose toISOString is overridden out of the wire format', () => {
+      const broken = new Date('2026-08-20T10:00:00.000Z')
+
+      ;(broken as any).toISOString = () => ({})
+      expect(typeof toOtlpAnyValue(broken as unknown as LogAttributeValue).stringValue).toBe('string')
+    })
+
+    it('encodes sibling references to one object twice, not as circular', () => {
+      const shared = { id: 1 }
+      expect(toOtlpAnyValue({ a: shared, b: shared })).toEqual({
+        kvlistValue: {
+          values: [
+            { key: 'a', value: { kvlistValue: { values: [{ key: 'id', value: { intValue: '1' } }] } } },
+            { key: 'b', value: { kvlistValue: { values: [{ key: 'id', value: { intValue: '1' } }] } } },
+          ],
+        },
+      })
+    })
+  })
+
+  describe('buildOtlpLogRecord attribute reads', () => {
+    // Reading `options.attributes` happens before the encoder's per-key guard.
+    it('marks an attribute whose getter throws without dropping the record', () => {
+      const attributes = {
+        ok: 1,
+        get bad(): number {
+          throw new Error('disposed store')
+        },
+      }
+      const record = buildOtlpLogRecord({ body: 'x', attributes }, {})
+      expect(record.attributes).toContainEqual({ key: 'ok', value: { intValue: '1' } })
+      expect(record.attributes).toContainEqual({ key: 'bad', value: { stringValue: '[Unserializable]' } })
+    })
+
+    // Plain assignment hits the prototype setter and the attribute vanishes.
+    it('keeps an attribute literally named __proto__', () => {
+      const attributes = JSON.parse('{"__proto__": {"a": 1}, "normal": "n"}')
+      const record = buildOtlpLogRecord({ body: 'x', attributes }, {})
+      expect(record.attributes.map((a) => a.key)).toContain('__proto__')
+    })
+
+    it('coerces a non-string body', () => {
+      // A non-string stringValue is refused for the whole request.
+      const record = buildOtlpLogRecord({ body: 12345 as unknown as string }, {})
+      expect(record.body).toEqual({ stringValue: '12345' })
+    })
+
+    it('keeps the record when the attributes object itself cannot be read', () => {
+      const revocable = Proxy.revocable({ a: 1 }, {})
+      revocable.revoke()
+
+      expect(buildOtlpLogRecord({ body: 'x', attributes: revocable.proxy }, {}).body).toEqual({ stringValue: 'x' })
     })
   })
 
@@ -130,7 +420,7 @@ describe('logs-utils', () => {
         })
       ).toEqual([
         { key: 'name', value: { stringValue: 'test' } },
-        { key: 'count', value: { intValue: 5 } },
+        { key: 'count', value: { intValue: '5' } },
         { key: 'active', value: { boolValue: true } },
       ])
     })

--- a/packages/core/src/logs/logs-utils.spec.ts
+++ b/packages/core/src/logs/logs-utils.spec.ts
@@ -402,6 +402,21 @@ describe('logs-utils', () => {
       expect(record.body).toEqual({ stringValue: '12345' })
     })
 
+    // `String()` throws on these, and buildOtlpLogRecord is called straight from
+    // captureLog — beforeSend can also hand back any body.
+    it('marks a body that cannot be coerced to a string', () => {
+      const throwing = {
+        toString() {
+          throw new Error('boom')
+        },
+      } as unknown as string
+      expect(() => buildOtlpLogRecord({ body: throwing }, {})).not.toThrow()
+      expect(buildOtlpLogRecord({ body: throwing }, {}).body).toEqual({ stringValue: '[Unserializable]' })
+      expect(buildOtlpLogRecord({ body: Object.create(null) }, {}).body).toEqual({
+        stringValue: '[Unserializable]',
+      })
+    })
+
     it('keeps the record when the attributes object itself cannot be read', () => {
       const revocable = Proxy.revocable({ a: 1 }, {})
       revocable.revoke()

--- a/packages/core/src/logs/logs-utils.ts
+++ b/packages/core/src/logs/logs-utils.ts
@@ -12,7 +12,16 @@ import type {
 import type { Logger } from '../types'
 import type { LogSdkContext, ResolvedPostHogLogsConfig } from './types'
 import { isArray, isBoolean, isNull, isNullish, isUndefined } from '../utils'
-import { sanitizeString } from '../utils/json-utils'
+import {
+  CIRCULAR_VALUE,
+  FUNCTION_VALUE,
+  MAX_JSON_SAFE_VALUE_DEPTH,
+  MAX_JSON_SAFE_VALUE_ITEMS,
+  MAX_JSON_SAFE_VALUE_NODES,
+  sanitizeString,
+  TRUNCATED_VALUE,
+  UNSERIALIZABLE_VALUE,
+} from '../utils/json-utils'
 
 // ============================================================================
 // Severity mapping
@@ -44,17 +53,6 @@ export function getOtlpSeverityNumber(level: LogSeverityLevel): number {
 // 2^63 — one past int64 max.
 const INT64_RANGE_LIMIT = 9223372036854775808
 
-// Matches `toJsonSafeValue`: depth bounds stack use, the counts stop a shared
-// object graph expanding into millions of key-values on the way to the wire.
-const MAX_DEPTH = 20
-const MAX_ITEMS = 1_000
-const MAX_NODES = 10_000
-
-const CIRCULAR_MARKER = '[Circular]'
-const TRUNCATED_MARKER = '[Truncated]'
-const UNSERIALIZABLE_MARKER = '[Unserializable]'
-const FUNCTION_MARKER = '[Function]'
-
 const propertyIsEnumerable = Object.prototype.propertyIsEnumerable
 
 interface EncodeState {
@@ -64,7 +62,7 @@ interface EncodeState {
 }
 
 function newState(): EncodeState {
-  return { ancestors: new WeakSet(), remainingNodes: MAX_NODES }
+  return { ancestors: new WeakSet(), remainingNodes: MAX_JSON_SAFE_VALUE_NODES }
 }
 
 export function toOtlpAnyValue(value: LogAttributeValue, logger?: Logger): OtlpAnyValue {
@@ -73,7 +71,7 @@ export function toOtlpAnyValue(value: LogAttributeValue, logger?: Logger): OtlpA
   } catch {
     // Runs inside `captureLog` and the metrics flush: an error escaping here
     // surfaces in the caller's own code.
-    return { stringValue: UNSERIALIZABLE_MARKER }
+    return { stringValue: UNSERIALIZABLE_VALUE }
   }
 }
 
@@ -92,7 +90,7 @@ function encodeAnyValue(
   depth: number
 ): OtlpAnyValue {
   if (state.remainingNodes <= 0) {
-    return { stringValue: TRUNCATED_MARKER }
+    return { stringValue: TRUNCATED_VALUE }
   }
   state.remainingNodes--
 
@@ -132,17 +130,17 @@ function encodeAnyValue(
   }
   // `String(value)` would put a function's source text on the wire.
   if (typeof value === 'function') {
-    return { stringValue: FUNCTION_MARKER }
+    return { stringValue: FUNCTION_VALUE }
   }
   if (typeof value === 'symbol') {
     return { stringValue: String(value) }
   }
   if (typeof value === 'object' && value !== null) {
     if (state.ancestors.has(value)) {
-      return { stringValue: CIRCULAR_MARKER }
+      return { stringValue: CIRCULAR_VALUE }
     }
-    if (depth >= MAX_DEPTH) {
-      return { stringValue: TRUNCATED_MARKER }
+    if (depth >= MAX_JSON_SAFE_VALUE_DEPTH) {
+      return { stringValue: TRUNCATED_VALUE }
     }
     if (value instanceof Date) {
       const time = value.getTime()
@@ -188,7 +186,7 @@ function encodeArrayValues(
   depth: number
 ): OtlpAnyValue[] {
   const result: OtlpAnyValue[] = []
-  const itemCount = Math.min(values.length, MAX_ITEMS)
+  const itemCount = Math.min(values.length, MAX_JSON_SAFE_VALUE_ITEMS)
   let index = 0
   for (; index < itemCount && state.remainingNodes > 0; index++) {
     try {
@@ -200,11 +198,11 @@ function encodeArrayValues(
       }
       result.push(encodeAnyValue(element as LogAttributeValue, logger, state, depth))
     } catch {
-      result.push({ stringValue: UNSERIALIZABLE_MARKER })
+      result.push({ stringValue: UNSERIALIZABLE_VALUE })
     }
   }
   if (values.length > index) {
-    result.push({ stringValue: TRUNCATED_MARKER })
+    result.push({ stringValue: TRUNCATED_VALUE })
   }
   return result
 }
@@ -222,7 +220,7 @@ function encodeKeyValueList(
     if (!propertyIsEnumerable.call(attrs, key)) {
       continue
     }
-    if (result.length >= MAX_ITEMS || state.remainingNodes <= 0) {
+    if (result.length >= MAX_JSON_SAFE_VALUE_ITEMS || state.remainingNodes <= 0) {
       // Reported rather than written into the attributes: a synthetic key would
       // land in the user's own namespace and could collide with a real one.
       logger?.debug('Attributes truncated: the value exceeds the OTLP encoder budget')
@@ -236,7 +234,7 @@ function encodeKeyValueList(
       result.push({ key: sanitizeString(key), value: encodeAnyValue(value, logger, state, depth) })
     } catch {
       // A getter that throws costs its own key, not the whole record.
-      result.push({ key: sanitizeString(key), value: { stringValue: UNSERIALIZABLE_MARKER } })
+      result.push({ key: sanitizeString(key), value: { stringValue: UNSERIALIZABLE_VALUE } })
     }
   }
   return result
@@ -267,6 +265,17 @@ function timestampToUnixNano(): string {
  *
  * User-provided `options.attributes` always wins on conflicts.
  */
+// `body` is only typed as a string. An untyped caller — or a `beforeSend` that
+// rewrites it — can pass anything, and `String()` throws on a value whose
+// `toString` does, or on a null-prototype object.
+function encodeBody(body: string): string {
+  try {
+    return sanitizeString(String(body))
+  } catch {
+    return UNSERIALIZABLE_VALUE
+  }
+}
+
 export function buildOtlpLogRecord(
   options: CaptureLogOptions,
   sdkContext: LogSdkContext,
@@ -322,7 +331,7 @@ export function buildOtlpLogRecord(
       try {
         value = userAttributes[key]
       } catch {
-        value = UNSERIALIZABLE_MARKER
+        value = UNSERIALIZABLE_VALUE
       }
       // defineProperty, not assignment: `attributes['__proto__'] = v` hits the
       // prototype setter and the attribute vanishes.
@@ -335,9 +344,7 @@ export function buildOtlpLogRecord(
     observedTimeUnixNano: now,
     severityNumber,
     severityText,
-    // `body` is only typed as a string: an untyped caller passing a number
-    // emits a non-string stringValue, which the server refuses.
-    body: { stringValue: sanitizeString(String(options.body)) },
+    body: { stringValue: encodeBody(options.body) },
     attributes: toOtlpKeyValueList(mergedAttributes, logger),
   }
 

--- a/packages/core/src/logs/logs-utils.ts
+++ b/packages/core/src/logs/logs-utils.ts
@@ -9,8 +9,10 @@ import type {
   OtlpSeverityEntry,
   OtlpSeverityText,
 } from '@posthog/types'
+import type { Logger } from '../types'
 import type { LogSdkContext, ResolvedPostHogLogsConfig } from './types'
 import { isArray, isBoolean, isNull, isNullish, isUndefined } from '../utils'
+import { sanitizeString } from '../utils/json-utils'
 
 // ============================================================================
 // Severity mapping
@@ -39,49 +41,203 @@ export function getOtlpSeverityNumber(level: LogSeverityLevel): number {
 // OTLP AnyValue conversion
 // ============================================================================
 
-export function toOtlpAnyValue(value: LogAttributeValue): OtlpAnyValue {
+// 2^63 — one past int64 max.
+const INT64_RANGE_LIMIT = 9223372036854775808
+
+// Matches `toJsonSafeValue`: depth bounds stack use, the counts stop a shared
+// object graph expanding into millions of key-values on the way to the wire.
+const MAX_DEPTH = 20
+const MAX_ITEMS = 1_000
+const MAX_NODES = 10_000
+
+const CIRCULAR_MARKER = '[Circular]'
+const TRUNCATED_MARKER = '[Truncated]'
+const UNSERIALIZABLE_MARKER = '[Unserializable]'
+const FUNCTION_MARKER = '[Function]'
+
+const propertyIsEnumerable = Object.prototype.propertyIsEnumerable
+
+interface EncodeState {
+  /** Containers on the current path, so a back-reference becomes a marker. */
+  ancestors: WeakSet<object>
+  remainingNodes: number
+}
+
+function newState(): EncodeState {
+  return { ancestors: new WeakSet(), remainingNodes: MAX_NODES }
+}
+
+export function toOtlpAnyValue(value: LogAttributeValue, logger?: Logger): OtlpAnyValue {
+  try {
+    return encodeAnyValue(value, logger, newState(), 0)
+  } catch {
+    // Runs inside `captureLog` and the metrics flush: an error escaping here
+    // surfaces in the caller's own code.
+    return { stringValue: UNSERIALIZABLE_MARKER }
+  }
+}
+
+export function toOtlpKeyValueList(attrs: Record<string, LogAttributeValue>, logger?: Logger): OtlpKeyValue[] {
+  try {
+    return encodeKeyValueList(attrs, logger, newState(), 0)
+  } catch {
+    return []
+  }
+}
+
+function encodeAnyValue(
+  value: LogAttributeValue,
+  logger: Logger | undefined,
+  state: EncodeState,
+  depth: number
+): OtlpAnyValue {
+  if (state.remainingNodes <= 0) {
+    return { stringValue: TRUNCATED_MARKER }
+  }
+  state.remainingNodes--
+
   if (isBoolean(value)) {
     return { boolValue: value }
   }
-  // NOTE: typeof check (not core's isNumber) so NaN is included. core's
-  // isNumber explicitly excludes NaN via the `x === x` guard, which would
-  // route NaN through the JSON.stringify branch below — JSON has no
-  // representation for non-finite floats and JSON.stringify turns them into
-  // `null`, losing the value server-side. proto3 JSON mapping (which OTLP/HTTP
-  // rides) requires the literal strings; we encode them as stringValue to keep
-  // the human-readable signal regardless of which downstream parser sees them.
+  // typeof, not core's isNumber, which excludes NaN — proto3 JSON distinguishes
+  // a non-finite float from an ordinary string.
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) {
       return { stringValue: String(value) }
     }
     if (Number.isInteger(value)) {
-      return { intValue: value }
+      if (Number.isSafeInteger(value)) {
+        return { intValue: String(value) }
+      }
+      // Past MAX_SAFE_INTEGER only BigInt gives the double's exact decimal:
+      // `String(-(2**63))` lands 192 below int64 min, outside the field it is
+      // about to be parsed into. Without BigInt the value rides as a string,
+      // which is never range-checked.
+      if (typeof BigInt === 'undefined') {
+        return { stringValue: String(value) }
+      }
+      const decimal = BigInt(value).toString()
+      if (value >= INT64_RANGE_LIMIT || value < -INT64_RANGE_LIMIT) {
+        // An out-of-range intValue 400s the whole logs request; on the metrics
+        // path it is swallowed server-side and the metric just disappears.
+        logger?.debug(`Attribute ${decimal} is outside the int64 range; encoding it as a string`)
+        return { stringValue: decimal }
+      }
+      return { intValue: decimal }
     }
     return { doubleValue: value }
   }
   if (typeof value === 'string') {
-    return { stringValue: value }
+    return { stringValue: sanitizeString(value) }
   }
-  if (isArray(value)) {
-    return { arrayValue: { values: value.map((v) => toOtlpAnyValue(v as LogAttributeValue)) } }
+  // `String(value)` would put a function's source text on the wire.
+  if (typeof value === 'function') {
+    return { stringValue: FUNCTION_MARKER }
   }
-  // Objects fall back to JSON. OTLP supports kvlistValue but the encoder
-  // stays flat for simplicity.
-  try {
-    return { stringValue: JSON.stringify(value) }
-  } catch {
+  if (typeof value === 'symbol') {
     return { stringValue: String(value) }
   }
+  if (typeof value === 'object' && value !== null) {
+    if (state.ancestors.has(value)) {
+      return { stringValue: CIRCULAR_MARKER }
+    }
+    if (depth >= MAX_DEPTH) {
+      return { stringValue: TRUNCATED_MARKER }
+    }
+    if (value instanceof Date) {
+      const time = value.getTime()
+      const iso = Number.isFinite(time) ? value.toISOString() : String(value)
+      // An overridden toISOString can return a non-string, which the server
+      // refuses for the whole request.
+      return { stringValue: typeof iso === 'string' ? sanitizeString(iso) : String(iso) }
+    }
+    // Registered before the toJSON probe: a toJSON returning a structure that
+    // references its own object is a cycle like any other.
+    state.ancestors.add(value)
+    try {
+      // The representation a value defines for itself — dayjs, Decimal, an ORM
+      // document, and a cross-realm Date that fails the `instanceof` above.
+      try {
+        const toJSON = (value as { toJSON?: unknown }).toJSON
+        if (typeof toJSON === 'function') {
+          return encodeAnyValue(toJSON.call(value) as LogAttributeValue, logger, state, depth + 1)
+        }
+      } catch {
+        // A throwing toJSON falls through to the plain walk.
+      }
+      if (isArray(value)) {
+        return { arrayValue: { values: encodeArrayValues(value, logger, state, depth + 1) } }
+      }
+      return {
+        kvlistValue: {
+          values: encodeKeyValueList(value as Record<string, LogAttributeValue>, logger, state, depth + 1),
+        },
+      }
+    } finally {
+      // Siblings that reference the same object are duplication, not a cycle.
+      state.ancestors.delete(value)
+    }
+  }
+  return { stringValue: sanitizeString(String(value)) }
 }
 
-export function toOtlpKeyValueList(attrs: Record<string, LogAttributeValue>): OtlpKeyValue[] {
+function encodeArrayValues(
+  values: unknown[],
+  logger: Logger | undefined,
+  state: EncodeState,
+  depth: number
+): OtlpAnyValue[] {
+  const result: OtlpAnyValue[] = []
+  const itemCount = Math.min(values.length, MAX_ITEMS)
+  let index = 0
+  for (; index < itemCount && state.remainingNodes > 0; index++) {
+    try {
+      const element = index in values ? values[index] : undefined
+      // Dropped, as iOS and Android do: proto3 JSON has no null AnyValue, and
+      // both `null` and `{}` here are rejected for the whole request.
+      if (isNullish(element)) {
+        continue
+      }
+      result.push(encodeAnyValue(element as LogAttributeValue, logger, state, depth))
+    } catch {
+      result.push({ stringValue: UNSERIALIZABLE_MARKER })
+    }
+  }
+  if (values.length > index) {
+    result.push({ stringValue: TRUNCATED_MARKER })
+  }
+  return result
+}
+
+function encodeKeyValueList(
+  attrs: Record<string, LogAttributeValue>,
+  logger: Logger | undefined,
+  state: EncodeState,
+  depth: number
+): OtlpKeyValue[] {
   const result: OtlpKeyValue[] = []
   for (const key in attrs) {
-    const value = attrs[key]
-    if (isNull(value) || isUndefined(value)) {
+    // for...in walks the prototype chain once own keys are exhausted. Skipped
+    // rather than broken out of: a proxy can yield keys in any order.
+    if (!propertyIsEnumerable.call(attrs, key)) {
       continue
     }
-    result.push({ key, value: toOtlpAnyValue(value) })
+    if (result.length >= MAX_ITEMS || state.remainingNodes <= 0) {
+      // Reported rather than written into the attributes: a synthetic key would
+      // land in the user's own namespace and could collide with a real one.
+      logger?.debug('Attributes truncated: the value exceeds the OTLP encoder budget')
+      break
+    }
+    try {
+      const value = attrs[key]
+      if (isNull(value) || isUndefined(value)) {
+        continue
+      }
+      result.push({ key: sanitizeString(key), value: encodeAnyValue(value, logger, state, depth) })
+    } catch {
+      // A getter that throws costs its own key, not the whole record.
+      result.push({ key: sanitizeString(key), value: { stringValue: UNSERIALIZABLE_MARKER } })
+    }
   }
   return result
 }
@@ -111,7 +267,11 @@ function timestampToUnixNano(): string {
  *
  * User-provided `options.attributes` always wins on conflicts.
  */
-export function buildOtlpLogRecord(options: CaptureLogOptions, sdkContext: LogSdkContext): OtlpLogRecord {
+export function buildOtlpLogRecord(
+  options: CaptureLogOptions,
+  sdkContext: LogSdkContext,
+  logger?: Logger
+): OtlpLogRecord {
   const level: LogSeverityLevel = options.level || 'info'
   const { text: severityText, number: severityNumber } = OTLP_SEVERITY_MAP[level] || DEFAULT_OTLP_SEVERITY
   const now = timestampToUnixNano()
@@ -146,9 +306,28 @@ export function buildOtlpLogRecord(options: CaptureLogOptions, sdkContext: LogSd
     autoAttributes.feature_flags = sdkContext.activeFeatureFlags
   }
 
-  const mergedAttributes = {
-    ...autoAttributes,
-    ...(options.attributes || {}),
+  // Read key by key rather than spreading: a getter over a disposed store or a
+  // revoked proxy throws on the read itself, before the encoder's guards see it.
+  const mergedAttributes: Record<string, LogAttributeValue> = { ...autoAttributes }
+  const userAttributes = options.attributes
+  if (userAttributes) {
+    let keys: string[] = []
+    try {
+      keys = Object.keys(userAttributes)
+    } catch {
+      keys = []
+    }
+    for (const key of keys) {
+      let value: LogAttributeValue
+      try {
+        value = userAttributes[key]
+      } catch {
+        value = UNSERIALIZABLE_MARKER
+      }
+      // defineProperty, not assignment: `attributes['__proto__'] = v` hits the
+      // prototype setter and the attribute vanishes.
+      Object.defineProperty(mergedAttributes, key, { value, enumerable: true, writable: true, configurable: true })
+    }
   }
 
   const record: OtlpLogRecord = {
@@ -156,8 +335,10 @@ export function buildOtlpLogRecord(options: CaptureLogOptions, sdkContext: LogSd
     observedTimeUnixNano: now,
     severityNumber,
     severityText,
-    body: { stringValue: options.body },
-    attributes: toOtlpKeyValueList(mergedAttributes),
+    // `body` is only typed as a string: an untyped caller passing a number
+    // emits a non-string stringValue, which the server refuses.
+    body: { stringValue: sanitizeString(String(options.body)) },
+    attributes: toOtlpKeyValueList(mergedAttributes, logger),
   }
 
   if (options.trace_id) {

--- a/packages/core/src/metrics/index.spec.ts
+++ b/packages/core/src/metrics/index.spec.ts
@@ -169,8 +169,22 @@ describe('PostHogMetrics', () => {
 
       const attrs = sentMetrics()[0].sum!.dataPoints[0].attributes
       expect(attrs).toContainEqual({ key: 'route', value: { stringValue: '/home' } })
-      expect(attrs).toContainEqual({ key: 'retries', value: { intValue: 2 } })
+      expect(attrs).toContainEqual({ key: 'retries', value: { intValue: '2' } })
       expect(attrs).toContainEqual({ key: 'cached', value: { boolValue: true } })
+    })
+
+    // The encoder is shared with logs, so the debug line it emits on the
+    // out-of-range path only reaches anyone if metrics passes its logger down.
+    it('encodes an out-of-int64 attribute as a string and reports it through the logger', async () => {
+      const metrics = createMetrics()
+      metrics.count('api_calls', 1, { attributes: { huge: 2 ** 63 } as any })
+      await metrics.flush()
+
+      const attrs = sentMetrics()[0].sum!.dataPoints[0].attributes
+      expect(attrs).toContainEqual({ key: 'huge', value: { stringValue: '9223372036854775808' } })
+      expect((logger.debug as jest.Mock).mock.calls.some((c) => String(c[0]).includes('outside the int64 range'))).toBe(
+        true
+      )
     })
 
     it('stamps delta data points with a window: startTimeUnixNano <= timeUnixNano, both nano strings', async () => {

--- a/packages/core/src/metrics/index.ts
+++ b/packages/core/src/metrics/index.ts
@@ -374,7 +374,7 @@ export class PostHogMetrics {
         byMetric.set(metricKey, metric)
       }
 
-      const attributes = toOtlpKeyValueList(state.attributes ?? {})
+      const attributes = toOtlpKeyValueList(state.attributes ?? {}, this._logger)
       const startNano = msToUnixNano(state.windowStartMs)
 
       if (state.type === 'count') {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -3,7 +3,9 @@ import { FetchLike } from '../types'
 export * from './bot-detection'
 export * from './browser-utils'
 export * from './bucketed-rate-limiter'
-export * from './json-utils'
+// Named rather than `export *`: the budgets, markers and `sanitizeString` are
+// shared with the OTLP encoder but are not public API.
+export { toJsonSafeValue } from './json-utils'
 export * from './number-utils'
 export * from './string-utils'
 export * from './type-utils'

--- a/packages/core/src/utils/json-utils.ts
+++ b/packages/core/src/utils/json-utils.ts
@@ -1,4 +1,5 @@
-/** Traversal budgets and markers, shared with the OTLP attribute encoder. */
+/** Traversal budgets and markers, shared with the OTLP attribute encoder. Not
+ * public API — `utils/index.ts` re-exports `toJsonSafeValue` only. */
 export const MAX_JSON_SAFE_VALUE_DEPTH = 20
 export const MAX_JSON_SAFE_VALUE_ITEMS = 1_000
 export const MAX_JSON_SAFE_VALUE_NODES = 10_000

--- a/packages/core/src/utils/json-utils.ts
+++ b/packages/core/src/utils/json-utils.ts
@@ -1,10 +1,11 @@
-const MAX_JSON_SAFE_VALUE_DEPTH = 20
-const MAX_JSON_SAFE_VALUE_ITEMS = 1_000
-const MAX_JSON_SAFE_VALUE_NODES = 10_000
-const CIRCULAR_VALUE = '[Circular]'
-const TRUNCATED_VALUE = '[Truncated]'
-const UNSERIALIZABLE_VALUE = '[Unserializable]'
-const FUNCTION_VALUE = '[Function]'
+/** Traversal budgets and markers, shared with the OTLP attribute encoder. */
+export const MAX_JSON_SAFE_VALUE_DEPTH = 20
+export const MAX_JSON_SAFE_VALUE_ITEMS = 1_000
+export const MAX_JSON_SAFE_VALUE_NODES = 10_000
+export const CIRCULAR_VALUE = '[Circular]'
+export const TRUNCATED_VALUE = '[Truncated]'
+export const UNSERIALIZABLE_VALUE = '[Unserializable]'
+export const FUNCTION_VALUE = '[Function]'
 
 const dateGetTime = Date.prototype.getTime
 const dateToISOString = Date.prototype.toISOString

--- a/packages/core/src/utils/json-utils.ts
+++ b/packages/core/src/utils/json-utils.ts
@@ -15,7 +15,12 @@ interface JsonSafeValueConversionState {
   remainingNodes: number
 }
 
-function sanitizeString(value: string): string {
+/**
+ * Replaces unpaired surrogates with U+FFFD. A lone surrogate survives
+ * `JSON.stringify` as a `\uD800`-style escape, which strict JSON parsers
+ * reject — for OTLP that means the whole request is refused.
+ */
+export function sanitizeString(value: string): string {
   let output = ''
   for (let index = 0; index < value.length; index++) {
     const codeUnit = value.charCodeAt(index)

--- a/packages/types/src/capture-log.ts
+++ b/packages/types/src/capture-log.ts
@@ -79,10 +79,17 @@ export interface Logger {
 
 export interface OtlpAnyValue {
     stringValue?: string
-    intValue?: number
+    /**
+     * proto3 JSON maps int64 to a string, which is the form the SDK emits.
+     * `number` stays valid because encoded records persist in the logs queue:
+     * one written by an earlier version rehydrates in the numeric form and is
+     * re-sent unchanged. The wire format accepts both.
+     */
+    intValue?: string | number
     doubleValue?: number
     boolValue?: boolean
     arrayValue?: { values: OtlpAnyValue[] }
+    kvlistValue?: { values: OtlpKeyValue[] }
 }
 
 export interface OtlpKeyValue {


### PR DESCRIPTION
## Problem

Fixes #4571.

`toOtlpAnyValue` encodes log and metric attributes into OTLP JSON. Several ordinary values encode into shapes PostHog's ingestion refuses — and a refusal is not scoped to the offending value. The request 400s and **every record in it is lost** (up to 100 logs). On `/i/v1/metrics` the same parse error is swallowed server-side: HTTP 200, and the metric never appears.

Verified against ingestion on project 381971:

| attribute value | what `main` sends | result |
| --- | --- | --- |
| integer ≥ 2^63, or `-(2**63)` | `{"intValue": 9223372036854775808}` | **400**, whole batch lost |
| a function or a symbol | `{}` — `JSON.stringify` returns `undefined` | **400**, whole batch lost |
| `[1, , 3]` | `null` as an array element | **400**, whole batch lost |
| `'ok\ud83d'` — a truncated emoji | a lone surrogate escape | **400**, whole batch lost |
| any of the above via `/i/v1/metrics` | same | **200**, metric silently dropped |

Separately, the encoding violates the canonical SDK contract in `sdk-specs` (`logs/spec.md`, "Attribute value encoding"): an integer must be a stringified int64, and an object must be a `kvlistValue`. iOS and Android already conform; posthog-js was the only SDK that didn't.

## Changes

- Integers encode as `{"intValue": "<decimal>"}`; outside int64, as the exact decimal in a `stringValue` with a debug warning — both per spec.
- Objects encode as a nested `kvlistValue` instead of a JSON string, per spec.
- Values that cannot be represented degrade to a marker rather than breaking the request: `[Circular]`, `[Truncated]` (20 levels, 1,000 items per container, 10,000 nodes), `[Unserializable]` (a property whose getter throws), `[Function]`.
- Strings and keys are surrogate-sanitised. Array holes and `null`s are dropped, matching iOS (`compactMap`) and Android (`mapNotNull`). `Date` encodes as ISO, `toJSON` is honoured, and an attribute named `__proto__` survives.
- `captureLog` no longer throws into caller code for any input, including a throwing getter or 25,000-level nesting — `JSON.stringify` threw too, but inside a `catch` this rewrite removed.
- `OtlpAnyValue.intValue` is now `string | number`. The SDK only emits strings; `number` stays valid because React Native rehydrates already-encoded records persisted by an older version and re-sends them unchanged.

### Verification

Every case below was POSTed to `/i/v1/logs` and read back out of ClickHouse.

| attribute | stored |
| --- | --- |
| `{ a: 1, nested: { deep: true } }` | `{"a":1,"nested":{"deep":true}}` — identical to the JSON-string form `main` sends |
| `2 ** 63` / `-(2 ** 63)` | `9223372036854775808` / `-9223372036854775808` |
| `'user said ok\ud83d'` | `user said ok�` |
| `{ ok: 1, get bad() { throw } }` | `{"bad":"[Unserializable]","ok":1}` |
| `{ handler: fn, retries: 2 }` | `{"handler":"[Function]","retries":2}` |
| 30-level nesting / 2^20-node graph | 20 levels then `[Truncated]` / capped at 496 KB |

**Object attributes store byte-identically** (same row, both forms, `length 40`, equal), so the change is invisible to anything querying them. Two stored values do move, both toward correctness: an integer above 2^53 stores its exact value rather than a rounded one, and `Date` loses the quotes `JSON.stringify` wrapped it in. Object attributes are ~2.4× larger on the wire, which brings the 413 batch-shrink path closer for object-heavy records.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes at runtime) — both wire forms are accepted and store identically. One intentional type-level break: widening `OtlpAnyValue.intValue` to `string | number` affects code that *reads* the field under strict TS. Disclosed in the changeset; no in-repo consumer reads it.
- [x] Took care not to unnecessarily increase the bundle size — **+1.54 kB per browser bundle** (`array.js` +0.6%), the recursive walker and its guards. The size bot's "+27 kB" is that same delta counted across 18 artifacts. Nothing here is optional at runtime: without the walker objects stay spec-violating, and without the guards ordinary values take down whole batches.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

The changeset-hygiene bot flags `posthog-js`, `posthog-node` and `posthog-react-native` as declared without modified source files. That is deliberate: the fix lives in `@posthog/core`, and `updateInternalDependencies: "patch"` against `workspace:^` ranges means a patch bump of core does not pull dependents into the release — without naming them, the three SDKs that ship this encoder would never cut a version carrying the fix. Precedent: `.changeset/metrics-node-wiring.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), directed by @turnipdabeets, who asked whether the issue was worth fixing before any code was written, then ran four independent review cycles over it.

- The scope came from reading the receiver (`rust/capture-logs`, `opentelemetry-proto` 0.29's `deserialize_from_value`) rather than the OTLP spec alone. That reversed two of the issue's three stated consequences — a numeric `intValue` is accepted by every conformant parser, and the sub-2^53 precision argument doesn't hold — and turned the missing range guard into a confirmed batch-killer, alongside four more the issue never mentioned.
- Every claim about what ingestion accepts was tested against a live project rather than inferred; two reviewer findings ("stored data changes", "`@posthog/types` needs a minor bump") were rejected on that evidence and on `validate-versioning.yml`, which fails a `fix:` PR carrying a `minor` changeset.
- The author made two calls the agent did not: follow the traces spec's `stringValue` rule for out-of-int64 integers rather than propose amending it, and close the `kvlistValue` gap here rather than track it separately.
- Follow-ups, not in this PR: the unmerged traces encoder (`packages/core/src/traces/otlp.ts`) has two of these batch-killers — `String(-(2**63))` and `{}` for nullish array elements — and #4570's encoder merge is mechanical once it lands. `Error`, `Map` and `Set` still encode as an empty `kvlistValue` (accepted by ingestion, but their contents are lost), and the markers and budgets here are SDK-specific behaviour no spec covers yet.

