### PR TITLE
fix(react-native): support bare Hermes sourcemaps

### DIFF
--- a/.changeset/fix-bare-rn-hermes-sourcemaps.md
+++ b/.changeset/fix-bare-rn-hermes-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix bare React Native Hermes sourcemap Chunk ID generation in the Metro serializer.

--- a/.changeset/fix-bare-rn-hermes-sourcemaps.md
+++ b/.changeset/fix-bare-rn-hermes-sourcemaps.md
@@ -2,4 +2,4 @@
 'posthog-react-native': patch
 ---
 
-Fix bare React Native Hermes sourcemap Chunk ID generation in the Metro serializer.
+Fix bare React Native Hermes sourcemap Chunk ID generation in the Metro serializer. Requires posthog-cli >= 0.14.1 to clone and upload the generated camel-case `chunkId` metadata.

--- a/packages/react-native/src/tooling/posthogMetroSerializer.ts
+++ b/packages/react-native/src/tooling/posthogMetroSerializer.ts
@@ -111,6 +111,7 @@ export const createPostHogMetroSerializer = (customSerializer?: MetroSerializer)
 
     const bundleMap: SourceMap = JSON.parse(bundleMapString)
     bundleMap['chunkId'] = debugId
+    bundleMap['debugId'] = debugId
 
     return {
       code: bundleCodeWithDebugId,

--- a/packages/react-native/src/tooling/posthogMetroSerializer.ts
+++ b/packages/react-native/src/tooling/posthogMetroSerializer.ts
@@ -2,13 +2,23 @@
 // Copyright (c) 2017 Sentry
 // Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 
+import * as crypto from 'crypto'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { MixedOutput, Module, ReadOnlyGraph } from 'metro'
-import type { MetroSerializer, MetroSerializerOutput, SerializedBundle, VirtualJSOutput } from './utils'
-import { createDebugIdSnippet, createVirtualJSModule, determineDebugIdFromBundleSource, prependModule } from './utils'
+import type { Bundle, MetroSerializer, MetroSerializerOutput, SerializedBundle, VirtualJSOutput } from './utils'
+import {
+  createDebugIdSnippet,
+  createVirtualJSModule,
+  determineDebugIdFromBundleSource,
+  prependModule,
+  stringToUUID,
+} from './utils'
 import { createDefaultMetroSerializer } from './vendor/metro/utils'
 
 type SourceMap = Record<string, unknown>
+type PostHogSerializerOptions = Parameters<MetroSerializer>[3] & {
+  posthogBundleCallback?: (bundle: Bundle) => Bundle
+}
 
 const DEBUG_ID_PLACE_HOLDER = '__POSTHOG_CHUNK_ID__'
 const DEBUG_ID_MODULE_PATH = '__chunkid__'
@@ -69,17 +79,21 @@ export const createPostHogMetroSerializer = (customSerializer?: MetroSerializer)
     }
 
     const debugIdModule = createDebugIdModule(DEBUG_ID_PLACE_HOLDER)
+    const serializerOptions = options as PostHogSerializerOptions
+    serializerOptions.posthogBundleCallback = createPostHogBundleCallback(debugIdModule)
     const modifiedPremodules = prependModule(premodules, debugIdModule)
 
-    // Run wrapped serializer
-    const serializerResult = serializer(entryPoint, modifiedPremodules, graph, options)
+    // The default serializer invokes posthogBundleCallback after Metro assembles
+    // the bundle and before it renders code/source maps, so both outputs contain
+    // the same real Chunk ID.
+    const serializerResult = serializer(entryPoint, modifiedPremodules, graph, serializerOptions)
     const { code: bundleCode, map: bundleMapString } = await extractSerializerResult(serializerResult)
 
-    // Add Chunk ID comment to the bundle
     const debugId = determineDebugIdFromBundleSource(bundleCode)
     if (!debugId) {
       throw new Error('Chunk ID was not found in the bundle.')
     }
+
     // Only print Chunk ID for command line builds => not hot reload from dev server
     // eslint-disable-next-line no-console
     console.log('info ' + `Bundle Chunk ID: ${debugId}`)
