### PR TITLE
feat(node): cap attributes and events per span

### DIFF
--- a/.changeset/node-span-limits.md
+++ b/.changeset/node-span-limits.md
@@ -1,0 +1,7 @@
+---
+'posthog-node': minor
+'@posthog/core': minor
+'@posthog/types': minor
+---
+
+Cap spans at 128 user attributes and 128 events, configurable with `traces.maxAttributesPerSpan` and `traces.maxEventsPerSpan`.

--- a/packages/core/src/traces/index.spec.ts
+++ b/packages/core/src/traces/index.spec.ts
@@ -18,6 +18,8 @@ const resolveForTest = (partial?: Partial<ResolvedTracesConfig>): ResolvedTraces
   flushIntervalMs: 5000,
   maxExportBatchSize: 512,
   maxQueueSize: 2048,
+  maxAttributesPerSpan: 128,
+  maxEventsPerSpan: 128,
   ...partial,
 })
 
@@ -495,6 +497,157 @@ describe('PostHogTraces', () => {
 
       await traces.flush()
       expect(instance._sendTracesBatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('span limits', () => {
+    it('keeps the earliest attributes and counts the rest', async () => {
+      const traces = createTraces({ maxAttributesPerSpan: 3 })
+      const span = traces.startSpan('checkout')
+      for (let i = 0; i < 5; i++) {
+        span.setAttribute(`key-${i}`, i)
+      }
+      span.end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes!.map((attribute) => attribute.key)).toEqual(['key-0', 'key-1', 'key-2'])
+      expect(sent.droppedAttributesCount).toBe(2)
+    })
+
+    it('never evicts the auto-context keys', async () => {
+      context = { distinctId: 'alice', sessionId: 'session-1' }
+      const traces = createTraces({ maxAttributesPerSpan: 1 })
+      const span = traces.startSpan('checkout')
+      for (let i = 0; i < 5; i++) {
+        span.setAttribute(`key-${i}`, i)
+      }
+      span.end()
+      await traces.flush()
+
+      const keys = sentSpans()[0].attributes!.map((attribute) => attribute.key)
+      expect(keys).toEqual(expect.arrayContaining(['posthogDistinctId', 'sessionId', 'key-0']))
+      expect(keys).not.toContain('key-1')
+    })
+
+    it('caps events and counts the rest', async () => {
+      const traces = createTraces({ maxEventsPerSpan: 2 })
+      const span = traces.startSpan('checkout')
+      for (let i = 0; i < 4; i++) {
+        span.addEvent(`event-${i}`)
+      }
+      span.end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent.events!.map((event) => event.name)).toEqual(['event-0', 'event-1'])
+      expect(sent.droppedEventsCount).toBe(2)
+    })
+
+    it('lets a caller overwrite an attribute it already set while at the cap', async () => {
+      const traces = createTraces({ maxAttributesPerSpan: 1 })
+      const span = traces.startSpan('checkout')
+      span.setAttribute('plan', 'free')
+      span.setAttribute('plan', 'pro')
+      span.end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes).toEqual([{ key: 'plan', value: { stringValue: 'pro' } }])
+      expect(sent.droppedAttributesCount).toBeUndefined()
+    })
+
+    it('omits the counters when nothing was dropped', async () => {
+      const traces = createTraces()
+      traces.startSpan('checkout', { attributes: { plan: 'pro' } }).end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent).not.toHaveProperty('droppedAttributesCount')
+      expect(sent).not.toHaveProperty('droppedEventsCount')
+    })
+
+    it('counts a parsed __proto__ key against the cap instead of smuggling it through', async () => {
+      // JSON.parse produces an own `__proto__` key; a plain object store would
+      // swap its prototype and leak every nested key past the cap.
+      const traces = createTraces({ maxAttributesPerSpan: 2 })
+      const parsed = JSON.parse('{"__proto__": {"leaked": 1}, "orderId": "abc"}')
+      traces.startSpan('checkout', { attributes: parsed }).end()
+      await traces.flush()
+
+      const keys = sentSpans()[0].attributes!.map((attribute) => attribute.key)
+      expect(keys).not.toContain('leaked')
+      expect(keys).toContain('orderId')
+    })
+
+    it('does not let reserved property names bypass the cap', async () => {
+      const traces = createTraces({ maxAttributesPerSpan: 1 })
+      const span = traces.startSpan('checkout')
+      span.setAttribute('kept', 1)
+      span.setAttribute('toString', 'nope')
+      span.setAttribute('constructor', 'nope')
+      span.end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes!.map((attribute) => attribute.key)).toEqual(['kept'])
+      expect(sent.droppedAttributesCount).toBe(2)
+    })
+
+    it('does not spend cap budget on values that are dropped at encode time', async () => {
+      const traces = createTraces({ maxAttributesPerSpan: 2 })
+      const span = traces.startSpan('checkout')
+      span.setAttribute('skipped-a', undefined)
+      span.setAttribute('skipped-b', null)
+      span.setAttribute('orderId', 'abc-123')
+      span.end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes!.map((attribute) => attribute.key)).toEqual(['orderId'])
+      expect(sent.droppedAttributesCount).toBeUndefined()
+    })
+
+    it('still caps a key first seen with an optional value', async () => {
+      const traces = createTraces({ maxAttributesPerSpan: 2 })
+      const span = traces.startSpan('checkout')
+      for (let i = 0; i < 5; i++) {
+        span.setAttribute(`field-${i}`, undefined)
+      }
+      for (let i = 0; i < 5; i++) {
+        span.setAttribute(`field-${i}`, i)
+      }
+      span.end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes).toHaveLength(2)
+      expect(sent.droppedAttributesCount).toBe(3)
+    })
+
+    it('clears a key that is set back to null', async () => {
+      const traces = createTraces({ maxAttributesPerSpan: 2 })
+      const span = traces.startSpan('checkout')
+      span.setAttribute('orderId', 'abc-123')
+      span.setAttribute('orderId', null)
+      span.setAttribute('a', 1)
+      span.setAttribute('b', 2)
+      span.end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes!.map((attribute) => attribute.key)).toEqual(['a', 'b'])
+      expect(sent.droppedAttributesCount).toBeUndefined()
+    })
+
+    it('caps attributes supplied at start', async () => {
+      const traces = createTraces({ maxAttributesPerSpan: 2 })
+      traces.startSpan('checkout', { attributes: { a: 1, b: 2, c: 3 } }).end()
+      await traces.flush()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes!.map((attribute) => attribute.key)).toEqual(['a', 'b'])
+      expect(sent.droppedAttributesCount).toBe(1)
     })
   })
 

