### PR TITLE
feat(error-tracking): standardize exception event metadata

### DIFF
--- a/.changeset/canonical-exception-metadata.md
+++ b/.changeset/canonical-exception-metadata.md
@@ -1,0 +1,8 @@
+---
+'@posthog/core': minor
+'posthog-js': minor
+'posthog-node': minor
+'posthog-react-native': minor
+---
+
+Standardize exception capture metadata, including severity, capture source, mechanism semantics, deterministic cause linkage, and reserved property ownership.

--- a/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
@@ -299,7 +299,7 @@ test.describe('ErrorTracking autocapture', () => {
             expect(first_exception.type).toBe('Error')
             expect(first_exception.value).toBe('This error should be captured with a stack')
             expect(first_exception.stacktrace).toBeDefined()
-            expect(first_exception.mechanism.handled).toBe(false)
+            expect(first_exception.mechanism.handled).toBe(true)
         })
     })
 })

--- a/packages/browser/playwright/mocked/error-tracking/capture-exception.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/capture-exception.spec.ts
@@ -41,7 +41,7 @@ test.describe('ErrorTracking captureException', () => {
             errorWithCause.cause = errorWithCause
             ph.captureException(errorWithCause)
         })
-        exceptionMatch(exception, 'Error', 'wat even am I', 5)
+        exceptionMatch(exception, 'Error', 'wat even am I', 1)
     })
 
     test('captureException(string)', async ({ posthog, events }) => {

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/__snapshots__/error-conversion.test.ts.snap
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/__snapshots__/error-conversion.test.ts.snap
@@ -6,6 +6,7 @@ exports[`Error conversion should use cause when it is an error 1`] = `
   "$exception_list": [
     {
       "mechanism": {
+        "exception_id": 0,
         "handled": true,
         "synthetic": false,
         "type": "generic",
@@ -19,9 +20,11 @@ exports[`Error conversion should use cause when it is an error 1`] = `
     },
     {
       "mechanism": {
-        "handled": true,
+        "exception_id": 1,
+        "parent_id": 0,
+        "source": "cause",
         "synthetic": false,
-        "type": "generic",
+        "type": "chained",
       },
       "stacktrace": {
         "frames": "<normalized stack frames>",

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
@@ -49,7 +49,7 @@ describe('Error conversion', () => {
                 {
                     type: 'InternalError',
                     value: 'but somehow still a string',
-                    mechanism: { synthetic: true, handled: true, type: 'generic' },
+                    mechanism: { synthetic: true, handled: true, type: 'generic', exception_id: 0 },
                 },
             ],
         }
@@ -65,7 +65,7 @@ describe('Error conversion', () => {
                 {
                     type: 'Error',
                     value: 'Object captured as exception with keys: foo, string',
-                    mechanism: { synthetic: true, handled: true, type: 'generic' },
+                    mechanism: { synthetic: true, handled: true, type: 'generic', exception_id: 0 },
                 },
             ],
         }
@@ -79,7 +79,7 @@ describe('Error conversion', () => {
                 {
                     type: 'MouseEvent',
                     value: 'MouseEvent captured as exception with keys: isTrusted',
-                    mechanism: { synthetic: true, handled: true, type: 'generic' },
+                    mechanism: { synthetic: true, handled: true, type: 'generic', exception_id: 0 },
                 },
             ],
         }
@@ -122,7 +122,7 @@ describe('Error conversion', () => {
                 {
                     type: 'DOMError',
                     value: 'click: foo',
-                    mechanism: { synthetic: false, handled: true, type: 'generic' },
+                    mechanism: { synthetic: false, handled: true, type: 'generic', exception_id: 0 },
                 },
             ],
         }
@@ -243,6 +243,6 @@ describe('Error conversion', () => {
         expect(errorProperties.$exception_list[0].mechanism.synthetic).toEqual(false)
         expect(errorProperties.$exception_list[0].mechanism.handled).toEqual(false)
         expect(errorProperties.$exception_list[1].mechanism.synthetic).toEqual(false)
-        expect(errorProperties.$exception_list[1].mechanism.handled).toEqual(true)
+        expect(errorProperties.$exception_list[1].mechanism.handled).toBeUndefined()
     })
 })

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -32,7 +32,9 @@ const wrapOnError = (captureFn: (props: ErrorTracking.ErrorProperties) => void) 
 
     win.onerror = function (...args: ErrorEventArgs): boolean {
         const errorProperties = errorPropertiesBuilder.buildFromUnknown(resolveOnErrorInput(args), {
-            mechanism: { handled: false },
+            level: 'error',
+            source: 'browser.window_onerror',
+            mechanism: { type: 'onuncaughtexception', handled: false },
         })
         captureFn(errorProperties)
         return isFunction(originalOnError) ? (originalOnError(...args) ?? false) : false
@@ -58,7 +60,9 @@ const wrapUnhandledRejection = (
 
     win.onunhandledrejection = function (ev: PromiseRejectionEvent): boolean {
         const errorProperties = errorPropertiesBuilder.buildFromUnknown(ev, {
-            mechanism: { handled: false },
+            level: 'error',
+            source: 'browser.unhandledrejection',
+            mechanism: { type: 'onunhandledrejection', handled: false },
         })
         captureFn(errorProperties)
         return isFunction(originalOnUnhandledRejection)
@@ -90,7 +94,9 @@ const wrapConsoleError = (captureFn: (props: ErrorTracking.ErrorProperties) => v
         }
         const error = args.find((arg) => arg instanceof Error)
         const errorProperties = errorPropertiesBuilder.buildFromUnknown(error || event, {
-            mechanism: { handled: false },
+            level: 'error',
+            source: 'browser.console',
+            mechanism: { type: 'onconsole', handled: true },
             syntheticException: new Error('PostHog syntheticException'),
             skipFirstLines: 2,
         })

--- a/packages/browser/src/extensions/sentry-integration.ts
+++ b/packages/browser/src/extensions/sentry-integration.ts
@@ -95,9 +95,23 @@ export function createEventProcessor(
 
         const exceptions: _SentryException[] = event.exception?.values || []
 
-        const exceptionList = exceptions.map((exception) => {
+        const exceptionList = exceptions.slice(0, 50).map((exception, index) => {
+            const mechanism: Record<string, any> = {
+                ...(exception.mechanism || {}),
+                exception_id: index,
+            }
+            if (index === 0) {
+                delete mechanism.parent_id
+                delete mechanism.source
+            } else {
+                mechanism.type = 'chained'
+                mechanism.source = 'cause'
+                mechanism.parent_id = index - 1
+                delete mechanism.handled
+            }
             return {
                 ...exception,
+                mechanism,
                 stacktrace: exception.stacktrace
                     ? {
                           ...exception.stacktrace,
@@ -117,11 +131,13 @@ export function createEventProcessor(
             $exception_type: any
             $exception_list: any
             $exception_level: SeverityLevel
+            $exception_source: string
         } = {
             // PostHog Exception Properties,
             $exception_message: exceptions[0]?.value || event.message,
             $exception_type: exceptions[0]?.type,
             $exception_level: event.level,
+            $exception_source: 'sentry.integration',
             $exception_list: exceptionList,
             // Sentry Exception Properties
             $sentry_event_id: event.event_id,

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -119,6 +119,7 @@ import {
     isBoolean,
     getEventUuid,
     minimizeFlagCalledEventProperties,
+    ErrorTracking,
 } from '@posthog/core'
 import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
 import { ExternalIntegrations } from './extensions/external-integration'
@@ -3929,11 +3930,14 @@ export class PostHog implements PostHogInterface {
         const syntheticException = new Error('PostHog syntheticException')
         const errorToProperties = this.exceptions.buildProperties(error, {
             handled: true,
+            type: 'generic',
+            level: 'error',
             syntheticException,
         })
+        const safeAdditionalProperties = ErrorTracking.sanitizeAdditionalExceptionProperties(additionalProperties)
         return this.exceptions.sendExceptionEvent({
+            ...safeAdditionalProperties,
             ...errorToProperties,
-            ...additionalProperties,
         })
     }
 

--- a/packages/browser/src/posthog-exceptions.ts
+++ b/packages/browser/src/posthog-exceptions.ts
@@ -87,12 +87,15 @@ export class PostHogExceptions implements Extension {
 
     buildProperties(
         input: unknown,
-        metadata?: { handled?: boolean; syntheticException?: Error }
+        metadata?: { handled?: boolean; type?: string; level?: string; source?: string; syntheticException?: Error }
     ): ErrorTracking.ErrorProperties {
         return this._errorPropertiesBuilder.buildFromUnknown(input, {
             syntheticException: metadata?.syntheticException,
+            level: metadata?.level,
+            source: metadata?.source,
             mechanism: {
                 handled: metadata?.handled,
+                type: metadata?.type,
             },
         })
     }

--- a/packages/core/src/error-tracking/error-properties-builder.metadata.spec.ts
+++ b/packages/core/src/error-tracking/error-properties-builder.metadata.spec.ts
@@ -1,0 +1,82 @@
+import { ErrorCoercer } from './coercers'
+import { ErrorPropertiesBuilder, sanitizeAdditionalExceptionProperties } from './error-properties-builder'
+import { chromeStackLineParser, createStackParser } from './parsers'
+
+const builder = new ErrorPropertiesBuilder(
+  [new ErrorCoercer()],
+  createStackParser('web:javascript', chromeStackLineParser)
+)
+
+describe('exception event metadata', () => {
+  it('adds canonical manual capture metadata and deterministic linkage', () => {
+    const cause = new Error('inner')
+    const error = new Error('outer', { cause })
+
+    expect(builder.buildFromUnknown(error)).toMatchObject({
+      $exception_level: 'error',
+      $exception_list: [
+        {
+          type: 'Error',
+          value: 'outer',
+          mechanism: { type: 'generic', handled: true, synthetic: false, exception_id: 0 },
+        },
+        {
+          type: 'Error',
+          value: 'inner',
+          mechanism: { type: 'chained', source: 'cause', synthetic: false, exception_id: 1, parent_id: 0 },
+        },
+      ],
+    })
+
+    expect(builder.buildFromUnknown(error).$exception_list[1].mechanism).not.toHaveProperty('handled')
+  })
+
+  it('normalizes trusted capture metadata', () => {
+    const properties = builder.buildFromUnknown(new Error('boom'), {
+      level: 'warn',
+      source: 'browser.console',
+      mechanism: { type: 'onconsole', handled: true },
+    })
+
+    expect(properties.$exception_level).toBe('warning')
+    expect(properties.$exception_source).toBe('browser.console')
+  })
+
+  it('ignores malformed typed fields without discarding valid siblings', () => {
+    const properties = builder.buildFromUnknown(new Error('boom'), {
+      level: 'unknown',
+      source: '',
+      mechanism: {
+        type: '',
+        handled: 'yes',
+        platform_extension: { safe: true },
+      },
+    } as any)
+
+    expect(properties.$exception_level).toBe('error')
+    expect(properties).not.toHaveProperty('$exception_source')
+    expect(properties.$exception_list[0].mechanism).toEqual({
+      type: 'generic',
+      handled: true,
+      synthetic: false,
+      exception_id: 0,
+      platform_extension: { safe: true },
+    })
+  })
+
+  it('keeps generic properties from overriding SDK and processor metadata', () => {
+    expect(
+      sanitizeAdditionalExceptionProperties({
+        area: 'checkout',
+        $exception_level: 'fatal',
+        $exception_source: 'fake.integration',
+        $exception_list: [],
+        $exception_sources: ['fake.ts'],
+        $exception_fingerprint: 'user-fingerprint',
+      })
+    ).toEqual({
+      area: 'checkout',
+      $exception_fingerprint: 'user-fingerprint',
+    })
+  })
+})

--- a/packages/core/src/error-tracking/error-properties-builder.metadata.spec.ts
+++ b/packages/core/src/error-tracking/error-properties-builder.metadata.spec.ts
@@ -79,4 +79,23 @@ describe('exception event metadata', () => {
       $exception_fingerprint: 'user-fingerprint',
     })
   })
+
+  it('caps deeply nested cause chains at 50 linked exceptions', () => {
+    let current = new Error('root')
+    for (let index = 0; index < 60; index++) {
+      current = new Error(`level ${index}`, { cause: current })
+    }
+
+    const exceptions = builder.buildFromUnknown(current).$exception_list
+
+    expect(exceptions).toHaveLength(50)
+    expect(exceptions[0].value).toBe('level 59')
+    expect(exceptions[49].value).toBe('level 10')
+    expect(exceptions.map((exception) => exception.mechanism.exception_id)).toEqual(
+      Array.from({ length: 50 }, (_, index) => index)
+    )
+    expect(exceptions.slice(1).map((exception) => exception.mechanism.parent_id)).toEqual(
+      Array.from({ length: 49 }, (_, index) => index)
+    )
+  })
 })

--- a/packages/core/src/error-tracking/error-properties-builder.ts
+++ b/packages/core/src/error-tracking/error-properties-builder.ts
@@ -17,7 +17,51 @@ import {
   Exception,
 } from './types'
 
-const MAX_CAUSE_RECURSION = 4
+const MAX_EXCEPTION_ENTRIES = 50
+const RESERVED_EXCEPTION_PROPERTIES = new Set([
+  '$exception_list',
+  '$exception_level',
+  '$exception_source',
+  '$debug_images',
+  '$exception_handled',
+  '$exception_types',
+  '$exception_values',
+  '$exception_sources',
+  '$exception_functions',
+  '$exception_fingerprint_version',
+  '$exception_fingerprint_record',
+  '$exception_issue_id',
+  '$exception_release',
+  '$cymbal_errors',
+])
+
+export function sanitizeAdditionalExceptionProperties(
+  properties?: Record<string | number, any>
+): Record<string | number, any> {
+  if (!properties) {
+    return {}
+  }
+  return Object.fromEntries(Object.entries(properties).filter(([key]) => !RESERVED_EXCEPTION_PROPERTIES.has(key)))
+}
+
+const SEVERITY_ALIASES: Record<string, ErrorProperties['$exception_level']> = {
+  fatal: 'fatal',
+  critical: 'fatal',
+  alert: 'fatal',
+  emergency: 'fatal',
+  error: 'error',
+  warning: 'warning',
+  warn: 'warning',
+  log: 'log',
+  notice: 'info',
+  info: 'info',
+  trace: 'debug',
+  debug: 'debug',
+}
+
+export function normalizeExceptionLevel(level: unknown): ErrorProperties['$exception_level'] | undefined {
+  return typeof level === 'string' ? SEVERITY_ALIASES[level.toLowerCase()] : undefined
+}
 
 export class ErrorPropertiesBuilder {
   constructor(
@@ -27,20 +71,20 @@ export class ErrorPropertiesBuilder {
   ) {}
 
   buildFromUnknown(input: unknown, hint: EventHint = {}): ErrorProperties {
-    const providedMechanism = hint && hint.mechanism
-    const mechanism = providedMechanism || {
-      handled: true,
-      type: 'generic',
-    }
-    const coercingContext: CoercingContext = this.buildCoercingContext(mechanism, hint, 0)
+    const mechanism = this.resolveOutermostMechanism(hint.mechanism)
+    const coercingContext: CoercingContext = this.buildCoercingContext(mechanism, hint, 0, new WeakSet())
     const exceptionWithCause = coercingContext.apply(input)
     const parsingContext: ParsingContext = this.buildParsingContext(hint)
     const exceptionWithStack = this.parseStacktrace(exceptionWithCause, parsingContext)
-    const exceptionList = this.convertToExceptionList(exceptionWithStack, mechanism)
-    return {
+    const exceptionList = this.convertToExceptionList(exceptionWithStack, mechanism, 0, undefined, { value: 0 })
+    const properties: ErrorProperties = {
       $exception_list: exceptionList,
-      $exception_level: 'error',
+      $exception_level: normalizeExceptionLevel(hint.level) ?? 'error',
     }
+    if (typeof hint.source === 'string' && hint.source.length > 0) {
+      properties.$exception_source = hint.source
+    }
+    return properties
   }
 
   async modifyFrames(exceptionList: ErrorProperties['$exception_list']): Promise<ErrorProperties['$exception_list']> {
@@ -99,15 +143,31 @@ export class ErrorPropertiesBuilder {
     return newFrames
   }
 
-  private convertToExceptionList(exceptionWithStack: ParsedException, mechanism: Mechanism): ExceptionList {
+  private convertToExceptionList(
+    exceptionWithStack: ParsedException,
+    mechanism: Mechanism,
+    exceptionId: number,
+    parentId: number | undefined,
+    nextId: { value: number }
+  ): ExceptionList {
+    const isNested = parentId !== undefined
+    const resolvedMechanism: Mechanism = isNested
+      ? {
+          type: 'chained',
+          source: 'cause',
+          synthetic: exceptionWithStack.synthetic,
+          exception_id: exceptionId,
+          parent_id: parentId,
+        }
+      : {
+          ...mechanism,
+          synthetic: exceptionWithStack.synthetic,
+          exception_id: exceptionId,
+        }
     const currentException: Exception = {
       type: exceptionWithStack.type,
       value: exceptionWithStack.value,
-      mechanism: {
-        type: mechanism.type ?? 'generic',
-        handled: mechanism.handled ?? true,
-        synthetic: exceptionWithStack.synthetic ?? false,
-      },
+      mechanism: resolvedMechanism,
     }
     if (exceptionWithStack.stack) {
       currentException.stacktrace = {
@@ -116,16 +176,28 @@ export class ErrorPropertiesBuilder {
       }
     }
     const exceptionList: ExceptionList = [currentException]
-    if (exceptionWithStack.cause != null) {
-      // Cause errors are necessarily handled
+    if (exceptionWithStack.cause != null && nextId.value + 1 < MAX_EXCEPTION_ENTRIES) {
+      const childId = ++nextId.value
       exceptionList.push(
-        ...this.convertToExceptionList(exceptionWithStack.cause, {
-          ...mechanism,
-          handled: true,
-        })
+        ...this.convertToExceptionList(exceptionWithStack.cause, mechanism, childId, exceptionId, nextId)
       )
     }
     return exceptionList
+  }
+
+  private resolveOutermostMechanism(provided?: Partial<Mechanism>): Mechanism {
+    const mechanism: Mechanism = {}
+    if (provided) {
+      for (const [key, value] of Object.entries(provided)) {
+        if (!['type', 'handled', 'source', 'synthetic', 'exception_id', 'parent_id'].includes(key)) {
+          mechanism[key] = value
+        }
+      }
+    }
+
+    mechanism.type = typeof provided?.type === 'string' && provided.type.length > 0 ? provided.type : 'generic'
+    mechanism.handled = typeof provided?.handled === 'boolean' ? provided.handled : true
+    return mechanism
   }
 
   private buildParsingContext(hint: EventHint): ParsingContext {
@@ -136,10 +208,21 @@ export class ErrorPropertiesBuilder {
     return context
   }
 
-  public buildCoercingContext(mechanism: Mechanism, hint: EventHint, depth: number = 0): CoercingContext {
+  public buildCoercingContext(
+    mechanism: Mechanism,
+    hint: EventHint,
+    depth: number = 0,
+    seen: WeakSet<object> = new WeakSet()
+  ): CoercingContext {
     const coerce = (input: unknown, depth: number) => {
-      if (depth <= MAX_CAUSE_RECURSION) {
-        const ctx = this.buildCoercingContext(mechanism, hint, depth)
+      if (depth < MAX_EXCEPTION_ENTRIES) {
+        if ((typeof input === 'object' && input !== null) || typeof input === 'function') {
+          if (seen.has(input)) {
+            return undefined
+          }
+          seen.add(input)
+        }
+        const ctx = this.buildCoercingContext(mechanism, hint, depth, seen)
         return this.applyCoercers(input, ctx)
       } else {
         return undefined

--- a/packages/core/src/error-tracking/types.ts
+++ b/packages/core/src/error-tracking/types.ts
@@ -19,6 +19,10 @@ export interface PolymorphicEvent {
 
 export interface EventHint {
   mechanism?: Partial<Mechanism>
+  /** Trusted capture-boundary severity. Generic event properties are not metadata overrides. */
+  level?: string
+  /** Trusted, stable identifier for the concrete capture integration or runtime hook. */
+  source?: string
   syntheticException?: Error | null
   skipFirstLines?: number
 }
@@ -30,6 +34,7 @@ export interface PreviouslyCapturedError {
 export interface ErrorProperties {
   $exception_list: Exception[]
   $exception_level?: SeverityLevel
+  $exception_source?: string
 }
 
 export interface Exception {
@@ -45,9 +50,12 @@ export type ExceptionList = Exception[]
 
 export interface Mechanism {
   handled?: boolean
-  type?: 'generic' | 'onunhandledrejection' | 'onuncaughtexception' | 'onconsole' | 'middleware'
+  type?: string
   source?: string
   synthetic?: boolean
+  exception_id?: number
+  parent_id?: number
+  [key: string]: unknown
 }
 
 export type GetModuleFn = (filename: string | undefined) => string | undefined

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -43,7 +43,7 @@ import {
 } from './posthog-core-stateless'
 import { uuidv7 } from './vendor/uuidv7'
 import { isEmptyObject, isNullish, getPersonPropertiesHash, isObject, isArray, isString, getEventUuid } from './utils'
-import { EventHint } from './error-tracking'
+import { EventHint, sanitizeAdditionalExceptionProperties } from './error-tracking'
 
 // Stores the parameters for a pending feature flags reload request
 interface FlagsAsyncOptions {
@@ -1359,9 +1359,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   captureException(error: unknown, additionalProperties?: PostHogEventProperties, hint?: EventHint): void {
     try {
       const exceptionProperties = this.getErrorPropertiesBuilder().buildFromUnknown(error, hint)
+      const safeAdditionalProperties = sanitizeAdditionalExceptionProperties(additionalProperties)
       this.capture(
         '$exception',
-        { ...exceptionProperties, ...additionalProperties } as unknown as PostHogEventProperties,
+        { ...safeAdditionalProperties, ...exceptionProperties } as unknown as PostHogEventProperties,
         { _originatedFromCaptureException: true }
       )
     } catch (e) {

--- a/packages/mcp/src/__tests__/edge-runtime-compatibility.test.ts
+++ b/packages/mcp/src/__tests__/edge-runtime-compatibility.test.ts
@@ -342,7 +342,8 @@ describe('Error Handling Robustness', () => {
     const captured = captureException(current)
 
     expect(captured.$exception_list[0].value).toBe('Level 19')
-    // Core caps the cause chain, so the list stays bounded.
-    expect(captured.$exception_list.length).toBeLessThanOrEqual(10)
+    // This chain is below core's 50-entry safety bound, so no runtime errors are lost.
+    expect(captured.$exception_list).toHaveLength(21)
+    expect(captured.$exception_list[20].value).toBe('Root')
   })
 })

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -1995,6 +1995,10 @@
         {
           "type": "Exception[]",
           "name": "$exception_list"
+        },
+        {
+          "type": "string",
+          "name": "$exception_source"
         }
       ],
       "path": "../core/src/error-tracking/types.ts"
@@ -2018,12 +2022,22 @@
       "name": "EventHint",
       "properties": [
         {
+          "description": "Trusted capture-boundary severity. Generic event properties are not metadata overrides.",
+          "type": "string",
+          "name": "level"
+        },
+        {
           "type": "Partial<Mechanism>",
           "name": "mechanism"
         },
         {
           "type": "number",
           "name": "skipFirstLines"
+        },
+        {
+          "description": "Trusted, stable identifier for the concrete capture integration or runtime hook.",
+          "type": "string",
+          "name": "source"
         },
         {
           "type": "Error | null",
@@ -2584,8 +2598,16 @@
       "name": "Mechanism",
       "properties": [
         {
+          "type": "number",
+          "name": "exception_id"
+        },
+        {
           "type": "boolean",
           "name": "handled"
+        },
+        {
+          "type": "number",
+          "name": "parent_id"
         },
         {
           "type": "string",
@@ -2596,7 +2618,7 @@
           "name": "synthetic"
         },
         {
-          "type": "'generic' | 'onunhandledrejection' | 'onuncaughtexception' | 'onconsole' | 'middleware'",
+          "type": "string",
           "name": "type"
         }
       ],

--- a/packages/node/src/__tests__/__snapshots__/server-wire-snapshots.spec.ts.snap
+++ b/packages/node/src/__tests__/__snapshots__/server-wire-snapshots.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`server wire snapshots snapshots a deterministic complete captureExcepti
           "$exception_list": [
             {
               "mechanism": {
+                "exception_id": 0,
                 "handled": true,
                 "synthetic": false,
                 "type": "generic",

--- a/packages/node/src/__tests__/extensions/exception-autocapture.spec.ts
+++ b/packages/node/src/__tests__/extensions/exception-autocapture.spec.ts
@@ -128,6 +128,8 @@ describe('exception autocapture', () => {
     handler?.(reason, 'unhandledRejection')
 
     expect(capture).toHaveBeenCalledWith(reason, {
+      level: 'fatal',
+      source: 'node.process_unhandled_rejection',
       mechanism: {
         type: 'onunhandledrejection',
         handled: false,
@@ -187,6 +189,8 @@ describe('exception autocapture', () => {
     handler?.(reason, 'unhandledRejection')
 
     expect(capture).toHaveBeenCalledWith(reason, {
+      level: 'fatal',
+      source: 'node.process_unhandled_rejection',
       mechanism: {
         type: 'onunhandledrejection',
         handled: false,

--- a/packages/node/src/extensions/error-tracking/autocapture.ts
+++ b/packages/node/src/extensions/error-tracking/autocapture.ts
@@ -83,11 +83,15 @@ const STARTUP_UNHANDLED_REJECTION_MODE = getUnhandledRejectionMode()
 function captureUncaughtException(
   captureFn: (exception: Error, hint: CoreErrorTracking.EventHint) => void,
   error: Error,
-  origin: NodeJS.UncaughtExceptionOrigin
+  origin: NodeJS.UncaughtExceptionOrigin,
+  expectedToTerminate: boolean
 ): void {
+  const isUnhandledRejection = origin === 'unhandledRejection'
   captureFn(error, {
+    level: expectedToTerminate ? 'fatal' : 'error',
+    source: isUnhandledRejection ? 'node.process_unhandled_rejection' : 'node.process_uncaught_exception',
     mechanism: {
-      type: origin === 'unhandledRejection' ? 'onunhandledrejection' : 'onuncaughtexception',
+      type: isUnhandledRejection ? 'onunhandledrejection' : 'onuncaughtexception',
       handled: false,
     },
   })
@@ -110,7 +114,7 @@ function makeUncaughtExceptionHandler(
         )
       }).length
 
-      captureUncaughtException(captureFn, error, origin)
+      captureUncaughtException(captureFn, error, origin, userProvidedListenersCount === 0)
 
       if (!calledFatalError && userProvidedListenersCount === 0) {
         calledFatalError = true
@@ -132,7 +136,7 @@ export function addUncaughtExceptionListener(
   }
 
   if (mode === 'strict') {
-    process.on('uncaughtExceptionMonitor', (error, origin) => captureUncaughtException(captureFn, error, origin))
+    process.on('uncaughtExceptionMonitor', (error, origin) => captureUncaughtException(captureFn, error, origin, true))
     return
   }
 
@@ -153,6 +157,8 @@ export function addUnhandledRejectionListener(
 
   process.on('unhandledRejection', (reason: unknown) => {
     captureFn(reason, {
+      level: 'error',
+      source: 'node.process_unhandled_rejection',
       mechanism: {
         type: 'onunhandledrejection',
         handled: false,

--- a/packages/node/src/extensions/error-tracking/index.ts
+++ b/packages/node/src/extensions/error-tracking/index.ts
@@ -49,7 +49,8 @@ export default class ErrorTracking {
     distinctId?: string,
     additionalProperties?: Record<string | number, any>
   ): Promise<EventMessage> {
-    const properties: EventMessage['properties'] = { ...additionalProperties }
+    const properties: EventMessage['properties'] =
+      CoreErrorTracking.sanitizeAdditionalExceptionProperties(additionalProperties)
 
     const exceptionProperties = builder.buildFromUnknown(error, hint)
     exceptionProperties.$exception_list = await builder.modifyFrames(exceptionProperties.$exception_list)
@@ -65,8 +66,10 @@ export default class ErrorTracking {
       // and falls back to a random UUID with $process_person_profile = false
       distinctId: distinctId,
       properties: {
-        ...exceptionProperties,
         ...properties,
+        // Canonical exception metadata is SDK-owned and cannot be impersonated through
+        // the generic application properties bag.
+        ...exceptionProperties,
       },
       _originatedFromCaptureException: true,
     }

--- a/packages/node/src/extensions/express.ts
+++ b/packages/node/src/extensions/express.ts
@@ -88,7 +88,12 @@ function posthogErrorHandler(posthog: PostHogBackendClient): ExpressErrorMiddlew
 
     const contextData = buildRequestContextData(posthog, req)
     const syntheticException = new Error('Synthetic exception')
-    const hint: CoreErrorTracking.EventHint = { mechanism: { type: 'middleware', handled: false }, syntheticException }
+    const hint: CoreErrorTracking.EventHint = {
+      level: 'error',
+      source: 'express.middleware',
+      mechanism: { type: 'middleware', handled: false },
+      syntheticException,
+    }
     const additionalProperties: Record<string, any> = {
       ...(contextData.sessionId !== undefined ? { $session_id: contextData.sessionId } : {}),
       ...(contextData.properties || {}),

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -1,6 +1,7 @@
 import type { IncomingHttpHeaders } from 'node:http'
 import { Observable, throwError } from 'rxjs'
 import { catchError } from 'rxjs/operators'
+import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 
 import ErrorTracking from './error-tracking'
 import { addProperty, getFirstHeaderValue, getPostHogTracingHeaderValues } from './tracing-headers'
@@ -114,7 +115,21 @@ export class PostHogInterceptor implements NestInterceptor {
                 const responseStatus = status ?? response?.statusCode
                 const additionalProperties: Record<string, any> | undefined =
                   responseStatus !== undefined ? { $response_status_code: responseStatus } : undefined
-                this.posthog.captureException(exception, distinctId, additionalProperties)
+                const hint: CoreErrorTracking.EventHint = {
+                  level: 'error',
+                  source: 'nestjs.interceptor',
+                  mechanism: { type: 'middleware', handled: false },
+                  syntheticException: new Error('Synthetic exception'),
+                }
+                this.posthog.addPendingPromise(
+                  ErrorTracking.buildEventMessage(
+                    this.posthog.getErrorPropertiesBuilder(),
+                    exception,
+                    hint,
+                    distinctId,
+                    additionalProperties
+                  ).then((message) => this.posthog._capturePreparedEvent(message, false))
+                )
                 return throwError(() => exception)
               })
             )

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -2439,6 +2439,10 @@
         {
           "type": "Exception[]",
           "name": "$exception_list"
+        },
+        {
+          "type": "string",
+          "name": "$exception_source"
         }
       ],
       "path": "../core/src/error-tracking/types.ts"
@@ -2477,12 +2481,22 @@
       "name": "EventHint",
       "properties": [
         {
+          "description": "Trusted capture-boundary severity. Generic event properties are not metadata overrides.",
+          "type": "string",
+          "name": "level"
+        },
+        {
           "type": "Partial<Mechanism>",
           "name": "mechanism"
         },
         {
           "type": "number",
           "name": "skipFirstLines"
+        },
+        {
+          "description": "Trusted, stable identifier for the concrete capture integration or runtime hook.",
+          "type": "string",
+          "name": "source"
         },
         {
           "type": "Error | null",
@@ -2829,8 +2843,16 @@
       "name": "Mechanism",
       "properties": [
         {
+          "type": "number",
+          "name": "exception_id"
+        },
+        {
           "type": "boolean",
           "name": "handled"
+        },
+        {
+          "type": "number",
+          "name": "parent_id"
         },
         {
           "type": "string",
@@ -2841,7 +2863,7 @@
           "name": "synthetic"
         },
         {
-          "type": "'generic' | 'onunhandledrejection' | 'onuncaughtexception' | 'onconsole' | 'middleware'",
+          "type": "string",
           "name": "type"
         }
       ],

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -261,16 +261,14 @@ export class ErrorTracking {
       }
 
       const hint: CoreErrorTracking.EventHint = {
+        level: isFatal ? 'fatal' : 'error',
+        source: 'react_native.error_utils',
         mechanism: {
           type: 'onuncaughtexception',
           handled: false,
         },
       }
       const additionalProperties: any = {}
-
-      if (isFatal) {
-        additionalProperties['$exception_level'] = 'fatal' as CoreErrorTracking.SeverityLevel
-      }
 
       this.instance.captureException(error, additionalProperties, hint)
 
@@ -300,6 +298,8 @@ export class ErrorTracking {
       }
 
       const hint: CoreErrorTracking.EventHint = {
+        level: 'error',
+        source: 'react_native.unhandled_rejection',
         mechanism: {
           type: 'onunhandledrejection',
           handled: false,
@@ -323,16 +323,15 @@ export class ErrorTracking {
       }
 
       const hint: CoreErrorTracking.EventHint = {
+        level,
+        source: 'react_native.console',
         mechanism: {
           type: 'onconsole',
           handled: true,
         },
         syntheticException,
       }
-      const additionalProperties = {
-        $exception_level: level as CoreErrorTracking.SeverityLevel,
-      }
-      this.instance.captureException(error, additionalProperties, hint)
+      this.instance.captureException(error, {}, hint)
     }
 
     try {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1863,7 +1863,7 @@ export class PostHog extends PostHogCore {
     super.captureException(error, additionalProperties, resolvedHint)
 
     // On a fatal crash, persist the exception + recent logs before the app may die.
-    if (additionalProperties?.$exception_level === 'fatal') {
+    if (CoreErrorTracking.normalizeExceptionLevel(resolvedHint.level) === 'fatal') {
       void this._eventsStorage.waitForPersist()
       void this._logsStorage.waitForPersist()
     }

--- a/packages/react-native/test/__snapshots__/event-snapshots.spec.ts.snap
+++ b/packages/react-native/test/__snapshots__/event-snapshots.spec.ts.snap
@@ -172,6 +172,7 @@ exports[`PostHog React Native event and request snapshots snapshots complete enr
           "$exception_list": [
             {
               "mechanism": {
+                "exception_id": 0,
                 "handled": true,
                 "synthetic": false,
                 "type": "generic",

--- a/packages/react-native/test/error-tracking-internal-errors.spec.ts
+++ b/packages/react-native/test/error-tracking-internal-errors.spec.ts
@@ -62,16 +62,14 @@ describe('ErrorTracking filters PostHog internal network errors', () => {
     expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
   })
 
-  it('tags a fatal uncaught exception with $exception_level so captureException flushes to disk', () => {
+  it('tags a fatal uncaught exception so captureException flushes to disk', () => {
     new ErrorTracking(mockPostHog, { autocapture: true }, mockLogger as any)
     const handler = (trackUncaughtExceptions as jest.Mock).mock.calls[0][0]
 
     handler(new Error('boom'), true)
 
-    // captureException drains storage to disk when the exception is fatal, so
-    // the handler must mark fatal crashes via $exception_level.
-    const [, additionalProperties] = (mockPostHog.captureException as jest.Mock).mock.calls[0]
-    expect(additionalProperties.$exception_level).toBe('fatal')
+    const [, , hint] = (mockPostHog.captureException as jest.Mock).mock.calls[0]
+    expect(hint.level).toBe('fatal')
   })
 
   it('does not tag a non-fatal uncaught exception as fatal', () => {
@@ -80,8 +78,8 @@ describe('ErrorTracking filters PostHog internal network errors', () => {
 
     handler(new Error('boom'), false)
 
-    const [, additionalProperties] = (mockPostHog.captureException as jest.Mock).mock.calls[0]
-    expect(additionalProperties.$exception_level).toBeUndefined()
+    const [, , hint] = (mockPostHog.captureException as jest.Mock).mock.calls[0]
+    expect(hint.level).toBe('error')
   })
 
   it('does not filter the console handler (console is left untouched)', () => {

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -666,7 +666,7 @@ describe('PostHog React Native', () => {
       posthog.setPersistedProperty(PostHogPersistedProperty.LogsQueue, [{ message: 'log' }])
       ;(storage.setItem as jest.Mock).mockClear()
 
-      posthog.captureException(new Error('boom'), { $exception_level: 'fatal' })
+      posthog.captureException(new Error('boom'), {}, { level: 'fatal' })
 
       // A fatal exception can crash the app within the debounce window, so both
       // pipelines reach disk synchronously: the events file (holding the


### PR DESCRIPTION
## Problem

Exception events emitted by different PostHog SDKs use inconsistent severity, source, mechanism, linkage, and metadata ownership semantics. This makes cross-platform grouping and processing less predictable.

## Changes

- Emit canonical `$exception_level` and `$exception_source` values at capture boundaries.
- Normalize mechanisms, synthetic provenance, and deterministic cause linkage across browser, Node.js, React Native, and Sentry integrations.
- Prevent generic properties from overriding SDK- and processor-owned exception metadata while preserving custom fingerprints.
- Add coverage for canonical metadata and a release changeset.

Canonical contract: https://github.com/PostHog/sdk-specs/blob/main/openspec/specs/exception-event-metadata/spec.md

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi using the archived OpenSpec contract as the source of truth. The implementation keeps custom fingerprints caller-owned while reserving canonical metadata for SDK capture boundaries and downstream processors.
