### PR TITLE
perf(browser): gzip feature flag requests when available

### DIFF
--- a/.changeset/bright-flags-compress.md
+++ b/.changeset/bright-flags-compress.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Use the best available compression for browser feature flag requests, preferring gzip when supported.

--- a/packages/browser/functional_tests/__snapshots__/feature-flags.test.ts.snap
+++ b/packages/browser/functional_tests/__snapshots__/feature-flags.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`FunctionalTests / Feature Flags snapshots the decoded /flags wire envelope from the real transport 1`] = `
 {
-  "bodyWrapper": "data=<base64>",
-  "compression": "base64",
-  "contentType": "application/x-www-form-urlencoded",
+  "bodyWrapper": "<gzip>",
+  "compression": null,
+  "contentType": "text/plain",
   "decodedBody": {
     "$device_id": "<generated-device-id>",
     "distinct_id": "<generated-distinct-id>",
@@ -46,6 +46,6 @@ exports[`FunctionalTests / Feature Flags snapshots the decoded /flags wire envel
     "timezone": "<runtime-timezone>",
     "token": "flags-wire-snapshot-token",
   },
-  "path": "/flags/?v=2&compression=base64",
+  "path": "/flags/?v=2",
 }
 `;

--- a/packages/browser/functional_tests/feature-flags.test.ts
+++ b/packages/browser/functional_tests/feature-flags.test.ts
@@ -4,6 +4,7 @@ import { createPosthogInstance } from '../src/__tests__/helpers/posthog-instance
 import { waitFor } from '@testing-library/dom'
 import { getFlagsWireRequests, getRequests, resetRequests } from './mock-server'
 import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
+import { Compression } from '@posthog/core'
 
 async function shortWait() {
     // no need to worry about ie11 compat in tests
@@ -22,11 +23,15 @@ describe('FunctionalTests / Feature Flags', () => {
         token = 'flags-wire-snapshot-token'
         resetRequests(token)
 
-        const posthog = await createPosthogInstance(token, {
-            advanced_disable_flags: false,
-            advanced_disable_feature_flags_on_first_load: true,
-            before_send: (cr) => cr,
-        })
+        const posthog = await createPosthogInstance(
+            token,
+            {
+                advanced_disable_flags: false,
+                advanced_disable_feature_flags_on_first_load: true,
+                before_send: (cr) => cr,
+            },
+            { supportedCompression: [Compression.GZipJS] }
+        )
         posthog.reloadFeatureFlags()
 
         await waitFor(() => expect(getFlagsWireRequests(token)).toHaveLength(1))

--- a/packages/browser/functional_tests/feature-flags.test.ts
+++ b/packages/browser/functional_tests/feature-flags.test.ts
@@ -4,7 +4,6 @@ import { createPosthogInstance } from '../src/__tests__/helpers/posthog-instance
 import { waitFor } from '@testing-library/dom'
 import { getFlagsWireRequests, getRequests, resetRequests } from './mock-server'
 import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
-import { Compression } from '@posthog/core'
 
 async function shortWait() {
     // no need to worry about ie11 compat in tests
@@ -28,7 +27,6 @@ describe('FunctionalTests / Feature Flags', () => {
             advanced_disable_feature_flags_on_first_load: true,
             before_send: (cr) => cr,
         })
-        posthog.compression = Compression.GZipJS
         posthog.reloadFeatureFlags()
 
         await waitFor(() => expect(getFlagsWireRequests(token)).toHaveLength(1))

--- a/packages/browser/functional_tests/feature-flags.test.ts
+++ b/packages/browser/functional_tests/feature-flags.test.ts
@@ -4,6 +4,7 @@ import { createPosthogInstance } from '../src/__tests__/helpers/posthog-instance
 import { waitFor } from '@testing-library/dom'
 import { getFlagsWireRequests, getRequests, resetRequests } from './mock-server'
 import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
+import { Compression } from '@posthog/core'
 
 async function shortWait() {
     // no need to worry about ie11 compat in tests
@@ -22,16 +23,22 @@ describe('FunctionalTests / Feature Flags', () => {
         token = 'flags-wire-snapshot-token'
         resetRequests(token)
 
-        await createPosthogInstance(token, { advanced_disable_flags: false, before_send: (cr) => cr })
+        const posthog = await createPosthogInstance(token, {
+            advanced_disable_flags: false,
+            advanced_disable_feature_flags_on_first_load: true,
+            before_send: (cr) => cr,
+        })
+        posthog.compression = Compression.GZipJS
+        posthog.reloadFeatureFlags()
 
         await waitFor(() => expect(getFlagsWireRequests(token)).toHaveLength(1))
 
         const wireRequest = getFlagsWireRequests(token)[0]
         expect(wireRequest).toMatchObject({
-            bodyWrapper: 'data=<base64>',
-            compression: 'base64',
-            contentType: 'application/x-www-form-urlencoded',
-            path: '/flags/?v=2&compression=base64',
+            bodyWrapper: '<gzip>',
+            compression: null,
+            contentType: 'text/plain',
+            path: '/flags/?v=2',
         })
         expect(wireRequest.decodedBody.$device_id).toEqual(expect.any(String))
         expect(wireRequest.decodedBody.distinct_id).toEqual(expect.any(String))

--- a/packages/browser/functional_tests/mock-server.ts
+++ b/packages/browser/functional_tests/mock-server.ts
@@ -20,7 +20,7 @@ const isGzipData = (data: Uint8Array): boolean => data[0] === 0x1f && data[1] ==
 
 const handleRequest = (group: string) => (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
     let body = req.body
-    const rawBody = body
+    let bodyWrapper = '<unknown>'
 
     if (typeof body === 'string') {
         try {
@@ -28,8 +28,10 @@ const handleRequest = (group: string) => (req: RestRequest, res: ResponseComposi
             const data = new Uint8Array(req._body)
             const gzipCompressed = isGzipData(data)
             if (b64Encoded) {
+                bodyWrapper = 'data=<base64>'
                 body = JSON.parse(Buffer.from(decodeURIComponent(body.split('=')[1]), 'base64').toString())
             } else if (gzipCompressed) {
+                bodyWrapper = '<gzip>'
                 const decoded = strFromU8(decompressSync(data))
                 body = JSON.parse(decoded)
             } else {
@@ -45,7 +47,7 @@ const handleRequest = (group: string) => (req: RestRequest, res: ResponseComposi
 
     if (group === '/flags/') {
         capturedFlagsWireRequests.push({
-            bodyWrapper: typeof rawBody === 'string' && rawBody.startsWith('data=') ? 'data=<base64>' : '<unknown>',
+            bodyWrapper,
             compression: req.url.searchParams.get('compression'),
             contentType: req.headers.get('content-type'),
             decodedBody: body,

--- a/packages/browser/playwright/mocked/cross-subdomain-cookie.spec.ts
+++ b/packages/browser/playwright/mocked/cross-subdomain-cookie.spec.ts
@@ -1,6 +1,7 @@
 import { BrowserContext, Page, Request } from '@playwright/test'
 import { expect, test, WindowWithPostHog } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
+import { decompressSync, strFromU8 } from 'fflate'
 
 const options = {
     waitForFlags: true,
@@ -39,12 +40,13 @@ async function startOnSubdomain(page: Page, context: BrowserContext, subdomain: 
 }
 
 function getFlagsPayload(request: Request): Record<string, any> {
-    const body = request.postData()
-    const data = body?.match(/data=(.*)/)?.[1]
+    const data = request.postDataBuffer()
     if (!data) {
-        throw new Error('Expected an encoded flags payload')
+        throw new Error('Expected flags request body')
     }
-    return JSON.parse(Buffer.from(decodeURIComponent(data), 'base64').toString())
+    expect(data[0]).toBe(0x1f)
+    expect(data[1]).toBe(0x8b)
+    return JSON.parse(strFromU8(decompressSync(data)))
 }
 
 async function distinctId(page: Page): Promise<string | undefined> {

--- a/packages/browser/playwright/mocked/cross-subdomain-cookie.spec.ts
+++ b/packages/browser/playwright/mocked/cross-subdomain-cookie.spec.ts
@@ -44,9 +44,15 @@ function getFlagsPayload(request: Request): Record<string, any> {
     if (!data) {
         throw new Error('Expected flags request body')
     }
-    expect(data[0]).toBe(0x1f)
-    expect(data[1]).toBe(0x8b)
-    return JSON.parse(strFromU8(decompressSync(data)))
+    if (data[0] === 0x1f && data[1] === 0x8b) {
+        return JSON.parse(strFromU8(decompressSync(data)))
+    }
+
+    const encodedData = new URLSearchParams(data.toString()).get('data')
+    if (!encodedData) {
+        throw new Error('Expected a gzip or Base64 encoded flags payload')
+    }
+    return JSON.parse(Buffer.from(encodedData, 'base64').toString())
 }
 
 async function distinctId(page: Page): Promise<string | undefined> {

--- a/packages/browser/playwright/mocked/flags.spec.ts
+++ b/packages/browser/playwright/mocked/flags.spec.ts
@@ -5,14 +5,20 @@ import { PostHog } from '@/posthog-core'
 import { pollUntilCondition } from './utils/event-capture-utils'
 import { decompressSync, strFromU8 } from 'fflate'
 
-function getGzipEncodedPayload(request: Request): Record<string, any> {
+function getFlagsPayload(request: Request): Record<string, any> {
     const data = request.postDataBuffer()
     if (!data) {
         throw new Error('Expected body to be present')
     }
-    expect(data[0]).toBe(0x1f)
-    expect(data[1]).toBe(0x8b)
-    return JSON.parse(strFromU8(decompressSync(data)))
+    if (data[0] === 0x1f && data[1] === 0x8b) {
+        return JSON.parse(strFromU8(decompressSync(data)))
+    }
+
+    const encodedData = new URLSearchParams(data.toString()).get('data')
+    if (!encodedData) {
+        throw new Error('Expected a gzip or Base64 encoded flags payload')
+    }
+    return JSON.parse(Buffer.from(encodedData, 'base64').toString())
 }
 
 const startOptions = {
@@ -66,7 +72,7 @@ test.describe('flags', () => {
     test('makes flags request on start', async () => {
         expect(flagsRequests.length).toBe(1)
         const flagsRequest = flagsRequests[0]
-        const flagsPayload = getGzipEncodedPayload(flagsRequest)
+        const flagsPayload = getFlagsPayload(flagsRequest)
         expect(flagsPayload).toEqual({
             token: 'test token',
             distinct_id: 'new-id',

--- a/packages/browser/playwright/mocked/flags.spec.ts
+++ b/packages/browser/playwright/mocked/flags.spec.ts
@@ -3,14 +3,16 @@ import { Request } from '@playwright/test'
 import { start } from './utils/setup'
 import { PostHog } from '@/posthog-core'
 import { pollUntilCondition } from './utils/event-capture-utils'
+import { decompressSync, strFromU8 } from 'fflate'
 
-function getBase64EncodedPayloadFromBody(body: unknown): Record<string, any> {
-    if (typeof body !== 'string') {
-        throw new Error('Expected body to be a string')
+function getGzipEncodedPayload(request: Request): Record<string, any> {
+    const data = request.postDataBuffer()
+    if (!data) {
+        throw new Error('Expected body to be present')
     }
-    const dataElement = body.match(/data=(.*)/)?.[1]
-    const data = decodeURIComponent(dataElement!)
-    return JSON.parse(Buffer.from(data, 'base64').toString())
+    expect(data[0]).toBe(0x1f)
+    expect(data[1]).toBe(0x8b)
+    return JSON.parse(strFromU8(decompressSync(data)))
 }
 
 const startOptions = {
@@ -64,7 +66,7 @@ test.describe('flags', () => {
     test('makes flags request on start', async () => {
         expect(flagsRequests.length).toBe(1)
         const flagsRequest = flagsRequests[0]
-        const flagsPayload = getBase64EncodedPayloadFromBody(flagsRequest.postData())
+        const flagsPayload = getGzipEncodedPayload(flagsRequest)
         expect(flagsPayload).toEqual({
             token: 'test token',
             distinct_id: 'new-id',

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -4678,6 +4678,11 @@
           "name": "compression"
         },
         {
+          "description": "Used when best-available compression negotiation does not select a format.",
+          "type": "Compression",
+          "name": "compressionFallback"
+        },
+        {
           "type": "Record<string, any> | Record<string, any>[]",
           "name": "data"
         },

--- a/packages/browser/src/__tests__/__snapshots__/featureflags.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/featureflags.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`featureflags _callFlagsEndpoint via reloadFeatureFlags builds a representative flags request 1`] = `
 {
   "callback": "<request-callback>",
-  "compression": "base64",
+  "compression": "best-available",
   "data": {
     "$anon_distinct_id": "anonymous-456",
     "$device_id": "device-123",

--- a/packages/browser/src/__tests__/extensions/browser-client.test.ts
+++ b/packages/browser/src/__tests__/extensions/browser-client.test.ts
@@ -401,7 +401,7 @@ describe('BrowserClientAdapter', () => {
             headers: { 'X-Extension-Header': 'value' },
             transport: 'XHR',
             timeoutMs: 321,
-            compression: 'base64',
+            compression: 'best-available',
             sentAt: 'body',
         })
 
@@ -415,7 +415,8 @@ describe('BrowserClientAdapter', () => {
                 headers: { 'X-Extension-Header': 'value' },
                 transport: 'XHR',
                 timeout: 321,
-                compression: 'base64',
+                compression: 'best-available',
+                compressionFallback: 'base64',
                 timestampMode: 'body',
                 fireCallbackOnDrop: true,
                 callback: expect.any(Function),

--- a/packages/browser/src/__tests__/featureflags-extension.test.ts
+++ b/packages/browser/src/__tests__/featureflags-extension.test.ts
@@ -687,7 +687,7 @@ describe('PostHogFeatureFlags extension lifecycle', () => {
             expect.objectContaining({
                 target: 'flags',
                 method: 'POST',
-                compression: 'base64',
+                compression: 'best-available',
                 sentAt: 'body',
                 timeoutMs: 1234,
                 body: expect.objectContaining({

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -2365,7 +2365,7 @@ describe('featureflags', () => {
             })
 
             // check right compression is sent
-            expect(instance._send_request.mock.calls[0][0].compression).toEqual('base64')
+            expect(instance._send_request.mock.calls[0][0].compression).toEqual('best-available')
 
             // check the request sent person properties
             expect(instance._send_request.mock.calls[0][0].data).toEqual({
@@ -3838,6 +3838,7 @@ describe('getRemoteConfigPayload', () => {
             expect.objectContaining({
                 method: 'POST',
                 url: 'flags/flags/?v=2',
+                compression: 'best-available',
                 data: expect.objectContaining({
                     distinct_id: 'test-distinct-id',
                     token: 'test-token',

--- a/packages/browser/src/__tests__/helpers/posthog-instance.ts
+++ b/packages/browser/src/__tests__/helpers/posthog-instance.ts
@@ -2,17 +2,17 @@
 import '../../entrypoints/default-extensions'
 
 import { PostHog, init_as_module } from '../../posthog-core'
-import { PostHogConfig } from '../../types'
+import { PostHogConfig, RemoteConfig } from '../../types'
 import { PostHogPersistence } from '../../posthog-persistence'
 import { assignableWindow } from '../../utils/globals'
 import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
-import { Compression } from '@posthog/core'
 
 export const createPosthogInstance = async (
     // Use a random UUID for the token, such that we don't have to worry
     // about collisions between test cases.
     token: string = uuidv7(),
-    config: Partial<PostHogConfig> = {}
+    config: Partial<PostHogConfig> = {},
+    remoteConfig: Partial<RemoteConfig> = {}
 ): Promise<PostHog> => {
     // We need to create a new instance of the library for each test, to ensure
     // that they are isolated from each other. The way the library is currently
@@ -23,7 +23,7 @@ export const createPosthogInstance = async (
     // NOTE: Temporary change whilst testing remote config
     assignableWindow._POSTHOG_REMOTE_CONFIG = {
         [token]: {
-            config: { autocapture_opt_out: false, supportedCompression: [Compression.GZipJS] },
+            config: { autocapture_opt_out: false, ...remoteConfig },
             siteApps: [],
         },
     } as any

--- a/packages/browser/src/__tests__/helpers/posthog-instance.ts
+++ b/packages/browser/src/__tests__/helpers/posthog-instance.ts
@@ -6,6 +6,7 @@ import { PostHogConfig } from '../../types'
 import { PostHogPersistence } from '../../posthog-persistence'
 import { assignableWindow } from '../../utils/globals'
 import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
+import { Compression } from '@posthog/core'
 
 export const createPosthogInstance = async (
     // Use a random UUID for the token, such that we don't have to worry
@@ -22,7 +23,7 @@ export const createPosthogInstance = async (
     // NOTE: Temporary change whilst testing remote config
     assignableWindow._POSTHOG_REMOTE_CONFIG = {
         [token]: {
-            config: { autocapture_opt_out: false },
+            config: { autocapture_opt_out: false, supportedCompression: [Compression.GZipJS] },
             siteApps: [],
         },
     } as any

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -4,7 +4,7 @@ import * as globals from '@posthog/browser-common/utils/globals'
 import { document, window } from '@posthog/browser-common/utils/globals'
 import { assignableWindow } from '../utils/globals'
 import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
-import { isUndefined } from '@posthog/core'
+import { Compression, isUndefined } from '@posthog/core'
 import {
     AUTOCAPTURE_DISABLED_SERVER_SIDE,
     ENABLE_PERSON_PROCESSING,
@@ -2022,5 +2022,19 @@ describe('_send_request', () => {
         const eventRequest = { url: 'http://localhost/e/' }
         posthog._send_request(eventRequest)
         expect(eventRequest.url).toBe('http://localhost/e/')
+    })
+
+    it('uses the configured fallback when best-available compression is unavailable', async () => {
+        const posthog = await createPosthogInstance(uuidv7(), { persistence: 'memory' })
+        posthog.compression = undefined
+        const requestOptions = {
+            url: 'http://localhost/flags/',
+            compression: 'best-available' as const,
+            compressionFallback: Compression.Base64,
+        }
+
+        posthog._send_request(requestOptions)
+
+        expect(requestOptions.compression).toBe(Compression.Base64)
     })
 })

--- a/packages/browser/src/extensions/browser-client.ts
+++ b/packages/browser/src/extensions/browser-client.ts
@@ -15,7 +15,7 @@ import type {
 } from '@posthog/browser-common'
 import { ExtensionRuntime } from '@posthog/browser-common/extension-runtime'
 import { logger } from '@posthog/browser-common/utils/logger'
-import { isUndefined, type Logger } from '@posthog/core'
+import { Compression, isUndefined, type Logger } from '@posthog/core'
 
 import Config from '../config'
 import { DEVICE_ID } from '../constants'
@@ -208,6 +208,8 @@ export class BrowserClientAdapter implements Client, Disposable {
             fireCallbackOnDrop: true,
             transport: init.transport,
             compression: init.compression,
+            compressionFallback:
+                init.target === 'flags' && init.compression === 'best-available' ? Compression.Base64 : undefined,
             timestampMode: init.sentAt,
         }
 

--- a/packages/browser/src/feature-flags-config.ts
+++ b/packages/browser/src/feature-flags-config.ts
@@ -17,7 +17,7 @@ export interface FeatureFlagsConfig {
     readonly cacheTtlMs?: number
     readonly refreshIntervalMs?: number
     readonly requestTimeoutMs: number
-    readonly compression: 'base64' | 'none'
+    readonly compression: 'best-available' | 'none'
     readonly evaluationContexts: readonly string[]
     readonly flagKeys?: readonly string[]
 }
@@ -38,7 +38,7 @@ const snapshot = (config: PostHogConfig, remoteRequestsDisabled: boolean): Featu
     cacheTtlMs: config.feature_flag_cache_ttl_ms,
     refreshIntervalMs: config.remote_config_refresh_interval_ms ?? DEFAULT_REFRESH_INTERVAL_MS,
     requestTimeoutMs: config.feature_flag_request_timeout_ms,
-    compression: config.disable_compression ? 'none' : 'base64',
+    compression: config.disable_compression ? 'none' : 'best-available',
     evaluationContexts: config.evaluation_contexts ?? config.evaluation_environments ?? [],
     flagKeys: isArray(config.flag_keys) ? config.flag_keys : undefined,
 })

--- a/packages/browser/src/feature-flags-config.ts
+++ b/packages/browser/src/feature-flags-config.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@posthog/browser-common/utils/logger'
 import { isArray, isUndefined } from '@posthog/core'
-import type { JsonType, PostHogConfig } from './types'
+import type { Compression, JsonType, PostHogConfig } from './types'
 
 const logger = createLogger('[FeatureFlags]')
 const DEFAULT_REFRESH_INTERVAL_MS = 5 * 60 * 1000
@@ -17,7 +17,7 @@ export interface FeatureFlagsConfig {
     readonly cacheTtlMs?: number
     readonly refreshIntervalMs?: number
     readonly requestTimeoutMs: number
-    readonly compression: 'best-available' | 'none'
+    readonly compression?: Compression | 'best-available'
     readonly evaluationContexts: readonly string[]
     readonly flagKeys?: readonly string[]
 }
@@ -38,7 +38,7 @@ const snapshot = (config: PostHogConfig, remoteRequestsDisabled: boolean): Featu
     cacheTtlMs: config.feature_flag_cache_ttl_ms,
     refreshIntervalMs: config.remote_config_refresh_interval_ms ?? DEFAULT_REFRESH_INTERVAL_MS,
     requestTimeoutMs: config.feature_flag_request_timeout_ms,
-    compression: config.disable_compression ? 'none' : 'best-available',
+    compression: config.disable_compression ? undefined : 'best-available',
     evaluationContexts: config.evaluation_contexts ?? config.evaluation_environments ?? [],
     flagKeys: isArray(config.flag_keys) ? config.flag_keys : undefined,
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1295,7 +1295,10 @@ export class PostHog implements PostHogInterface {
             ...this.config.request_headers,
             ...options.headers,
         }
-        options.compression = options.compression === 'best-available' ? this.compression : options.compression
+        options.compression =
+            options.compression === 'best-available'
+                ? (this.compression ?? options.compressionFallback)
+                : options.compression
         const disableBeacon = isUndefined(this.config.disable_beacon)
             ? this.config.__preview_disable_beacon
             : this.config.disable_beacon

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -7,7 +7,6 @@ import {
     EarlyAccessFeatureResponse,
     Properties,
     JsonType,
-    Compression,
     EarlyAccessFeature,
     RemoteConfigFeatureFlagCallback,
     EarlyAccessFeatureStage,
@@ -920,7 +919,7 @@ export class PostHogFeatureFlags implements Extension {
                     target: 'flags',
                     method: 'POST',
                     body: data,
-                    compression: this._config.compression === 'base64' ? Compression.Base64 : undefined,
+                    compression: this._config.compression === 'best-available' ? 'best-available' : undefined,
                     sentAt: 'body',
                     timeoutMs: this._config.requestTimeoutMs,
                 })
@@ -1218,7 +1217,7 @@ export class PostHogFeatureFlags implements Extension {
                 target: 'flags',
                 method: 'POST',
                 body: data,
-                compression: this._config.compression === 'base64' ? Compression.Base64 : undefined,
+                compression: this._config.compression === 'best-available' ? 'best-available' : undefined,
                 sentAt: 'body',
                 timeoutMs: this._config.requestTimeoutMs,
             })

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -919,7 +919,7 @@ export class PostHogFeatureFlags implements Extension {
                     target: 'flags',
                     method: 'POST',
                     body: data,
-                    compression: this._config.compression === 'best-available' ? 'best-available' : undefined,
+                    compression: this._config.compression,
                     sentAt: 'body',
                     timeoutMs: this._config.requestTimeoutMs,
                 })
@@ -1217,7 +1217,7 @@ export class PostHogFeatureFlags implements Extension {
                 target: 'flags',
                 method: 'POST',
                 body: data,
-                compression: this._config.compression === 'best-available' ? 'best-available' : undefined,
+                compression: this._config.compression,
                 sentAt: 'body',
                 timeoutMs: this._config.requestTimeoutMs,
             })

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -246,6 +246,8 @@ export interface RequestWithOptions {
     noRetries?: boolean
     disableTransport?: ('XHR' | 'fetch' | 'sendBeacon')[]
     compression?: Compression | 'best-available'
+    /** Used when best-available compression negotiation does not select a format. */
+    compressionFallback?: Compression
     /**
      * Controls where the request dispatch time is sent.
      * - `body` adds ISO `sent_at` to the request object, or every object in an array (for example, flags and recordings).


### PR DESCRIPTION
## Problem

Browser feature flag requests always use Base64 encoding, even when the server advertises gzip support. Base64 increases the request size instead of compressing it, which is especially wasteful when person or group properties make the flag payload large.

## Changes

Feature flag requests now use the Browser SDK's existing `best-available` compression mode. This prefers gzip when remote config advertises `gzip-js`, uses Base64 when it is the only advertised mode, and preserves Base64 as the feature flag fallback when negotiation fails or selects no format. Uncompressed JSON is used only when compression is explicitly disabled.

The functional transport test now verifies that a feature flag request is sent as a gzip body with `text/plain` content type and no compression query parameter. Playwright request assertions decode both gzip and legacy Base64 payloads so backward-compatibility runs continue to exercise published SDK versions. The Rust `/flags` service accepts `gzip-js` and also detects query-less gzip bodies from their magic bytes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent implemented this change after inspecting the Rust feature flag service and verifying gzip request decoding against the hosted US and EU endpoints. The existing compression negotiation and fallback behavior was reused rather than adding another compression path.
