### PR TITLE
fix(surveys): respect NextToTrigger position for tab widget surveys

### DIFF
--- a/packages/browser/src/__tests__/extensions/surveys/feedback-widget.test.tsx
+++ b/packages/browser/src/__tests__/extensions/surveys/feedback-widget.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { FeedbackWidget } from '../../../extensions/surveys'
-import { Survey, SurveyQuestionType, SurveyType, SurveyWidgetType } from '../../../posthog-surveys-types'
+import { Survey, SurveyPosition, SurveyQuestionType, SurveyType, SurveyWidgetType } from '../../../posthog-surveys-types'
 import { createMockPostHog } from '../../helpers/posthog-instance'
 import { PostHogFeatureFlags } from '../../../posthog-featureflags'
 
@@ -271,6 +271,44 @@ describe('FeedbackWidget', () => {
         })
 
         expectSurveySentEvent(selectorWidgetSurvey.id, { '$survey_response_q-open-1': 'Selector feedback!' })
+    })
+
+    test('positions survey next to the tab button when position is NextToTrigger', async () => {
+        const nextToTriggerTabSurvey: Survey = {
+            ...baseWidgetSurvey,
+            id: 'widget-survey-tab-next-to-trigger',
+            appearance: {
+                ...baseWidgetSurvey.appearance,
+                position: SurveyPosition.NextToTrigger,
+            },
+        }
+
+        render(<FeedbackWidget survey={nextToTriggerTabSurvey} posthog={mockPosthog} />)
+
+        const tab = screen.getByText('Feedback')
+        // jsdom returns a zero rect by default; just needs to be a real DOMRect so
+        // getNextToTriggerPosition can compute against it.
+        tab.getBoundingClientRect = jest.fn(() => ({
+            top: 200,
+            bottom: 240,
+            left: 300,
+            right: 380,
+            width: 80,
+            height: 40,
+            x: 300,
+            y: 200,
+            toJSON: () => {},
+        }))
+
+        fireEvent.click(tab)
+
+        const form = await screen.findByRole('form')
+        const popup = form.closest('.ph-survey') as HTMLElement
+
+        // Should be positioned relative to the tab button (fixed + computed left/top), not the
+        // hardcoded `top: 50%` used for the tab widget's default (non-NextToTrigger) position.
+        expect(popup.style.position).toBe('fixed')
+        expect(popup.style.top).not.toBe('50%')
     })
 
     test('closes survey popup when cancel button is clicked', async () => {

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1725,8 +1725,25 @@ export function FeedbackWidget({
     const [showSurvey, setShowSurvey] = useState(false)
     const [styleOverrides, setStyleOverrides] = useState<JSX.CSSProperties>({})
     const resetTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+    const tabButtonRef = useRef<HTMLButtonElement>(null)
 
     const toggleSurvey = () => {
+        // Mirror the selector widget's behavior: when the tab widget is configured to show the
+        // survey next to its trigger, compute the position relative to the tab button itself
+        // instead of relying on the widgetType default below, which always wins otherwise.
+        if (
+            survey.appearance?.widgetType === 'tab' &&
+            survey.appearance?.position === SurveyPosition.NextToTrigger &&
+            tabButtonRef.current
+        ) {
+            const nextToTriggerStyle = getNextToTriggerPosition(
+                tabButtonRef.current,
+                parseInt(survey.appearance?.maxWidth || defaultSurveyAppearance.maxWidth)
+            )
+            if (nextToTriggerStyle) {
+                setStyleOverrides(nextToTriggerStyle)
+            }
+        }
         setShowSurvey(!showSurvey)
     }
 
@@ -1739,7 +1756,7 @@ export function FeedbackWidget({
             return
         }
 
-        if (survey.appearance?.widgetType === 'tab') {
+        if (survey.appearance?.widgetType === 'tab' && survey.appearance?.position !== SurveyPosition.NextToTrigger) {
             setStyleOverrides({
                 top: '50%',
                 bottom: 'auto',
@@ -1771,6 +1788,7 @@ export function FeedbackWidget({
         survey.appearance?.widgetType,
         survey.appearance?.widgetSelector,
         survey.appearance?.borderColor,
+        survey.appearance?.position,
     ])
 
     useHideSurveyOnURLChange({
@@ -1802,6 +1820,7 @@ export function FeedbackWidget({
         <Fragment>
             {survey.appearance?.widgetType === 'tab' && (
                 <button
+                    ref={tabButtonRef}
                     className={`ph-survey-widget-tab ${survey.appearance?.tabPosition === SurveyTabPosition.Top ? 'widget-tab-top' : ''}`}
                     onClick={toggleSurvey}
                     disabled={readOnly}


### PR DESCRIPTION
## Problem

Fixes PostHog/posthog#31267.

Similar to #1885 / posthog/posthog#31034 (which fixed this for the *selector* widget type), the **tab** widget type ignores the survey's configured position when it's set to "next to trigger" - the popup always renders vertically centered next to the tab, regardless of the position setting.

## Root cause

`FeedbackWidget`'s mount effect unconditionally sets:

\`\`\`ts
if (survey.appearance?.widgetType === 'tab') {
    setStyleOverrides({ top: '50%', bottom: 'auto' })
}
\`\`\`

This `styleOverrides` object is spread *last* onto the popup's `style` in `SurveyPopup` (after `getPopoverPosition(...)`), so it always wins - even when `survey.appearance?.position === SurveyPosition.NextToTrigger`.

The selector widget type doesn't have this problem: its click listener already checks for `NextToTrigger` and computes a position from the click target's bounding rect via `getNextToTriggerPosition`, dispatched through the `ph:show_survey_widget` custom event.

## Fix

Mirror that behavior for the tab widget:
- Added a ref to the tab `<button>`.
- In `toggleSurvey`, if `widgetType === 'tab'` and `position === NextToTrigger`, compute the position relative to the tab button via the existing `getNextToTriggerPosition` helper.
- The mount effect's hardcoded `{ top: '50%', bottom: 'auto' }` now only applies when position is *not* `NextToTrigger`, so it no longer clobbers the computed position.

## Test plan

- Added `positions survey next to the tab button when position is NextToTrigger` to `feedback-widget.test.tsx`, asserting the popup gets `position: fixed` with a computed (non-`50%`) `top`, using a mocked `getBoundingClientRect` on the tab button.
- **Note:** I wasn't able to get a full `pnpm build` + `jest` run working end-to-end in my environment (workspace package build chain / husky prepare script friction unrelated to this change), so I wasn't able to execute the suite locally. I traced the logic carefully by hand against the existing selector-widget code path it mirrors. Happy to fix up anything CI flags.