@@ -96,13 +110,28 @@ export const createPostHogMetroSerializer = (customSerializer?: MetroSerializer)
           )}`
 
     const bundleMap: SourceMap = JSON.parse(bundleMapString)
-
     bundleMap['chunkId'] = debugId
 
     return {
       code: bundleCodeWithDebugId,
       map: JSON.stringify(bundleMap),
     }
+  }
+}
+
+/**
+ * Called by the default Metro serializer after baseJSBundle has produced the
+ * final bundle but before source-map generation. That ordering is important:
+ * both generated code and sourcesContent must contain the same real Chunk ID.
+ */
+function createPostHogBundleCallback(
+  debugIdModule: Module<VirtualJSOutput> & { setSource: (code: string) => void }
+): (bundle: Bundle) => Bundle {
+  return (bundle) => {
+    const debugId = calculateDebugId(bundle.pre, bundle.modules)
+    debugIdModule.setSource(injectDebugId(debugIdModule.getSource().toString(), debugId))
+    bundle.pre = injectDebugId(bundle.pre, debugId)
+    return bundle
   }
 }
 
@@ -125,4 +154,19 @@ async function extractSerializerResult(serializerResult: MetroSerializerOutput):
 
 function createDebugIdModule(debugId: string): Module<VirtualJSOutput> & { setSource: (code: string) => void } {
   return createVirtualJSModule(DEBUG_ID_MODULE_PATH, createDebugIdSnippet(debugId))
+}
+
+function calculateDebugId(bundleCode: string, modules?: Array<[id: number, code: string]>): string {
+  const hash = crypto.createHash('md5')
+  hash.update(bundleCode)
+  if (modules) {
+    for (const [, code] of modules) {
+      hash.update(code)
+    }
+  }
+  return stringToUUID(hash.digest('hex'))
+}
+
+function injectDebugId(code: string, debugId: string): string {
+  return code.replace(new RegExp(DEBUG_ID_PLACE_HOLDER, 'g'), debugId)
 }

--- a/packages/react-native/src/tooling/posthogMetroSerializer.ts
+++ b/packages/react-native/src/tooling/posthogMetroSerializer.ts
@@ -111,7 +111,6 @@ export const createPostHogMetroSerializer = (customSerializer?: MetroSerializer)
 
     const bundleMap: SourceMap = JSON.parse(bundleMapString)
     bundleMap['chunkId'] = debugId
-    bundleMap['debugId'] = debugId
 
     return {
       code: bundleCodeWithDebugId,

--- a/packages/react-native/src/tooling/utils.ts
+++ b/packages/react-native/src/tooling/utils.ts
@@ -64,15 +64,15 @@ export function stringToUUID(str: string): string {
 }
 
 /**
- * Looks for an injected `_posthogChunkIds[n] = "debugId"` pattern
- * in the bundle source and extracts the `debugId` value from it.
- *
- * Matches both string and numeric keys for `n`, e.g.:
- *   _posthogChunkIds["abc"] = "1234"
- *   _posthogChunkIds[42] = "1234"
+ * Looks for an injected `_posthogChunkIds[...] = "uuid"` pattern in bundle
+ * source and extracts the generated Chunk ID. The runtime key is the stack
+ * expression and can be minified to a variable such as `n`, so the key itself
+ * must not be restricted to string or numeric literals.
  */
 export function determineDebugIdFromBundleSource(code: string): string | undefined {
-  const match = code.match(/_posthogChunkIds\[\s*(?:(?:"[^"]*")|(?:'[^']*')|\d+)\s*\]\s*=\s*"([^"]+)"/)
+  const match = code.match(
+    /_posthogChunkIds\[[^\]]+\]\s*=\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})"/
+  )
   return match ? match[1] : undefined
 }
 

--- a/packages/react-native/src/tooling/utils.ts
+++ b/packages/react-native/src/tooling/utils.ts
@@ -157,10 +157,17 @@ export function createVirtualJSModule(
   moduleCode: string
 ): Module<VirtualJSOutput> & { setSource: (code: string) => void } {
   let sourceCode = moduleCode
+  const outputData: VirtualJSOutput['data'] = {
+    code: sourceCode,
+    lineCount: countLines(sourceCode),
+    map: [],
+  }
 
   return {
     setSource: (code: string) => {
       sourceCode = code
+      outputData.code = code
+      outputData.lineCount = countLines(code)
     },
     dependencies: new Map(),
     getSource: () => Buffer.from(sourceCode),
@@ -169,11 +176,7 @@ export function createVirtualJSModule(
     output: [
       {
         type: 'js/script/virtual',
-        data: {
-          code: sourceCode,
-          lineCount: countLines(sourceCode),
-          map: [],
-        },
+        data: outputData,
       },
     ],
   }

--- a/packages/react-native/src/tooling/vendor/metro/utils.ts
+++ b/packages/react-native/src/tooling/vendor/metro/utils.ts
@@ -29,7 +29,7 @@ import type { MixedOutput, Module, ReadOnlyGraph } from 'metro'
 import type * as baseJSBundleType from 'metro/private/DeltaBundler/Serializers/baseJSBundle'
 import type * as sourceMapStringType from 'metro/private/DeltaBundler/Serializers/sourceMapString'
 import type * as bundleToStringType from 'metro/private/lib/bundleToString'
-import type { MetroSerializer } from '../../utils'
+import type { Bundle, MetroSerializer } from '../../utils'
 
 let baseJSBundleModule: any
 try {
@@ -78,6 +78,10 @@ type NewSourceMapStringExport = {
   sourceMapString: typeof sourceMapString
 }
 
+type PostHogSerializerOptions = Parameters<MetroSerializer>[3] & {
+  posthogBundleCallback?: (bundle: Bundle) => Bundle
+}
+
 /**
  * This function ensures that modules in source maps are sorted in the same
  * order as in a plain JS bundle.
@@ -113,6 +117,13 @@ export const createDefaultMetroSerializer = (): MetroSerializer => {
   return (entryPoint, premodules, graph, options) => {
     // baseJSBundle assigns IDs to modules in a consistent order
     let bundle = (baseJSBundle.default || baseJSBundle)(entryPoint, premodules, graph, options)
+    const serializerOptions = options as PostHogSerializerOptions
+
+    // Inject the final Chunk ID before both code rendering and source-map
+    // generation so they describe the same bundle bytes.
+    if (serializerOptions.posthogBundleCallback && !graph.transformOptions.hot) {
+      bundle = serializerOptions.posthogBundleCallback(bundle)
+    }
 
     const { code } = (bundleToString.default || bundleToString)(bundle)
     if (graph.transformOptions.hot) {

--- a/packages/react-native/test/posthogMetroSerializer.spec.ts
+++ b/packages/react-native/test/posthogMetroSerializer.spec.ts
@@ -29,8 +29,9 @@ describe('PostHog Metro serializer', () => {
     expect(first.code).not.toContain('__POSTHOG_CHUNK_ID__')
     expect(first.code).toContain(`//# chunkId=${firstChunkId}`)
 
