### PR TITLE
chore(react-native): require @posthog/react-native-plugin 2.4.3

### DIFF
--- a/.changeset/rn-plugin-floor-2-4-3.md
+++ b/.changeset/rn-plugin-floor-2-4-3.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix session replay started with `startRecording()` capturing nothing on Android by requiring `@posthog/react-native-plugin` 2.4.3 or newer.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -97,7 +97,7 @@
     "expo-device": ">= 4.0.0",
     "expo-file-system": ">= 13.0.0",
     "expo-localization": ">= 11.0.0",
-    "@posthog/react-native-plugin": ">= 2.4.2",
+    "@posthog/react-native-plugin": ">= 2.4.3",
     "posthog-react-native-session-replay": ">= 1.6.0",
     "react-native-device-info": ">= 10.0.0",
     "react-native-localize": ">= 3.0.0",


### PR DESCRIPTION
Draft — **do not merge until `@posthog/react-native-plugin@2.4.3` is published**, since the floor points at a version that does not exist yet.

Follow-up to #4630. That PR bumps the plugin's `com.posthog:posthog-android` pin to 3.60.7 for the manual session replay fix, and will release the plugin as 2.4.3.

`posthog-react-native` declares the plugin as a peer with a hand-maintained floor (`packages/react-native/package.json`), currently `>= 2.4.2`. Nothing cascades it — it is a literal range, not `workspace:`, so changesets will not raise it. Left alone, an app can stay on 2.4.2 and never pick up the Android fix.

Raises the floor to `>= 2.4.3`.

Spotted by @ioannisj.