### PR TITLE
fix(node): send gzip bytes instead of a Blob request body

### DIFF
--- a/.changeset/node-gzip-uint8array-body.md
+++ b/.changeset/node-gzip-uint8array-body.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-node': patch
+---
+
+The Node SDK now sends the raw gzip bytes as the request body instead of wrapping them in a `Blob`. On Node 24.16 and later, reading a `Blob` request body leaks a native `BlobReader` that is never released, so a service calling `capture()` and `flush()` once per request grew by roughly 2.3 KB of heap per event and never gave it back. This completes the work in #4423: switching to `node:zlib` removed the compression-time Blob reads, but the body itself was still a Blob and still got read once per request. Compression behaviour, headers and the wire format are unchanged, and the edge build keeps using `CompressionStream`.

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -1447,7 +1447,7 @@ export abstract class PostHogCoreStateless {
    * Compresses an outgoing payload. Runtime-specific clients can override this
    * to avoid using the Web Streams compression implementation.
    */
-  protected compressPayload(payload: string): Promise<Blob | null> {
+  protected compressPayload(payload: string): Promise<Blob | Uint8Array<ArrayBuffer> | null> {
     return gzipCompress(payload, this.isDebug)
   }
 
@@ -1766,12 +1766,16 @@ export abstract class PostHogCoreStateless {
     try {
       if (body instanceof Blob) {
         reqByteLength = body.size
+      } else if (body instanceof Uint8Array) {
+        reqByteLength = body.byteLength
       } else {
         reqByteLength = Buffer.byteLength(body, STRING_FORMAT)
       }
     } catch {
       if (body instanceof Blob) {
         reqByteLength = body.size
+      } else if (body instanceof Uint8Array) {
+        reqByteLength = body.byteLength
       } else {
         const encoded = new TextEncoder().encode(body)
         reqByteLength = encoded.length

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -17,6 +17,7 @@ import {
   FeatureFlagDetail,
   SurveyResponse,
   PostHogFetchResponse,
+  PostHogFetchBodyBytes,
   PostHogFetchOptions,
   PostHogPersistedProperty,
   PostHogQueueItem,
@@ -1447,7 +1448,7 @@ export abstract class PostHogCoreStateless {
    * Compresses an outgoing payload. Runtime-specific clients can override this
    * to avoid using the Web Streams compression implementation.
    */
-  protected compressPayload(payload: string): Promise<Blob | Uint8Array<ArrayBuffer> | null> {
+  protected compressPayload(payload: string): Promise<Blob | PostHogFetchBodyBytes | null> {
     return gzipCompress(payload, this.isDebug)
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -299,12 +299,14 @@ export enum PostHogPersistedProperty {
   DeviceId = 'device_id', // only used by posthog-react-native
 }
 
+export type PostHogFetchBodyBytes = Uint8Array & { buffer: ArrayBuffer }
+
 export type PostHogFetchOptions = {
   method: 'GET' | 'POST' | 'PUT' | 'PATCH'
   mode?: 'no-cors'
   credentials?: 'omit'
   headers: { [key: string]: string }
-  body?: string | Blob | Uint8Array<ArrayBuffer>
+  body?: string | Blob | PostHogFetchBodyBytes
   signal?: AbortSignal
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -304,7 +304,7 @@ export type PostHogFetchOptions = {
   mode?: 'no-cors'
   credentials?: 'omit'
   headers: { [key: string]: string }
-  body?: string | Blob
+  body?: string | Blob | Uint8Array<ArrayBuffer>
   signal?: AbortSignal
 }
 

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -3160,6 +3160,38 @@
       "path": "../core/src/types.ts"
     },
     {
+      "id": "PostHogFetchBodyBytes",
+      "name": "PostHogFetchBodyBytes",
+      "properties": [
+        {
+          "description": "The size in bytes of each element in the array.",
+          "type": "number",
+          "name": "BYTES_PER_ELEMENT"
+        },
+        {
+          "description": "The ArrayBuffer instance referenced by the array.",
+          "type": "ArrayBufferLike & ArrayBuffer",
+          "name": "buffer"
+        },
+        {
+          "description": "The length in bytes of the array.",
+          "type": "number",
+          "name": "byteLength"
+        },
+        {
+          "description": "The offset in bytes of the array.",
+          "type": "number",
+          "name": "byteOffset"
+        },
+        {
+          "description": "The length of the array.",
+          "type": "number",
+          "name": "length"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
       "id": "PostHogFetchOptions",
       "name": "PostHogFetchOptions",
       "properties": [
@@ -3180,7 +3212,7 @@
           "name": "headers"
         },
         {
-          "type": "string | Blob",
+          "type": "string | PostHogFetchBodyBytes | Blob",
           "name": "body"
         },
         {

--- a/packages/node/src/__tests__/capture-v1/wiring.spec.ts
+++ b/packages/node/src/__tests__/capture-v1/wiring.spec.ts
@@ -46,8 +46,9 @@ describe('capture v1 wiring (Node SDK)', () => {
     let originalCompressionStream: PropertyDescriptor | undefined
     let compressionStreamSpy: jest.Mock
 
-    const readCompressedBody = async (body: Blob): Promise<any> => {
-      return JSON.parse(gunzipSync(Buffer.from(await body.arrayBuffer())).toString())
+    const readCompressedBody = async (body: Blob | Uint8Array): Promise<any> => {
+      const bytes = body instanceof Uint8Array ? Buffer.from(body) : Buffer.from(await body.arrayBuffer())
+      return JSON.parse(gunzipSync(bytes).toString())
     }
 
     beforeEach(() => {
@@ -77,7 +78,7 @@ describe('capture v1 wiring (Node SDK)', () => {
 
       const [, options] = callsTo('/batch/')[0]
       expect(options.headers['Content-Encoding']).toBe('gzip')
-      expect(options.body).toBeInstanceOf(Blob)
+      expect(options.body).toBeInstanceOf(Uint8Array)
       expect((await readCompressedBody(options.body)).batch[0].event).toBe('custom')
       expect(compressionStreamSpy).not.toHaveBeenCalled()
     })
@@ -89,7 +90,7 @@ describe('capture v1 wiring (Node SDK)', () => {
 
       const [, options] = callsTo('/i/v1/analytics/events')[0]
       expect(options.headers['Content-Encoding']).toBe('gzip')
-      expect(options.body).toBeInstanceOf(Blob)
+      expect(options.body).toBeInstanceOf(Uint8Array)
       expect((await readCompressedBody(options.body)).batch[0].event).toBe('custom')
       expect(compressionStreamSpy).not.toHaveBeenCalled()
     })
@@ -107,7 +108,7 @@ describe('capture v1 wiring (Node SDK)', () => {
       expect(outcome).toEqual({ kind: 'ok' })
       const [, options] = callsTo(path)[0]
       expect(options.headers['Content-Encoding']).toBe('gzip')
-      expect(options.body).toBeInstanceOf(Blob)
+      expect(options.body).toBeInstanceOf(Uint8Array)
       expect((await readCompressedBody(options.body))[payloadKey]).toEqual([])
       expect(compressionStreamSpy).not.toHaveBeenCalled()
     })

--- a/packages/node/src/__tests__/gzip.node.spec.ts
+++ b/packages/node/src/__tests__/gzip.node.spec.ts
@@ -1,11 +1,35 @@
-jest.mock('node:zlib', () => ({
-  gzip: (_input: string, callback: (error: Error) => void) => callback(new Error('compression failed')),
-}))
+let mockFailCompression = false
 
+jest.mock('node:zlib', () => {
+  const actual = jest.requireActual<typeof import('node:zlib')>('node:zlib')
+  return {
+    ...actual,
+    gzip: (input: Buffer | string, callback: (error: Error | null, result?: Buffer) => void) =>
+      mockFailCompression ? callback(new Error('compression failed')) : actual.gzip(input, callback),
+  }
+})
+
+import { gunzipSync } from 'node:zlib'
 import { gzipCompress } from '@/gzip.node'
 
 describe('Node gzip compression', () => {
+  afterEach(() => {
+    mockFailCompression = false
+  })
+
+  it('returns the gzip bytes rather than a Blob', async () => {
+    const payload = JSON.stringify({ batch: [{ event: 'custom' }] })
+
+    const compressed = await gzipCompress(payload)
+
+    // A Blob body leaks a native BlobReader per request on Node >= 24.16 (nodejs/node#63574)
+    expect(compressed).toBeInstanceOf(Uint8Array)
+    expect(compressed).not.toBeInstanceOf(Blob)
+    expect(gunzipSync(compressed!).toString()).toBe(payload)
+  })
+
   it('falls back when zlib compression fails', async () => {
+    mockFailCompression = true
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     await expect(gzipCompress('payload')).resolves.toBeNull()

--- a/packages/node/src/capture-v1/sender.ts
+++ b/packages/node/src/capture-v1/sender.ts
@@ -47,7 +47,7 @@ export interface V1CaptureSenderHooks {
   now?: () => number
   sleep?: (ms: number) => Promise<void>
   generateRequestId?: () => string
-  compress?: (payload: string, isDebug?: boolean) => Promise<Blob | null>
+  compress?: (payload: string, isDebug?: boolean) => Promise<Blob | Uint8Array<ArrayBuffer> | null>
 }
 
 interface V1CaptureAttempt {
@@ -77,7 +77,7 @@ export class V1CaptureSender {
   private readonly now: () => number
   private readonly sleep: (ms: number) => Promise<void>
   private readonly generateRequestId: () => string
-  private readonly compress: (payload: string, isDebug?: boolean) => Promise<Blob | null>
+  private readonly compress: (payload: string, isDebug?: boolean) => Promise<Blob | Uint8Array<ArrayBuffer> | null>
 
   constructor(config: V1CaptureSenderConfig, hooks: V1CaptureSenderHooks) {
     this.config = config
@@ -187,7 +187,7 @@ export class V1CaptureSender {
 
   private async sendOnce(url: string, payload: string, attempt: number, requestId: string): Promise<V1CaptureAttempt> {
     const headers = this.buildHeaders(attempt, requestId)
-    let body: string | Blob = payload
+    let body: string | Blob | Uint8Array<ArrayBuffer> = payload
     if (this.config.compressionEnabled) {
       const compressed = await this.compress(payload, this.config.isDebug)
       if (compressed !== null) {

--- a/packages/node/src/capture-v1/sender.ts
+++ b/packages/node/src/capture-v1/sender.ts
@@ -1,6 +1,7 @@
 import {
   type FetchLike,
   type PostHogEventProperties,
+  type PostHogFetchBodyBytes,
   type PostHogFetchOptions,
   type PostHogFetchResponse,
   gzipCompress,
@@ -47,7 +48,7 @@ export interface V1CaptureSenderHooks {
   now?: () => number
   sleep?: (ms: number) => Promise<void>
   generateRequestId?: () => string
-  compress?: (payload: string, isDebug?: boolean) => Promise<Blob | Uint8Array<ArrayBuffer> | null>
+  compress?: (payload: string, isDebug?: boolean) => Promise<Blob | PostHogFetchBodyBytes | null>
 }
 
 interface V1CaptureAttempt {
@@ -77,7 +78,7 @@ export class V1CaptureSender {
   private readonly now: () => number
   private readonly sleep: (ms: number) => Promise<void>
   private readonly generateRequestId: () => string
-  private readonly compress: (payload: string, isDebug?: boolean) => Promise<Blob | Uint8Array<ArrayBuffer> | null>
+  private readonly compress: (payload: string, isDebug?: boolean) => Promise<Blob | PostHogFetchBodyBytes | null>
 
   constructor(config: V1CaptureSenderConfig, hooks: V1CaptureSenderHooks) {
     this.config = config
@@ -187,7 +188,7 @@ export class V1CaptureSender {
 
   private async sendOnce(url: string, payload: string, attempt: number, requestId: string): Promise<V1CaptureAttempt> {
     const headers = this.buildHeaders(attempt, requestId)
-    let body: string | Blob | Uint8Array<ArrayBuffer> = payload
+    let body: string | Blob | PostHogFetchBodyBytes = payload
     if (this.config.compressionEnabled) {
       const compressed = await this.compress(payload, this.config.isDebug)
       if (compressed !== null) {

--- a/packages/node/src/entrypoints/index.node.ts
+++ b/packages/node/src/entrypoints/index.node.ts
@@ -4,6 +4,7 @@ import { createModulerModifier } from '../extensions/error-tracking/modifiers/mo
 import { addSourceContext } from '../extensions/error-tracking/modifiers/context-lines.node'
 import { createRelativePathModifier } from '../extensions/error-tracking/modifiers/relative-path.node'
 
+import type { PostHogFetchBodyBytes } from '@posthog/core'
 import { PostHogBackendClient } from '../client'
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { PostHogContext } from '../extensions/context/context'
@@ -14,7 +15,7 @@ export class PostHog extends PostHogBackendClient {
     return 'posthog-node'
   }
 
-  protected override compressPayload(payload: string): Promise<Uint8Array<ArrayBuffer> | null> {
+  protected override compressPayload(payload: string): Promise<PostHogFetchBodyBytes | null> {
     return gzipCompress(payload, this.isDebug)
   }
 

--- a/packages/node/src/entrypoints/index.node.ts
+++ b/packages/node/src/entrypoints/index.node.ts
@@ -14,7 +14,7 @@ export class PostHog extends PostHogBackendClient {
     return 'posthog-node'
   }
 
-  protected override compressPayload(payload: string): Promise<Blob | null> {
+  protected override compressPayload(payload: string): Promise<Uint8Array<ArrayBuffer> | null> {
     return gzipCompress(payload, this.isDebug)
   }
 

--- a/packages/node/src/gzip.node.ts
+++ b/packages/node/src/gzip.node.ts
@@ -1,9 +1,10 @@
+import type { PostHogFetchBodyBytes } from '@posthog/core'
 import { gzip } from 'node:zlib'
 import { promisify } from 'node:util'
 
 const gzipAsync = promisify(gzip)
 
-export async function gzipCompress(input: string, isDebug = true): Promise<Uint8Array<ArrayBuffer> | null> {
+export async function gzipCompress(input: string, isDebug = true): Promise<PostHogFetchBodyBytes | null> {
   try {
     const compressed = await gzipAsync(input)
     return new Uint8Array(compressed)

--- a/packages/node/src/gzip.node.ts
+++ b/packages/node/src/gzip.node.ts
@@ -3,10 +3,10 @@ import { promisify } from 'node:util'
 
 const gzipAsync = promisify(gzip)
 
-export async function gzipCompress(input: string, isDebug = true): Promise<Blob | null> {
+export async function gzipCompress(input: string, isDebug = true): Promise<Uint8Array<ArrayBuffer> | null> {
   try {
     const compressed = await gzipAsync(input)
-    return new Blob([new Uint8Array(compressed)])
+    return new Uint8Array(compressed)
   } catch (error) {
     if (isDebug) {
       console.error('Failed to gzip compress data', error)

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -3539,6 +3539,38 @@
       "path": "../core/src/types.ts"
     },
     {
+      "id": "PostHogFetchBodyBytes",
+      "name": "PostHogFetchBodyBytes",
+      "properties": [
+        {
+          "description": "The size in bytes of each element in the array.",
+          "type": "number",
+          "name": "BYTES_PER_ELEMENT"
+        },
+        {
+          "description": "The ArrayBuffer instance referenced by the array.",
+          "type": "ArrayBuffer",
+          "name": "buffer"
+        },
+        {
+          "description": "The length in bytes of the array.",
+          "type": "number",
+          "name": "byteLength"
+        },
+        {
+          "description": "The offset in bytes of the array.",
+          "type": "number",
+          "name": "byteOffset"
+        },
+        {
+          "description": "The length of the array.",
+          "type": "number",
+          "name": "length"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
       "id": "PostHogFetchOptions",
       "name": "PostHogFetchOptions",
       "properties": [
@@ -3559,7 +3591,7 @@
           "name": "headers"
         },
         {
-          "type": "string | Blob",
+          "type": "string | PostHogFetchBodyBytes | Blob",
           "name": "body"
         },
         {


### PR DESCRIPTION
## Problem

#4423 moved Node compression to `node:zlib`, which removed the `Blob.slice().arrayBuffer()` reads in `validateNativeGzip`. The compressed payload is still wrapped in a `Blob` though, and that Blob is what gets handed to `fetch` as the request body — so one Blob is still read per request.

On Node 24.16 and later every Blob read leaks a native `BlobReader` that stays registered on the Node `Environment` for the life of the process (nodejs/node#63574). That lines up with the numbers in #4423: RSS improved from 145 MB to 111 MB but kept climbing instead of flattening.

Measuring retained `heapUsed` after a forced GC, on published `posthog-node` 5.50.0. Module-level client, `flushAt: 1`, `flushInterval: 0`, `capture()` + `await flush()` in a loop against a local sink:

| Node | Config | heap per capture |
| --- | --- | --- |
| 24.17.0 | default | **2.29 KB, linear across 8,000 captures** |
| 24.17.0 | `disableCompression: true` | ~0, flat |
| 20.11.1 | default | ~0, flat |

A heap snapshot after 4,200 captures has 4,201 live `BlobReader`, 4,203 `Blob` and 4,204 `ReadableStream` instances one per capture. The strong retainer path ends in Node itself, not in SDK code:

```
(GC root) -> Node / Environment -> Node / PrincipalRealm
          -> Node / BaseObjectList -> native: Node / Blob::Reader -> BlobReader
```

With this change the same run is flat at ~10.2 MB across 8,000 captures, and the snapshot has zero live `BlobReader`s. 

## Changes

`fetch` takes a `Uint8Array` body directly, so the `Blob` wrapper isn't needed.

- `gzip.node.ts` returns the `Uint8Array` instead of wrapping it in a `Blob`.
- Widen the body type through the places it flows: `compressPayload` in core and in the Node entrypoint, `PostHogFetchOptions.body`, and the Capture V1 `compress` hook and local `body`.
- `fetchWithRetry` computes `reqByteLength` from either a `Blob` or a string; it now handles `Uint8Array` too, in both the `try` and the `catch`.
- The Capture V1 wiring tests asserted `toBeInstanceOf(Blob)` on the request body, so those assertions and the test's `readCompressedBody` helper now expect bytes.
- Added a case to `gzip.node.spec.ts` covering the success path — it asserts the result is a `Uint8Array`, not a `Blob`, and gunzips back to the input. The existing spec mocked `node:zlib` to always fail, so the mock is now toggleable to keep both cases in one file.

The edge entrypoint is untouched and still uses `CompressionStream`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This started from a memory leak on my own Next.js site, which turned out to be a different SDK entirely. Chasing it down meant building a harness that forces GC over the V8 inspector before sampling `heapUsed`, so the numbers are retention rather than GC lag, that's why they disagree with the RSS/`heapTotal` figures in #4423, which plateau visually but keep climbing underneath.

Claude Code did the bisecting, heap-snapshot analysis and the patch under my direction. The `Uint8Array<ArrayBuffer>` detail and the `fetchWithRetry` byte-length branch only surfaced from type-checking the real monorepo, not from reading the source.

Verified locally: `pnpm build`, `pnpm test:unit` (882 in core, 921 in node), `pnpm test:functional`, `test:edge-compat`, and lint. `posthog-js` and `posthog-react-native` build too, since they also consume `PostHogFetchOptions`. The leak measurement used the freshly built fork `dist` overlaid on a 5.50.0 install, and a sink that gunzips and parses the body accepted 10/10 requests with `Content-Encoding: gzip` intact, so the wire format is unchanged.