-    const map = JSON.parse(first.map) as { chunkId?: string; sourcesContent?: string[] }
+    const map = JSON.parse(first.map) as { chunkId?: string; debugId?: string; sourcesContent?: string[] }
     expect(map.chunkId).toBe(firstChunkId)
+    expect(map.debugId).toBe(firstChunkId)
     expect(map.sourcesContent?.join('\n')).toContain(firstChunkId)
     expect(map.sourcesContent?.join('\n')).not.toContain('__POSTHOG_CHUNK_ID__')
   })

--- a/packages/react-native/test/posthogMetroSerializer.spec.ts
+++ b/packages/react-native/test/posthogMetroSerializer.spec.ts
@@ -1,10 +1,6 @@
 import type { MixedOutput, Module } from 'metro'
 import { createPostHogMetroSerializer } from '../src/tooling/posthogMetroSerializer'
-import {
-  createDebugIdSnippet,
-  determineDebugIdFromBundleSource,
-  type MetroSerializer,
-} from '../src/tooling/utils'
+import { createDebugIdSnippet, determineDebugIdFromBundleSource, type MetroSerializer } from '../src/tooling/utils'
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 

--- a/packages/react-native/test/posthogMetroSerializer.spec.ts
+++ b/packages/react-native/test/posthogMetroSerializer.spec.ts
@@ -29,9 +29,8 @@ describe('PostHog Metro serializer', () => {
     expect(first.code).not.toContain('__POSTHOG_CHUNK_ID__')
     expect(first.code).toContain(`//# chunkId=${firstChunkId}`)
 
-    const map = JSON.parse(first.map) as { chunkId?: string; debugId?: string; sourcesContent?: string[] }
+    const map = JSON.parse(first.map) as { chunkId?: string; sourcesContent?: string[] }
     expect(map.chunkId).toBe(firstChunkId)
-    expect(map.debugId).toBe(firstChunkId)
     expect(map.sourcesContent?.join('\n')).toContain(firstChunkId)
     expect(map.sourcesContent?.join('\n')).not.toContain('__POSTHOG_CHUNK_ID__')
   })

