### PR TITLE
fix(react-native): use project-local CLI for Android symbol uploads

### DIFF
--- a/.changeset/rn-local-android-cli.md
+++ b/.changeset/rn-local-android-cli.md
@@ -2,4 +2,4 @@
 'posthog-react-native': patch
 ---
 
-Fix Android native symbol uploads in Expo projects to use a project-local `@posthog/cli` installation when available.
+Fix Android native symbol uploads in Expo projects on macOS and Linux to use a project-local `@posthog/cli` installation when available.

--- a/.changeset/rn-local-android-cli.md
+++ b/.changeset/rn-local-android-cli.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix Android native symbol uploads in Expo projects to use a project-local `@posthog/cli` installation when available.

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -112,12 +112,11 @@ export function addPostHogAndroidGradlePluginClasspath(projectBuildGradle: strin
 }
 
 const POSTHOG_ANDROID_LOCAL_CLI_CONFIG = `// Prefer a project-local CLI so native symbol uploads work on clean CI machines.
-def postHogLocalCliDirectory = new File(rootDir.parentFile, "node_modules/.bin")
-def postHogLocalCli = ["posthog-cli", "posthog-cli.cmd"]
-    .collect { new File(postHogLocalCliDirectory, it) }
-    .find { it.isFile() }
+// Keep the Gradle plugin's existing resolution on Windows, where npm's launcher is a .cmd file.
+def postHogLocalCli = new File(rootDir.parentFile, "node_modules/.bin/posthog-cli")
+def postHogCanUseLocalCli = !System.getProperty("os.name").toLowerCase().contains("windows")
 
-if (postHogLocalCli != null) {
+if (postHogCanUseLocalCli && postHogLocalCli.isFile()) {
     tasks.withType(com.posthog.android.PostHogCliExecTask).configureEach {
         // A user-provided postHogExecutable still takes precedence over this convention.
         postHogExecutable.convention(postHogLocalCli.absolutePath)
@@ -147,7 +146,7 @@ export function applyPostHogAndroidGradlePlugin(appBuildGradle: string): string 
     }
   }
 
-  if (!contents.includes('postHogLocalCliDirectory')) {
+  if (!contents.includes('postHogCanUseLocalCli')) {
     contents = contents.replace(
       /^(apply plugin: ["']com\.posthog\.android["'].*)$/m,
       `$1\n\n${POSTHOG_ANDROID_LOCAL_CLI_CONFIG}`

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -111,28 +111,50 @@ export function addPostHogAndroidGradlePluginClasspath(projectBuildGradle: strin
   }
 }
 
-// Applies the com.posthog.android plugin in the app module. Idempotent.
+const POSTHOG_ANDROID_LOCAL_CLI_CONFIG = `// Prefer a project-local CLI so native symbol uploads work on clean CI machines.
+def postHogLocalCliDirectory = new File(rootDir.parentFile, "node_modules/.bin")
+def postHogLocalCli = ["posthog-cli", "posthog-cli.cmd"]
+    .collect { new File(postHogLocalCliDirectory, it) }
+    .find { it.isFile() }
+
+if (postHogLocalCli != null) {
+    tasks.withType(com.posthog.android.PostHogCliExecTask).configureEach {
+        // A user-provided postHogExecutable still takes precedence over this convention.
+        postHogExecutable.convention(postHogLocalCli.absolutePath)
+    }
+}`
+
+// Applies the com.posthog.android plugin and configures its tasks to prefer a project-local CLI.
+// Idempotent, including when migrating a build.gradle that already applies the plugin.
 export function applyPostHogAndroidGradlePlugin(appBuildGradle: string): string {
-  if (/apply plugin: ["']com\.posthog\.android["']/.test(appBuildGradle)) {
-    return appBuildGradle
-  }
-
   const applyLine = 'apply plugin: "com.posthog.android"'
+  let contents = appBuildGradle
 
-  // Apply right after com.android.application so the plugin can hook AGP variants.
-  const appPluginPattern = /^([ \t]*apply plugin: ["']com\.android\.application["'].*)$/m
-  if (appPluginPattern.test(appBuildGradle)) {
-    return appBuildGradle.replace(appPluginPattern, `$1\n${applyLine}`)
+  if (!/apply plugin: ["']com\.posthog\.android["']/.test(contents)) {
+    // Apply right after com.android.application so the plugin can hook AGP variants.
+    const appPluginPattern = /^([ \t]*apply plugin: ["']com\.android\.application["'].*)$/m
+    if (appPluginPattern.test(contents)) {
+      contents = contents.replace(appPluginPattern, `$1\n${applyLine}`)
+    } else {
+      // Fallback: insert directly above the android { } block.
+      const androidBlockPattern = /^android\s*\{/m
+      if (androidBlockPattern.test(contents)) {
+        contents = contents.replace(androidBlockPattern, `${applyLine}\n\nandroid {`)
+      } else {
+        console.warn('PostHog: Could not find where to apply com.posthog.android in the app build.gradle')
+        return contents
+      }
+    }
   }
 
-  // Fallback: insert directly above the android { } block.
-  const androidBlockPattern = /^android\s*\{/m
-  if (androidBlockPattern.test(appBuildGradle)) {
-    return appBuildGradle.replace(androidBlockPattern, `${applyLine}\n\nandroid {`)
+  if (!contents.includes('postHogLocalCliDirectory')) {
+    contents = contents.replace(
+      /^(apply plugin: ["']com\.posthog\.android["'].*)$/m,
+      `$1\n\n${POSTHOG_ANDROID_LOCAL_CLI_CONFIG}`
+    )
   }
 
-  console.warn('PostHog: Could not find where to apply com.posthog.android in the app build.gradle')
-  return appBuildGradle
+  return contents
 }
 
 const withAndroidNativeSymbolsPlugin = (config: any) => {

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -594,6 +594,24 @@ describe('applyPostHogAndroidGradlePlugin', () => {
     expect(lines[appIdx + 1]).toContain('com.posthog.android')
   })
 
+  it('configures native symbol tasks to prefer a project-local CLI', () => {
+    const result = applyPostHogAndroidGradlePlugin(appBuildGradle)
+    expect(result).toContain('new File(rootDir.parentFile, "node_modules/.bin")')
+    expect(result).toContain('["posthog-cli", "posthog-cli.cmd"]')
+    expect(result).toContain('tasks.withType(com.posthog.android.PostHogCliExecTask).configureEach')
+    expect(result).toContain('postHogExecutable.convention(postHogLocalCli.absolutePath)')
+  })
+
+  it('adds local CLI configuration when migrating a build.gradle that already applies the plugin', () => {
+    const existing = appBuildGradle.replace(
+      'apply plugin: "com.android.application"',
+      'apply plugin: "com.android.application"\napply plugin: "com.posthog.android"'
+    )
+    const result = applyPostHogAndroidGradlePlugin(existing)
+    expect(result.match(/apply plugin: "com\.posthog\.android"/g)).toHaveLength(1)
+    expect(result).toContain('postHogExecutable.convention(postHogLocalCli.absolutePath)')
+  })
+
   it('is idempotent', () => {
     const once = applyPostHogAndroidGradlePlugin(appBuildGradle)
     const twice = applyPostHogAndroidGradlePlugin(once)

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -596,8 +596,8 @@ describe('applyPostHogAndroidGradlePlugin', () => {
 
   it('configures native symbol tasks to prefer a project-local CLI', () => {
     const result = applyPostHogAndroidGradlePlugin(appBuildGradle)
-    expect(result).toContain('new File(rootDir.parentFile, "node_modules/.bin")')
-    expect(result).toContain('["posthog-cli", "posthog-cli.cmd"]')
+    expect(result).toContain('new File(rootDir.parentFile, "node_modules/.bin/posthog-cli")')
+    expect(result).toContain('!System.getProperty("os.name").toLowerCase().contains("windows")')
     expect(result).toContain('tasks.withType(com.posthog.android.PostHogCliExecTask).configureEach')
     expect(result).toContain('postHogExecutable.convention(postHogLocalCli.absolutePath)')
   })


### PR DESCRIPTION
## Problem

Expo Android release builds fail to upload ProGuard mappings when `@posthog/cli` is installed as a project dependency. The Android Gradle plugin does not find `node_modules/.bin/posthog-cli` and asks for a global installation instead. This commonly affects clean EAS Build and GitHub Actions environments.

Closes #4599.

## Changes

The Expo config plugin now adds Gradle configuration that uses the project's `node_modules/.bin/posthog-cli` for native symbol upload tasks on macOS and Linux. It sets this as a convention, so an explicit `postHogExecutable` value still takes precedence. If the local executable is absent, the Android Gradle plugin keeps its existing global lookup behavior.

Running Expo prebuild again also adds the configuration to projects that already apply `com.posthog.android`. Windows keeps the existing resolver because npm uses a different launcher there.

Added tests for local CLI configuration, migration, and idempotency.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and reviewed with Pi. The change stays in the Expo config plugin so affected React Native projects can use their existing local CLI dependency without requiring a new Android Gradle plugin release. Windows keeps the current behavior because its npm CLI launcher requires separate handling.
