### PR TITLE
feat(replay): capture clipboard interactions

### DIFF
--- a/.changeset/tidy-cats-clip.md
+++ b/.changeset/tidy-cats-clip.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Record cut, copy, and paste interactions in session replays without storing clipboard text.

--- a/packages/browser/playwright/mocked/session-recording/lazy-session-recording.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/lazy-session-recording.spec.ts
@@ -386,3 +386,70 @@ test.describe('Session recording - array.js', () => {
         expect(targetEvent!['properties']['$sdk_debug_session_start']).toBeDefined()
     })
 })
+
+test.describe('Session recording - lazy recorder compatibility', () => {
+    test('captures clipboard events from persisted config before fresh config responds', async ({ page, context }) => {
+        let releaseConfigResponse: () => void = () => {}
+        const remoteConfigResponseGate = new Promise<void>((resolve) => {
+            releaseConfigResponse = resolve
+        })
+        const privateClipboardText = 'private pasted value'
+
+        try {
+            await start(
+                {
+                    waitForFlags: false,
+                    remoteConfigResponseGate,
+                    options: { session_recording: {} },
+                    flagsResponseOverrides: {
+                        sessionRecording: { endpoint: '/ses/' },
+                        autocapture_opt_out: true,
+                    },
+                    url: './playground/cypress/index.html',
+                    runBeforePostHogInit: async (currentPage) => {
+                        await currentPage.evaluate(() => {
+                            window.localStorage.setItem(
+                                'ph_test token_posthog',
+                                JSON.stringify({
+                                    distinct_id: 'clipboard-compat-user',
+                                    $session_recording_remote_config: {
+                                        enabled: true,
+                                        endpoint: '/ses/',
+                                        cache_timestamp: Date.now(),
+                                    },
+                                })
+                            )
+                        })
+                    },
+                },
+                page,
+                context
+            )
+
+            await waitForSessionRecordingToStart(page)
+            await page.resetCapturedEvents()
+            const responsePromise = page.waitForResponse('**/ses/*')
+            await page.evaluate((clipboardText) => {
+                const input = document.querySelector('[data-cy-input]') as HTMLInputElement
+                const event = new Event('paste', { bubbles: true, cancelable: true, composed: true })
+                Object.defineProperty(event, 'clipboardData', {
+                    value: { getData: () => clipboardText },
+                })
+                input.dispatchEvent(event)
+            }, privateClipboardText)
+            await responsePromise
+
+            const clipboardEvents = (await page.capturedEvents())
+                .filter((event) => event.event === '$snapshot')
+                .flatMap((event) => event.properties.$snapshot_data)
+                .filter((event: any) => event.type === 5 && event.data?.tag === '$clipboard')
+            expect(clipboardEvents).toHaveLength(1)
+            expect(clipboardEvents[0].data.payload).toEqual(
+                expect.objectContaining({ type: 'paste', textLength: privateClipboardText.length })
+            )
+            expect(JSON.stringify(clipboardEvents[0])).not.toContain(privateClipboardText)
+        } finally {
+            releaseConfigResponse()
+        }
+    })
+})

--- a/packages/browser/playwright/mocked/utils/setup.ts
+++ b/packages/browser/playwright/mocked/utils/setup.ts
@@ -32,6 +32,7 @@ export interface StartOptions {
     type?: 'navigate' | 'reload'
     options?: Partial<PostHogConfig>
     flagsResponseOverrides?: Partial<FlagsResponse>
+    remoteConfigResponseGate?: Promise<void>
     url?: string
 }
 
