### PR TITLE
fix(flags): handle empty evaluation key scopes

### DIFF
--- a/.changeset/handle-empty-flag-scopes.md
+++ b/.changeset/handle-empty-flag-scopes.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+Handle empty feature flag evaluation key scopes without running local or remote evaluation.

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -1722,7 +1722,7 @@
           "name": "disableGeoip"
         },
         {
-          "description": "Restrict local evaluation, the `/flags` request, and the returned snapshot to these keys.\n`evaluateFlags()` falls back remotely when a requested key is missing from local definitions\nunless `onlyEvaluateLocally` is true. Remote evaluation responses are not cached, so a key\nmissing both locally and remotely costs one `/flags` request per `evaluateFlags()` call.",
+          "description": "Restrict local evaluation, the `/flags` request, and the returned snapshot to these keys.\nAn empty array returns an empty snapshot without evaluating flags; omitting this option\nevaluates all flags. `evaluateFlags()` falls back remotely when a requested key is missing\nfrom local definitions unless `onlyEvaluateLocally` is true. Remote evaluation responses are\nnot cached, so a key missing both locally and remotely costs one `/flags` request per call.",
           "type": "string[]",
           "name": "flagKeys"
         }

--- a/packages/node/src/__tests__/evaluate-flags.spec.ts
+++ b/packages/node/src/__tests__/evaluate-flags.spec.ts
@@ -107,6 +107,16 @@ describe('evaluateFlags', () => {
       expect(url).toMatch(/\/flags\/\?v=2(?:&|$)/)
     })
 
+    it('treats a runtime null flagKeys value as evaluating all flags', async () => {
+      const flags = await posthog.evaluateFlags('user-1', { flagKeys: null } as any)
+
+      expect(flags.keys.sort()).toEqual(['boolean-flag', 'disabled-flag', 'variant-flag'])
+      expect(mockedFetch).toHaveBeenCalledTimes(1)
+      const [, init] = mockedFetch.mock.calls[0]
+      const body = JSON.parse((init as any).body as string)
+      expect(body.flag_keys_to_evaluate).toBeUndefined()
+    })
+
     it('does not fire $feature_flag_called events for flags that are not accessed', async () => {
       await posthog.evaluateFlags('user-1')
       await waitForPromises()
@@ -696,6 +706,29 @@ describe('evaluateFlags', () => {
 
       // No remote /flags request since local evaluation covered it.
       const remoteFlagCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/flags/?v=2'))
+      expect(remoteFlagCalls).toHaveLength(0)
+    })
+
+    it('returns an empty snapshot without property setup or local/remote work for an empty key list', async () => {
+      await posthog.reloadFeatureFlags()
+      const poller = (posthog as any).featureFlagsPoller
+      const propertySetupSpy = jest.spyOn(posthog as any, 'addLocalPersonAndGroupProperties')
+      const contextSetupSpy = jest.spyOn(posthog as any, 'createFeatureFlagEvaluationContext')
+      const localEvaluationSpy = jest.spyOn(poller, 'getAllFlagsAndPayloads')
+      const definitionsLoadSpy = jest.spyOn(poller, 'loadFeatureFlags')
+      const definitionsReadSpy = jest.spyOn(poller, 'getFlagDefinitionsLoadedAt')
+      mockedFetch.mockClear()
+
+      const flags = await posthog.evaluateFlags('user-1', { flagKeys: [] })
+
+      expect(flags).toBeInstanceOf(FeatureFlagEvaluations)
+      expect(flags.keys).toEqual([])
+      expect(propertySetupSpy).not.toHaveBeenCalled()
+      expect(contextSetupSpy).not.toHaveBeenCalled()
+      expect(localEvaluationSpy).not.toHaveBeenCalled()
+      expect(definitionsLoadSpy).not.toHaveBeenCalled()
+      expect(definitionsReadSpy).not.toHaveBeenCalled()
+      const remoteFlagCalls = mockedFetch.mock.calls.filter((call) => String(call[0]).includes('/flags/?v=2'))
       expect(remoteFlagCalls).toHaveLength(0)
     })
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2029,7 +2029,19 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       })
     }
 
-    const { groups, disableGeoip, flagKeys } = resolvedOptions || {}
+    const { groups, disableGeoip } = resolvedOptions || {}
+    const flagKeys = resolvedOptions?.flagKeys ?? undefined
+
+    if (flagKeys?.length === 0) {
+      return new FeatureFlagEvaluations({
+        host: this._getFeatureFlagEvaluationsHost(),
+        distinctId: resolvedDistinctId,
+        groups,
+        disableGeoip,
+        flags: {},
+      })
+    }
+
     let { onlyEvaluateLocally, personProperties, groupProperties } = resolvedOptions || {}
 
     const adjustedProperties = this.addLocalPersonAndGroupProperties(

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -121,9 +121,10 @@ export type FlagEvaluationOptions = BaseFlagEvaluationOptions & {
 export type AllFlagsOptions = BaseFlagEvaluationOptions & {
   /**
    * Restrict local evaluation, the `/flags` request, and the returned snapshot to these keys.
-   * `evaluateFlags()` falls back remotely when a requested key is missing from local definitions
-   * unless `onlyEvaluateLocally` is true. Remote evaluation responses are not cached, so a key
-   * missing both locally and remotely costs one `/flags` request per `evaluateFlags()` call.
+   * An empty array returns an empty snapshot without evaluating flags; omitting this option
+   * evaluates all flags. `evaluateFlags()` falls back remotely when a requested key is missing
+   * from local definitions unless `onlyEvaluateLocally` is true. Remote evaluation responses are
+   * not cached, so a key missing both locally and remotely costs one `/flags` request per call.
    */
   flagKeys?: string[]
 }


### PR DESCRIPTION
## Problem

The Node SDK does not distinguish an explicit empty `flagKeys` list from other evaluation scopes early enough. A caller that requests no flags should receive an empty snapshot without property setup, local evaluation, definition loading, or a remote `/flags` request.

This aligns the Node SDK with the behavior defined in [sdk-specs PR #47](https://github.com/PostHog/sdk-specs/pull/47).

## Changes

- Omitted `flagKeys`, and a runtime `null` value from untyped JavaScript, continue to evaluate all flags.
- An explicit empty array returns an empty `FeatureFlagEvaluations` snapshot without local or remote evaluation work.
- A non-empty array continues to restrict evaluation and fallback to the requested keys.
- Added unit coverage for the runtime `null` and explicit empty cases, updated the option documentation and generated public API reference, and added a patch changeset for `posthog-node`.

### Validation

- `pnpm --filter posthog-node test:unit -- src/__tests__/evaluate-flags.spec.ts --runInBand` - passed 1 suite and 47 tests.
- `pnpm --filter posthog-node lint` - passed ESLint.
- `pnpm exec prettier --check packages/node/src/client.ts packages/node/src/types.ts packages/node/src/__tests__/evaluate-flags.spec.ts .changeset/handle-empty-flag-scopes.md` - all files matched Prettier formatting.
- `pnpm turbo --filter=posthog-node build` - passed all 3 dependency-aware build tasks, including declaration generation.
- `pnpm generate-references` - regenerated all public API references successfully.
- `pnpm check:public-api` - confirmed committed public API references are up to date.

The commands emitted a workspace engine warning because the validation environment used Node 26.7.0 while the repository requests Node 24.x. No validation command failed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's implementation agent and bundled autoreview tool were used. The requested sdk-spec behavior defined the scope. Autoreview reported no actionable findings.
