### PR TITLE
fix(react-native): order native symbol upload after dSYM generation

### DIFF
--- a/.changeset/quiet-dsyms-order.md
+++ b/.changeset/quiet-dsyms-order.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Ensure the Expo native-symbol upload phase runs last and declares the main app dSYM as an Xcode input, preventing EAS archives from uploading symbols before the dSYM is ready.

--- a/examples/example-expo-57/app.json
+++ b/examples/example-expo-57/app.json
@@ -35,6 +35,10 @@
                 }
             ],
             "expo-localization",
+            "expo-font",
+            "expo-image",
+            "expo-status-bar",
+            "expo-web-browser",
             [
                 "posthog-react-native/expo",
                 {
@@ -42,11 +46,7 @@
                         "includeSource": true
                     }
                 }
-            ],
-            "expo-font",
-            "expo-image",
-            "expo-status-bar",
-            "expo-web-browser"
+            ]
         ],
         "experiments": {
             "typedRoutes": true,

--- a/examples/example-expo-57/ios/exampleexpo57.xcodeproj/project.pbxproj
+++ b/examples/example-expo-57/ios/exampleexpo57.xcodeproj/project.pbxproj
@@ -146,8 +146,8 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				FC2E0023F40A49AF9AF58B3C /* Upload PostHog Debug Symbols */,
 				D0D932E4B6A271D918B55C8D /* [CP] Embed Pods Frameworks */,
+				FC2E0023F40A49AF9AF58B3C /* Upload PostHog Debug Symbols */,
 			);
 			buildRules = (
 			);
