### PR TITLE
fix(core): clamp uuidv7 RNG output to a valid uint32 so a nonconformant Math.random cannot crash event capture

### DIFF
--- a/.changeset/fix-uuidv7-clamp-nextuint32.md
+++ b/.changeset/fix-uuidv7-clamp-nextuint32.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Stop crashing when the environment's `Math.random()` misbehaves. The vendored UUIDv7 generator builds its random fields from a `Math.random()`-based `nextUint32()`, and a nonconformant implementation that returns a value of 1 or greater, or NaN, pushed those fields out of range, so `fromFieldsV7` threw `RangeError: invalid field value` on every event captured. On React Native this is not hypothetical: Hermes implements `Math.random` with C++ `std::uniform_real_distribution`, which is documented to occasionally return its upper bound, and affected Android devices crash-looped on startup during the SDK's internal event-queue flush — a path applications cannot wrap in a try/catch. `nextUint32()` now clamps its result to a valid unsigned 32-bit integer (`>>> 0`), so a bad random value degrades UUID entropy for that id instead of taking the app down; the timestamp bits are untouched and generated ids remain spec-valid UUIDv7.

--- a/.changeset/fix-uuidv7-clamp-nextuint32.md
+++ b/.changeset/fix-uuidv7-clamp-nextuint32.md
@@ -1,5 +1,6 @@
 ---
 '@posthog/core': patch
+'posthog-react-native': patch
 ---
 
 Stop crashing when the environment's `Math.random()` misbehaves. The vendored UUIDv7 generator builds its random fields from a `Math.random()`-based `nextUint32()`, and a nonconformant implementation that returns a value of 1 or greater, or NaN, pushed those fields out of range, so `fromFieldsV7` threw `RangeError: invalid field value` on every event captured. On React Native this is not hypothetical: Hermes implements `Math.random` with C++ `std::uniform_real_distribution`, which is documented to occasionally return its upper bound, and affected Android devices crash-looped on startup during the SDK's internal event-queue flush — a path applications cannot wrap in a try/catch. `nextUint32()` now clamps its result to a valid unsigned 32-bit integer (`>>> 0`), so a bad random value degrades UUID entropy for that id instead of taking the app down; the timestamp bits are untouched and generated ids remain spec-valid UUIDv7.

--- a/packages/core/src/vendor/uuidv7.spec.ts
+++ b/packages/core/src/vendor/uuidv7.spec.ts
@@ -1,0 +1,26 @@
+import { V7Generator } from './uuidv7'
+
+describe('uuidv7 default RNG', () => {
+  const realRandom = Math.random
+
+  afterEach(() => {
+    Math.random = realRandom
+  })
+
+  it.each([
+    ['exactly 1.0', 1.0],
+    ['greater than 1', 1.5],
+    ['NaN', NaN],
+  ])('does not throw when Math.random() returns %s', (_label, value) => {
+    Math.random = () => value
+    const generator = new V7Generator()
+    const uuid = generator.generate().toString()
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+
+  it('still generates well-formed v7 UUIDs with the real Math.random', () => {
+    const generator = new V7Generator()
+    const uuid = generator.generate().toString()
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+})

--- a/packages/core/src/vendor/uuidv7.ts
+++ b/packages/core/src/vendor/uuidv7.ts
@@ -429,9 +429,15 @@ const getDefaultRandom = (): { nextUint32(): number } => {
 //     };
 //   }
   return {
+    // Clamp to a valid uint32: a nonconformant Math.random() that returns >= 1 or NaN
+    // (e.g. Hermes on Android implements Math.random with C++ std::uniform_real_distribution,
+    // which is documented to occasionally return its upper bound) would otherwise overflow the
+    // field ranges and make fromFieldsV7 throw `RangeError: invalid field value` on every
+    // generate call, crashing React Native apps during the internal event-queue flush.
     nextUint32: (): number =>
-      Math.trunc(Math.random() * 0x1_0000) * 0x1_0000 +
-      Math.trunc(Math.random() * 0x1_0000),
+      (Math.trunc(Math.random() * 0x1_0000) * 0x1_0000 +
+        Math.trunc(Math.random() * 0x1_0000)) >>>
+      0,
   };
 };
 


### PR DESCRIPTION
## Problem

The vendored UUIDv7 generator in `@posthog/core` builds its random fields from a `Math.random()`-based `nextUint32()` (Web Crypto is deliberately disabled for React Native compatibility). If the environment's `Math.random()` ever returns a nonconformant value — **≥ 1.0 or NaN** — `nextUint32()` produces a value outside `[0, 2^32)`, and `UUID.fromFieldsV7` throws `RangeError: invalid field value`.

This is not hypothetical. On React Native Android, Hermes implements `Math.random` with C++ `std::uniform_real_distribution` ([facebook/hermes#1169](https://github.com/facebook/hermes/issues/1169)), which is [documented](https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution) to occasionally return its upper bound (1.0) in most standard-library implementations. In our production fintech app (posthog-react-native 4.61.4 / @posthog/core 1.46.7) affected devices hit the throw inside `PromiseQueue.add → uuidv7()` during the SDK's **internal event-queue flush** — a code path the host app cannot wrap in a try/catch — producing a fatal startup crash loop ~1.5 s after every cold start (Crashlytics: repeated `RangeError: invalid field value` with the `fromFieldsV7 → generateOrAbortCore → generateOrResetCore → generate → uuidv7 → add → addPendingPromise → flushInternal → flush` JS stack). Reinstalling the app does not help; those users are hard-locked out. Related older report: #710.

## Changes

- `packages/core/src/vendor/uuidv7.ts`: clamp `getDefaultRandom().nextUint32()` with `>>> 0` (ToUint32). A misbehaving `Math.random` now degrades entropy for that one id (NaN → 0, ≥ 2^32 wraps) instead of throwing. The timestamp bits are untouched and every downstream field (`randA ≤ 0xfff`, `randBHi < 2^30`, `randBLo ≤ 0xffffffff`, counter ≤ MAX_COUNTER) is mathematically in range, so generated ids remain spec-valid UUIDv7. Conformant engines are unaffected: for in-range inputs `>>> 0` is an identity.
- `packages/core/src/vendor/uuidv7.spec.ts`: new spec asserting `V7Generator.generate()` returns a well-formed v7 UUID when `Math.random()` is stubbed to `1.0`, `1.5`, and `NaN` (all three throw today), plus a sanity check with the real `Math.random`.
- Changeset included (`@posthog/core`: patch).

## Release info Sub-libraries affected

### Libraries affected

The changed package is `@posthog/core`, so every SDK consuming it picks the fix up via the changesets `updateInternalDependencies` flow. The consumer where the crash was observed:

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms (identity for conformant `Math.random`; only nonconforming values change behavior, from throw to wrap)
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size (one `>>> 0`)

### If releasing new changes

- [x] Changeset file added (`.changeset/fix-uuidv7-clamp-nextuint32.md` — authored manually, same format as `pnpm changeset` output)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code during a production Crashlytics investigation directed by @shahidrogers (who previously attempted the broader #4064, closed by the stale bot).
- Decisions: an earlier approach sanitized the timestamp/inputs across the generator (#4064); this PR is deliberately narrower — since 1.46.x already validates `unixTsMs` in `generateOrAbortCore` with a distinct error message, production stacks prove the failing fields are RNG-derived, so only `nextUint32` needs guarding.
- Verified by running the patched generator (tsx) with `Math.random` stubbed to 1.0 / 1.5 / NaN — all previously threw, all now produce regex-valid v7 UUIDs. Full monorepo test suite not run locally; relying on CI.