### PR TITLE
fix(react-native-plugin): raise posthog-ios floor to 3.69.9

### DIFF
--- a/.changeset/olive-spoons-jam.md
+++ b/.changeset/olive-spoons-jam.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Raise the posthog-ios floor to `3.69.9`, which masks React Native New Architecture (Fabric) text and image component views (`RCTParagraphComponentView`, `RCTImageComponentView`) and `react-native-svg` root views (`RNSVGSvgView`) during session replay. Without it, Fabric apps recorded those views unmasked.

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.69.2'
+posthog_ios_version = '3.69.9'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"


### PR DESCRIPTION
## Problem

posthog-ios `3.69.9` masks React Native New Architecture (Fabric) text and image component views (`RCTParagraphComponentView`, `RCTImageComponentView`) and `react-native-svg` root views (`RNSVGSvgView`) during session replay, matching the handling the legacy `RCTTextView`/`RCTImageView` already had (PostHog/posthog-ios#777). Until the plugin's floor moves, a Fabric app on the lower bound of our range records those views unmasked.

The pin is already at `3.69.2`, so `~> 3.69.2` does admit `3.69.9` and a fresh resolve picks it up on its own. This raises the guaranteed floor rather than unblocking anything: it moves consumers pinned lower by `Podfile.lock`, and makes the requirement explicit for anyone reading the podspec.

## Changes

Bumps `posthog_ios_version` in `packages/react-native-plugin/posthog-react-native-plugin.podspec` from `3.69.2` to `3.69.9`. That single variable feeds both resolution paths, the CocoaPods `s.dependency 'PostHog'` and the SPM `spm_dependency` requirement, so one line covers both.

Patch-level, matching how previous native floor raises shipped (#4148 for posthog-ios `3.64.7`, #4154 for posthog-android `3.54.0`).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
