### PR TITLE
fix(browser): keep internal logs out of console capture

### DIFF
--- a/.changeset/internal-logger-console-isolation.md
+++ b/.changeset/internal-logger-console-isolation.md
@@ -1,0 +1,8 @@
+---
+'posthog-js': patch
+'@posthog/browser-common': patch
+---
+
+fix(browser): keep PostHog logger output out of console capture
+
+PostHog logger output now bypasses PostHog console instrumentation. Client rate-limit diagnostics remain visible without appearing as customer exceptions or logs.

--- a/packages/browser-common/src/utils/console-utils.ts
+++ b/packages/browser-common/src/utils/console-utils.ts
@@ -1,0 +1,16 @@
+// Console wrappers share rrweb's marker so separately loaded bundles can resolve the same original method.
+export type ConsoleMethod = ((...args: any[]) => void) & {
+    __rrweb_original__?: ConsoleMethod
+}
+
+export const getOriginalConsoleMethod = (method: ConsoleMethod): ConsoleMethod => {
+    while (method?.__rrweb_original__) {
+        method = method.__rrweb_original__
+    }
+    return method
+}
+
+export const markConsoleWrapper = (wrapper: ConsoleMethod, original: ConsoleMethod): ConsoleMethod => {
+    wrapper.__rrweb_original__ = getOriginalConsoleMethod(original)
+    return wrapper
+}

--- a/packages/browser-common/src/utils/logger.ts
+++ b/packages/browser-common/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import Config from '../config'
-import { isUndefined } from '@posthog/core'
+import { isFunction, isUndefined } from '@posthog/core'
 import type { Logger } from '@posthog/types'
