### PR TITLE
fix(react-native): require posthog-ios 3.69.10

### DIFF
--- a/.changeset/calm-symbols-wait.md
+++ b/.changeset/calm-symbols-wait.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Require posthog-ios 3.69.10 so native dSYMs are uploaded after they are ready.

--- a/packages/react-native-plugin/ios/Package.swift
+++ b/packages/react-native-plugin/ios/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: reactNativeDependencies + [
         .package(
             url: "https://github.com/PostHog/posthog-ios.git",
-            .upToNextMinor(from: "3.69.2")
+            .upToNextMinor(from: "3.69.10")
         ),
     ],
     targets: [

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.69.2'
+posthog_ios_version = '3.69.10'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"


### PR DESCRIPTION
## Problem

The React Native plugin currently accepts posthog-ios 3.69.2. Versions before 3.69.10 can start a native symbol upload before Xcode has finished writing the current app dSYM.

The native fix shipped in [posthog-ios#776](https://github.com/PostHog/posthog-ios/pull/776) as posthog-ios 3.69.10. This dependency update complements the Hermes source map changes in [posthog-js#4602](https://github.com/PostHog/posthog-js/pull/4602).

## Changes

- Raise the minimum posthog-ios version to 3.69.10 for CocoaPods.
- Raise the minimum posthog-ios version to 3.69.10 for Swift Package Manager.
- Add a patch changeset for `@posthog/react-native-plugin`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi. The version floor stays aligned across CocoaPods and Swift Package Manager, and the existing manifest consistency test covers both declarations. Autoreview reported no actionable findings.