--- a/packages/react-native/test/posthogMetroSerializer.spec.ts
+++ b/packages/react-native/test/posthogMetroSerializer.spec.ts
@@ -1,0 +1,81 @@
+import type { MixedOutput, Module } from 'metro'
+import { createPostHogMetroSerializer } from '../src/tooling/posthogMetroSerializer'
+import {
+  createDebugIdSnippet,
+  determineDebugIdFromBundleSource,
+  type MetroSerializer,
+} from '../src/tooling/utils'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('PostHog Metro serializer', () => {
+  test('generates a real deterministic chunk id for a bare React Native bundle', async () => {
+    const serializer = createPostHogMetroSerializer()
+
+    const first = await serializer(...mockSerializerArgs())
+    const second = await serializer(...mockSerializerArgs())
+
+    expect(typeof first).not.toBe('string')
+    expect(typeof second).not.toBe('string')
+    if (typeof first === 'string' || typeof second === 'string') {
+      throw new Error('Expected serialized bundle output')
+    }
+
+    const firstChunkId = determineDebugIdFromBundleSource(first.code)
+    const secondChunkId = determineDebugIdFromBundleSource(second.code)
+
+    expect(firstChunkId).toMatch(UUID_PATTERN)
+    expect(secondChunkId).toBe(firstChunkId)
+    expect(first.code).not.toContain('__POSTHOG_CHUNK_ID__')
+    expect(first.code).toContain(`//# chunkId=${firstChunkId}`)
+
+    const map = JSON.parse(first.map) as { chunkId?: string; sourcesContent?: string[] }
+    expect(map.chunkId).toBe(firstChunkId)
+    expect(map.sourcesContent?.join('\n')).toContain(firstChunkId)
+    expect(map.sourcesContent?.join('\n')).not.toContain('__POSTHOG_CHUNK_ID__')
+  })
+
+  test('extracts the generated id when the runtime map uses a variable stack key', () => {
+    const chunkId = '12345678-1234-4abc-8def-123456789abc'
+    const snippet = createDebugIdSnippet(chunkId)
+
+    expect(snippet).toContain('_posthogChunkIds[n]')
+    expect(determineDebugIdFromBundleSource(snippet)).toBe(chunkId)
+    expect(determineDebugIdFromBundleSource(createDebugIdSnippet('__POSTHOG_CHUNK_ID__'))).toBeUndefined()
+  })
+})
+
+function mockSerializerArgs(): Parameters<MetroSerializer> {
+  let modulesCounter = 0
+  const options: Record<string, unknown> = {
+    asyncRequireModulePath: 'asyncRequire',
+    createModuleId: (_filePath: string): number => modulesCounter++,
+    dev: false,
+    getRunModuleStatement: (_moduleId: string | number): string => '',
+    includeAsyncPaths: false,
+    modulesOnly: false,
+    processModuleFilter: (_module: Module<MixedOutput>) => true,
+    projectRoot: '/project/root',
+    runBeforeMainModule: [],
+    runModule: false,
+    serverRoot: '/server/root',
+    shouldAddToIgnoreList: (_module: Module<MixedOutput>) => false,
+  }
+
+  return [
+    'index.js',
+    [],
+    {
+      entryPoints: new Set(),
+      dependencies: new Map(),
+      transformOptions: {
+        hot: false,
+        dev: false,
+        minify: false,
+        type: 'script',
+        unstable_transformProfile: 'hermes-stable',
+      },
+    },
+    options as Parameters<MetroSerializer>[3],
+  ]
+}

