### PR TITLE
fix(react-native): require react-native-plugin 2.4.2 for Fabric replay masking

### DIFF
--- a/.changeset/brave-donkeys-wonder.md
+++ b/.changeset/brave-donkeys-wonder.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Require `@posthog/react-native-plugin` 2.4.2 or later, which raises the posthog-ios floor to `3.69.9`. That release masks React Native New Architecture (Fabric) text and image component views and `react-native-svg` root views during session replay; on older plugin versions Fabric apps recorded those views unmasked.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -97,7 +97,7 @@
     "expo-device": ">= 4.0.0",
     "expo-file-system": ">= 13.0.0",
     "expo-localization": ">= 11.0.0",
-    "@posthog/react-native-plugin": ">= 2.3.0",
+    "@posthog/react-native-plugin": ">= 2.4.2",
     "posthog-react-native-session-replay": ">= 1.6.0",
     "react-native-device-info": ">= 10.0.0",
     "react-native-localize": ">= 3.0.0",


### PR DESCRIPTION
## Problem

`@posthog/react-native-plugin` 2.4.2 raises its posthog-ios floor to `3.69.9` (#4621), which masks React Native New Architecture (Fabric) text and image component views and `react-native-svg` root views during session replay (PostHog/posthog-ios#777). The plugin is a peer dependency, so consumers choose their own version; on anything below 2.4.2 a Fabric app can still record those views unmasked.

Raising the declared floor is the only mechanism that surfaces the requirement at install time.

## Changes

Bumps the `@posthog/react-native-plugin` peer floor in `packages/react-native/package.json` from `>= 2.3.0` to `>= 2.4.2`.

Worth a reviewer's opinion: this is a departure from how we have handled native floor raises so far. The floor last moved for a capability gate (#4415, push notifications), and the patch-level native bumps since then (2.3.1, 2.4.0, 2.4.1) left it alone. The argument for moving it here is that unmasked PII in replay is a different class of problem from a missing feature, so silently leaving consumers on an older plugin is worse than the upgrade friction. If you would rather keep the floor at `>= 2.3.0` and let the changeset text carry the recommendation, say so and I will drop the `package.json` change and keep the changeset.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