@@ -44,6 +45,7 @@ export async function start(
         runAfterPostHogInit = undefined,
         type = 'navigate',
         options = {},
+        remoteConfigResponseGate,
         flagsResponseOverrides = {
             sessionRecording: undefined,
             isAuthenticated: false,
@@ -93,7 +95,8 @@ export async function start(
     // Mock the remote config endpoint to return the same config data as the flags response.
     // RemoteConfig is now the sole config loading mechanism, so tests must serve it.
     // Uses a regex that excludes config.js (script) — only intercepts the JSON config endpoint.
-    void context.route(/\/array\/[^/]+\/config(\?|$)/, (route) => {
+    void context.route(/\/array\/[^/]+\/config(\?|$)/, async (route) => {
+        await remoteConfigResponseGate
         route.fulfill({
             status: 200,
             contentType: 'application/json',
@@ -103,7 +106,8 @@ export async function start(
 
     // allow promise in e2e tests
     const flagsMock = new Promise((resolve) => {
-        void context.route('**/flags/*', (route) => {
+        void context.route('**/flags/*', async (route) => {
+            await remoteConfigResponseGate
             route.fulfill({
                 status: 200,
                 contentType: 'application/json',

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 
 import '@testing-library/jest-dom'
-import { isUndefined } from '@posthog/core'
+import { isFunction, isUndefined } from '@posthog/core'
 
 import { PostHogPersistence } from '../../../posthog-persistence'
 import {
@@ -50,6 +50,7 @@ import {
     IncrementalSource,
     type metaEvent,
     type pluginEvent,
+    type RecordPlugin,
 } from '../../../extensions/replay/types/rrweb-types'
 import { ConsentManager } from '../../../consent'
 import { SimpleEventEmitter } from '@posthog/browser-common/utils/simple-event-emitter'
@@ -182,6 +183,16 @@ const createPluginSnapshot = (event = {}): pluginEvent => ({
     ...event,
 })
 
+function dispatchClipboardEvent(target: EventTarget, type: 'copy' | 'cut' | 'paste', clipboardValue?: unknown): void {
+    const event = new Event(type, { bubbles: true, cancelable: true, composed: true })
+    if (!isUndefined(clipboardValue)) {
+        Object.defineProperty(event, 'clipboardData', {
+            value: { getData: () => clipboardValue },
+        })
+    }
+    target.dispatchEvent(event)
+}
+
 function makeFlagsResponse(partialResponse: Partial<FlagsResponse>): RemoteConfigResult {
     return { ok: true, config: partialResponse as unknown as RemoteConfig }
 }
@@ -237,9 +248,13 @@ describe('Lazy SessionRecording', () => {
 
     const addRRwebToWindow = () => {
         assignableWindow.__PosthogExtensions__.rrweb = {
-            record: jest.fn(({ emit }) => {
+            record: jest.fn(({ emit, plugins = [] }) => {
                 _emit = emit
-                return () => {}
+                const pluginCleanups = plugins
+                    .filter(Boolean)
+                    .map((plugin: RecordPlugin) => plugin.observer?.(jest.fn(), window as Window, plugin.options))
+                    .filter(isFunction)
+                return () => pluginCleanups.forEach((cleanup: () => void) => cleanup())
             }),
             version: 'fake',
             wasMaxDepthReached: jest.fn(() => false),
@@ -2397,6 +2412,28 @@ describe('Lazy SessionRecording', () => {
                     expect(shippedSessionIds()).toEqual(new Set([sessionId]))
                 })
 
+                it('a clipboard interaction after many idle rotations ships exactly one session', () => {
+                    const rotationsBeforeClipboard = runExternalRotations(startingTimestamp, 1)
+                    expect(rotationsBeforeClipboard).toBeGreaterThan(25)
+                    expect(shippedSessionIds()).toEqual(new Set())
+
+                    _addCustomEvent.mockImplementation((tag: string, payload: any) => {
+                        _emit(createCustomSnapshot({ timestamp: Date.now() }, payload, tag))
+                    })
+                    try {
+                        dispatchClipboardEvent(document, 'copy')
+                        sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
+                        const clipboardSessionIds = shippedSessionIds()
+                        expect(clipboardSessionIds.size).toBe(1)
+
+                        const rotationsAfterClipboard = runExternalRotations(Date.now(), 1)
+                        expect(rotationsAfterClipboard).toBeGreaterThan(25)
+                        expect(shippedSessionIds()).toEqual(clipboardSessionIds)
+                    } finally {
+                        _addCustomEvent.mockReset()
+                    }
+                })
+
                 // The Jul 2026 idle-rotation family: an idle tab rotates, the markers for the
                 // rotation land in the new session's empty buffer, and shipping them opens a
                 // recording that bills the customer and plays back as nothing.
@@ -3428,6 +3465,179 @@ describe('Lazy SessionRecording', () => {
     })
 
     describe('recording', () => {
+        describe('clipboard interactions', () => {
+            beforeEach(() => {
+                sessionRecording.onRemoteConfig(makeFlagsResponse({ sessionRecording: { endpoint: '/s/' } }))
+                _addCustomEvent.mockClear()
+            })
+
+            it.each(['copy', 'cut'] as const)('records %s with the selected input length and no text', (type) => {
+                const input = document.createElement('input')
+                input.value = 'private clipboard value'
+                document.body.appendChild(input)
+                input.setSelectionRange(2, 9)
+
+                try {
+                    dispatchClipboardEvent(input, type)
+
+                    expect(_addCustomEvent).toHaveBeenCalledWith('$clipboard', {
+                        type,
+                        textLength: 7,
+                    })
+                    expect(JSON.stringify(_addCustomEvent.mock.calls[0][1])).not.toContain('private clipboard value')
+                } finally {
+                    input.remove()
+                }
+            })
+
+            it('records paste with the clipboard text length and target node id', () => {
+                const input = document.createElement('input')
+                const clipboardText = 'private pasted value'
+                document.body.appendChild(input)
+                assignableWindow.__PosthogExtensions__.rrweb.record.mirror = {
+                    getId: jest.fn(() => 42),
+                    getNode: jest.fn(),
+                }
+
+                try {
+                    dispatchClipboardEvent(input, 'paste', clipboardText)
+
+                    expect(_addCustomEvent).toHaveBeenCalledWith('$clipboard', {
+                        type: 'paste',
+                        textLength: clipboardText.length,
+                        nodeId: 42,
+                    })
+                    expect(JSON.stringify(_addCustomEvent.mock.calls[0][1])).not.toContain(clipboardText)
+                } finally {
+                    input.remove()
+                }
+            })
+
+            it('uses zero when clipboard data does not return a string', () => {
+                dispatchClipboardEvent(document, 'paste', { length: { privateValue: 'not numeric' } })
+
+                expect(_addCustomEvent).toHaveBeenCalledWith('$clipboard', {
+                    type: 'paste',
+                    textLength: 0,
+                })
+                expect(_addCustomEvent.mock.calls[0][1]).toEqual({ type: 'paste', textLength: 0 })
+            })
+
+            it('does not record clipboard events inside ph-no-capture', () => {
+                const privateContainer = document.createElement('div')
+                const input = document.createElement('input')
+                privateContainer.className = 'ph-no-capture'
+                privateContainer.appendChild(input)
+                document.body.appendChild(privateContainer)
+
+                try {
+                    dispatchClipboardEvent(input, 'paste', 'private pasted value')
+
+                    expect(_addCustomEvent).not.toHaveBeenCalled()
+                } finally {
+                    privateContainer.remove()
+                }
+            })
+
+            it('does not record clipboard events inside the configured block selector', () => {
+                const privateContainer = document.createElement('div')
+                const input = document.createElement('input')
+                privateContainer.dataset.private = 'true'
+                privateContainer.appendChild(input)
+                document.body.appendChild(privateContainer)
+                posthog.config.session_recording.blockSelector = '[data-private]'
+
+                try {
+                    dispatchClipboardEvent(input, 'paste', 'private pasted value')
+
+                    expect(_addCustomEvent).not.toHaveBeenCalled()
+                } finally {
+                    posthog.config.session_recording.blockSelector = undefined
+                    privateContainer.remove()
+                }
+            })
+
+            it('uses the original shadow DOM target', () => {
+                const host = document.createElement('div')
+                const shadowRoot = host.attachShadow({ mode: 'open' })
+                const input = document.createElement('input')
+                input.value = 'private clipboard value'
+                input.setSelectionRange(3, 11)
+                shadowRoot.appendChild(input)
+                document.body.appendChild(host)
+                const getId = jest.fn((node) => (node === input ? 42 : -1))
+                assignableWindow.__PosthogExtensions__.rrweb.record.mirror = {
+                    getId,
+                    getNode: jest.fn(),
+                }
+
+                try {
+                    dispatchClipboardEvent(input, 'copy')
+
+                    expect(_addCustomEvent).toHaveBeenCalledWith('$clipboard', {
+                        type: 'copy',
+                        textLength: 8,
+                        nodeId: 42,
+                    })
+                    expect(getId).toHaveBeenCalledWith(input)
+                } finally {
+                    host.remove()
+                }
+            })
+
+            it('observes clipboard events in same-origin iframe documents', () => {
+                const iframe = document.createElement('iframe')
+                document.body.appendChild(iframe)
+                const recordMock = assignableWindow.__PosthogExtensions__.rrweb.record as Mock
+                const recordOptions = recordMock.mock.calls[recordMock.mock.calls.length - 1][0]
+                const clipboardPlugin = recordOptions.plugins.find(
+                    (plugin: RecordPlugin) => plugin.name === 'posthog/clipboard-observer'
+                ) as RecordPlugin
+                const removeIframeObserver = clipboardPlugin.observer?.(
+                    jest.fn(),
+                    iframe.contentWindow as Window,
+                    clipboardPlugin.options
+                )
+
+                try {
+                    dispatchClipboardEvent(iframe.contentDocument as Document, 'paste', 'private pasted value')
+
+                    expect(_addCustomEvent).toHaveBeenCalledWith('$clipboard', {
+                        type: 'paste',
+                        textLength: 20,
+                    })
+                } finally {
+                    removeIframeObserver?.()
+                    iframe.remove()
+                }
+            })
+
+            it('treats clipboard custom events as activity', () => {
+                const lazyRecorder = sessionRecording['_lazyLoadedSessionRecording']
+                lazyRecorder['_isIdle'] = true
+                lazyRecorder['_holdFlushUntilInteraction'] = true
+
+                sessionRecording.onRRwebEmit(
+                    createCustomSnapshot({ timestamp: Date.now() }, { type: 'copy', textLength: 5 }, '$clipboard')
+                )
+
+                expect(lazyRecorder['_isIdle']).toBe(false)
+                expect(lazyRecorder['_holdFlushUntilInteraction']).toBe(false)
+                expect(lazyRecorder['_buffer'].data).toContainEqual(
+                    expect.objectContaining({ data: expect.objectContaining({ tag: '$clipboard' }) })
+                )
+            })
+
+            it('removes clipboard listeners when recording stops', () => {
+                sessionRecording.stopRecording()
+                _addCustomEvent.mockClear()
+
+                dispatchClipboardEvent(document, 'paste', 'private pasted value')
+
+                expect(_addCustomEvent).not.toHaveBeenCalled()
+            })
+        })
+
         it('calls rrweb.record with the right options', () => {
             sessionRecording.onRemoteConfig(
                 makeFlagsResponse({
@@ -3454,10 +3664,18 @@ describe('Lazy SessionRecording', () => {
                 maskAttributeFn: undefined,
                 slimDOMOptions: {},
                 collectFonts: false,
-                plugins: [],
+                plugins: [
+                    {
+                        name: 'posthog/clipboard-observer',
+                        observer: expect.any(Function),
+                        options: {},
+                    },
+                ],
                 inlineStylesheet: true,
                 inlineStylesheetBudgetRules: 10_000,
                 recordCrossOriginIframes: false,
+                sampling: undefined,
+                attributeFilter: undefined,
             })
         })
 
@@ -7264,6 +7482,27 @@ describe('Lazy SessionRecording', () => {
 
             sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording.started).toBe(true)
+        })
+
+        it('captures clipboard events with an older core before fresh remote config arrives', () => {
+            ;(sessionManager as any).on = undefined
+            posthog.persistence?.register({
+                [SESSION_RECORDING_REMOTE_CONFIG]: {
+                    enabled: true,
+                    endpoint: '/s/',
+                    cache_timestamp: Date.now(),
+                },
+            })
+
+            sessionRecording.startIfEnabledOrStop()
+            _addCustomEvent.mockClear()
+            dispatchClipboardEvent(document, 'paste', 'private pasted value')
+
+            expect(sessionRecording.started).toBe(true)
+            expect(_addCustomEvent).toHaveBeenCalledWith('$clipboard', {
+                type: 'paste',
+                textLength: 20,
+            })
         })
 
         it('does not start recording from stale persisted config', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -108,6 +108,10 @@ const FIVE_MINUTES = ONE_MINUTE * 5
 const ONE_HOUR = ONE_MINUTE * 60
 const MIN_TRIGGER_PENDING_BUFFER_INTERVAL_MILLIS = 1000
 const MAX_TRIGGER_PENDING_BUFFER_INTERVAL_MILLIS = ONE_HOUR
+const CLIPBOARD_EVENT_TAG = '$clipboard'
+const CLIPBOARD_EVENT_TYPES = ['copy', 'cut', 'paste'] as const
+const CLIPBOARD_OBSERVER_PLUGIN = 'posthog/clipboard-observer'
+const MAX_SAFE_INTEGER = 9007199254740991
 
 // A full snapshot runs as one uninterruptible task, so anything at this scale is a
 // visible freeze - no rendering, scrolling, or cursor movement - and worth a warning.
@@ -195,6 +199,78 @@ function getRRWeb() {
 
 function getRRWebRecord(): rrwebRecordType | undefined {
     return getRRWeb()?.record
+}
+
+function getClipboardEventPath(event: ClipboardEvent): EventTarget[] {
+    try {
+        const path = event.composedPath?.()
+        if (path?.length) {
+            return path
+        }
+    } catch {}
+
+    return event.target ? [event.target] : []
+}
+
+function getElementFromEventTarget(target: EventTarget | null): Element | null {
+    const element = target as Element | null
+    if (isFunction(element?.matches)) {
+        return element
+    }
+
+    const parentElement = (target as Node | null)?.parentElement
+    return isFunction(parentElement?.matches) ? parentElement : null
+}
+
+function isClipboardEventBlocked(eventPath: EventTarget[], blockSelector: string | null | undefined): boolean {
+    for (const target of eventPath) {
+        const element = getElementFromEventTarget(target)
+        if (!element) {
+            continue
+        }
+
+        try {
+            if (element.closest('.ph-no-capture') || (blockSelector && element.closest(blockSelector))) {
+                return true
+            }
+        } catch {
+            return true
+        }
+    }
+
+    return false
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+    return isNumber(value) && value >= 0 && value <= MAX_SAFE_INTEGER && Math.floor(value) === value
+}
+
+function getClipboardTextLength(event: ClipboardEvent, target: EventTarget | null): number {
+    try {
+        if (event.type === 'paste') {
+            const clipboardText = event.clipboardData?.getData('text/plain')
+            return typeof clipboardText === 'string' ? clipboardText.length : 0
+        }
+
+        const input = target as HTMLInputElement | HTMLTextAreaElement | null
+        if (isNonNegativeSafeInteger(input?.selectionStart) && isNonNegativeSafeInteger(input?.selectionEnd)) {
+            return Math.max(0, input.selectionEnd - input.selectionStart)
+        }
+
+        const selectionText = (target as Node | null)?.ownerDocument?.defaultView?.getSelection?.()?.toString()
+        return typeof selectionText === 'string' ? selectionText.length : 0
+    } catch {
+        return 0
+    }
+}
+
+function getClipboardNodeId(target: EventTarget | null): number | undefined {
+    try {
+        const nodeId = getRRWebRecord()?.mirror?.getId(target as Node | null)
+        return isNonNegativeSafeInteger(nodeId) ? nodeId : undefined
+    } catch {
+        return undefined
+    }
 }
 
 export type compressedFullSnapshotEvent = {
@@ -804,6 +880,22 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
     private _gatherRRWebPlugins() {
         const plugins: RecordPlugin[] = []
+
+        plugins.push({
+            name: CLIPBOARD_OBSERVER_PLUGIN,
+            options: {},
+            observer: (_callback, currentWindow) => {
+                const clipboardDocument = currentWindow.document
+                CLIPBOARD_EVENT_TYPES.forEach((eventType) =>
+                    addEventListener(clipboardDocument, eventType, this._onClipboardEvent, { capture: true })
+                )
+                return () => {
+                    CLIPBOARD_EVENT_TYPES.forEach((eventType) =>
+                        clipboardDocument.removeEventListener(eventType, this._onClipboardEvent, true)
+                    )
+                }
+            },
+        })
 
         const recordConsolePlugin = assignableWindow.__PosthogExtensions__?.rrwebPlugins?.getRecordConsolePlugin
         if (recordConsolePlugin && this._isConsoleLogCaptureEnabled) {
@@ -2318,6 +2410,22 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         this._tryAddCustomEvent('browser online', {})
     }
 
+    private _onClipboardEvent = (event: Event): void => {
+        const clipboardEvent = event as ClipboardEvent
+        const eventPath = getClipboardEventPath(clipboardEvent)
+        if (isClipboardEventBlocked(eventPath, this._masking?.blockSelector)) {
+            return
+        }
+
+        const target = eventPath[0] ?? clipboardEvent.target
+        const nodeId = getClipboardNodeId(target)
+        this._tryAddCustomEvent(CLIPBOARD_EVENT_TAG, {
+            type: clipboardEvent.type,
+            textLength: getClipboardTextLength(clipboardEvent, target),
+            ...(isNumber(nodeId) ? { nodeId } : {}),
+        })
+    }
+
     private _onVisibilityChange = (): void => {
         if (document?.visibilityState) {
             if (document.visibilityState === 'visible') {
@@ -2343,8 +2451,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
     private _isInteractiveEvent(event: eventWithTime) {
         return (
-            event.type === INCREMENTAL_SNAPSHOT_EVENT_TYPE &&
-            ACTIVE_SOURCES.indexOf(event.data?.source as IncrementalSource) !== -1
+            isCustomEvent(event, CLIPBOARD_EVENT_TAG) ||
+            (event.type === INCREMENTAL_SNAPSHOT_EVENT_TYPE &&
+                ACTIVE_SOURCES.indexOf(event.data?.source as IncrementalSource) !== -1)
         )
     }
 

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -479,6 +479,7 @@
         "_onCapturedEvent",
         "_onClick",
         "_onClickHandler",
+        "_onClipboardEvent",
         "_onDeadClick",
         "_onFocusChange",
         "_onIdentityChanged",


### PR DESCRIPTION
## Summary

- capture cut, copy, and paste actions as rrweb custom `$clipboard` events
- record only the action type, text length, and rrweb node ID, never clipboard contents
- respect replay block selectors and `.ph-no-capture` before reading clipboard metadata
- support Shadow DOM and same-origin iframe documents through an rrweb observer plugin
- count clipboard activity in replay idle and fresh-session handling
- add a `posthog-js` patch changeset

## Privacy

Clipboard text is not recorded. Each event contains the clipboard action, the string length, and the rrweb node ID when one is available. Blocked elements do not produce clipboard events.

## Test plan

- [x] 378 focused replay unit tests pass
- [x] Clipboard unit coverage includes cut, copy, paste, blocked elements, invalid clipboard data, Shadow DOM, iframes, listener cleanup, idle handling, and fresh-session behavior
- [x] Playwright compatibility test passes with published `posthog-js@1.418.13` and the new recorder bundle
- [x] Lint, Prettier, and browser source type checks pass
- [x] Recorder bundle builds complete and emit output

## Build note

The full Rollup build emitted all bundles and declarations, but the process stayed alive after the final output in two runs. Focused lazy-recorder and recorder builds exited successfully.
