### PR TITLE
feat(autocapture): capture paste interactions

### DIFF
--- a/.changeset/fuzzy-dogs-paste.md
+++ b/.changeset/fuzzy-dogs-paste.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Capture paste interactions with clipboard autocapture without collecting pasted text.

--- a/.changeset/fuzzy-dogs-paste.md
+++ b/.changeset/fuzzy-dogs-paste.md
@@ -1,5 +1,6 @@
 ---
 'posthog-js': patch
+'@posthog/types': patch
 ---
 
 Capture paste interactions with clipboard autocapture without collecting pasted text.

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -926,7 +926,7 @@ describe('Autocapture system', () => {
                 }
             })
 
-            it('does not capture paste from sensitive fields or ancestors', async () => {
+            it('captures paste from sensitive fields and ancestors without content', async () => {
                 const pasteBeforeSend = jest.fn().mockImplementation((event) => event)
                 const pastePosthog = await createPosthogInstance(uuidv7(), {
                     autocapture: { capture_copied_text: true },
@@ -946,7 +946,13 @@ describe('Autocapture system', () => {
                     passwordInput.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }))
                     sensitiveInput.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }))
 
-                    expect(pasteBeforeSend).not.toHaveBeenCalled()
+                    expect(pasteBeforeSend).toHaveBeenCalledTimes(2)
+                    for (const [captured] of pasteBeforeSend.mock.calls) {
+                        expect(captured.event).toEqual('$copy_autocapture')
+                        expect(captured.properties).toHaveProperty('$copy_type', 'paste')
+                        expect(captured.properties).not.toHaveProperty('$clipboard_text_length')
+                        expect(captured.properties).not.toHaveProperty('$selected_content')
+                    }
                 } finally {
                     container.remove()
                     await pastePosthog.shutdown()

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -878,7 +878,7 @@ describe('Autocapture system', () => {
                 const mockCall = beforeSendMock.mock.calls[0][0]
                 expect(mockCall.event).toEqual('$copy_autocapture')
                 expect(mockCall.properties).toHaveProperty('$selected_content', 'copy this test')
-                expect(mockCall.properties).toHaveProperty('$clipboard_text_length', 14)
+                expect(mockCall.properties).not.toHaveProperty('$clipboard_text_length')
                 expect(mockCall.properties).toHaveProperty('$copy_type', 'copy')
             })
 
@@ -895,14 +895,14 @@ describe('Autocapture system', () => {
                 expect(spyArgs.length).toBe(1)
                 expect(spyArgs[0][0].event).toEqual('$copy_autocapture')
                 expect(spyArgs[0][0].properties).toHaveProperty('$selected_content', 'cut this test')
-                expect(spyArgs[0][0].properties).toHaveProperty('$clipboard_text_length', 13)
+                expect(spyArgs[0][0].properties).not.toHaveProperty('$clipboard_text_length')
                 expect(spyArgs[0][0].properties).toHaveProperty('$copy_type', 'cut')
             })
 
-            it('captures paste length from the DOM without capturing pasted text', async () => {
+            it('captures paste without reading pasted text', async () => {
                 const pasteBeforeSend = jest.fn().mockImplementation((event) => event)
                 const pastePosthog = await createPosthogInstance(uuidv7(), {
-                    autocapture: { capture_copied_text: true },
+                    autocapture: { capture_copied_text: true, dom_event_allowlist: ['click'] },
                     before_send: pasteBeforeSend,
                 })
 
@@ -914,14 +914,41 @@ describe('Autocapture system', () => {
 
                     elTarget.dispatchEvent(pasteEvent)
 
-                    expect(getData).toHaveBeenCalledWith('text/plain')
+                    expect(getData).not.toHaveBeenCalled()
                     expect(pasteBeforeSend).toHaveBeenCalledTimes(1)
                     const captured = pasteBeforeSend.mock.calls[0][0]
                     expect(captured.event).toEqual('$copy_autocapture')
                     expect(captured.properties).toHaveProperty('$copy_type', 'paste')
-                    expect(captured.properties).toHaveProperty('$clipboard_text_length', 15)
+                    expect(captured.properties).not.toHaveProperty('$clipboard_text_length')
                     expect(captured.properties).not.toHaveProperty('$selected_content')
                 } finally {
+                    await pastePosthog.shutdown()
+                }
+            })
+
+            it('does not capture paste from sensitive fields or ancestors', async () => {
+                const pasteBeforeSend = jest.fn().mockImplementation((event) => event)
+                const pastePosthog = await createPosthogInstance(uuidv7(), {
+                    autocapture: { capture_copied_text: true },
+                    before_send: pasteBeforeSend,
+                })
+                const container = document.createElement('div')
+                const passwordInput = document.createElement('input')
+                passwordInput.type = 'password'
+                const sensitiveParent = document.createElement('div')
+                sensitiveParent.className = 'ph-sensitive'
+                const sensitiveInput = document.createElement('input')
+                sensitiveParent.appendChild(sensitiveInput)
+                container.append(passwordInput, sensitiveParent)
+                document.body.appendChild(container)
+
+                try {
+                    passwordInput.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }))
+                    sensitiveInput.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }))
+
+                    expect(pasteBeforeSend).not.toHaveBeenCalled()
+                } finally {
+                    container.remove()
                     await pastePosthog.shutdown()
                 }
             })

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -878,6 +878,7 @@ describe('Autocapture system', () => {
                 const mockCall = beforeSendMock.mock.calls[0][0]
                 expect(mockCall.event).toEqual('$copy_autocapture')
                 expect(mockCall.properties).toHaveProperty('$selected_content', 'copy this test')
+                expect(mockCall.properties).toHaveProperty('$clipboard_text_length', 14)
                 expect(mockCall.properties).toHaveProperty('$copy_type', 'copy')
             })
 