@@ -359,6 +359,7 @@
 			files = (
 			);
 			inputPaths = (
+				"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(EXECUTABLE_NAME)",
 			);
 			name = "Upload PostHog Debug Symbols";
 			outputPaths = (

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -314,7 +314,7 @@ export function addDsymUploadBuildPhase(xcodeProject: any, includeSource = false
         new Set([...(Array.isArray(existing.inputPaths) ? existing.inputPaths : []), POSTHOG_DSYM_INPUT_PATH])
       )
 
-      const buildPhases = xcodeProject.getFirstTarget?.().target?.buildPhases
+      const buildPhases = xcodeProject.getFirstTarget?.().firstTarget?.buildPhases
       if (Array.isArray(buildPhases)) {
         const phaseIndex = buildPhases.findIndex((phase: any) => phase.comment === POSTHOG_DSYM_BUILD_PHASE_NAME)
         if (phaseIndex !== -1 && phaseIndex !== buildPhases.length - 1) {

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2017 Sentry
 // Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 
-const { withAppBuildGradle, withGradleProperties, withProjectBuildGradle, withXcodeProject } =
+const { withAppBuildGradle, withBaseMod, withGradleProperties, withProjectBuildGradle, withXcodeProject } =
   require('@expo/config-plugins')
 
 // com.posthog.android uploads R8 mapping files and injects a matching map-id so native
@@ -295,6 +295,30 @@ function decodePbxShellScript(stored: string): string {
   return stored.slice(1, -1).replace(/\\(.)/g, (_match, ch) => (ch === 'n' ? '\n' : ch === 't' ? '\t' : ch))
 }
 
+function isPluginGeneratedDsymUploadBuildPhase(phase: any): boolean {
+  if (typeof phase?.shellScript !== 'string') {
+    return false
+  }
+  return [false, true].some((source) =>
+    [false, true].some((skip) => decodePbxShellScript(phase.shellScript) === buildDsymUploadShellScript(source, skip))
+  )
+}
+
+export function moveDsymUploadBuildPhaseToEnd(xcodeProject: any): void {
+  const existing = xcodeProject.pbxItemByComment(POSTHOG_DSYM_BUILD_PHASE_NAME, 'PBXShellScriptBuildPhase')
+  if (!isPluginGeneratedDsymUploadBuildPhase(existing)) {
+    return
+  }
+
+  const buildPhases = xcodeProject.getFirstTarget?.().firstTarget?.buildPhases
+  if (Array.isArray(buildPhases)) {
+    const phaseIndex = buildPhases.findIndex((phase: any) => phase.comment === POSTHOG_DSYM_BUILD_PHASE_NAME)
+    if (phaseIndex !== -1 && phaseIndex !== buildPhases.length - 1) {
+      buildPhases.push(...buildPhases.splice(phaseIndex, 1))
+    }
+  }
+}
+
 // Keeps the upload phase last and declares the main DWARF as an input, matching the native iOS
 // setup guide. Both are required: the input makes Xcode wait for dSYM generation, while placing
 // the phase after extension embedding avoids dependency cycles in apps with app extensions.
@@ -302,34 +326,21 @@ function decodePbxShellScript(stored: string): string {
 export function addDsymUploadBuildPhase(xcodeProject: any, includeSource = false, skipOnConflict = false): void {
   const existing = xcodeProject.pbxItemByComment(POSTHOG_DSYM_BUILD_PHASE_NAME, 'PBXShellScriptBuildPhase')
   if (existing) {
-    const generatedVariants = [false, true].flatMap((source) =>
-      [false, true].map((skip) => buildDsymUploadShellScript(source, skip))
-    )
-    if (
-      typeof existing.shellScript === 'string' &&
-      generatedVariants.includes(decodePbxShellScript(existing.shellScript))
-    ) {
+    if (isPluginGeneratedDsymUploadBuildPhase(existing)) {
       existing.shellScript = encodePbxShellScript(buildDsymUploadShellScript(includeSource, skipOnConflict))
       existing.inputPaths = Array.from(
         new Set([...(Array.isArray(existing.inputPaths) ? existing.inputPaths : []), POSTHOG_DSYM_INPUT_PATH])
       )
-
-      const buildPhases = xcodeProject.getFirstTarget?.().firstTarget?.buildPhases
-      if (Array.isArray(buildPhases)) {
-        const phaseIndex = buildPhases.findIndex((phase: any) => phase.comment === POSTHOG_DSYM_BUILD_PHASE_NAME)
-        if (phaseIndex !== -1 && phaseIndex !== buildPhases.length - 1) {
-          buildPhases.push(...buildPhases.splice(phaseIndex, 1))
-        }
-      }
     }
-    return
+  } else {
+    xcodeProject.addBuildPhase([], 'PBXShellScriptBuildPhase', POSTHOG_DSYM_BUILD_PHASE_NAME, null, {
+      inputPaths: [POSTHOG_DSYM_INPUT_PATH],
+      shellPath: '/bin/sh',
+      shellScript: buildDsymUploadShellScript(includeSource, skipOnConflict),
+    })
   }
 
-  xcodeProject.addBuildPhase([], 'PBXShellScriptBuildPhase', POSTHOG_DSYM_BUILD_PHASE_NAME, null, {
-    inputPaths: [POSTHOG_DSYM_INPUT_PATH],
-    shellPath: '/bin/sh',
-    shellScript: buildDsymUploadShellScript(includeSource, skipOnConflict),
-  })
+  moveDsymUploadBuildPhaseToEnd(xcodeProject)
 }
 
 export function disableUserScriptSandboxing(xcodeProject: any): void {
@@ -513,8 +524,25 @@ export function resolveNativeSymbolUpload(prop: PostHogPluginProps['uploadNative
   return { enabled: false, includeSource: false }
 }
 
+// Expo's standard mods run their action before the previously registered action. This wrapper
+// deliberately runs its action after the rest of the Xcode mod chain, so later config plugins
+// cannot leave a newly created extension-embedding phase after the PostHog upload phase.
+const withFinalizedXcodeProject = (config: any, action: (config: any) => any) => {
+  return withBaseMod(config, {
+    platform: 'ios',
+    mod: 'xcodeproj',
+    async action(config: any) {
+      const { nextMod, ...modRequest } = config.modRequest
+      const results = await nextMod({ ...config, modRequest })
+      return action(results)
+    },
+  })
+}
+
 const withIosPlugin = (config: any, props: PostHogPluginProps = {}) => {
-  return withXcodeProject(config, (config: any) => {
+  const nativeSymbols = resolveNativeSymbolUpload(props.uploadNativeSymbols)
+
+  config = withXcodeProject(config, (config: any) => {
     const xcodeProject = config.modResults
 
     const bundleReactNativePhase = xcodeProject.pbxItemByComment(
@@ -524,7 +552,6 @@ const withIosPlugin = (config: any, props: PostHogPluginProps = {}) => {
 
     modifyExistingXcodeBuildScript(bundleReactNativePhase, props.skipOnConflict === true)
 
-    const nativeSymbols = resolveNativeSymbolUpload(props.uploadNativeSymbols)
     if (nativeSymbols.enabled) {
       addDsymUploadBuildPhase(xcodeProject, nativeSymbols.includeSource, props.skipOnConflict === true)
     }
@@ -544,6 +571,15 @@ const withIosPlugin = (config: any, props: PostHogPluginProps = {}) => {
 
     return config
   })
+
+  if (nativeSymbols.enabled) {
+    config = withFinalizedXcodeProject(config, (config: any) => {
+      moveDsymUploadBuildPhaseToEnd(config.modResults)
+      return config
+    })
+  }
+
+  return config
 }
 
 const withPostHogPlugin = (config: any, rawProps: PostHogPluginProps = {}) => {
@@ -574,6 +610,7 @@ module.exports.addPostHogWithBundledScriptsToBundleShellScript = addPostHogWithB
 module.exports.disableUserScriptSandboxing = disableUserScriptSandboxing
 module.exports.buildDsymUploadShellScript = buildDsymUploadShellScript
 module.exports.addDsymUploadBuildPhase = addDsymUploadBuildPhase
+module.exports.moveDsymUploadBuildPhaseToEnd = moveDsymUploadBuildPhaseToEnd
 module.exports.resolveNativeSymbolUpload = resolveNativeSymbolUpload
 module.exports.buildAndroidSkipOnConflictGradleLine = buildAndroidSkipOnConflictGradleLine
 module.exports.addPostHogAndroidGradlePluginClasspath = addPostHogAndroidGradlePluginClasspath

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -238,6 +238,8 @@ export function addPostHogWithBundledScriptsToBundleShellScript(script: string, 
 }
 
 const POSTHOG_DSYM_BUILD_PHASE_NAME = 'Upload PostHog Debug Symbols'
+const POSTHOG_DSYM_INPUT_PATH =
+  '"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(EXECUTABLE_NAME)"'
 
 // Shell script for the dSYM upload build phase. It locates and runs posthog-ios's
 // upload-symbols.sh (CocoaPods or SwiftPM) rather than re-implementing dSYM upload.
@@ -293,9 +295,10 @@ function decodePbxShellScript(stored: string): string {
   return stored.slice(1, -1).replace(/\\(.)/g, (_match, ch) => (ch === 'n' ? '\n' : ch === 't' ? '\t' : ch))
 }
 
-// Appends a Run Script build phase that uploads dSYMs; appended last so it runs after the
-// dSYM bundle is produced. Re-runs refresh a still-plugin-generated script so option
-// changes take effect without a clean prebuild.
+// Keeps the upload phase last and declares the main DWARF as an input, matching the native iOS
+// setup guide. Both are required: the input makes Xcode wait for dSYM generation, while placing
+// the phase after extension embedding avoids dependency cycles in apps with app extensions.
+// Re-runs refresh only a still-plugin-generated phase so user customizations remain untouched.
 export function addDsymUploadBuildPhase(xcodeProject: any, includeSource = false, skipOnConflict = false): void {
   const existing = xcodeProject.pbxItemByComment(POSTHOG_DSYM_BUILD_PHASE_NAME, 'PBXShellScriptBuildPhase')
   if (existing) {
@@ -307,11 +310,23 @@ export function addDsymUploadBuildPhase(xcodeProject: any, includeSource = false
       generatedVariants.includes(decodePbxShellScript(existing.shellScript))
     ) {
       existing.shellScript = encodePbxShellScript(buildDsymUploadShellScript(includeSource, skipOnConflict))
+      existing.inputPaths = Array.from(
+        new Set([...(Array.isArray(existing.inputPaths) ? existing.inputPaths : []), POSTHOG_DSYM_INPUT_PATH])
+      )
+
+      const buildPhases = xcodeProject.getFirstTarget?.().target?.buildPhases
+      if (Array.isArray(buildPhases)) {
+        const phaseIndex = buildPhases.findIndex((phase: any) => phase.comment === POSTHOG_DSYM_BUILD_PHASE_NAME)
+        if (phaseIndex !== -1 && phaseIndex !== buildPhases.length - 1) {
+          buildPhases.push(...buildPhases.splice(phaseIndex, 1))
+        }
+      }
     }
     return
   }
 
   xcodeProject.addBuildPhase([], 'PBXShellScriptBuildPhase', POSTHOG_DSYM_BUILD_PHASE_NAME, null, {
+    inputPaths: [POSTHOG_DSYM_INPUT_PATH],
     shellPath: '/bin/sh',
     shellScript: buildDsymUploadShellScript(includeSource, skipOnConflict),
   })

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -262,7 +262,7 @@ describe('modifyExistingXcodeBuildScript', () => {
 const mockXcodeProjectForBuildPhase = (existingPhase: any = undefined, buildPhases: any[] = []) => ({
   pbxItemByComment: jest.fn(() => existingPhase),
   addBuildPhase: jest.fn(),
-  getFirstTarget: jest.fn(() => ({ target: { buildPhases } })),
+  getFirstTarget: jest.fn(() => ({ firstTarget: { buildPhases } })),
 })
 
 describe('buildDsymUploadShellScript', () => {

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -259,11 +259,10 @@ describe('modifyExistingXcodeBuildScript', () => {
   })
 })
 
-const mockXcodeProjectForBuildPhase = (
-  existingPhase: any = undefined
-): { pbxItemByComment: jest.Mock; addBuildPhase: jest.Mock } => ({
+const mockXcodeProjectForBuildPhase = (existingPhase: any = undefined, buildPhases: any[] = []) => ({
   pbxItemByComment: jest.fn(() => existingPhase),
   addBuildPhase: jest.fn(),
+  getFirstTarget: jest.fn(() => ({ target: { buildPhases } })),
 })
 
 describe('buildDsymUploadShellScript', () => {
@@ -311,6 +310,9 @@ describe('addDsymUploadBuildPhase', () => {
     expect(files).toEqual([])
     expect(isa).toBe('PBXShellScriptBuildPhase')
     expect(comment).toBe('Upload PostHog Debug Symbols')
+    expect(opts.inputPaths).toEqual([
+      '"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(EXECUTABLE_NAME)"',
+    ])
     expect(opts.shellPath).toBe('/bin/sh')
     expect(opts.shellScript).toContain('upload-symbols.sh')
     expect(opts.shellScript).not.toContain('POSTHOG_INCLUDE_SOURCE')
@@ -341,15 +343,41 @@ describe('addDsymUploadBuildPhase', () => {
   const encodePbx = (script: string): string => '"' + script.replace(/"/g, '\\"') + '"'
 
   it('refreshes an existing plugin-generated phase script so option changes take effect', () => {
-    const existing = { isa: 'PBXShellScriptBuildPhase', shellScript: encodePbx(buildDsymUploadShellScript()) }
+    const existing: any = {
+      isa: 'PBXShellScriptBuildPhase',
+      shellScript: encodePbx(buildDsymUploadShellScript()),
+      inputPaths: ['"$(SRCROOT)/custom-input"'],
+    }
     const xp = mockXcodeProjectForBuildPhase(existing)
 
     addDsymUploadBuildPhase(xp, false, true)
     expect(xp.addBuildPhase).not.toHaveBeenCalled()
     expect(existing.shellScript).toBe(encodePbx(buildDsymUploadShellScript(false, true)))
+    expect(existing.inputPaths).toEqual([
+      '"$(SRCROOT)/custom-input"',
+      '"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(EXECUTABLE_NAME)"',
+    ])
 
     addDsymUploadBuildPhase(xp, false, false)
     expect(existing.shellScript).toBe(encodePbx(buildDsymUploadShellScript()))
+  })
+
+  it('moves an existing plugin-generated phase after extension embedding', () => {
+    const existing = { isa: 'PBXShellScriptBuildPhase', shellScript: encodePbx(buildDsymUploadShellScript()) }
+    const buildPhases = [
+      { value: 'SOURCES', comment: 'Sources' },
+      { value: 'POSTHOG', comment: 'Upload PostHog Debug Symbols' },
+      { value: 'EXTENSION', comment: 'Embed App Extensions' },
+    ]
+    const xp = mockXcodeProjectForBuildPhase(existing, buildPhases)
+
+    addDsymUploadBuildPhase(xp)
+
+    expect(buildPhases.map((phase) => phase.comment)).toEqual([
+      'Sources',
+      'Embed App Extensions',
+      'Upload PostHog Debug Symbols',
+    ])
   })
 
   it('refreshing with unchanged options preserves the stored pbxproj representation', () => {
@@ -379,12 +407,13 @@ describe('addDsymUploadBuildPhase', () => {
 
   it('leaves a user-customized phase script untouched', () => {
     const customized = encodePbx(`${buildDsymUploadShellScript()}\necho "my custom step"`)
-    const existing = { isa: 'PBXShellScriptBuildPhase', shellScript: customized }
+    const existing: any = { isa: 'PBXShellScriptBuildPhase', shellScript: customized }
     const xp = mockXcodeProjectForBuildPhase(existing)
 
     addDsymUploadBuildPhase(xp, false, true)
     expect(xp.addBuildPhase).not.toHaveBeenCalled()
     expect(existing.shellScript).toBe(customized)
+    expect(existing.inputPaths).toBeUndefined()
   })
 })
 

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -1,5 +1,7 @@
+import { withXcodeProject } from '@expo/config-plugins'
 import { spawnSync } from 'child_process'
 
+import * as postHogExpoPluginModule from '../src/tooling/expoconfig'
 import {
   addDsymUploadBuildPhase,
   addPostHogAndroidGradlePluginClasspath,
@@ -12,10 +14,13 @@ import {
   buildIosDotenvFileBuildSetting,
   disableUserScriptSandboxing,
   modifyExistingXcodeBuildScript,
+  moveDsymUploadBuildPhaseToEnd,
   resolveDotenvFileProp,
   resolveNativeSymbolUpload,
   updateDotenvFileGradleProperties,
 } from '../src/tooling/expoconfig'
+
+const postHogExpoPlugin = (postHogExpoPluginModule as any).default
 
 type MockBuildConfig = { buildSettings: Record<string, string> }
 
@@ -378,6 +383,77 @@ describe('addDsymUploadBuildPhase', () => {
       'Embed App Extensions',
       'Upload PostHog Debug Symbols',
     ])
+  })
+
+  it('moves a newly added phase again after a later plugin appends extension embedding', () => {
+    let existing: any
+    const buildPhases = [{ value: 'SOURCES', comment: 'Sources' }]
+    const xp = mockXcodeProjectForBuildPhase(undefined, buildPhases)
+    xp.pbxItemByComment.mockImplementation(() => existing)
+    xp.addBuildPhase.mockImplementation((_files, _isa, comment, _target, options) => {
+      existing = {
+        isa: 'PBXShellScriptBuildPhase',
+        shellScript: encodePbx(options.shellScript),
+      }
+      buildPhases.push({ value: 'POSTHOG', comment })
+    })
+
+    addDsymUploadBuildPhase(xp)
+    buildPhases.push({ value: 'EXTENSION', comment: 'Embed App Extensions' })
+    moveDsymUploadBuildPhaseToEnd(xp)
+
+    expect(buildPhases.map((phase) => phase.comment)).toEqual([
+      'Sources',
+      'Embed App Extensions',
+      'Upload PostHog Debug Symbols',
+    ])
+  })
+
+  it('finalizes phase ordering after all Expo Xcode project mods', async () => {
+    jest.useRealTimers()
+    let uploadPhase: any
+    const bundlePhase = {
+      shellScript: JSON.stringify('../node_modules/react-native/scripts/react-native-xcode.sh'),
+    }
+    const buildPhases: any[] = [{ value: 'SOURCES', comment: 'Sources' }]
+    const xcodeProject = {
+      pbxItemByComment: jest.fn((comment: string) => {
+        if (comment === 'Bundle React Native code and images') {
+          return bundlePhase
+        }
+        if (comment === 'Upload PostHog Debug Symbols') {
+          return uploadPhase
+        }
+      }),
+      addBuildPhase: jest.fn((_files, _isa, comment, _target, options) => {
+        uploadPhase = {
+          isa: 'PBXShellScriptBuildPhase',
+          shellScript: encodePbx(options.shellScript),
+        }
+        buildPhases.push({ value: 'POSTHOG', comment })
+      }),
+      getFirstTarget: jest.fn(() => ({ firstTarget: { buildPhases } })),
+      pbxXCBuildConfigurationSection: jest.fn(() => ({})),
+    }
+
+    let config: any = { name: 'Test', slug: 'test' }
+    config = withXcodeProject(config, (config: any) => {
+      buildPhases.push({ value: 'EXTENSION', comment: 'Embed App Extensions' })
+      return config
+    })
+    config = postHogExpoPlugin(config, {
+      disableSandboxing: false,
+      uploadNativeSymbols: true,
+    })
+
+    await config.mods.ios.xcodeproj({ ...config, modRequest: {}, modResults: xcodeProject })
+
+    expect(buildPhases.map((phase) => phase.comment)).toEqual([
+      'Sources',
+      'Embed App Extensions',
+      'Upload PostHog Debug Symbols',
+    ])
+    jest.useFakeTimers()
   })
 
   it('refreshing with unchanged options preserves the stored pbxproj representation', () => {


### PR DESCRIPTION
## Problem

Expo apps with `uploadNativeSymbols` can start the PostHog upload phase before Xcode produces the main app dSYM. In apps with an embedded extension, the upload script can then wait for 60 seconds and fail every archive because later build work is blocked behind the running phase.

Fixes #4646.

## Changes

- Add the documented main app DWARF path to the upload phase's Xcode input files.
- Keep plugin-generated upload phases last, after app extension embedding, while preserving custom input paths and customized scripts.
- Update the Expo 57 example so the PostHog plugin and generated Xcode phase run last and include the documented input path.
- Add regression coverage for new and existing build phases, input preservation, extension ordering, and customized phases.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and implemented with Pi. A minimal Xcode 26.6 project with an embedded app extension reproduced the timeout when the phase ran too early and the dependency cycle when only the dSYM input was added. Putting the phase after extension embedding and declaring the dSYM input built successfully. Pi autoreview found one incorrect use of the `xcode` API, which was fixed and reviewed again with no remaining findings.
