### PR TITLE
fix(react-native): deduplicate survey position warnings

### DIFF
--- a/.changeset/quiet-surveys-warn.md
+++ b/.changeset/quiet-surveys-warn.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Deduplicate unknown survey position warnings after normalizing equivalent position names.

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -101,8 +101,8 @@ export function resolveSurveyAlignment(position: string | undefined): {
     const normalizedPosition = typeof position === 'string' ? normalizeSurveyPosition(position) : ''
     if (KNOWN_SURVEY_POSITIONS.has(normalizedPosition)) {
       resolvedPosition = normalizedPosition as SurveyPosition
-    } else if (!warnedUnknownPositions.has(position)) {
-      warnedUnknownPositions.add(position)
+    } else if (!warnedUnknownPositions.has(normalizedPosition)) {
+      warnedUnknownPositions.add(normalizedPosition)
       console.warn(
         `[PostHog.surveys] Unknown survey position ${JSON.stringify(position)} — falling back to ${defaultSurveyAppearance.position}. Expected one of: ${Object.values(SurveyPosition).join(', ')}.`
       )

--- a/packages/react-native/test/resolveSurveyAlignment.spec.ts
+++ b/packages/react-native/test/resolveSurveyAlignment.spec.ts
@@ -41,18 +41,19 @@ describe('resolveSurveyAlignment', () => {
     }
   })
 
-  it('warns once and falls back to the default for unknown position strings', () => {
+  it('warns once for unknown positions that normalize to the same value', () => {
     // Module-scope dedup of warned positions persists across tests, so use a
     // unique unknown string per run to avoid coupling to other tests' state.
-    const unknown = `unknown-${Math.random().toString(36).slice(2)}`
+    const suffix = Math.random().toString(36).slice(2)
+    const unknownWithHyphen = `unknown-${suffix}`
+    const unknownWithUnderscore = `unknown_${suffix}`
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
     try {
-      const result = resolveSurveyAlignment(unknown)
+      const result = resolveSurveyAlignment(unknownWithHyphen)
       expect(result).toEqual({ vertical: 'flex-end', horizontal: 'center' })
       expect(warn).toHaveBeenCalledTimes(1)
-      expect(warn.mock.calls[0][0]).toContain(unknown)
-      // Calling again with the same unknown string does not re-warn.
-      resolveSurveyAlignment(unknown)
+      expect(warn.mock.calls[0][0]).toContain(unknownWithHyphen)
+      resolveSurveyAlignment(unknownWithUnderscore)
       expect(warn).toHaveBeenCalledTimes(1)
     } finally {
       warn.mockRestore()


### PR DESCRIPTION
## Problem

Follow-up to #4650.

React Native normalizes CSS-style survey positions before checking whether they are supported. Warning deduplication still uses the original value, so equivalent unknown values such as `foo-bar` and `foo_bar` each produce a warning.

## Changes

- Use the normalized survey position as the warning deduplication key.
- Add regression coverage for equivalent unknown position names.
- Add a patch changeset for `posthog-react-native`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented and reviewed this follow-up after review feedback arrived on #4650 after it merged. The change stays within React Native warning behavior and does not change survey placement.
