### PR TITLE
fix(react-native): use posthog-cli Info.plist support for Hermes uploads

### DIFF
--- a/.changeset/bright-ios-symbols.md
+++ b/.changeset/bright-ios-symbols.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Use posthog-cli 0.15.1 and newer to read iOS release metadata directly from Info.plist during Hermes source map uploads.

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -280,6 +280,88 @@ describe('posthog-xcode.sh release version resolution', () => {
       fs.rmSync(tempDir, { recursive: true, force: true })
     }
   })
+
+  const captureReleaseArgs = (cliVersion: string): { commands: string[]; infoPlist: string } => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-xcode-release-args-'))
+    const derivedDir = path.join(tempDir, 'derived')
+    const configurationDir = path.join(tempDir, 'configuration')
+    const homeDir = path.join(tempDir, 'home')
+    const sourceRoot = path.join(tempDir, 'source')
+    const iosDir = path.join(sourceRoot, 'ios')
+    const infoPlist = path.join(sourceRoot, 'ExampleApp', 'Info.plist')
+    const reactNativePath = path.join(tempDir, 'react-native-xcode.sh')
+    const plistBuddyPath = path.join(tempDir, 'plist-buddy')
+    const cliPath = path.join(homeDir, '.posthog', 'posthog-cli')
+    const cliTracePath = path.join(tempDir, 'cli-trace.log')
+
+    try {
+      for (const directory of [derivedDir, configurationDir, iosDir, path.dirname(infoPlist), path.dirname(cliPath)]) {
+        fs.mkdirSync(directory, { recursive: true })
+      }
+      fs.writeFileSync(infoPlist, '')
+      fs.writeFileSync(reactNativePath, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+      fs.writeFileSync(
+        plistBuddyPath,
+        '#!/bin/sh\ncase "$2" in\n  *CFBundleShortVersionString*) printf %s 2.10.0 ;;\n  *CFBundleVersion*) printf %s 154 ;;\nesac\n',
+        { mode: 0o755 }
+      )
+      fs.writeFileSync(
+        cliPath,
+        '#!/bin/sh\nif [ "$1" = "--version" ]; then\n  echo "posthog-cli $TEST_CLI_VERSION"\n  exit 0\nfi\nprintf "%s\\n" "$*" >> "$TEST_CLI_TRACE"\n',
+        { mode: 0o755 }
+      )
+
+      execFileSync(SCRIPT_PATH, [reactNativePath], {
+        cwd: iosDir,
+        env: {
+          ...process.env,
+          CONFIGURATION_BUILD_DIR: configurationDir,
+          CURRENT_PROJECT_VERSION: '1',
+          DERIVED_FILE_DIR: derivedDir,
+          GITHUB_SHA: 'test-sha',
+          HOME: homeDir,
+          INFOPLIST_FILE: 'ExampleApp/Info.plist',
+          MARKETING_VERSION: '1.0',
+          POSTHOG_PLIST_BUDDY: plistBuddyPath,
+          PRODUCT_BUNDLE_IDENTIFIER: 'com.example.app',
+          SRCROOT: sourceRoot,
+          TEST_CLI_TRACE: cliTracePath,
+          TEST_CLI_VERSION: cliVersion,
+        },
+        stdio: 'pipe',
+      })
+
+      return {
+        commands: fs.readFileSync(cliTracePath, 'utf8').trim().split('\n'),
+        infoPlist,
+      }
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  }
+
+  it.each([
+    ['0.15.0', false],
+    ['0.15.1', true],
+    ['0.16.0', true],
+  ])('uses Info.plist arguments with posthog-cli %s: %s', (cliVersion, usesInfoPlist) => {
+    const { commands, infoPlist } = captureReleaseArgs(cliVersion)
+
+    expect(commands).toHaveLength(2)
+    for (const command of commands) {
+      if (usesInfoPlist) {
+        expect(command).toContain(`--info-plist ${infoPlist}`)
+        expect(command).not.toContain('--release-name')
+        expect(command).not.toContain('--release-version')
+        expect(command).not.toContain('--build')
+      } else {
+        expect(command).not.toContain('--info-plist')
+        expect(command).toContain('--release-name com.example.app')
+        expect(command).toContain('--release-version 2.10.0')
+        expect(command).toContain('--build 154')
+      }
+    }
+  })
 })
 
 describe('posthog-xcode.sh skipOnConflict upload flag', () => {

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -124,6 +124,16 @@ if [ -z "$PH_CLI_PATH" ] || [ ! -x "$PH_CLI_PATH" ]; then
   exit 1
 fi
 
+INFO_PLIST_MIN_POSTHOG_CLI_VERSION="0.15.1"
+PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1 || true)
+POSTHOG_CLI_SUPPORTS_INFO_PLIST=0
+if [ -n "$PH_CLI_VERSION" ]; then
+  LOWEST_POSTHOG_CLI_VERSION=$(printf '%s\n%s\n' "$INFO_PLIST_MIN_POSTHOG_CLI_VERSION" "$PH_CLI_VERSION" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)
+  if [ "$LOWEST_POSTHOG_CLI_VERSION" = "$INFO_PLIST_MIN_POSTHOG_CLI_VERSION" ]; then
+    POSTHOG_CLI_SUPPORTS_INFO_PLIST=1
+  fi
+fi
+
 # mimics how the file is defined in node_modules/react-native/scripts/react-native-xcode.sh (PACKAGER_SOURCEMAP_FILE)
 SOURCEMAP_PACKAGER_FILE="$CONFIGURATION_BUILD_DIR/$SOURCEMAP_NAME"
 
@@ -153,10 +163,11 @@ resolve_posthog_ios_release_info() {
   POSTHOG_BUILD_VERSION="${CURRENT_PROJECT_VERSION:-}"
   POSTHOG_PLIST_BUDDY="${POSTHOG_PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
   POSTHOG_INFO_PLIST="${INFOPLIST_FILE:-}"
+  POSTHOG_USE_INFO_PLIST=0
 
   # Bare C preprocessor macros cannot be expanded safely here, and the product plist may belong to
   # a previous build. Preserve the existing Xcode-setting fallback for preprocessed plists.
-  if [ "${INFOPLIST_PREPROCESS:-}" = "YES" ] || [ -z "$POSTHOG_INFO_PLIST" ] || [ ! -x "$POSTHOG_PLIST_BUDDY" ]; then
+  if [ "${INFOPLIST_PREPROCESS:-}" = "YES" ] || [ -z "$POSTHOG_INFO_PLIST" ]; then
     return 0
   fi
   case "$POSTHOG_INFO_PLIST" in
@@ -164,6 +175,13 @@ resolve_posthog_ios_release_info() {
     *) POSTHOG_INFO_PLIST="${SRCROOT}/${POSTHOG_INFO_PLIST}" ;;
   esac
   if [ ! -f "$POSTHOG_INFO_PLIST" ]; then
+    return 0
+  fi
+  if [ "$POSTHOG_CLI_SUPPORTS_INFO_PLIST" = "1" ]; then
+    POSTHOG_USE_INFO_PLIST=1
+    return 0
+  fi
+  if [ ! -x "$POSTHOG_PLIST_BUDDY" ]; then
     return 0
   fi
 
@@ -185,14 +203,18 @@ resolve_posthog_ios_release_info() {
 resolve_posthog_ios_release_info
 
 CLI_RELEASE_ARGS=()
-if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
-  CLI_RELEASE_ARGS+=(--release-name "$PRODUCT_BUNDLE_IDENTIFIER")
-fi
-if [ -n "${POSTHOG_RELEASE_VERSION}" ]; then
-  CLI_RELEASE_ARGS+=(--release-version "$POSTHOG_RELEASE_VERSION")
-fi
-if [ -n "${POSTHOG_BUILD_VERSION}" ]; then
-  CLI_RELEASE_ARGS+=(--build "$POSTHOG_BUILD_VERSION")
+if [ "$POSTHOG_USE_INFO_PLIST" = "1" ]; then
+  CLI_RELEASE_ARGS+=(--info-plist "$POSTHOG_INFO_PLIST")
+else
+  if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
+    CLI_RELEASE_ARGS+=(--release-name "$PRODUCT_BUNDLE_IDENTIFIER")
+  fi
+  if [ -n "${POSTHOG_RELEASE_VERSION}" ]; then
+    CLI_RELEASE_ARGS+=(--release-version "$POSTHOG_RELEASE_VERSION")
+  fi
+  if [ -n "${POSTHOG_BUILD_VERSION}" ]; then
+    CLI_RELEASE_ARGS+=(--build "$POSTHOG_BUILD_VERSION")
+  fi
 fi
 
 # RN deletes the PACKAGER_SOURCEMAP_FILE file after execution but we need it


### PR DESCRIPTION
## Problem

The React Native Xcode upload script duplicates Info.plist parsing before every Hermes source map upload. posthog-cli 0.15.1 added native `--info-plist` support, including Xcode build-setting resolution and fallback behavior.

## Changes

- Detect whether posthog-cli is version 0.15.1 or newer.
- Pass the source Info.plist to both `hermes clone` and `hermes upload` when supported.
- Keep the existing script-side release metadata resolution for older CLI versions, preprocessed plists, and missing plists.
- Add integration-style shell tests around the `0.15.1` cutoff.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. XcodeBuildMCP was used for the Expo Release builds. The implementation keeps the old CLI path intact below version 0.15.1 and delegates Info.plist resolution to newer CLI versions.
