### PR TITLE
fix(replay): keep backdated idle lifecycle markers out of rotation-born sessions

### DIFF
--- a/.changeset/idle-marker-session-attribution.md
+++ b/.changeset/idle-marker-session-attribution.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): attribute the backdated sessionIdle marker to the session that went idle, so a rotation-born session's recording no longer starts hours before its first snapshot

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1270,28 +1270,47 @@ describe('Lazy SessionRecording', () => {
                 expect(bufferedEvent.data.tag).toBe(eventTag)
             })
 
-            it.each(['$session_ending', '$session_starting'])(
-                'corrects timestamp for %s events when idle',
-                (eventTag: string) => {
-                    const lastActivityTime = startingTimestamp + 100
-                    const eventRecordedTime = startingTimestamp + 5000
+            it('corrects timestamp for $session_ending events when idle', () => {
+                const lastActivityTime = startingTimestamp + 100
+                const eventRecordedTime = startingTimestamp + 5000
 
-                    // force idle state
-                    sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = true
-                    sessionRecording['_lazyLoadedSessionRecording']['_lastActivityTimestamp'] = lastActivityTime
+                // force idle state
+                sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = true
+                sessionRecording['_lazyLoadedSessionRecording']['_lastActivityTimestamp'] = lastActivityTime
 
-                    const event = createCustomSnapshot(
-                        { timestamp: eventRecordedTime },
-                        { lastActivityTimestamp: lastActivityTime },
-                        eventTag
-                    )
-                    sessionRecording.onRRwebEmit(event as eventWithTime)
+                const event = createCustomSnapshot(
+                    { timestamp: eventRecordedTime },
+                    { lastActivityTimestamp: lastActivityTime },
+                    '$session_ending'
+                )
+                sessionRecording.onRRwebEmit(event as eventWithTime)
 
-                    const bufferedEvent = sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data[0]
-                    // timestamp should be corrected to lastActivityTimestamp, not the time rrweb recorded it
-                    expect(bufferedEvent.timestamp).toBe(lastActivityTime)
-                }
-            )
+                const bufferedEvent = sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data[0]
+                // timestamp should be corrected to lastActivityTimestamp, not the time rrweb recorded it,
+                // so a late-detected idle period doesn't artificially extend the old session
+                expect(bufferedEvent.timestamp).toBe(lastActivityTime)
+            })
+
+            it('does not backdate $session_starting events when idle', () => {
+                const lastActivityTime = startingTimestamp + 100
+                const eventRecordedTime = startingTimestamp + 5000
+
+                // force idle state
+                sessionRecording['_lazyLoadedSessionRecording']['_isIdle'] = true
+                sessionRecording['_lazyLoadedSessionRecording']['_lastActivityTimestamp'] = lastActivityTime
+
+                const event = createCustomSnapshot(
+                    { timestamp: eventRecordedTime },
+                    { lastActivityTimestamp: lastActivityTime },
+                    '$session_starting'
+                )
+                sessionRecording.onRRwebEmit(event as eventWithTime)
+
+                const bufferedEvent = sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data[0]
+                // $session_starting ships to the NEW session: stamping it with the old session's
+                // last activity would drag the new recording's start back by the whole idle gap
+                expect(bufferedEvent.timestamp).toBe(eventRecordedTime)
+            })
 
             it("enters idle state within one session if the activity is non-user generated and there's no activity for (RECORDING_IDLE_ACTIVITY_TIMEOUT_MS) 5 minutes", () => {
                 const firstActivityTimestamp = startingTimestamp + 100
@@ -2652,6 +2671,62 @@ describe('Lazy SessionRecording', () => {
                     expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual('unknown')
                     // exactly one restart: the initial start plus a single re-record for the rotation
                     expect(recordMock).toHaveBeenCalledTimes(2)
+                } finally {
+                    _addCustomEvent.mockReset()
+                }
+            })
+
+            it('attributes the backdated sessionIdle marker to the session that went idle, not a rotation-born session', () => {
+                // A suspended tab emits nothing while backgrounded, so idle is only detected on
+                // wake — by which time an app-level capture may already have rotated the session.
+                // The sessionIdle marker is restamped to lastActivity + threshold (up to hours in
+                // the past); if it follows the rotation into the new session, it drags the new
+                // recording's start back by the whole idle gap and the player reports the prefix
+                // as unplayable ("the initial snapshot of the screen arrived late").
+                _addCustomEvent.mockImplementation((tag: string, payload: any) => {
+                    _emit({ type: EventType.Custom, data: { tag, payload }, timestamp: Date.now() })
+                })
+                try {
+                    const lazy = sessionRecording['_lazyLoadedSessionRecording']!
+                    jest.useFakeTimers().setSystemTime(new Date(startingTimestamp + 100))
+                    emitActiveEvent(startingTimestamp + 100)
+                    _emit(createFullSnapshot({ timestamp: startingTimestamp + 110 }))
+                    jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+                    ;(posthog.capture as Mock).mockClear()
+
+                    // the tab sleeps well past the session timeout; on wake an app-level capture
+                    // rotates the session before any rrweb event reaches the recorder
+                    const rotatedSessionId = 'wake-rotated-session-id'
+                    sessionIdGeneratorMock.mockImplementation(() => rotatedSessionId)
+                    const wakeTimestamp = startingTimestamp + 97 * 60 * 1000
+                    jest.setSystemTime(new Date(wakeTimestamp))
+                    sessionManager.checkAndGetSessionAndWindowId(false, wakeTimestamp)
+                    expect(lazy['_sessionId']).toEqual(rotatedSessionId)
+
+                    // the idle marker ships with the session that actually went idle
+                    expect(posthog.capture).toHaveBeenCalledWith(
+                        '$snapshot',
+                        expect.objectContaining({
+                            $session_id: sessionId,
+                            $snapshot_data: expect.arrayContaining([
+                                expect.objectContaining({ data: expect.objectContaining({ tag: 'sessionIdle' }) }),
+                            ]),
+                        }),
+                        expect.any(Object)
+                    )
+
+                    // nothing attributed to the rotation-born session predates the rotation
+                    const newEpochEvents = [
+                        ...(posthog.capture as Mock).mock.calls
+                            .filter(([name, props]) => name === '$snapshot' && props.$session_id === rotatedSessionId)
+                            .flatMap(([, props]) => props.$snapshot_data),
+                        ...lazy['_buffer'].data,
+                    ]
+                    expect(lazy['_buffer'].sessionId).toEqual(rotatedSessionId)
+                    expect(newEpochEvents.length).toBeGreaterThan(0)
+                    newEpochEvents.forEach((e) => {
+                        expect(e.timestamp).toBeGreaterThanOrEqual(wakeTimestamp)
+                    })
                 } finally {
                     _addCustomEvent.mockReset()
                 }

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -156,6 +156,11 @@ interface SessionIdlePayload {
     threshold: number
     bufferLength: number
     bufferSize: number
+    // the session that went idle. The marker is restamped to lastActivityTimestamp + threshold,
+    // so routing it by the recorder's live session id backdates a rotation-born session by the
+    // whole idle gap when a rotation lands between emit and capture (see onRRwebEmit)
+    sessionId?: string
+    windowId?: string
 }
 
 export interface SnapshotBuffer {
@@ -424,6 +429,10 @@ function isCustomEvent(e: eventWithTime, tag: string): e is eventWithTime & cust
 
 function isSessionIdleEvent(e: eventWithTime): e is eventWithTime & customEvent {
     return isCustomEvent(e, 'sessionIdle')
+}
+
+function getSessionIdlePayload(e: eventWithTime): SessionIdlePayload | null {
+    return isSessionIdleEvent(e) ? (e.data.payload as SessionIdlePayload) : null
 }
 
 type SessionEndingPayload = {
@@ -1789,23 +1798,29 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // TODO: Re-add ensureMaxMessageSize once we are confident in it
         const event = truncateLargeConsoleLogs(throttledEvent)
 
-        // Session lifecycle events ($session_ending, $session_starting) carry their target session ID
-        // in the payload. We must extract this BEFORE _updateWindowAndSessionIds runs, because that
-        // method triggers checkAndGetSessionAndWindowId() which would update this._sessionId.
-        // This is critical for $session_ending which must go to the OLD session, not the new one,
-        // and for $session_starting which must go to the NEW session.
+        // Session lifecycle events ($session_ending, $session_starting, sessionIdle) carry their
+        // target session ID in the payload. We must extract this BEFORE _updateWindowAndSessionIds
+        // runs, because that method triggers checkAndGetSessionAndWindowId() which would update
+        // this._sessionId. This is critical for $session_ending which must go to the OLD session,
+        // not the new one, and for $session_starting which must go to the NEW session.
         const sessionEndingPayload = getSessionEndingPayload(event)
         const sessionStartingPayload = getSessionStartingPayload(event)
+        const sessionIdlePayload = getSessionIdlePayload(event)
 
         if (sessionEndingPayload || sessionStartingPayload) {
-            // Adjust timestamp from payload to avoid artificially extending session duration
-            const payload = (sessionEndingPayload ?? sessionStartingPayload) as {
-                lastActivityTimestamp?: number
+            // Backdate $session_ending to the old session's real end so a late-detected idle
+            // period doesn't artificially extend it. $session_starting must NOT be backdated:
+            // it ships to the NEW session, and stamping it with the old session's last activity
+            // drags the new recording's start back by the whole idle gap
+            if (sessionEndingPayload?.lastActivityTimestamp) {
+                event.timestamp = sessionEndingPayload.lastActivityTimestamp
             }
-            if (payload?.lastActivityTimestamp) {
-                event.timestamp = payload.lastActivityTimestamp
-            }
-        } else {
+        } else if (!sessionIdlePayload?.sessionId) {
+            // sessionIdle markers with a pinned session id skip the session check: they are only
+            // emitted from inside _updateWindowAndSessionIds, whose caller runs the check itself
+            // right after, and running it here first can adopt a pending rotation before the
+            // marker is captured — attributing a marker backdated by the idle gap to the new
+            // session, which drags the new recording's start back and makes its prefix unplayable
             this._updateWindowAndSessionIds(event)
         }
 
@@ -1819,11 +1834,18 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // Route lifecycle events using their payload IDs:
         // - $session_ending uses currentSessionId (the old session it's ending)
         // - $session_starting uses nextSessionId (the new session it's starting)
+        // - sessionIdle uses the session that went idle (backdated markers must not follow a rotation)
         // - All other events use the current session ID
         const targetSessionId =
-            sessionEndingPayload?.currentSessionId ?? sessionStartingPayload?.nextSessionId ?? this._sessionId
+            sessionEndingPayload?.currentSessionId ??
+            sessionStartingPayload?.nextSessionId ??
+            sessionIdlePayload?.sessionId ??
+            this._sessionId
         const targetWindowId =
-            sessionEndingPayload?.currentWindowId ?? sessionStartingPayload?.nextWindowId ?? this._windowId
+            sessionEndingPayload?.currentWindowId ??
+            sessionStartingPayload?.nextWindowId ??
+            sessionIdlePayload?.windowId ??
+            this._windowId
 
         // When in an idle state we keep recording but don't capture the events,
         // we don't want to return early if idle is 'unknown'
@@ -1839,16 +1861,11 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             this._eventsDroppedWhileIdle = 0
         }
 
-        if (isSessionIdleEvent(event)) {
+        if (sessionIdlePayload) {
             // session idle events have a timestamp when rrweb sees them
             // which can artificially lengthen a session
             // we know when we detected it based on the payload and can correct the timestamp
-            const payload = event.data.payload as SessionIdlePayload
-            if (payload) {
-                const lastActivity = payload.lastActivityTimestamp
-                const threshold = payload.threshold
-                event.timestamp = lastActivity + threshold
-            }
+            event.timestamp = sessionIdlePayload.lastActivityTimestamp + sessionIdlePayload.threshold
         }
 
         const compressionEnabled = this._instance.config.session_recording.compress_events ?? true
@@ -2311,6 +2328,13 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                     threshold: this._sessionIdleThresholdMilliseconds,
                     bufferLength: this._buffer.data.length,
                     bufferSize: this._buffer.size,
+                    // pin the marker to the session that actually went idle: it is restamped to
+                    // lastActivityTimestamp + threshold, and if a pending rotation is adopted
+                    // before it is captured (e.g. waking from a long-suspended tab), routing it
+                    // by the live session id would backdate the rotation-born session's start
+                    // by the whole idle gap
+                    sessionId: this._sessionId,
+                    windowId: this._windowId,
                 })
 
                 // proactively flush the buffer in case the session is idle for a long time


### PR DESCRIPTION
## Problem

A tab suspended for a long time emits nothing while backgrounded, so idle is only detected on wake — by which time an app-level capture may already have rotated the session. Two lifecycle events then landed in the rotation-born session with timestamps from before it existed, dragging the recording's start back by the whole idle gap. The player reports that prefix as unplayable: *"The first 1h 31m of this recording can't be shown — the initial snapshot of the screen arrived late."* Diagnosed from a customer recording (support ticket #68226) where a single backdated `sessionIdle` marker started the session 1h31m before its first full snapshot.

## Changes

- `sessionIdle` markers now pin their target session/window ids in the payload at emit time (same pattern as `$session_ending`) and skip the nested session check, so the backdated marker is captured into the old epoch's buffer before any rotation adoption. Falls back to the old routing when the payload carries no ids.
- `$session_starting` is no longer restamped to the old session's `lastActivityTimestamp` — it ships to the *new* session, so it keeps its emit-time stamp (the rotation moment). Only `$session_ending` keeps the backdating.
- New regression test simulates the wake sequence (confirmed active → 97min suspension → wake rotation) and asserts the marker ships with the old session and nothing in the new epoch predates the rotation; fails without the fix.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5) while investigating support ticket #68226. The root cause was pinned down by analysing the affected recording's raw export: the only content in the "unplayable" prefix was one `sessionIdle` marker stamped `lastActivity + threshold`, in a session whose UUIDv7 creation time matched the first full snapshot. The regression test's timestamp invariant then surfaced the second vector (`$session_starting` backdating), which was fixed the same way rather than clamped, since the backdating is only correct for the session that actually went idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
