### PR TITLE
chore(react-native-plugin): bump posthog-android to 3.60.7 for the manual session replay fix

### DIFF
--- a/.changeset/rn-plugin-android-manual-replay-fix.md
+++ b/.changeset/rn-plugin-android-manual-replay-fix.md
@@ -2,4 +2,4 @@
 '@posthog/react-native-plugin': patch
 ---
 
-Bump `com.posthog:posthog-android` to `3.60.7`. The pinned `3.58.0` stopped a manually started session replay (`sessionReplay.enabled: false` plus `startRecording()`) as soon as it started, and reported `isSessionReplayActive()` as `true` while capturing nothing. 3.60.7 also keeps that recording alive after the session is cleared on a long background.
+Fix session replay started with `startRecording()` capturing nothing on Android by bumping `com.posthog:posthog-android` to `3.60.7`.

--- a/.changeset/rn-plugin-android-manual-replay-fix.md
+++ b/.changeset/rn-plugin-android-manual-replay-fix.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Bump `com.posthog:posthog-android` to `3.60.7`. The pinned `3.58.0` stopped a manually started session replay (`sessionReplay.enabled: false` plus `startRecording()`) as soon as it started, and reported `isSessionReplayActive()` as `true` while capturing nothing. 3.60.7 also keeps that recording alive after the session is cleared on a long background.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,6 +85,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.58.0"
+  implementation "com.posthog:posthog-android:3.60.7"
 }
 


### PR DESCRIPTION
Bumps the pinned posthog-android from 3.58.0 to 3.60.7.

3.58.0 stopped a manually started session replay (`sessionReplay.enabled: false` plus `startRecording()`) as soon as it started, while `isSessionReplayActive()` still reported `true` — so it captured nothing with no error. 3.60.7 fixes that and also keeps the recording alive after the session is cleared on a long background (PostHog/posthog-android#722, PostHog/posthog-android#725).

The plugin never sets `PostHogSessionManager.isReactNative`, so RN on Android runs the full native session lifecycle and is exposed to both.