--- a/packages/react-native/test/posthogMetroSerializer.spec.ts
+++ b/packages/react-native/test/posthogMetroSerializer.spec.ts
@@ -6,10 +6,14 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0
 
 describe('PostHog Metro serializer', () => {
   test('generates a real deterministic chunk id for a bare React Native bundle', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
     const serializer = createPostHogMetroSerializer()
 
     const first = await serializer(...mockSerializerArgs())
     const second = await serializer(...mockSerializerArgs())
+
+    expect(consoleLogSpy).toHaveBeenCalledTimes(2)
+    consoleLogSpy.mockRestore()
 
     expect(typeof first).not.toBe('string')
     expect(typeof second).not.toBe('string')


### PR DESCRIPTION
Addresses the remaining `posthog-react-native` SDK gaps from #3338.

## Problem

Bare React Native Metro builds currently inject `__POSTHOG_CHUNK_ID__`, but the default serializer does not replace that placeholder with a real deterministic ID early enough for bundle code and source maps to stay aligned.

The runtime snippet also writes `_posthogChunkIds[n]`, while the current extractor only accepts quoted or numeric keys, so bare bundles can fail with:

`Chunk ID was not found in the bundle.`

## Changes

- derive a deterministic Chunk ID from the assembled Metro bundle
- inject that ID before final code and source-map rendering
- keep bundle bytes and `sourcesContent` aligned
- accept the variable stack-expression key emitted by the runtime snippet
- preserve existing failure behavior when no real Chunk ID can be found
- add focused regression coverage for bare/Hermes serialization, variable-key extraction, placeholder removal, source-map identity, and deterministic output
- add a patch changeset for `posthog-react-native`

The separate `posthog-cli hermes clone` path mentioned in #3338 appears to already be fixed in current `PostHog/posthog`, so this PR stays scoped to the SDK-side Metro/Hermes gaps in this repository.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Validation

Validated in the fork against the exact product files in this PR.

Repository-level CI-aligned checks passed, including:

- `pnpm build`
- `pnpm lint`
- `pnpm lint:playground`
- `pnpm test:unit`
- `pnpm test:functional`

React Native package validation passed, including:

- `pnpm --filter=posthog-react-native lint`
- React Native package/dependency build
- `pnpm --filter=posthog-react-native test`
- local SDK packaging
- a real bare React Native 0.81.6 bundle with Hermes

The bare React Native smoke test verifies that:

- the emitted bundle contains a real UUID Chunk ID
- the source map carries the same `chunkId`
- neither output contains `__POSTHOG_CHUNK_ID__`
- `sourcesContent` contains the generated Chunk ID

Additional fork workflows passed, including CodeQL, bundled-size checks, ES5 support, minimum TypeScript version, TestCafe, Playwright integration, changeset hygiene, and versioning validation.

Dedicated bare React Native/Hermes validation:
https://github.com/AyobamiH/posthog-js/actions/runs/32621534574

Full Library checks:
https://github.com/AyobamiH/posthog-js/actions/runs/32621534795

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of changes across different platforms
- [x] Accounted for backwards compatibility of the changes
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- ChatGPT (GPT-5.6 Sol) with GitHub tooling assisted with repository investigation, implementation iteration, and verification under human direction.
- The implementation was kept scoped to the SDK-side issue, compared against the established Sentry React Native Metro serializer approach, and validated against a real bare React Native Hermes bundle rather than relying only on unit tests.
- The ChatGPT session is private and no public session share link is available from the connected tooling. The contributor remains the human DRI and owns the submitted code and review discussion.