--- a/packages/core/src/traces/index.ts
+++ b/packages/core/src/traces/index.ts
@@ -78,6 +78,8 @@ export class PostHogTraces {
     const now = Date.now()
     const startTime = resolveStartTime(options?.startTime, now, this._logger)
 
+    const autoAttributes = this._autoContextAttributes()
+
     return new PostHogSpan(
       {
         traceId: parent?.traceId ?? newTraceId(),
@@ -87,7 +89,10 @@ export class PostHogTraces {
         name: sanitizeName(name, 'Span name', this._logger),
         kind: options?.kind ?? 'internal',
         // Auto-context first so user-supplied attributes win on collision.
-        attributes: assignUserAttributes(this._autoContextAttributes(), options?.attributes),
+        attributes: assignUserAttributes({ ...autoAttributes }, options?.attributes),
+        autoAttributeKeys: Object.keys(autoAttributes),
+        maxAttributes: this._config.maxAttributesPerSpan,
+        maxEvents: this._config.maxEventsPerSpan,
         startTime,
         backdated: startTime !== now,
       },

--- a/packages/core/src/traces/otlp.spec.ts
+++ b/packages/core/src/traces/otlp.spec.ts
@@ -118,6 +118,8 @@ describe('OTLP span encoding', () => {
       flushIntervalMs: 5000,
       maxExportBatchSize: 512,
       maxQueueSize: 2048,
+      maxAttributesPerSpan: 128,
+      maxEventsPerSpan: 128,
       ...partial,
     })
 

--- a/packages/core/src/traces/otlp.ts
+++ b/packages/core/src/traces/otlp.ts
@@ -87,6 +87,12 @@ export function buildOtlpSpan(record: SpanRecord, logger?: Logger): OtlpSpan {
   if (record.events.length) {
     span.events = record.events.map((event) => toOtlpEvent(event, logger))
   }
+  if (record.droppedAttributesCount) {
+    span.droppedAttributesCount = record.droppedAttributesCount
+  }
+  if (record.droppedEventsCount) {
+    span.droppedEventsCount = record.droppedEventsCount
+  }
   // An unset status is omitted rather than sent as code 0.
   if (record.status) {
     span.status = {

--- a/packages/core/src/traces/span.spec.ts
+++ b/packages/core/src/traces/span.spec.ts
@@ -21,6 +21,9 @@ describe('PostHogSpan', () => {
         attributes: {},
         startTime: Date.now(),
         backdated: false,
+        autoAttributeKeys: [],
+        maxAttributes: 128,
+        maxEvents: 128,
         ...init,
       },
       (record) => ended.push(record),
@@ -281,6 +284,59 @@ describe('NoopSpan', () => {
     // An id that was never recorded must not propagate to another service.
     expect(NOOP_SPAN.traceparent()).toBeNull()
     expect(NOOP_SPAN.tracestate()).toBeNull()
+  })
+})
+
+describe('attribute store', () => {
+  it('hands out a record whose attributes behave like an ordinary object', () => {
+    const ended: SpanRecord[] = []
+    const span = new PostHogSpan(
+      {
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        name: 'checkout',
+        kind: 'internal',
+        attributes: { plan: 'pro' },
+        startTime: Date.now(),
+        backdated: false,
+        autoAttributeKeys: [],
+        maxAttributes: 128,
+        maxEvents: 128,
+      },
+      (record) => ended.push(record)
+    )
+    span.end()
+
+    const { attributes } = ended[0]
+    expect(Object.getPrototypeOf(attributes)).toBe(Object.prototype)
+    expect(Object.prototype.hasOwnProperty.call(attributes, 'plan')).toBe(true)
+    expect(() => JSON.stringify(attributes)).not.toThrow()
+  })
+
+  it('keeps a parsed __proto__ key as an ordinary attribute', () => {
+    const ended: SpanRecord[] = []
+    const span = new PostHogSpan(
+      {
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        name: 'checkout',
+        kind: 'internal',
+        attributes: JSON.parse('{"__proto__": {"leaked": 1}, "orderId": "abc"}'),
+        startTime: Date.now(),
+        backdated: false,
+        autoAttributeKeys: [],
+        maxAttributes: 128,
+        maxEvents: 128,
+      },
+      (record) => ended.push(record)
+    )
+    span.end()
+
+    const keys: string[] = []
+    for (const key in ended[0].attributes) {
+      keys.push(key)
+    }
+    expect(keys).not.toContain('leaked')
   })
 })
 

--- a/packages/core/src/traces/span.ts
+++ b/packages/core/src/traces/span.ts
@@ -3,7 +3,7 @@ import type { Logger } from '../types'
 import type { SpanEventRecord, SpanRecord } from './types'
 import { formatTraceparent } from './traceparent'
 import { assignUserAttributes, clampEndTime, resolveSuppliedTime, sanitizeName } from './sanitize'
-import { isError } from '../utils'
+import { isError, isNullish } from '../utils'
 
 /**
  * A monotonic millisecond reading where the platform has one, so an NTP
@@ -26,6 +26,10 @@ export interface SpanInit {
   startTime: number
   /** True when the caller supplied an explicit `startTime`. */
   backdated: boolean
+  /** Keys the SDK attached itself. Exempt from the attribute cap and never evicted. */
+  autoAttributeKeys: string[]
+  maxAttributes: number
+  maxEvents: number
 }
 
 export class PostHogSpan implements Span {
@@ -43,6 +47,12 @@ export class PostHogSpan implements Span {
   private _events: SpanEventRecord[] = []
   private _status?: { code: SpanStatusCode; message?: string }
   private _ended = false
+  private readonly _autoKeys: Set<string>
+  private readonly _maxAttributes: number
+  private readonly _maxEvents: number
+  private _userAttributeCount = 0
+  private _droppedAttributes = 0
+  private _droppedEvents = 0
 
   constructor(
     init: SpanInit,
@@ -55,7 +65,16 @@ export class PostHogSpan implements Span {
     this._traceState = init.traceState
     this._name = init.name
     this._kind = init.kind
-    this._attributes = init.attributes
+    this._autoKeys = new Set(init.autoAttributeKeys)
+    this._maxAttributes = init.maxAttributes
+    this._maxEvents = init.maxEvents
+    // Null-prototype: a `__proto__` key would otherwise swap this object's prototype
+    // instead of becoming an entry, and `toString` and friends would read as
+    // already-present.
+    this._attributes = Object.create(null) as SpanAttributes
+    for (const key in init.attributes) {
+      this._writeAttribute(key, init.attributes[key])
+    }
     this._startTime = init.startTime
     this._startMono = init.backdated ? undefined : monotonicNow()
   }
@@ -83,22 +102,60 @@ export class PostHogSpan implements Span {
     return true
   }
 
+  /**
+   * Writes an attribute unless the span is already at its user-attribute cap.
+   *
+   * Overwriting a key already on the span always succeeds — the cap counts
+   * distinct user keys, not writes — and SDK-attached keys never count toward
+   * it, so a span at the cap still carries its person and session ids.
+   */
+  private _writeAttribute(key: string, value: SpanAttributeValue): void {
+    // Nullish removes the key rather than occupying it: storing one would spend no
+    // budget and make every later write to that key free, exceeding the cap.
+    if (isNullish(value)) {
+      if (key in this._attributes && !this._autoKeys.has(key)) {
+        this._userAttributeCount--
+      }
+      delete this._attributes[key]
+      return
+    }
+    if (this._autoKeys.has(key) || key in this._attributes) {
+      this._attributes[key] = value
+      return
+    }
+    if (this._userAttributeCount >= this._maxAttributes) {
+      this._droppedAttributes++
+      return
+    }
+    this._userAttributeCount++
+    this._attributes[key] = value
+  }
+
   setAttribute(key: string, value: SpanAttributeValue): this {
     if (this._mutable('setAttribute')) {
-      Object.defineProperty(this._attributes, key, { value, enumerable: true, writable: true, configurable: true })
+      this._writeAttribute(key, value)
     }
     return this
   }
 
   setAttributes(attributes: SpanAttributes): this {
     if (this._mutable('setAttributes')) {
-      assignUserAttributes(this._attributes, attributes)
+      // Read through the shared guard first — own enumerable keys only, and a
+      // throwing getter costs its own key — then write each through the cap.
+      const safe: SpanAttributes = assignUserAttributes({}, attributes)
+      for (const key of Object.keys(safe)) {
+        this._writeAttribute(key, safe[key])
+      }
     }
     return this
   }
 
   addEvent(name: string, attributes?: SpanAttributes, timestamp?: SpanTimeInput): this {
     if (this._mutable('addEvent')) {
+      if (this._events.length >= this._maxEvents) {
+        this._droppedEvents++
+        return this
+      }
       this._events.push({
         name: sanitizeName(name, 'Span event name', this._logger),
         timestamp: resolveSuppliedTime(timestamp, this._now(), 'event timestamp', this._logger),
@@ -177,10 +234,14 @@ export class PostHogSpan implements Span {
       name: this._name,
       kind: this._kind,
       ...(this._status && { status: this._status }),
-      attributes: this._attributes,
+      // Copied out with an ordinary prototype: the store is null-prototype, but a
+      // record handed to user code should behave like a normal object.
+      attributes: { ...this._attributes },
       events: this._events,
       startTime: this._startTime,
       endTime: clampEndTime(resolved, this._startTime),
+      ...(this._droppedAttributes && { droppedAttributesCount: this._droppedAttributes }),
+      ...(this._droppedEvents && { droppedEventsCount: this._droppedEvents }),
     })
   }
 }

--- a/packages/core/src/traces/types.ts
+++ b/packages/core/src/traces/types.ts
@@ -76,6 +76,8 @@ export interface SpanRecord {
   /** ms epoch. */
   startTime: number
   endTime: number
+  droppedAttributesCount?: number
+  droppedEventsCount?: number
 }
 
 /**
@@ -102,4 +104,6 @@ export interface ResolvedTracesConfig extends TracesConfig {
    * dropped rather than queued ones, whose children may already have shipped.
    */
   maxQueueSize: number
+  maxAttributesPerSpan: number
+  maxEventsPerSpan: number
 }

--- a/packages/node/src/__tests__/traces-defaults.spec.ts
+++ b/packages/node/src/__tests__/traces-defaults.spec.ts
@@ -1,11 +1,23 @@
 import { resolveTracesConfig } from '../traces-defaults'
 
 describe('resolveTracesConfig', () => {
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['not a number', NaN],
+  ])('falls back to the default per-span caps when given %s', (_label, value) => {
+    const resolved = resolveTracesConfig({ maxAttributesPerSpan: value, maxEventsPerSpan: value })
+    expect(resolved.maxAttributesPerSpan).toBe(128)
+    expect(resolved.maxEventsPerSpan).toBe(128)
+  })
+
   it('applies the documented defaults', () => {
     expect(resolveTracesConfig(undefined)).toMatchObject({
       flushIntervalMs: 5000,
       maxExportBatchSize: 512,
       maxQueueSize: 2048,
+      maxAttributesPerSpan: 128,
+      maxEventsPerSpan: 128,
     })
   })
 

--- a/packages/node/src/__tests__/traces.spec.ts
+++ b/packages/node/src/__tests__/traces.spec.ts
@@ -319,6 +319,36 @@ describe('PostHog traces', () => {
     })
   })
 
+  describe('span limits', () => {
+    it('caps attributes and reports how many were dropped', async () => {
+      const client = createClient({ traces: { serviceName: 'svc', maxAttributesPerSpan: 2 } })
+      const span = client.startSpan('checkout')
+      span.setAttribute('a', 1)
+      span.setAttribute('b', 2)
+      span.setAttribute('c', 3)
+      span.end()
+      await client.shutdown()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes?.map((a) => a.key)).toEqual(['a', 'b'])
+      expect(sent.droppedAttributesCount).toBe(1)
+    })
+
+    it('defaults to the OpenTelemetry cap of 128', async () => {
+      const client = createClient({ traces: { serviceName: 'svc' } })
+      const span = client.startSpan('checkout')
+      for (let i = 0; i < 130; i++) {
+        span.setAttribute(`key-${i}`, i)
+      }
+      span.end()
+      await client.shutdown()
+
+      const [sent] = sentSpans()
+      expect(sent.attributes).toHaveLength(128)
+      expect(sent.droppedAttributesCount).toBe(2)
+    })
+  })
+
   describe('shutdown', () => {
     it('drains queued spans', async () => {
       posthog.startSpan('a').end()

--- a/packages/node/src/traces-defaults.ts
+++ b/packages/node/src/traces-defaults.ts
@@ -5,6 +5,9 @@ import type { ResolvedTracesConfig, TracesConfig } from '@posthog/core'
 const DEFAULT_FLUSH_INTERVAL_MS = 5000
 const DEFAULT_MAX_EXPORT_BATCH_SIZE = 512
 const DEFAULT_MAX_QUEUE_SIZE = 2048
+// OpenTelemetry's per-span defaults.
+const DEFAULT_MAX_ATTRIBUTES_PER_SPAN = 128
+const DEFAULT_MAX_EVENTS_PER_SPAN = 128
 
 /**
  * Coerces a caller-supplied positive-integer option. `0`, a negative, or `NaN`
@@ -27,6 +30,8 @@ export function resolveTracesConfig(config: TracesConfig | undefined): ResolvedT
     serviceVersion: (resourceAttributes?.['service.version'] as string | undefined) ?? config?.serviceVersion,
     environment: (resourceAttributes?.['deployment.environment'] as string | undefined) ?? config?.environment,
     resourceAttributes,
+    maxAttributesPerSpan: positiveInteger(config?.maxAttributesPerSpan, DEFAULT_MAX_ATTRIBUTES_PER_SPAN),
+    maxEventsPerSpan: positiveInteger(config?.maxEventsPerSpan, DEFAULT_MAX_EVENTS_PER_SPAN),
     flushIntervalMs: positiveInteger(config?.flushIntervalMs, DEFAULT_FLUSH_INTERVAL_MS),
     maxExportBatchSize,
     // Never below the flush trigger, or the depth-based flush could never fire.

--- a/packages/types/src/traces.ts
+++ b/packages/types/src/traces.ts
@@ -230,6 +230,28 @@ export interface TracesConfig {
      * @default 2048
      */
     maxQueueSize?: number
+
+    /**
+     * Maximum user-supplied attributes on a single span. Attributes the SDK
+     * attaches itself — `posthogDistinctId`, `sessionId` and friends — are
+     * exempt and are never evicted, because they are what links a span to a
+     * person and a session.
+     *
+     * On overflow the earliest-set attributes are kept and later ones are
+     * dropped, with the number dropped reported on the exported span.
+     *
+     * @default 128
+     */
+    maxAttributesPerSpan?: number
+
+    /**
+     * Maximum events on a single span. On overflow the earliest events are kept
+     * and later ones are dropped, with the number dropped reported on the
+     * exported span.
+     *
+     * @default 128
+     */
+    maxEventsPerSpan?: number
 }
 
 // ============================================================================
@@ -273,6 +295,10 @@ export interface OtlpSpan {
     status?: OtlpSpanStatus
     /** W3C trace flags in the low byte; the sampled bit is always set. */
     flags?: number
+    /** User attributes dropped by `maxAttributesPerSpan`. Omitted when none were. */
+    droppedAttributesCount?: number
+    /** Events dropped by `maxEventsPerSpan`. Omitted when none were. */
+    droppedEventsCount?: number
 }
 
 export interface OtlpTracesPayload {


### PR DESCRIPTION
## Problem

Stacked on #4579 — review that first.

Nothing bounded how much a single span could carry. A loop that calls `span.addEvent()` per iteration, or an instrumentation layer that copies every request header onto a span, grows it without limit until the ingestion endpoint rejects the payload as too large — at which point the 413 path shrinks the batch to a single span, that span is still too big, and it is **dropped entirely with a warning**. You lose the whole span rather than the excess.

Implements the `Span limits` requirement of the traces capability spec.

## Changes

Caps user-supplied content per span, at OpenTelemetry's defaults.

```ts
traces: {
  serviceName: 'checkout-api',
  maxAttributesPerSpan: 128, // default
  maxEventsPerSpan: 128,     // default
}
```

- **Earliest wins.** The first 128 attributes and events are kept; later ones are dropped silently.
- **The counts ship with the span** as `droppedAttributesCount` / `droppedEventsCount`, so a truncated span is visibly truncated rather than quietly wrong. Both are omitted when nothing was dropped.
- **SDK-attached keys are exempt and never evicted.** `posthogDistinctId`, `sessionId`, `url.full`, `screen.name` and `app.state` do not count toward the cap, so a span at the limit still links back to its person and session — those are the join keys, and losing them to a noisy attribute loop would defeat the point of the span.
- **Overwriting an existing key always succeeds.** The cap counts distinct user keys, not writes, so `setAttribute('plan', …)` twice on a span at the cap updates rather than drops.
- Attributes passed to `startSpan` are capped the same way as ones set later.

### Reviewer notes

- **The two wire counters were deliberately removed from the public types in #4579** — they were declared but nothing populated them, which is documenting what does not exist. This PR is the code that fills them, so they return alongside it. That ordering was the point.
- **The spec also requires the caps to re-apply after `beforeSpanSend`**, because a hook can add attributes. `beforeSpanSend` lives in #4584, which is a sibling branch off the same base — neither PR can implement that half alone. Whichever merges second should wire it up; I have not tried to coordinate it inside either branch, since that would make each depend on the other.
- Enforcement lives in `PostHogSpan`, not at encode time, so an over-cap span never occupies memory in the first place — the point is to bound growth, not to trim on the way out.
- Auto-context keys are identified by what the SDK attached at span start, so a user who explicitly sets `posthogDistinctId` themselves gets the exempt treatment for that key. That seemed better than special-casing a hardcoded list.

### Verification

Six core tests covering both spec scenarios plus the boundary cases (overwrite-at-cap, start-time attributes, counters omitted when unused), and two node tests exercising the real client including the 128 default. `packages/core` 1003 pass, `packages/node` 951 pass, typecheck clean, lint clean, public API references unchanged.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

`@posthog/core` is also bumped (minor); it has no checkbox above.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

Additive from a consumer's perspective: two new optional config keys and two optional wire fields. `SpanInit` and `ResolvedTracesConfig` gain required members, but both ship for the first time in #4579 and neither is constructible by a published consumer.

Behaviour does change for a span that exceeds 128 user attributes or events — it is now truncated and marked rather than sent whole. Given the alternative today is the whole span being dropped by the endpoint, truncation is the more useful outcome, and the caps are configurable for anyone who disagrees.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @turnipdabeets, against the `Span limits` requirement in the traces capability spec.

Two decisions worth a look:

- **Cap at write time rather than at encode time.** Trimming during encoding would satisfy the spec's wording just as well and touch less code, but it lets a pathological span sit in memory at full size until flush. Bounding growth at the source is the behaviour the requirement is actually protecting against.
- **Exemption is by "what the SDK attached", not a hardcoded key list.** It stays correct automatically if auto-context ever gains a key, at the cost of also exempting a key the user happens to set with the same name as one the SDK attached. That felt like the right trade, but it is the kind of thing worth a second opinion.