+import { getOriginalConsoleMethod } from './console-utils'
 import { window } from './globals'
 
 interface DebugWindow extends Window {
@@ -23,6 +24,14 @@ export type PosthogJsLogger = Omit<Logger, 'createLogger' | 'debug' | 'info' | '
 }
 
 const _createLogger = (prefix: string, { debugEnabled }: CreateLoggerOptions = {}): PosthogJsLogger => {
+    const writeToConsole = (level: 'debug' | 'log' | 'warn' | 'error', ...args: any[]): void => {
+        const targetConsole = window?.console ?? console
+        const consoleLog = getOriginalConsoleMethod(targetConsole[level] as any)
+        if (isFunction(consoleLog)) {
+            consoleLog(prefix, ...args)
+        }
+    }
+
     const logger: PosthogJsLogger = {
         _log: (level: 'debug' | 'log' | 'warn' | 'error', ...args: any[]) => {
             if (
@@ -31,12 +40,7 @@ const _createLogger = (prefix: string, { debugEnabled }: CreateLoggerOptions = {
                 !isUndefined(window.console) &&
                 window.console
             ) {
-                const consoleLog =
-                    '__rrweb_original__' in window.console[level]
-                        ? (window.console[level] as any)['__rrweb_original__']
-                        : window.console[level]
-
-                consoleLog(prefix, ...args)
+                writeToConsole(level, ...args)
             }
         },
 
@@ -58,8 +62,7 @@ const _createLogger = (prefix: string, { debugEnabled }: CreateLoggerOptions = {
 
         critical: (...args: any[]) => {
             // Critical errors are always logged to the console
-            // eslint-disable-next-line no-console
-            console.error(prefix, ...args)
+            writeToConsole('error', ...args)
         },
 
         uninitializedWarning: (methodName: string) => {

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/error-wrapping-functions.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/error-wrapping-functions.test.ts
@@ -1,5 +1,6 @@
 import posthogErrorWrappingFunctions from '../../../entrypoints/exception-autocapture'
 import { ErrorTracking } from '@posthog/core'
+import { createLogger, logger } from '@posthog/browser-common/utils/logger'
 
 const { wrapOnError, wrapUnhandledRejection, wrapConsoleError } = posthogErrorWrappingFunctions
 
@@ -105,16 +106,60 @@ describe('error wrapping functions', () => {
             expect(captureFn).toHaveBeenCalled()
         })
 
-        it('still chains to a callable original handler', () => {
+        it('captures customer output that resembles a PostHog log and still chains to the original handler', () => {
             const con = console as any
             const original = jest.fn()
             con.error = original
             unwrap = wrapConsoleError(captureFn)
 
-            con.error('boom')
+            con.error('[PostHog.js]', 'customer error')
 
-            expect(original).toHaveBeenCalledWith('boom')
-            expect(captureFn).toHaveBeenCalled()
+            expect(original).toHaveBeenCalledWith('[PostHog.js]', 'customer error')
+            expect(captureFn).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not capture PostHog logger output through stacked console wrappers', () => {
+            const con = console as any
+            const original = jest.fn()
+            const existingWrapper = jest.fn((...args: any[]) => original(...args))
+            ;(existingWrapper as any).__rrweb_original__ = original
+            con.error = existingWrapper
+            unwrap = wrapConsoleError(captureFn)
+
+            logger.critical('critical message')
+            createLogger('[Test]', { debugEnabled: true }).error('debug message')
+
+            expect(original).toHaveBeenNthCalledWith(1, '[PostHog.js]', 'critical message')
+            expect(original).toHaveBeenNthCalledWith(2, '[PostHog.js] [Test]', 'debug message')
+            expect(existingWrapper).not.toHaveBeenCalled()
+            expect(captureFn).not.toHaveBeenCalled()
+        })
+
+        it('does not re-enter capture when the capture path logs another console error', () => {
+            const con = console as any
+            const original = jest.fn()
+            con.error = original
+            captureFn.mockImplementationOnce(() => con.error('nested error'))
+            unwrap = wrapConsoleError(captureFn)
+
+            con.error('outer error')
+
+            expect(captureFn).toHaveBeenCalledTimes(1)
+            expect(original).toHaveBeenNthCalledWith(1, 'nested error')
+            expect(original).toHaveBeenNthCalledWith(2, 'outer error')
+        })
+
+        it('still logs when capture throws', () => {
+            const con = console as any
+            const original = jest.fn()
+            con.error = original
+            captureFn.mockImplementationOnce(() => {
+                throw new Error('capture failed')
+            })
+            unwrap = wrapConsoleError(captureFn)
+
+            expect(() => con.error('customer error')).not.toThrow()
+            expect(original).toHaveBeenCalledWith('customer error')
         })
     })
 })

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -1,6 +1,7 @@
 import { window } from '@posthog/browser-common/utils/globals'
 import { assignableWindow } from '../utils/globals'
 import { ErrorEventArgs } from '../types'
+import { markConsoleWrapper } from '@posthog/browser-common/utils/console-utils'
 import { createLogger } from '@posthog/browser-common/utils/logger'
 import { isArray, isFunction, isNull, isString, type ErrorTracking } from '@posthog/core'
 import { buildErrorPropertiesBuilder } from '../posthog-exceptions'
@@ -80,25 +81,37 @@ const wrapConsoleError = (captureFn: (props: ErrorTracking.ErrorProperties) => v
     }
 
     const originalConsoleError = con.error
+    let isCapturingConsoleError = false
 
-    con.error = function (...args: any[]): void {
-        let event
-        if (args.length == 1) {
-            event = args[0]
-        } else {
-            event = args.join(' ')
-        }
-        const error = args.find((arg) => arg instanceof Error)
-        const errorProperties = errorPropertiesBuilder.buildFromUnknown(error || event, {
-            mechanism: { handled: false },
-            syntheticException: new Error('PostHog syntheticException'),
-            skipFirstLines: 2,
-        })
-        captureFn(errorProperties)
-        if (isFunction(originalConsoleError)) {
-            originalConsoleError(...args)
+    const wrappedConsoleError = function (...args: any[]): void {
+        let acquiredGuard = false
+        try {
+            if (!isCapturingConsoleError) {
+                isCapturingConsoleError = true
+                acquiredGuard = true
+
+                const event = args.length == 1 ? args[0] : args.join(' ')
+                const error = args.find((arg) => arg instanceof Error)
+                const errorProperties = errorPropertiesBuilder.buildFromUnknown(error || event, {
+                    mechanism: { handled: false },
+                    syntheticException: new Error('PostHog syntheticException'),
+                    skipFirstLines: 2,
+                })
+                captureFn(errorProperties)
+            }
+        } catch {
+            // Error capture must not break the page's console output.
+        } finally {
+            if (acquiredGuard) {
+                isCapturingConsoleError = false
+            }
+            if (isFunction(originalConsoleError)) {
+                originalConsoleError(...args)
+            }
         }
     }
+
+    con.error = markConsoleWrapper(wrappedConsoleError, originalConsoleError)
     con.error.__POSTHOG_INSTRUMENTED__ = true
 
     return () => {

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -1,5 +1,6 @@
 import { assignableWindow } from '../utils/globals'
 import { PostHog } from '../posthog-core'
+import { markConsoleWrapper } from '@posthog/browser-common/utils/console-utils'
 import { isArray, isBoolean, isFunction, isNull, isNumber, isObject } from '@posthog/core'
 import type { LogSeverityLevel } from '@posthog/types'
 
@@ -343,13 +344,6 @@ const LEVEL_MAP: Record<ConsoleLevel, LogSeverityLevel> = {
     info: 'info',
 }
 
-const originalConsoleMethod = (method: any): any => {
-    while (method?.__rrweb_original__) {
-        method = method.__rrweb_original__
-    }
-    return method
-}
-
 const initializeLogs = (posthog: PostHog) => {
     // `host` is carried here because the core SDK context has no equivalent. Session
     // attributes (window.id, sessionStartTimestamp, lastActivityTimestamp) are added
@@ -407,12 +401,8 @@ const initializeLogs = (posthog: PostHog) => {
 
         const originalConsoleLog = assignableWindow.console[level]
         const wrapped = logWrapper(originalConsoleLog)
-        // Expose the original console method the same way rrweb's console plugin does, so
-        // PostHog's internal logger (utils/logger.ts) writes to the real console instead of
-        // re-entering this wrapper when it emits debug lines from inside the capture path.
-        // Flatten an existing marker if another console plugin already wrapped this method.
-        ;(wrapped as any).__rrweb_original__ = originalConsoleMethod(originalConsoleLog)
-        assignableWindow.console[level] = wrapped
+        // PostHog's logger uses the flattened original to bypass all PostHog console instrumentation.
+        assignableWindow.console[level] = markConsoleWrapper(wrapped, originalConsoleLog)
     }
 }
 


### PR DESCRIPTION
## Problem

- Customers using console error capture can receive PostHog diagnostics as their own exceptions.
- An internal critical log can re-enter capture and recurse while the client drops events.

## Changes

- Every PostHog logger level now resolves the deepest original console method before writing.
- Critical diagnostics remain visible without entering PostHog console instrumentation.
- Error capture marks its wrapper with the shared original-method protocol.
- A local guard prevents direct console calls inside capture from starting another capture.
- Customer console errors remain captured, including messages that start with `[PostHog.js]`.
- The Logs wrapper now uses the same shared console utility without changing its behavior.
- This PR has no visual changes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- This PR supersedes #4479 after design review.
- The first commit defines the failing console-isolation contract. The second commit implements it.
- PostHog Desktop and pi used the existing Logs and Session Replay wrapper protocol instead of message filtering or global state.
- Skills used: writing code comments, writing tests, writing user-facing copy, writing PR descriptions, and ReviewHog review perspectives.
