### PR TITLE
fix(rollup): upload Vite 8 client sourcemaps

### DIFF
--- a/.changeset/fix-vite8-client-sourcemaps.md
+++ b/.changeset/fix-vite8-client-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rollup-plugin': patch
+---
+
+Restore chunk ID comments after Vite 8 output minification so client source maps are uploaded.

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -17,9 +17,10 @@
     "scripts": {
         "build": "rslib build",
         "clean": "rimraf dist",
-        "lint": "eslint src",
-        "lint:fix": "eslint src --fix",
+        "lint": "eslint src 'test/*.mjs'",
+        "lint:fix": "eslint src 'test/*.mjs' --fix",
         "test:unit": "jest --passWithNoTests",
+        "test:functional": "node --test test/*.test.mjs",
         "dev": "rslib build --watch",
         "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
     },
@@ -41,6 +42,7 @@
         "@rslib/core": "catalog:",
         "@types/jest": "catalog:",
         "jest": "catalog:",
-        "rollup": "~4.53.2"
+        "rollup": "~4.53.2",
+        "vite": "^8.0.16"
     }
 }

--- a/packages/rollup-plugin/src/index.spec.ts
+++ b/packages/rollup-plugin/src/index.spec.ts
@@ -34,6 +34,10 @@ type TestPlugin = {
         order: 'post'
         handler: (code: string, chunk: { fileName: string }) => RenderChunkResult
     }