@@ -894,7 +895,35 @@ describe('Autocapture system', () => {
                 expect(spyArgs.length).toBe(1)
                 expect(spyArgs[0][0].event).toEqual('$copy_autocapture')
                 expect(spyArgs[0][0].properties).toHaveProperty('$selected_content', 'cut this test')
+                expect(spyArgs[0][0].properties).toHaveProperty('$clipboard_text_length', 13)
                 expect(spyArgs[0][0].properties).toHaveProperty('$copy_type', 'cut')
+            })
+
+            it('captures paste length from the DOM without capturing pasted text', async () => {
+                const pasteBeforeSend = jest.fn().mockImplementation((event) => event)
+                const pastePosthog = await createPosthogInstance(uuidv7(), {
+                    autocapture: { capture_copied_text: true },
+                    before_send: pasteBeforeSend,
+                })
+
+                try {
+                    document.body.appendChild(elTarget)
+                    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true })
+                    const getData = jest.fn().mockReturnValue('paste this test')
+                    Object.defineProperty(pasteEvent, 'clipboardData', { value: { getData } })
+
+                    elTarget.dispatchEvent(pasteEvent)
+
+                    expect(getData).toHaveBeenCalledWith('text/plain')
+                    expect(pasteBeforeSend).toHaveBeenCalledTimes(1)
+                    const captured = pasteBeforeSend.mock.calls[0][0]
+                    expect(captured.event).toEqual('$copy_autocapture')
+                    expect(captured.properties).toHaveProperty('$copy_type', 'paste')
+                    expect(captured.properties).toHaveProperty('$clipboard_text_length', 15)
+                    expect(captured.properties).not.toHaveProperty('$selected_content')
+                } finally {
+                    await pastePosthog.shutdown()
+                }
             })
 
             it('ignores empty selection', () => {

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -878,7 +878,7 @@ describe('Autocapture system', () => {
                 const mockCall = beforeSendMock.mock.calls[0][0]
                 expect(mockCall.event).toEqual('$copy_autocapture')
                 expect(mockCall.properties).toHaveProperty('$selected_content', 'copy this test')
-                expect(mockCall.properties).not.toHaveProperty('$clipboard_text_length')
+                expect(mockCall.properties).toHaveProperty('$clipboard_text_length', 14)
                 expect(mockCall.properties).toHaveProperty('$copy_type', 'copy')
             })
 
@@ -895,7 +895,7 @@ describe('Autocapture system', () => {
                 expect(spyArgs.length).toBe(1)
                 expect(spyArgs[0][0].event).toEqual('$copy_autocapture')
                 expect(spyArgs[0][0].properties).toHaveProperty('$selected_content', 'cut this test')
-                expect(spyArgs[0][0].properties).not.toHaveProperty('$clipboard_text_length')
+                expect(spyArgs[0][0].properties).toHaveProperty('$clipboard_text_length', 13)
                 expect(spyArgs[0][0].properties).toHaveProperty('$copy_type', 'cut')
             })
 

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -34,6 +34,15 @@ const COPY_AUTOCAPTURE_EVENT = '$copy_autocapture'
 
 const logger = createLogger('[AutoCapture]')
 
+function getPastedTextLength(event: ClipboardEvent): number {
+    try {
+        const pastedText = event.clipboardData?.getData('text/plain')
+        return typeof pastedText === 'string' ? pastedText.length : 0
+    } catch {
+        return 0
+    }
+}
+
 function limitText(length: number, text: string): string {
     if (text.length > length) {
         return text.slice(0, length) + '...'
@@ -365,12 +374,13 @@ export class Autocapture implements Extension {
                 try {
                     this._captureEvent(e, COPY_AUTOCAPTURE_EVENT)
                 } catch (error) {
-                    logger.error('Failed to capture copy/cut event', error)
+                    logger.error('Failed to capture clipboard event', error)
                 }
             })
 
             addEventListener(document, 'copy', copiedTextHandler, { capture: true })
             addEventListener(document, 'cut', copiedTextHandler, { capture: true })
+            addEventListener(document, 'paste', copiedTextHandler, { capture: true })
         }
     }
 
@@ -384,6 +394,7 @@ export class Autocapture implements Extension {
         if (this._copiedTextHandler) {
             document?.removeEventListener('copy', this._copiedTextHandler, true)
             document?.removeEventListener('cut', this._copiedTextHandler, true)
+            document?.removeEventListener('paste', this._copiedTextHandler, true)
             this._copiedTextHandler = undefined
         }
         this._initialized = false
@@ -489,19 +500,19 @@ export class Autocapture implements Extension {
             }
         }
 
-        const isCopyAutocapture = eventName === COPY_AUTOCAPTURE_EVENT
+        const isClipboardAutocapture = eventName === COPY_AUTOCAPTURE_EVENT
         if (
             target &&
             shouldCaptureDomEvent(
                 target,
                 e,
                 config,
-                // mostly this method cares about the target element, but in the case of copy events,
+                // mostly this method cares about the target element, but for clipboard events,
                 // we want some of the work this check does without insisting on the target element's type
-                isCopyAutocapture,
-                // we also don't want to restrict copy checks to clicks,
+                isClipboardAutocapture,
+                // we also don't want to restrict clipboard checks to clicks,
                 // so we pass that knowledge in here, rather than add the logic inside the check
-                isCopyAutocapture ? ['copy', 'cut'] : undefined,
+                isClipboardAutocapture ? ['copy', 'cut', 'paste'] : undefined,
                 { config: { get_current_url: config.getCurrentUrl } }
             )
         ) {
@@ -524,14 +535,24 @@ export class Autocapture implements Extension {
             }
 
             if (eventName === COPY_AUTOCAPTURE_EVENT) {
-                // you can't read the data from the clipboard event,
-                // but you can guess that you can read it from the window's current selection
-                const selectedContent = makeSafeText(window?.getSelection()?.toString())
-                const clipType = (e as ClipboardEvent).type || 'clipboard'
-                if (!selectedContent) {
-                    return false
+                const clipboardEvent = e as ClipboardEvent
+                const clipType = clipboardEvent.type || 'clipboard'
+
+                if (clipType === 'paste') {
+                    const pastedTextLength = getPastedTextLength(clipboardEvent)
+                    if (!pastedTextLength) {
+                        return false
+                    }
+                    props['$clipboard_text_length'] = pastedTextLength
+                } else {
+                    const selectedText = window?.getSelection()?.toString()
+                    const selectedContent = makeSafeText(selectedText)
+                    if (!selectedContent) {
+                        return false
+                    }
+                    props['$selected_content'] = selectedContent
+                    props['$clipboard_text_length'] = selectedText?.length ?? 0
                 }
-                props['$selected_content'] = selectedContent
                 props['$copy_type'] = clipType
             }
 

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -159,9 +159,9 @@ export function autocapturePropertiesForElement(
         elementsChainAsString: boolean
         disableCaptureUrlHashes: boolean
     }
-): { props: Properties; explicitNoCapture?: boolean; hasNonCapturableElement?: boolean } {
+): { props: Properties; explicitNoCapture?: boolean } {
     if (!isElementNode(target)) {
-        return { props: {}, hasNonCapturableElement: true }
+        return { props: {} }
     }
 
     const targetElementList: Element[] = [target]
@@ -197,11 +197,9 @@ export function autocapturePropertiesForElement(
     const autocaptureAugmentProperties: Properties = {}
     let href: string | false = false
     let explicitNoCapture = false
-    let hasNonCapturableElement = false
 
     each(targetElementList, (el) => {
         const shouldCaptureEl = shouldCaptureElement(el)
-        hasNonCapturableElement ||= !shouldCaptureEl
 
         // if the element or a parent element is an anchor tag
         // include the href as a property
@@ -236,7 +234,7 @@ export function autocapturePropertiesForElement(
     })
 
     if (explicitNoCapture) {
-        return { props: {}, explicitNoCapture, hasNonCapturableElement }
+        return { props: {}, explicitNoCapture }
     }
 
     if (!maskAllText) {
@@ -270,7 +268,7 @@ export function autocapturePropertiesForElement(
         autocaptureAugmentProperties
     )
 
-    return { props, hasNonCapturableElement }
+    return { props }
 }
 
 export class Autocapture implements Extension {
@@ -510,7 +508,7 @@ export class Autocapture implements Extension {
                 { config: { get_current_url: config.getCurrentUrl } }
             )
         ) {
-            const { props, explicitNoCapture, hasNonCapturableElement } = autocapturePropertiesForElement(target, {
+            const { props, explicitNoCapture } = autocapturePropertiesForElement(target, {
                 e,
                 maskAllElementAttributes: config.maskAllElementAttributes,
                 maskAllText: config.maskAllText,
@@ -531,11 +529,7 @@ export class Autocapture implements Extension {
             if (eventName === COPY_AUTOCAPTURE_EVENT) {
                 const clipType = e.type || 'clipboard'
 
-                if (clipType === 'paste') {
-                    if (hasNonCapturableElement) {
-                        return false
-                    }
-                } else {
+                if (clipType !== 'paste') {
                     const selectedText = window?.getSelection()?.toString()
                     const selectedContent = makeSafeText(selectedText)
                     if (!selectedContent) {

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -529,6 +529,7 @@ export class Autocapture implements Extension {
             if (eventName === COPY_AUTOCAPTURE_EVENT) {
                 const clipType = e.type || 'clipboard'
 
+                // The page usually emits an input change event with the new value, so paste only records the interaction.
                 if (clipType !== 'paste') {
                     const selectedText = window?.getSelection()?.toString()
                     const selectedContent = makeSafeText(selectedText)

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -536,6 +536,7 @@ export class Autocapture implements Extension {
                         return false
                     }
                     props['$selected_content'] = selectedContent
+                    props['$clipboard_text_length'] = selectedText?.length ?? 0
                 }
                 props['$copy_type'] = clipType
             }

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -529,7 +529,7 @@ export class Autocapture implements Extension {
             if (eventName === COPY_AUTOCAPTURE_EVENT) {
                 const clipType = e.type || 'clipboard'
 
-                // The page usually emits an input change event with the new value, so paste only records the interaction.
+                // Don't add the contents for paste events, as usually the page emits an input change with the new value
                 if (clipType !== 'paste') {
                     const selectedText = window?.getSelection()?.toString()
                     const selectedContent = makeSafeText(selectedText)

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -34,15 +34,6 @@ const COPY_AUTOCAPTURE_EVENT = '$copy_autocapture'
 
 const logger = createLogger('[AutoCapture]')
 
-function getPastedTextLength(event: ClipboardEvent): number {
-    try {
-        const pastedText = event.clipboardData?.getData('text/plain')
-        return typeof pastedText === 'string' ? pastedText.length : 0
-    } catch {
-        return 0
-    }
-}
-
 function limitText(length: number, text: string): string {
     if (text.length > length) {
         return text.slice(0, length) + '...'
@@ -168,9 +159,9 @@ export function autocapturePropertiesForElement(
         elementsChainAsString: boolean
         disableCaptureUrlHashes: boolean
     }
-): { props: Properties; explicitNoCapture?: boolean } {
+): { props: Properties; explicitNoCapture?: boolean; hasNonCapturableElement?: boolean } {
     if (!isElementNode(target)) {
-        return { props: {} }
+        return { props: {}, hasNonCapturableElement: true }
     }
 
     const targetElementList: Element[] = [target]
@@ -206,9 +197,11 @@ export function autocapturePropertiesForElement(
     const autocaptureAugmentProperties: Properties = {}
     let href: string | false = false
     let explicitNoCapture = false
+    let hasNonCapturableElement = false
 
     each(targetElementList, (el) => {
         const shouldCaptureEl = shouldCaptureElement(el)
+        hasNonCapturableElement ||= !shouldCaptureEl
 
         // if the element or a parent element is an anchor tag
         // include the href as a property
@@ -243,7 +236,7 @@ export function autocapturePropertiesForElement(
     })
 
     if (explicitNoCapture) {
-        return { props: {}, explicitNoCapture }
+        return { props: {}, explicitNoCapture, hasNonCapturableElement }
     }
 
     if (!maskAllText) {
@@ -277,7 +270,7 @@ export function autocapturePropertiesForElement(
         autocaptureAugmentProperties
     )
 
-    return { props }
+    return { props, hasNonCapturableElement }
 }
 
 export class Autocapture implements Extension {
@@ -501,12 +494,13 @@ export class Autocapture implements Extension {
         }
 
         const isClipboardAutocapture = eventName === COPY_AUTOCAPTURE_EVENT
+        const eventConfig = isClipboardAutocapture ? { ...config, dom_event_allowlist: undefined } : config
         if (
             target &&
             shouldCaptureDomEvent(
                 target,
                 e,
-                config,
+                eventConfig,
                 // mostly this method cares about the target element, but for clipboard events,
                 // we want some of the work this check does without insisting on the target element's type
                 isClipboardAutocapture,
@@ -516,7 +510,7 @@ export class Autocapture implements Extension {
                 { config: { get_current_url: config.getCurrentUrl } }
             )
         ) {
-            const { props, explicitNoCapture } = autocapturePropertiesForElement(target, {
+            const { props, explicitNoCapture, hasNonCapturableElement } = autocapturePropertiesForElement(target, {
                 e,
                 maskAllElementAttributes: config.maskAllElementAttributes,
                 maskAllText: config.maskAllText,
@@ -535,15 +529,12 @@ export class Autocapture implements Extension {
             }
 
             if (eventName === COPY_AUTOCAPTURE_EVENT) {
-                const clipboardEvent = e as ClipboardEvent
-                const clipType = clipboardEvent.type || 'clipboard'
+                const clipType = e.type || 'clipboard'
 
                 if (clipType === 'paste') {
-                    const pastedTextLength = getPastedTextLength(clipboardEvent)
-                    if (!pastedTextLength) {
+                    if (hasNonCapturableElement) {
                         return false
                     }
-                    props['$clipboard_text_length'] = pastedTextLength
                 } else {
                     const selectedText = window?.getSelection()?.toString()
                     const selectedContent = makeSafeText(selectedText)
@@ -551,7 +542,6 @@ export class Autocapture implements Extension {
                         return false
                     }
                     props['$selected_content'] = selectedContent
-                    props['$clipboard_text_length'] = selectedText?.length ?? 0
                 }
                 props['$copy_type'] = clipType
             }

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -96,7 +96,7 @@ export interface AutocaptureConfig {
     element_attribute_ignorelist?: string[]
 
     /**
-     * When true, autocapture captures cut, copy, and paste interactions. Paste events contain the text length, not the text.
+     * When true, autocapture captures cut, copy, and paste interactions. Paste events do not contain pasted text.
      */
     capture_copied_text?: boolean
 }

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -96,7 +96,7 @@ export interface AutocaptureConfig {
     element_attribute_ignorelist?: string[]
 
     /**
-     * When set to true, autocapture will capture the text of any element that is cut or copied.
+     * When true, autocapture captures cut, copy, and paste interactions. Paste events contain the text length, not the text.
      */
     capture_copied_text?: boolean
 }


### PR DESCRIPTION
## Problem

Users can autocapture copy and cut interactions, but paste interactions are missing from the event stream.

Paste contents can contain secrets, so paste capture must not read clipboard data.

## Changes

- Users can capture paste interactions through the existing clipboard autocapture setting.
- Paste events record `$copy_type: paste` and do not read clipboard contents.
- Copy and cut events retain `$selected_content` and `$clipboard_text_length` for compatibility.
- Sensitive fields can emit paste markers because the events contain no clipboard data.
- `dom_event_allowlist` continues to control normal autocapture without disabling clipboard events.
- Regression tests cover content-free capture, DOM allowlists, sensitive fields, and existing copy and cut behavior.
- The public config description and patch changeset are mechanical.
- This change has no visual UI.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop authored this human-directed change. It used the Simplified Technical English, writing-tests, and writing-pr-descriptions skills.

Input change events already describe content changes, so paste events record only the interaction.

Review feedback added compatibility with `dom_event_allowlist`. Only paste omits clipboard text and length.
