### PR TITLE
fix: narrow pinterest bot-detection entry to avoid blocking Pinterest's in-app browser

### DIFF
--- a/.changeset/narrow-pinterest-bot.md
+++ b/.changeset/narrow-pinterest-bot.md
@@ -1,0 +1,8 @@
+---
+'@posthog/core': patch
+'@posthog/browser-common': patch
+'posthog-js': patch
+'posthog-node': patch
+---
+
+Narrow the `pinterest` entry in the bot-detection blocklist to `pinterestbot`, so real users on Pinterest's in-app browser (whose UA also contains the substring `pinterest`) are no longer misclassified as bots and silently excluded from analytics. The crawler's other UA variant remains covered by the existing generic `bot.htm` entry, so no bot-detection coverage is lost.

--- a/packages/browser/src/__tests__/utils.test.ts
+++ b/packages/browser/src/__tests__/utils.test.ts
@@ -174,6 +174,7 @@ describe('utils', () => {
                 'Mozilla/5.0 (compatible; SeznamBot/4.0; +https://o-seznam.cz/napoveda/vyhledavani/en/seznambot-crawler/)',
             ],
             ['BrightEdge Crawler/1.0 (crawler@brightedge.com)'],
+            ['Mozilla/5.0 (compatible; Pinterestbot/1.0; +http://www.pinterest.com/bot.html)'],
         ])('blocks based on user agent', (botString) => {
             expect(isBlockedUA(botString, [])).toBe(true)
             expect(isBlockedUA(botString.toLowerCase(), [])).toBe(true)
@@ -193,6 +194,10 @@ describe('utils', () => {
             ],
             [
                 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) elec/1.0.0 Chrome/126.0.6478.127 Electron/31.2.1 Safari/537.36',
+            ],
+            [
+                // Pinterest app's own in-app browser -- a real user, not the Pinterestbot crawler
+                'Mozilla/5.0 (iPad; CPU OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 [Pinterest/iOS]',
             ],
         ])('does not block based on non-bot user agent', (userAgent) => {
             expect(isBlockedUA(userAgent, [])).toBe(false)

--- a/packages/core/src/utils/bot-detection.ts
+++ b/packages/core/src/utils/bot-detection.ts
@@ -28,7 +28,11 @@ export const DEFAULT_BLOCKED_UA_STRS = [
   'msnbot',
   'nessus',
   'petalbot',
-  'pinterest',
+  // not the bare 'pinterest' -- that also matches the Pinterest app's own in-app
+  // browser UA (e.g. "...Mobile/15D100 [Pinterest/iOS]"), which is a real user,
+  // not the crawler. The crawler's other UA variant ("...pinterest.com/bot.html")
+  // is still covered by the generic 'bot.htm' entry below.
+  'pinterestbot',
   'prerender',
   'rogerbot',
   'screaming frog',


### PR DESCRIPTION
## What

Fixes a bot-detection false positive reported in #83413: Pinterest's own in-app browser gets misclassified as the Pinterestbot crawler and silently excluded from analytics.

## Root cause

`DEFAULT_BLOCKED_UA_STRS` (`packages/core/src/utils/bot-detection.ts`) contains the bare substring `'pinterest'`. `isBlockedUA` does a case-insensitive substring match of every blocklist entry against the *whole* user-agent string:

```ts
const uaLower = ua.toLowerCase()
return DEFAULT_BLOCKED_UA_STRS.concat(customBlockedUserAgents).some((blockedUA) => {
    const blockedUaLower = blockedUA.toLowerCase()
    return uaLower.indexOf(blockedUaLower) !== -1
})
```

Pinterest's own iOS/Android app in-app browser identifies itself with a UA like:

```
Mozilla/5.0 (iPad; CPU OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 [Pinterest/iOS]
```

— a real human user, not the crawler — but it contains the substring `pinterest`, so it gets blocked exactly like the actual bot.

## Fix

Narrowed the entry to `'pinterestbot'`, which still matches the crawler's primary UA (`"...Pinterestbot/1.0; +http://www.pinterest.com/bot.html)"`) but not the in-app browser's. The crawler's other known UA variant (`"Pinterest/0.2 (+https://www.pinterest.com/bot.html)"`) doesn't contain "pinterestbot" as a contiguous substring, but stays covered by the pre-existing generic `'bot.htm'` entry a few lines down — so no bot-detection coverage is lost, only the false positive is removed.

## Scope note

#83413 also reports that several *other* in-app browsers (Instagram, LinkedIn, TikTok, WeChat, etc.) aren't detected at all, across three separate implementations (this repo, posthog-js-lite, and a CDP transformation in the main posthog repo) — a much larger piece of work already partially underway via a draft PR (posthog-js#4510). This PR only fixes the one narrow false-positive substring-match bug described above; it isn't a fix for the broader detection gap, so it doesn't use a `Fixes` keyword for #83413 in the commit (it should stay open for the rest of that work).

## How did you test this code?

Added a case to each existing `it.each` block in `packages/browser/src/__tests__/utils.test.ts`:
- the crawler's `Pinterestbot/1.0` UA still gets blocked
- the in-app browser's `[Pinterest/iOS]` UA no longer does

Verified by executing the actual (copy-pasted, unmodified) `isBlockedUA` logic and the fixed `DEFAULT_BLOCKED_UA_STRS` array directly in plain Node against three UAs -- the crawler's two known variants (both still blocked, one via the new `pinterestbot` entry, one via the pre-existing `bot.htm` entry) and the in-app browser (no longer blocked). The actual jest suite could not be run locally (`pnpm --filter @posthog/core build` fails on this Windows machine because `@rspack/binding-win32-x64-msvc` is missing from the pnpm store -- present for every other platform, seemingly unrelated to this change), so please treat CI as the first real run of the added test cases.

## AI assistance

**AI assistance:** Developed with AI assistance (Claude Code), then reviewed and test-verified by @yfwmaniish before submission.

- Tool: Claude Code, used to help trace the root cause and draft the fix and tests.
- Skills invoked: none.
- The narrower fix (vs. attempting the full multi-repo in-app-browser detection gap from #83413) was a deliberate scope decision after finding the existing draft PR posthog-js#4510 already covers that broader work.
- Local verification was done by direct Node execution of the extracted logic, not a full local test run, because of the Windows-specific rspack binary gap noted above -- disclosed so review treats CI as the first real run of the added tests.
- No customer data, tickets, or internal PostHog information was used; all reasoning is from public repository source and the public linked issue.

