### PR TITLE
fix(browser): dedupe external scripts when api_host is a relative path

### DIFF
--- a/.changeset/fix-relative-api-host-script-dedupe.md
+++ b/.changeset/fix-relative-api-host-script-dedupe.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Stop adding PostHog's optional feature scripts, such as the session replay recorder and exception autocapture, to the page more than once. Sites that proxy PostHog through their own domain, by setting `api_host` to a path like `/ingest` rather than a full URL, ended up with the same `<script>` tag three or four times: the check meant to spot the duplicate compared the browser's resolved absolute URL against the relative one, so it never matched. The network tab showed a single request either way, because the browser served the repeats from its cache, which is why this was easy to miss. Nothing measurable got slower as a result, so this is a correctness fix rather than a speed one.

--- a/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
@@ -22,6 +22,7 @@ describe('external-scripts-loader', () => {
         const callback = jest.fn()
         beforeEach(() => {
             callback.mockClear()
+            mockPostHog.config.api_host = 'https://us.posthog.com'
             mockPostHog.config.strict_script_versioning = false
             mockPostHog.config.asset_host = null
             delete mockPostHog.config.__preview_external_dependency_versioned_paths
@@ -60,6 +61,21 @@ describe('external-scripts-loader', () => {
             expect(headScripts[0].src).toContain('recorder.js')
 
             mockPostHog.config.external_scripts_inject_target = 'body'
+        })
+
+        it('does not add duplicate scripts when api_host is a relative path', () => {
+            // a reverse-proxied host, which endpointFor returns as a relative URL
+            mockPostHog.config.api_host = '/ingest'
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+
+            const scripts = document!.getElementsByTagName('script')
+            expect(scripts).toHaveLength(1)
+            expect(scripts[0].src).toBe(`${document!.baseURI.replace(/\/$/, '')}/ingest/static/recorder.js?v=1.0.0`)
+
+            scripts[0].dispatchEvent(new Event('load'))
+            expect(callback).toHaveBeenCalledTimes(2)
         })
 
         it('does not add duplicate scripts', () => {

--- a/packages/browser/src/entrypoints/external-scripts-loader.ts
+++ b/packages/browser/src/entrypoints/external-scripts-loader.ts
@@ -9,7 +9,11 @@ const findScript = (url: string): HTMLScriptElement | undefined => {
     const scripts = document?.querySelectorAll('script')
     if (scripts) {
         for (let i = 0; i < scripts.length; i++) {
-            if (scripts[i].src === url) {
+            // `.src` reads back as a resolved absolute URL, but `url` is relative
+            // whenever `api_host` is a path such as `/ingest`, so that comparison
+            // alone never matches for reverse-proxied setups. The `src` attribute
+            // holds exactly what `loadScript` wrote, so compare against both.
+            if (scripts[i].src === url || scripts[i].getAttribute('src') === url) {
                 return scripts[i]
             }
         }


### PR DESCRIPTION
## Problem

When `api_host` is a relative path such as `/ingest`, which is the documented reverse-proxy setup, `loadExternalDependency` adds a new `<script>` tag every time it is called for the same asset.

`findScript` compares `script.src` against the url `loadScript` was given:

```ts
if (scripts[i].src === url) {
```

`script.src` is a URL-reflecting IDL attribute, so reading it back always gives the resolved absolute URL (`https://example.com/ingest/static/1.417.0/recorder.js`). But `RequestRouter.endpointFor` returns a **relative** url for a relative `api_host` (`/ingest/static/1.417.0/recorder.js`), because a relative host always falls into the `CUSTOM` region branch: the US and EU detection regexes only match absolute `https://...posthog.com` hosts. The two strings are never equal, so the dedupe never fires. The `addScript` re-entrancy guard uses the same comparison, so it does not catch it either.

The comment directly above the call says what should happen, which is what makes this a bug rather than a design choice:

```ts
// Share the result when the same script is requested more than once so the browser
// only downloads and executes it once.
```

**Measured on a production site** running 1.417.0 behind a Next.js rewrite, Chrome 140, mobile emulation:

| asset | `<script>` elements | network requests |
| --- | --- | --- |
| `exception-autocapture.js` | 4 | 1 |
| `dead-clicks-autocapture.js` | 3 | 1 |
| `posthog-recorder.js` | 1 | 1 |
| `web-vitals.js` | 1 | 1 |

The browser serves the extra copies from its HTTP cache, so the network panel shows one request and the problem is easy to miss.

**This is not a performance fix, and I want to be straight about that.** I patched 1.417.0 in that app, rebuilt, and profiled it under a 4x CPU throttle, three runs each. The duplicate tags went away (4 to 1, and 3 to 1) but total PostHog main-thread time was **205 ms both before and after**. V8 serves the repeat executions from its compilation cache, and these modules only re-run a few top-level assignments onto `window.__PosthogExtensions__`.

So the reasons to fix it are correctness ones:

- The code does not do what its own comment says.
- It puts multiple identical `<script>` elements in the DOM.
- Every module's top level runs three or four times. Those top levels happen to be idempotent today, and nothing enforces that. An extension that ever registered a listener or started a timer at module scope would silently do it three times.

## Changes

`findScript` now also compares the raw `src` **attribute**, which holds exactly the string `loadScript` wrote:

```ts
if (scripts[i].src === url || scripts[i].getAttribute('src') === url) {
```

I first wrote this as `new URL(url, document.baseURI).href`, which is the more general fix. Your compat lint rejected it:

```
error  URL is not supported in op_mini all  compat/compat
```

so I used the attribute comparison instead. It needs no new API, and it is exact rather than approximate, because `loadScript` is the only thing writing these tags.

Behaviour with an absolute `api_host` is unchanged, and the existing inline snapshots still match.

**Tests.** `does not add duplicate scripts` already asserted the correct behaviour and passed only because its mock uses `api_host: 'https://us.posthog.com'`. I added a sibling test using `/ingest`, and reset `api_host` in `beforeEach` so the value cannot leak into other tests.

## Test strategy

Everything below was run in this branch.

**Unit suite** for `packages/browser`:

```
pnpm test:unit
Test Suites: 127 passed, 127 total
Tests:       8 skipped, 5530 passed, 5538 total
Snapshots:   40 passed, 40 total
```

**Functional suite**:

```
pnpm test:functional
Test Suites: 2 passed, 2 total
Tests:       8 passed, 8 total
```

**Lint** on both changed files: clean.

**The new test was verified to fail without the fix**, so it is a guard rather than decoration. Reverting only the `findScript` comparison gives:

```
✕ does not add duplicate scripts when api_host is a relative path
  Expected length: 1
  Received length: 2
  Received object: [<script src="/ingest/static/recorder.js?v=1.0.0" />,
                    <script src="/ingest/static/recorder.js?v=1.0.0" />]
```

During that same run the existing `does not add duplicate scripts` test still passed, because its mock uses an absolute `api_host`. That is exactly the blind spot this PR closes.

**Verified end to end in a real app, not only in unit tests.** I applied the same change to 1.417.0 with `pnpm patch` in a Next.js site configured with `api_host: '/ingest'`, rebuilt, and loaded it in Chrome with the capture endpoints blocked so no test events were sent. Script-element counts went from 4 and 3 down to 1 and 1, matching the unit test.

Edge cases considered: absolute `api_host` (unchanged, covered by the existing tests and inline snapshots), `strict_script_versioning` in both `true` and `'fallback'` modes, and the `DOMContentLoaded` path where `addScript` is deferred. All covered by existing tests, all passing.

**Everything CI gates on is covered.** `library-ci.yml` runs `pnpm test:unit`, `pnpm test:functional` and `pnpm lint`, and all three pass here, the last one as `pnpm --filter posthog-js lint` (`eslint src && eslint playwright`), clean.

One small aside while I was there: `packages/browser` has a `test:typecheck` script that nothing invokes. It appears exactly once in the repo, in its own `package.json`, and is referenced by no workflow and no turbo task (turbo's tasks are `clean, build, prepublish, check-types, package, lint, lint:fix, test:unit, test:functional, test:e2e, test, dev, generate-references`). It also fails on an unmodified tree with:

```
error TS2688: Cannot find type definition file for 'dompurify'.
error TS2688: Cannot find type definition file for 'dotenv'.
```

because `@types/dompurify` and `@types/dotenv` are deprecated stubs that ship no type definitions. Nothing to do with this PR, and not a gate, but you may want to either wire it up or delete it.

No UI change, so no screenshot.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while I was profiling my own site's mobile PageSpeed scores with Claude Code. The lead came from Lighthouse's `duplicated-javascript` audit listing the same PostHog asset several times; I confirmed it in a real Chrome session by counting `<script>` elements against network requests, and printed both URL forms off the same element to see the mismatch. The cause was then traced through `external-scripts-loader.ts` and `request-router.ts`.

Two decisions worth flagging for review. I chose the attribute comparison over resolving the url because your compat lint rejects the `URL` constructor for `op_mini all`; the resolving version is more general if you would rather relax that rule. And I rejected a module-scope `Map` registry keyed by resolved url, which would also fix it and would survive a tag being removed from the DOM, because it adds state that has to be invalidated and this keeps the existing "the DOM is the registry" design.

I also measured before claiming anything, which changed the framing of this PR: the original write-up pitched it as saving ~74 kB of redundant parse and execute, and the measurement showed no wall-clock difference at all. It is submitted as a correctness fix.