+    generateBundle: {
+        order: 'pre'
+        handler: (options: OutputOptions, bundle: Record<string, unknown>) => void
+    }
     writeBundle: {
         sequential: true
         handler: (options: OutputOptions, bundle: Record<string, unknown>) => Promise<void>
@@ -222,6 +226,49 @@ describe('posthogRollupPlugin', () => {
 
             expect(plugin.renderChunk.handler(code, { fileName: 'style.css' })).toBeNull()
             expect(disabled.renderChunk.handler(code, { fileName: 'index.js' })).toBeNull()
+        })
+    })
+
+    describe('generateBundle', () => {
+        const code = 'console.log("app");'
+        const preliminaryFileName = 'index-!~{001}~.js'
+        const fileName = 'index-abc123.js'
+
+        it('restores a chunk id comment removed after renderChunk', () => {
+            const plugin = testPlugin(options)
+            const rendered = plugin.renderChunk.handler(code, { fileName: preliminaryFileName })!
+            const chunkId = determineChunkIdFromSource(rendered.code)!
+            const minifiedCode = rendered.code.replace(createChunkIdComment(chunkId), '')
+            const bundle = {
+                [fileName]: { type: 'chunk', fileName, preliminaryFileName, code: minifiedCode },
+            }
+
+            plugin.generateBundle.handler({} as OutputOptions, bundle)
+
+            expect(determineChunkIdFromSource(bundle[fileName].code)).toBe(chunkId)
+        })
+
+        it('does not duplicate a chunk id comment that survived output minification', () => {
+            const plugin = testPlugin(options)
+            const rendered = plugin.renderChunk.handler(code, { fileName: preliminaryFileName })!
+            const bundle = {
+                [fileName]: { type: 'chunk', fileName, preliminaryFileName, code: rendered.code },
+            }
+
+            plugin.generateBundle.handler({} as OutputOptions, bundle)
+
+            expect(bundle[fileName].code.match(/\/\/# chunkId=/g)).toHaveLength(1)
+        })
+
+        it('does not add a chunk id to prebuilt chunks that skipped renderChunk', () => {
+            const plugin = testPlugin(options)
+            const bundle = {
+                [fileName]: { type: 'chunk', fileName, preliminaryFileName, code },
+            }
+
+            plugin.generateBundle.handler({} as OutputOptions, bundle)
+
+            expect(determineChunkIdFromSource(bundle[fileName].code)).toBeUndefined()
         })
     })
 

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -46,6 +46,13 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
     // which is a different release.
     let releaseIdPromise: Promise<string | undefined> | undefined
     let warnedAboutMissingRelease = false
+    const chunkIdsByPreliminaryFileName = new Map<string, Set<string>>()
+
+    function rememberChunkId(preliminaryFileName: string, chunkId: string) {
+        const chunkIds = chunkIdsByPreliminaryFileName.get(preliminaryFileName) ?? new Set<string>()
+        chunkIds.add(chunkId)
+        chunkIdsByPreliminaryFileName.set(preliminaryFileName, chunkIds)
+    }
 
     function injectChunkId(code: string, chunkId: string, releaseId?: string) {
         const magicString = new MagicString(code)
@@ -64,6 +71,7 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
         buildStart() {
             releaseIdPromise = undefined
             warnedAboutMissingRelease = false
+            chunkIdsByPreliminaryFileName.clear()
         },
 
         config() {
@@ -98,7 +106,9 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
                 if (!posthogOptions.sourcemaps.enabled) return null
                 if (!JS_CHUNK_REGEX.test(chunk.fileName)) return null
                 // Already carries an id (watch-mode re-render, another tool)
-                if (determineChunkIdFromSource(code)) {
+                const existingChunkId = determineChunkIdFromSource(code)
+                if (existingChunkId) {
+                    rememberChunkId(chunk.fileName, existingChunkId)
                     if (eventReleaseMode) {
                         console.warn(
                             `PostHog: ${chunk.fileName} already carries a chunk id, so no release id was injected — its exceptions will report no release`
@@ -108,7 +118,9 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
                 }
 
                 if (!eventReleaseMode) {
-                    return injectChunkId(code, createChunkId())
+                    const chunkId = createChunkId()
+                    rememberChunkId(chunk.fileName, chunkId)
+                    return injectChunkId(code, chunkId)
                 }
 
                 // Event mode carries the release inside the chunk, which means resolving it before
@@ -116,6 +128,7 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
                 // id (and its symbol set) across rebuilds.
                 releaseIdPromise ??= resolveReleaseId(posthogOptions)
                 const chunkId = createStableChunkId(code)
+                rememberChunkId(chunk.fileName, chunkId)
                 return releaseIdPromise.then((releaseId) => {
                     // A build that identifies no release still symbolicates from its chunk ids, so
                     // this warns rather than failing, matching what posthog-cli does in the same
@@ -128,6 +141,30 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
                     }
                     return injectChunkId(code, chunkId, releaseId)
                 })
+            },
+        },
+
+        // Vite 8's Oxc output minifier runs after renderChunk and removes the CLI-facing comment,
+        // while preserving the executable snippet. Restore the same comment once output minification
+        // is complete. preliminaryFileName links the final OutputChunk back to its RenderedChunk even
+        // when Rollup replaces a [hash] placeholder. Matching against the tracked id avoids treating
+        // unrelated bundled `_posthogChunkIds` strings as injected chunks.
+        generateBundle: {
+            order: 'pre',
+            handler(_options, bundle) {
+                for (const chunk of Object.values(bundle)) {
+                    if (chunk.type !== 'chunk' || !JS_CHUNK_REGEX.test(chunk.fileName)) continue
+                    if (determineChunkIdFromSource(chunk.code)) continue
+
+                    const chunkId = Array.from(chunkIdsByPreliminaryFileName.get(chunk.preliminaryFileName) ?? []).find(
+                        (candidate) => chunk.code.includes(candidate)
+                    )
+                    if (chunkId) {
+                        // This only appends an unmapped trailing comment, so existing source-map
+                        // positions remain valid. `order: pre` also lets SRI plugins hash final code.
+                        chunk.code += createChunkIdComment(chunkId)
+                    }
+                }
             },
         },
 

--- a/packages/rollup-plugin/test/vite8.test.mjs
+++ b/packages/rollup-plugin/test/vite8.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import test from 'node:test'
+import { build } from 'vite'
+import posthogRollupPlugin from '../dist/index.js'
+
+const CHUNK_ID_COMMENT = /(?:^|\n)\/\/# chunkId=(\S{1,128})/
+
+test('uploads client chunks after Vite 8 Oxc output minification', async (t) => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-rollup-plugin-vite-'))
+    t.after(() => fs.rm(root, { recursive: true, force: true }))
+
+    const capturePath = path.join(root, 'posthog-cli-call.json')
+    const cliPath = path.join(root, 'posthog-cli.mjs')
+    await fs.writeFile(
+        cliPath,
+        `#!/usr/bin/env node
+import fs from 'node:fs'
+let stdin = ''
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', (chunk) => { stdin += chunk })
+process.stdin.on('end', () => {
+    fs.writeFileSync(process.env.POSTHOG_CLI_CAPTURE_PATH, JSON.stringify({ args: process.argv.slice(2), stdin }))
+})
+`
+    )
+    await fs.chmod(cliPath, 0o755)
+    await fs.writeFile(path.join(root, 'index.html'), '<script type="module" src="/src.ts"></script>')
+    await fs.writeFile(path.join(root, 'src.ts'), 'console.log("app")')
+
+    const previousCapturePath = process.env.POSTHOG_CLI_CAPTURE_PATH
+    process.env.POSTHOG_CLI_CAPTURE_PATH = capturePath
+    t.after(() => {
+        if (previousCapturePath === undefined) {
+            delete process.env.POSTHOG_CLI_CAPTURE_PATH
+        } else {
+            process.env.POSTHOG_CLI_CAPTURE_PATH = previousCapturePath
+        }
+    })
+
+    await build({
+        configFile: false,
+        root,
+        logLevel: 'silent',
+        plugins: [
+            posthogRollupPlugin({
+                personalApiKey: 'phx_test',
+                projectId: '1',
+                cliBinaryPath: cliPath,
+                sourcemaps: { deleteAfterUpload: false },
+            }),
+        ],
+        build: { outDir: 'dist', minify: 'oxc' },
+    })
+
+    const cliCall = JSON.parse(await fs.readFile(capturePath, 'utf8'))
+    assert.deepEqual(cliCall.args.slice(0, 3), ['sourcemap', 'upload', '--stdin'])
+
+    const uploadedChunks = cliCall.stdin.trim().split('\n')
+    assert.equal(uploadedChunks.length, 1)
+
+    const chunk = await fs.readFile(uploadedChunks[0], 'utf8')
+    const chunkId = CHUNK_ID_COMMENT.exec(chunk)?.[1]
+    assert.ok(chunkId, 'final chunk should retain its CLI-facing chunk id comment')
+    assert.match(chunk, /_posthogChunkIds/)
+    assert.ok(
+        chunk.replace(`//# chunkId=${chunkId}`, '').includes(chunkId),
+        'the runtime snippet and upload comment should carry the same chunk id'
+    )
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1186,6 +1186,9 @@ importers:
       rollup:
         specifier: ~4.53.2
         version: 4.53.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.2.0(@types/node@20.19.9)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
 
   packages/rrweb/all:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -61,6 +61,9 @@
             "cache": false
         },
         "test:functional": {},
+        "@posthog/rollup-plugin#test:functional": {
+            "dependsOn": ["build"]
+        },
         "test:e2e": {},
         "test": {
             "dependsOn": ["lint", "test:unit", "test:functional", "test:e2e"]


### PR DESCRIPTION
## Problem

Vite 8 uses Oxc to minify client output after the Rollup `renderChunk` hook. Oxc removes the `//# chunkId=` comment added by the PostHog plugin but keeps the runtime chunk ID code. The plugin then skips every client chunk in `writeBundle`, so the build succeeds without uploading client source maps.

Closes #4596

## Changes

The plugin now remembers each chunk ID during `renderChunk` and restores a missing chunk ID comment in an early `generateBundle` hook after output minification. It uses Rollup's preliminary filename and the tracked ID to avoid adding comments to prebuilt or unrelated chunks.

This also adds focused unit tests and a functional test that runs a minified Vite 8 client build with Oxc and verifies that the client chunk is passed to `posthog-cli sourcemap upload`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [x] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the fix and ran the autoreview skill. The implementation restores the existing CLI-facing comment after minification instead of parsing arbitrary runtime code or uploading every JavaScript chunk. This keeps the existing prebuilt chunk exclusion and does not require a coordinated `posthog-cli` protocol change.
