### PR TITLE
fix(core): send logs and metrics through one OTLP batch sender

### DIFF
--- a/.changeset/logs-retry-transient-failures.md
+++ b/.changeset/logs-retry-transient-failures.md
@@ -1,0 +1,6 @@
+---
+'posthog-react-native': patch
+'@posthog/core': patch
+---
+
+Fix buffered logs being dropped instead of retried after HTTP 408, 429 or 5xx

--- a/.changeset/web-logs-metrics-retry-408.md
+++ b/.changeset/web-logs-metrics-retry-408.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix logs and metrics batches being dropped instead of retried after HTTP 408

--- a/packages/browser/src/__tests__/posthog-logs.test.ts
+++ b/packages/browser/src/__tests__/posthog-logs.test.ts
@@ -1098,6 +1098,11 @@ describe('posthog-logs', () => {
                 expect((logs as any)._queue).toHaveLength(1)
             })
 
+            it('keeps records on a 408 so they retry later', async () => {
+                await flushWith(408)
+                expect((logs as any)._queue).toHaveLength(1)
+            })
+
             it('drops records on a 4xx client error', async () => {
                 await flushWith(400)
                 expect((logs as any)._queue).toHaveLength(0)

--- a/packages/browser/src/__tests__/posthog-metrics.test.ts
+++ b/packages/browser/src/__tests__/posthog-metrics.test.ts
@@ -93,6 +93,16 @@ describe('posthog-metrics', () => {
         expect(last.sum.dataPoints[0].asDouble).toBe(2)
     })
 
+    it('retains the window on a 408', async () => {
+        respondWithStatus(408)
+        metrics.count('a', 5)
+        await metrics.flush()
+
+        respondWithStatus(200)
+        await metrics.flush()
+        expect(sentRequests()[1].data.resourceMetrics[0].scopeMetrics[0].metrics[0].sum.dataPoints[0].asDouble).toBe(5)
+    })
+
     it('captures nothing when the instance is not capturing', async () => {
         ;(mockPostHog.is_capturing as jest.Mock).mockReturnValue(false)
         metrics.count('a', 1)

--- a/packages/browser/src/posthog-logs.ts
+++ b/packages/browser/src/posthog-logs.ts
@@ -343,8 +343,8 @@ export class PostHogLogs implements Extension {
                         settle({ kind: 'ok' })
                     } else if (status === 413) {
                         settle({ kind: 'too-large' })
-                    } else if (status === 0 || status === 429 || status >= 500) {
-                        // Transient (network / rate-limit / server error): keep and retry.
+                    } else if (status === 0 || status === 408 || status === 429 || status >= 500) {
+                        // Transient (network / timeout / rate-limit / server error): keep and retry.
                         if (status === 0) {
                             // `_send_request` already logs fetch failures. Bare status 0 is the
                             // XHR/synthetic path, so keep one warning for it here.

--- a/packages/browser/src/posthog-metrics.ts
+++ b/packages/browser/src/posthog-metrics.ts
@@ -151,8 +151,8 @@ export class PostHogMetrics implements Extension {
                         settle({ kind: 'ok' })
                     } else if (status === 413) {
                         settle({ kind: 'too-large' })
-                    } else if (status === 0 || status === 429 || status >= 500) {
-                        // Transient (network / rate-limit / server error): keep and retry.
+                    } else if (status === 0 || status === 408 || status === 429 || status >= 500) {
+                        // Transient (network / timeout / rate-limit / server error): keep and retry.
                         settle({
                             kind: 'retry-later',
                             error: response.error ?? new Error(`metrics request failed with status ${status}`),

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -800,7 +800,10 @@ describe('PostHog Core', () => {
       // transport on the first response for the caller to shrink its batch and
       // retry the same records, where a 5xx is worth re-sending as-is.
       it.each([
+        [408, 3],
+        [429, 3],
         [500, 3],
+        [503, 3],
         [413, 1],
         [400, 1],
       ])('sends %i %i time(s) before returning', async (status, attempts) => {

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -454,24 +454,6 @@ describe('PostHog Core', () => {
       expect(Date.now() - time).toBeLessThan(1000)
     })
 
-    it.each([408, 429, 500])('keeps logs batches retryable after exhausted retries with %s error', async (status) => {
-      ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
-        fetchRetryCount: 0,
-        preloadFeatureFlags: false,
-      })
-      mocks.fetch.mockResolvedValue({
-        status,
-        text: async () => 'err',
-        json: async () => ({ status: 'err' }),
-      })
-
-      await expect(posthog._sendLogsBatch({ resourceLogs: [] })).resolves.toMatchObject({
-        kind: 'retry-later',
-        error: { name: 'PostHogFetchHttpError', status },
-      })
-      expect(mocks.fetch).toHaveBeenCalledTimes(1)
-    })
-
     it('responds with an error after retries with network error ', async () => {
       mocks.fetch.mockImplementation(() => {
         return Promise.reject(new Error('network problems'))
@@ -776,6 +758,58 @@ describe('PostHog Core', () => {
       expect(mocks.storage.getItem(PostHogPersistedProperty.Queue)).toMatchObject([
         { message: { event: 'test-event-3' } },
       ])
+    })
+  })
+
+  describe('OTLP batch senders', () => {
+    // Both share one `_sendOtlpBatch`; the table pins them to the same
+    // classification so a wrapper can't reintroduce a per-signal retry policy.
+    const senders = {
+      logs: (client: PostHogCoreTestClient) => client._sendLogsBatch({ resourceLogs: [] }),
+      metrics: (client: PostHogCoreTestClient) => client._sendMetricsBatch({ resourceMetrics: [] }),
+    }
+
+    const cases: [number, string][] = [
+      [408, 'retry-later'],
+      [429, 'retry-later'],
+      [500, 'retry-later'],
+      [503, 'retry-later'],
+      [413, 'too-large'],
+      [400, 'fatal'],
+      [401, 'fatal'],
+    ]
+
+    describe.each(Object.entries(senders))('%s', (_name, send) => {
+      it.each(cases)('classifies an exhausted %i as %s', async (status, kind) => {
+        ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
+          fetchRetryCount: 0,
+          preloadFeatureFlags: false,
+        })
+        mocks.fetch.mockResolvedValue({
+          status,
+          text: async () => 'err',
+          json: async () => ({ status: 'err' }),
+        })
+
+        await expect(send(posthog)).resolves.toMatchObject({ kind })
+        expect(mocks.fetch).toHaveBeenCalledTimes(1)
+      })
+
+      it('carries the HTTP error on a retry-later outcome', async () => {
+        ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
+          fetchRetryCount: 0,
+          preloadFeatureFlags: false,
+        })
+        mocks.fetch.mockResolvedValue({
+          status: 503,
+          text: async () => 'err',
+          json: async () => ({ status: 'err' }),
+        })
+
+        await expect(send(posthog)).resolves.toMatchObject({
+          error: { name: 'PostHogFetchHttpError', status: 503 },
+        })
+      })
     })
   })
 })

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -795,6 +795,31 @@ describe('PostHog Core', () => {
         expect(mocks.fetch).toHaveBeenCalledTimes(1)
       })
 
+      // The classification cases run with retries off, so they never reach the
+      // `retryCheck` the senders share. This pins it: 413 has to leave the
+      // transport on the first response for the caller to shrink its batch and
+      // retry the same records, where a 5xx is worth re-sending as-is.
+      it.each([
+        [500, 3],
+        [413, 1],
+        [400, 1],
+      ])('sends %i %i time(s) before returning', async (status, attempts) => {
+        jest.useRealTimers()
+        ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
+          fetchRetryCount: 2,
+          fetchRetryDelay: 1,
+          preloadFeatureFlags: false,
+        })
+        mocks.fetch.mockResolvedValue({
+          status,
+          text: async () => 'err',
+          json: async () => ({ status: 'err' }),
+        })
+
+        await send(posthog)
+        expect(mocks.fetch).toHaveBeenCalledTimes(attempts)
+      })
+
       it('carries the HTTP error on a retry-later outcome', async () => {
         ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
           fetchRetryCount: 0,

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -454,6 +454,24 @@ describe('PostHog Core', () => {
       expect(Date.now() - time).toBeLessThan(1000)
     })
 
+    it.each([408, 429, 500])('keeps logs batches retryable after exhausted retries with %s error', async (status) => {
+      ;[posthog, mocks] = createTestClient('TEST_API_KEY', {
+        fetchRetryCount: 0,
+        preloadFeatureFlags: false,
+      })
+      mocks.fetch.mockResolvedValue({
+        status,
+        text: async () => 'err',
+        json: async () => ({ status: 'err' }),
+      })
+
+      await expect(posthog._sendLogsBatch({ resourceLogs: [] })).resolves.toMatchObject({
+        kind: 'retry-later',
+        error: { name: 'PostHogFetchHttpError', status },
+      })
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    })
+
     it('responds with an error after retries with network error ', async () => {
       mocks.fetch.mockImplementation(() => {
         return Promise.reject(new Error('network problems'))

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -116,6 +116,37 @@ describe('PostHogLogs over the core sender', () => {
     expect(queueOf(client)).toHaveLength(1)
   })
 
+  it('retains and resends records after transport retries are exhausted', async () => {
+    jest.useRealTimers()
+    const [client, mocks] = createTestClient('TEST_API_KEY', {
+      fetchRetryCount: 2,
+      fetchRetryDelay: 1,
+      preloadFeatureFlags: false,
+    })
+    const unavailableResponse = { status: 503, text: async () => 'unavailable', json: async () => ({}) }
+    mocks.fetch
+      .mockResolvedValueOnce(unavailableResponse)
+      .mockResolvedValueOnce(unavailableResponse)
+      .mockResolvedValueOnce(unavailableResponse)
+      .mockResolvedValueOnce({ status: 200, text: async () => 'ok', json: async () => ({}) })
+    const logs = new PostHogLogs(
+      client,
+      resolveForTest(),
+      createMockLogger(),
+      () => ({ distinctId: 'user-123' }),
+      immediateOnReady
+    )
+
+    logs.captureLog({ body: 'retry me' })
+    await expect(logs.flush()).rejects.toHaveProperty('name', 'PostHogFetchHttpError')
+    expect(mocks.fetch).toHaveBeenCalledTimes(3)
+    expect(queueOf(client)).toHaveLength(1)
+
+    await expect(logs.flush()).resolves.toBeUndefined()
+    expect(mocks.fetch).toHaveBeenCalledTimes(4)
+    expect(queueOf(client)).toHaveLength(0)
+  })
+
   it('drops the batch when the endpoint answers 401', async () => {
     const { logs, client } = createLogsOverCore(401)
     logs.captureLog({ body: 'unauthorized' })

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -1,4 +1,5 @@
 import { PostHogPersistedProperty } from '../types'
+import { createTestClient, PostHogCoreTestClient } from '../testing'
 import type { Logger } from '../types'
 import { PostHogLogs } from './index'
 import type { BufferedLogEntry, ResolvedPostHogLogsConfig } from './types'
@@ -78,6 +79,51 @@ const readQueue = (instance: any): BufferedLogEntry[] => {
 const getContextFor = (instance: any) => (): { distinctId?: string; sessionId?: string } => ({
   distinctId: instance.getDistinctId() || undefined,
   sessionId: instance.getSessionId() || undefined,
+})
+
+// Drives a real core host rather than a stubbed `_sendLogsBatch`, so the sender's
+// error classification and the queue bookkeeping are exercised together.
+describe('PostHogLogs over the core sender', () => {
+  const createLogsOverCore = (status: number): { logs: PostHogLogs; client: PostHogCoreTestClient } => {
+    const [client, mocks] = createTestClient('TEST_API_KEY', {
+      fetchRetryCount: 0,
+      preloadFeatureFlags: false,
+    })
+    mocks.fetch.mockResolvedValue({
+      status,
+      text: () => Promise.resolve('err'),
+      json: () => Promise.resolve({ status: 'err' }),
+    })
+    const logs = new PostHogLogs(
+      client,
+      resolveForTest(),
+      createMockLogger(),
+      () => ({ distinctId: 'user-123' }),
+      immediateOnReady
+    )
+    return { logs, client }
+  }
+
+  const queueOf = (client: PostHogCoreTestClient): BufferedLogEntry[] =>
+    client.getPersistedProperty<BufferedLogEntry[]>(PostHogPersistedProperty.LogsQueue) ?? []
+
+  it.each([408, 429, 500, 503])('keeps records queued when the endpoint answers %i', async (status) => {
+    const { logs, client } = createLogsOverCore(status)
+    logs.captureLog({ body: 'keep me' })
+
+    await expect(logs.flush()).rejects.toHaveProperty('name', 'PostHogFetchHttpError')
+
+    expect(queueOf(client)).toHaveLength(1)
+  })
+
+  it('drops the batch when the endpoint answers 401', async () => {
+    const { logs, client } = createLogsOverCore(401)
+    logs.captureLog({ body: 'unauthorized' })
+
+    await expect(logs.flush()).rejects.toHaveProperty('name', 'PostHogFetchHttpError')
+
+    expect(queueOf(client)).toHaveLength(0)
+  })
 })
 
 describe('PostHogLogs', () => {

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -262,7 +262,7 @@ export class PostHogLogs {
       }
 
       if (outcome.kind === 'retry-later') {
-        // Network error: keep records in the queue for the next flush cycle
+        // Transient failure: keep records in the queue for the next flush cycle
         // and surface the error so the caller can log/react.
         throw outcome.error
       }

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -237,6 +237,17 @@ export type SendLogsBatchOutcome =
   | { kind: 'retry-later'; error: unknown }
   | { kind: 'fatal'; error: unknown }
 
+/**
+ * Each signal keeps its own exported outcome type because each belongs to a
+ * separate host contract. The wrappers return this value directly, so one
+ * drifting out of shape fails to compile.
+ */
+type SendOtlpBatchOutcome =
+  | { kind: 'ok' }
+  | { kind: 'too-large' }
+  | { kind: 'retry-later'; error: unknown }
+  | { kind: 'fatal'; error: unknown }
+
 export enum QuotaLimitedFeature {
   FeatureFlags = 'feature_flags',
   Recordings = 'recordings',
@@ -1632,20 +1643,28 @@ export abstract class PostHogCoreStateless {
   }
 
   /**
-   * Sends a pre-built OTLP logs payload to `/i/v1/logs`. Returns a tagged
-   * outcome instead of throwing so PostHogLogs doesn't have to know about the
-   * core's error class hierarchy. Error classification lives here.
+   * Shared implementation behind the OTLP senders, which differ only in path.
+   * Returns a tagged outcome instead of throwing so the queue owners don't
+   * have to know the core's error class hierarchy.
    *
-   * 413 is passed through as `too-large` (not auto-retried) so the caller can
-   * shrink `maxBatchRecordsPerPost` and retry the same records.
+   * Exhausted 408/429/5xx stay `retry-later`, unlike the events `_flush()`
+   * which drops anything that isn't a network error: every OTLP queue is
+   * bounded and retried with backoff, so holding a batch through an outage can
+   * neither grow without limit nor spin.
    */
-  async _sendLogsBatch(payload: OtlpLogsPayload): Promise<SendLogsBatchOutcome> {
+  private async _sendOtlpBatch({
+    path,
+    payload,
+  }: {
+    path: 'logs' | 'metrics'
+    payload: OtlpLogsPayload | OtlpMetricsPayload
+  }): Promise<SendOtlpBatchOutcome> {
     if (this.disabled) {
       return { kind: 'fatal', error: new Error('The client is disabled') }
     }
 
     const serialized = JSON.stringify(payload)
-    const url = `${this.host}/i/v1/logs?token=${encodeURIComponent(this.apiKey)}`
+    const url = `${this.host}/i/v1/${path}?token=${encodeURIComponent(this.apiKey)}`
 
     const gzippedPayload = !this.disableCompression ? await this.compressPayload(serialized) : null
     const fetchOptions: PostHogFetchOptions = {
@@ -1684,58 +1703,12 @@ export abstract class PostHogCoreStateless {
     }
   }
 
-  /**
-   * Sends a pre-built OTLP metrics payload to `/i/v1/metrics`. Same tagged
-   * outcome contract and error classification as `_sendLogsBatch` — this is
-   * the `MetricsHost._sendMetricsBatch` implementation, so `PostHogMetrics`
-   * can use any core-based SDK as its host.
-   */
+  async _sendLogsBatch(payload: OtlpLogsPayload): Promise<SendLogsBatchOutcome> {
+    return this._sendOtlpBatch({ path: 'logs', payload })
+  }
+
   async _sendMetricsBatch(payload: OtlpMetricsPayload): Promise<SendMetricsBatchOutcome> {
-    if (this.disabled) {
-      return { kind: 'fatal', error: new Error('The client is disabled') }
-    }
-
-    const serialized = JSON.stringify(payload)
-    const url = `${this.host}/i/v1/metrics?token=${encodeURIComponent(this.apiKey)}`
-
-    const gzippedPayload = !this.disableCompression ? await this.compressPayload(serialized) : null
-    const fetchOptions: PostHogFetchOptions = {
-      method: 'POST',
-      headers: {
-        ...this.getCustomHeaders(),
-        'Content-Type': 'application/json',
-        ...(gzippedPayload !== null && { 'Content-Encoding': 'gzip' }),
-      },
-      body: gzippedPayload || serialized,
-    }
-
-    try {
-      await this.fetchWithRetry(
-        url,
-        fetchOptions,
-        { type: 'successful-write' },
-        {
-          retryCheck: (err) => {
-            if (isPostHogFetchContentTooLargeError(err)) {
-              return false
-            }
-            return isPostHogFetchRetryableError(err)
-          },
-        }
-      )
-      return { kind: 'ok' }
-    } catch (err) {
-      if (isPostHogFetchContentTooLargeError(err)) {
-        return { kind: 'too-large' }
-      }
-      // Exhausted retries on a retryable failure (network error, 408/429/5xx)
-      // still classify as retry-later so the window rides the next flush; only
-      // non-retryable HTTP errors (and 413 above) drop the batch.
-      if (isPostHogFetchRetryableError(err)) {
-        return { kind: 'retry-later', error: err }
-      }
-      return { kind: 'fatal', error: err }
-    }
+    return this._sendOtlpBatch({ path: 'metrics', payload })
   }
 
   private fetchWithRetry<T>(

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -222,13 +222,12 @@ function isPostHogEventProperties(value: JsonType | undefined): value is PostHog
 }
 
 /**
- * Outcome of a logs batch send. Keeps HTTP error classification inside core
- * (single source of truth — same policy events already use in `_flush()`) so
+ * Outcome of a logs batch send. Keeps HTTP error classification inside core so
  * PostHogLogs doesn't need to know about specific error types.
  *
  *   - ok            → records are accepted; drop them from the queue
  *   - too-large     → 413; caller should halve batch size and retry same records
- *   - retry-later   → network error; caller keeps records and retries next cycle
+ *   - retry-later   → retryable network or HTTP error; caller keeps records and retries next cycle
  *   - fatal         → anything else (auth, malformed, etc.); caller drops the
  *                     batch and surfaces the error
  */
@@ -1635,9 +1634,7 @@ export abstract class PostHogCoreStateless {
   /**
    * Sends a pre-built OTLP logs payload to `/i/v1/logs`. Returns a tagged
    * outcome instead of throwing so PostHogLogs doesn't have to know about the
-   * core's error class hierarchy. Error classification lives here (single
-   * source of truth, same policy the events `_flush()` uses for its own
-   * 413 / network / fatal handling).
+   * core's error class hierarchy. Error classification lives here.
    *
    * 413 is passed through as `too-large` (not auto-retried) so the caller can
    * shrink `maxBatchRecordsPerPost` and retry the same records.
@@ -1680,7 +1677,7 @@ export abstract class PostHogCoreStateless {
       if (isPostHogFetchContentTooLargeError(err)) {
         return { kind: 'too-large' }
       }
-      if (err instanceof PostHogFetchNetworkError) {
+      if (isPostHogFetchRetryableError(err)) {
         return { kind: 'retry-later', error: err }
       }
       return { kind: 'fatal', error: err }


### PR DESCRIPTION
## Problem

Fixes #4570. Supersedes #4575, which GitHub auto-closed when the branch it was stacked on was rewritten; the content is the same minus the traces sender, which now lands in #4579.

`PostHogCoreStateless` grew near-identical OTLP senders — `_sendLogsBatch` and `_sendMetricsBatch`, each around 50 lines, differing only in endpoint path. Nothing kept them in sync and they had already drifted: logs classified an exhausted 408/429/5xx as `fatal`, so `PostHogLogs` advanced its persisted queue and **dropped the batch**, while metrics returned `retry-later` and kept theirs.

Probing each sender through `createTestClient` with retries exhausted:

| status | `_sendLogsBatch` (before) | `_sendMetricsBatch` |
| --- | --- | --- |
| 408 / 429 / 500 / 503 | `fatal` (dropped) | `retry-later` |

The existing specs in `logs/index.spec.ts` already pin the consequence: a `fatal` outcome leaves the queue at length 0, a `retry-later` outcome leaves it at 1.

Logs was the odd one out in a second way. The browser's own logs adapter in `packages/browser/src/posthog-logs.ts` already returned `retry-later` for 429/5xx, so the same product dropped records on React Native and retried them on web. That, more than the metrics comparison, is what makes the old logs behaviour a bug rather than a deliberate choice — though it was a deliberate choice once: the original docblock said logs used "the same policy the events `_flush()` uses", and the events flush really does drop anything that isn't a `PostHogFetchNetworkError`.

## Changes

**One sender.** Both bodies collapse into a private `_sendOtlpBatch({ path, payload })`; the two public methods become one-line wrappers that keep their existing host-contract return types. Every duplicated concern now exists once: the disabled check, `JSON.stringify`, the gzip-unless-`disableCompression` branch, custom headers, the `fetchWithRetry` call with its 413-excluding `retryCheck`, and the four-way outcome mapping.

**One policy.** Everything routes through `isPostHogFetchRetryableError`, so exhausted 408/429/5xx are `retry-later` for both signals. This deliberately diverges from the events `_flush()`: every OTLP queue is bounded by its buffer cap and retried with exponential backoff, so holding a batch through an outage can neither grow without limit nor spin on a poison payload — the property the events queue can't rely on.

**Browser parity.** The browser logs and metrics adapters classified 408 as a plain 4xx and dropped the batch. They now treat it as transient, matching `isPostHogFetchRetryableError`.

**Coverage.** The single-signal test from the first commit becomes a per-signal table in `posthog.flush.spec.ts` pinning both senders to the same classification, including the 413 → `too-large` and non-retryable-4xx → `fatal` cases that had no coverage at all before. `logs/index.spec.ts` gains a block driving `PostHogLogs` over a real core host instead of a stubbed `_sendLogsBatch`, so the sender classification and the queue bookkeeping are exercised together — that is the seam where the records were actually lost.

Both guards were checked by reverting the classification in `_sendOtlpBatch`: the matrix and the end-to-end block both fail. The browser 408 tests fail without the adapter change.

### Notes for reviewers

A project over its quota gets a 429, so logs now retry it with backoff until the buffer cap evicts rather than dropping it immediately. That is bounded, and it is already how metrics and web logs behave.

`SendLogsBatchOutcome` and `SendMetricsBatchOutcome` are still two identical unions and were left that way on purpose: they appear expanded inline in the generated public API reference snapshots, so aliasing them to one type would rewrite those snapshots and show an opaque alias in the docs for no behavioural gain. The drift risk is closed instead by each wrapper returning the shared value directly, which makes either going out of shape a compile error.

`_sendOtlpBatch` takes no auth parameter here because both signals authenticate with `?token=`. The traces sender needs `Authorization: Bearer`, so #4579 reintroduces an `auth` argument when it folds `_sendTracesBatch` into the same helper — it stays out of `main` until there is a caller for it.

`posthog-node` doesn't wire `PostHogLogs`, so nothing changes for it.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The first commit is the original posthog-watcher/pi draft: a one-condition change to the logs outcome mapping. Reviewing that draft (Claude Code) found the title promised an extraction it did not perform, it shipped without a changeset, it deleted the comment recording the old rationale rather than replacing it, and it lacked both the 413/4xx assertions its own description claimed and any test at the layer where records were actually lost.

The second commit does the extraction the issue asked for and closes those gaps. The behaviour fix was kept as its own commit so it stays reviewable independently, as the issue requested. An alternative — extracting first with a per-caller retry classifier to preserve the logs behaviour exactly — was rejected: it would have added a knob to the new helper whose only purpose was preserving the bug.

This work was originally stacked on the traces PR (#4579) because `_sendTracesBatch` was a third copy of the same sender. Splitting it so the shared helper lands on `main` first and traces joins it afterwards was the reason for reopening as a new PR.

Verification was local (`jest` across `packages/core`, `packages/browser`, `packages/node`, plus `eslint`); no manual device testing was done.
