### PR TITLE
ci: update shared workflow pins

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     call-flags-project:
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@95c20087fda2dc10fbbbcc3f1ef32b7bae779339
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}

--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -14,6 +14,6 @@ concurrency:
 
 jobs:
   check:
-    uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@836a5e06cdf40ed2a46b16f131b0a9b03c1ffea1
+    uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
     with:
       script-ref: 836a5e06cdf40ed2a46b16f131b0a9b03c1ffea1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
         name: Notify Slack - Approval Needed
         needs: check-changesets
         if: needs.check-changesets.outputs.has-changesets == 'true'
-        uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@836a5e06cdf40ed2a46b16f131b0a9b03c1ffea1
+        uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
         with:
             slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
             slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}


### PR DESCRIPTION
## Problem

The reusable workflows pinned by this repository have changed in `PostHog/.github`. The current pins do not include the latest fork and Dependabot guards or workflow timeouts.

## Changes

- Pin `flags-project-board.yml` to `PostHog/.github@5ba5d24966f2c416ca792654638e4ce6f19f545b`.
- Pin `changeset-hygiene.yml` to the same audited commit.
- Pin `notify-approval-needed.yml` to the same audited commit.

Only reusable workflow references whose file content changed were updated.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi updated only the reusable workflow references whose pinned and audited workflow blobs differ. Workflow YAML was checked with actionlint. No SDK source or package release files changed.
