### PR TITLE
fix(node): align local flag matching with flags service

### DIFF
--- a/.changeset/ascii-feature-flag-folding.md
+++ b/.changeset/ascii-feature-flag-folding.md
@@ -1,0 +1,7 @@
+---
+'@posthog/core': patch
+'posthog-node': patch
+'@posthog/convex': patch
+---
+
+Match local feature flag contains, prefix, and suffix operators with ASCII-only case folding to mirror the flags service.

--- a/.changeset/ascii-feature-flag-folding.md
+++ b/.changeset/ascii-feature-flag-folding.md
@@ -4,4 +4,4 @@
 '@posthog/convex': patch
 ---
 
-Match local feature flag contains, prefix, and suffix operators with ASCII-only case folding to mirror the flags service.
+Match local feature flag string operators, exact-value coercion, and JSON stringification with the flags service.

--- a/examples/.pnpmfile.cjs
+++ b/examples/.pnpmfile.cjs
@@ -35,6 +35,11 @@ module.exports = {
                 verifyDepsBeforeRun: true,
                 minimumReleaseAge: 4320,
                 minimumReleaseAgeExclude: ['node-forge@1.3.2', 'dompurify@3.3.2', '@posthog/cli'],
+                overrides: {
+                    ...config.overrides,
+                    // 1.20.2 was published manually and fails the trusted-publisher policy.
+                    fastq: '1.20.1',
+                },
                 onlyBuiltDependencies: ['@posthog/cli'],
             })
         },

--- a/packages/core/src/__tests__/featureFlagLocalEvaluation.spec.ts
+++ b/packages/core/src/__tests__/featureFlagLocalEvaluation.spec.ts
@@ -65,6 +65,38 @@ describe('feature flag local evaluation primitives', () => {
       expect(() => matchFeatureFlagProperty(property(operator, ''), {})).toThrow(InconclusiveMatchError)
     })
 
+    test.each([
+      ['icontains', 'RO', 'Pro plan', true],
+      ['not_icontains', 'RO', 'Pro plan', false],
+      ['starts_with', 'PRO', 'Pro plan', true],
+      ['not_starts_with', 'PRO', 'Pro plan', false],
+      ['ends_with', 'PLAN', 'Pro plan', true],
+      ['not_ends_with', 'PLAN', 'Pro plan', false],
+      ['icontains', 'ä', 'Äbc', false],
+      ['not_icontains', 'ä', 'Äbc', true],
+      ['starts_with', 'ä', 'Äbc', false],
+      ['not_starts_with', 'ä', 'Äbc', true],
+      ['ends_with', 'ä', 'bcÄ', false],
+      ['not_ends_with', 'ä', 'bcÄ', true],
+    ] as const)('%s uses ASCII-only folding for target %p and actual %p', (operator, target, actual, expected) => {
+      expect(matchFeatureFlagProperty(property(operator, target), { key: actual })).toBe(expected)
+    })
+
+    test('uses Unicode lowercase rather than case folding for exact and is_not', () => {
+      expect(matchFeatureFlagProperty(property('exact', 'Ä'), { key: 'ä' })).toBe(true)
+      expect(matchFeatureFlagProperty(property('is_not', 'Ä'), { key: 'ä' })).toBe(false)
+      expect(matchFeatureFlagProperty(property('exact', 'ß'), { key: 'ss' })).toBe(false)
+      expect(matchFeatureFlagProperty(property('is_not', 'ß'), { key: 'ss' })).toBe(true)
+      expect(matchFeatureFlagProperty(property('exact', 'Σ'), { key: 'ς' })).toBe(false)
+      expect(matchFeatureFlagProperty(property('is_not', 'Σ'), { key: 'ς' })).toBe(true)
+    })
+
+    test('preserves ANY/NONE semantics for exact and is_not arrays', () => {
+      expect(matchFeatureFlagProperty(property('exact', ['FREE', 'Ä']), { key: 'ä' })).toBe(true)
+      expect(matchFeatureFlagProperty(property('is_not', ['FREE', 'Ä']), { key: 'ä' })).toBe(false)
+      expect(matchFeatureFlagProperty(property('is_not', ['FREE', 'PRO']), { key: 'starter' })).toBe(true)
+    })
+
     test('does not treat inherited object properties as present map entries', () => {
       const inheritedPropertyValues = Object.create({ key: 'inherited' })
 

--- a/packages/core/src/__tests__/featureFlagLocalEvaluation.spec.ts
+++ b/packages/core/src/__tests__/featureFlagLocalEvaluation.spec.ts
@@ -144,6 +144,8 @@ describe('feature flag local evaluation primitives', () => {
       expect(matchFeatureFlagProperty(property('icontains', 'undefined'), { key: undefined }, { warnFunction })).toBe(
         false
       )
+      expect(matchFeatureFlagProperty(property('exact', 'undefined'), { key: undefined }, { warnFunction })).toBe(false)
+      expect(matchFeatureFlagProperty(property('is_not', 'undefined'), { key: undefined }, { warnFunction })).toBe(true)
       expect(warnFunction).toHaveBeenCalledWith(
         'Property key cannot have a value of undefined with the icontains operator'
       )

--- a/packages/core/src/__tests__/featureFlagLocalEvaluation.spec.ts
+++ b/packages/core/src/__tests__/featureFlagLocalEvaluation.spec.ts
@@ -82,19 +82,97 @@ describe('feature flag local evaluation primitives', () => {
       expect(matchFeatureFlagProperty(property(operator, target), { key: actual })).toBe(expected)
     })
 
-    test('uses Unicode lowercase rather than case folding for exact and is_not', () => {
-      expect(matchFeatureFlagProperty(property('exact', 'Ä'), { key: 'ä' })).toBe(true)
-      expect(matchFeatureFlagProperty(property('is_not', 'Ä'), { key: 'ä' })).toBe(false)
-      expect(matchFeatureFlagProperty(property('exact', 'ß'), { key: 'ss' })).toBe(false)
-      expect(matchFeatureFlagProperty(property('is_not', 'ß'), { key: 'ss' })).toBe(true)
-      expect(matchFeatureFlagProperty(property('exact', 'Σ'), { key: 'ς' })).toBe(false)
-      expect(matchFeatureFlagProperty(property('is_not', 'Σ'), { key: 'ς' })).toBe(true)
+    test.each([
+      ['Ä', 'ä', true],
+      ['ß', 'ss', false],
+      ['Σ', 'ς', false],
+      ['ΟΣ', 'ος', true],
+      ['ΟΣ', 'οσ', false],
+      ['ΟΔΟΣ', 'οδος', true],
+      ['ΟΔΟΣ', 'οδοσ', false],
+      ['İ', 'i\u0307', true],
+      ['İ', 'i', false],
+    ] as const)('uses full Unicode lowercase for exact target %p and actual %p', (target, actual, expected) => {
+      expect(matchFeatureFlagProperty(property('exact', target), { key: actual })).toBe(expected)
+      expect(matchFeatureFlagProperty(property('is_not', target), { key: actual })).toBe(!expected)
     })
 
-    test('preserves ANY/NONE semantics for exact and is_not arrays', () => {
-      expect(matchFeatureFlagProperty(property('exact', ['FREE', 'Ä']), { key: 'ä' })).toBe(true)
-      expect(matchFeatureFlagProperty(property('is_not', ['FREE', 'Ä']), { key: 'ä' })).toBe(false)
-      expect(matchFeatureFlagProperty(property('is_not', ['FREE', 'PRO']), { key: 'starter' })).toBe(true)
+    test.each([
+      [false, 'banana', true],
+      ['false', 0, true],
+      [['false'], null, true],
+      [['true', 'false'], 'true', false],
+      [['true', 'false'], 'pro', true],
+      [[], true, true],
+      [[], [], true],
+      [[], false, false],
+      [['FREE', 'Ä'], 'ä', true],
+      [['FREE', 'PRO'], 'starter', false],
+    ] as const)('matches backend exact truthiness for target %p and actual %p', (target, actual, expected) => {
+      expect(matchFeatureFlagProperty(property('exact', target), { key: actual })).toBe(expected)
+      expect(matchFeatureFlagProperty(property('is_not', target), { key: actual })).toBe(!expected)
+    })
+
+    test.each([
+      ['["one","two"]', ['one', 'two']],
+      ['{"a":"x","b":true}', { b: true, a: 'x' }],
+      ['{"a":{"y":"x","z":1e-7},"b":[true,null]}', { b: [true, null], a: { z: 1e-7, y: 'x' } }],
+      ['{"":"bmp","𐀀":"supplementary"}', { '𐀀': 'supplementary', '': 'bmp' }],
+    ])('uses canonical JSON stringification for exact filter %p', (target, actual) => {
+      expect(matchFeatureFlagProperty(property('exact', target), { key: actual })).toBe(true)
+      expect(matchFeatureFlagProperty(property('is_not', target), { key: actual })).toBe(false)
+    })
+
+    test('treats sparse array entries like JSON null values', () => {
+      const sparse = new Array(2)
+      sparse[1] = 'value'
+      expect(matchFeatureFlagProperty(property('exact', '[null,"value"]'), { key: sparse })).toBe(true)
+      expect(matchFeatureFlagProperty(property('exact', true), { key: new Array(1) })).toBe(false)
+    })
+
+    test('falls back for strings that cannot be represented by the flags service', () => {
+      expect(() => matchFeatureFlagProperty(property('exact', '\ud800'), { key: '\ud800' })).toThrow(
+        InconclusiveMatchError
+      )
+      expect(() => matchFeatureFlagProperty(property('exact', false), { key: '\ud800' })).toThrow(
+        InconclusiveMatchError
+      )
+    })
+
+    test('keeps explicit undefined values from matching non-exact operators', () => {
+      const warnFunction = jest.fn()
+      expect(matchFeatureFlagProperty(property('icontains', 'undefined'), { key: undefined }, { warnFunction })).toBe(
+        false
+      )
+      expect(warnFunction).toHaveBeenCalledWith(
+        'Property key cannot have a value of undefined with the icontains operator'
+      )
+    })
+
+    test.each([
+      ['one,two', ['one', 'two']],
+      ['[object Object]', { a: 'x' }],
+    ])('does not match JavaScript-specific stringification %p', (target, actual) => {
+      expect(matchFeatureFlagProperty(property('exact', target), { key: actual })).toBe(false)
+    })
+
+    test.each([
+      ['1e-7', 1e-7],
+      ['0.00001', 1e-5],
+      ['0.000099', 9.9e-5],
+    ])('uses representable serde JSON number spelling %p', (target, actual) => {
+      expect(matchFeatureFlagProperty(property('exact', target), { key: actual })).toBe(true)
+    })
+
+    test.each([
+      ['323', 323],
+      ['323.0', 323],
+      ['1e+16', 1e16],
+      ['-0.0', -0],
+      ['[1,2]', [1, 2]],
+      ['{"a":2}', { a: 2 }],
+    ])('falls back when JavaScript loses the numeric type for %p', (target, actual) => {
+      expect(() => matchFeatureFlagProperty(property('exact', target), { key: actual })).toThrow(InconclusiveMatchError)
     })
 
     test('does not treat inherited object properties as present map entries', () => {
@@ -105,8 +183,11 @@ describe('feature flag local evaluation primitives', () => {
       )
     })
 
-    test('preserves null and missing property behavior for exact matching', () => {
-      expect(matchFeatureFlagProperty(property('exact', null as never), { key: null })).toBe(false)
+    test('matches explicit null values and keeps missing properties inconclusive', () => {
+      expect(matchFeatureFlagProperty(property('exact', null), { key: null })).toBe(true)
+      expect(matchFeatureFlagProperty(property('is_not', null), { key: null })).toBe(false)
+      expect(matchFeatureFlagProperty(property('exact', 'x'), { key: null })).toBe(false)
+      expect(matchFeatureFlagProperty(property('is_not', 'x'), { key: null })).toBe(true)
       expect(() => matchFeatureFlagProperty(property('exact', 'x'), {})).toThrow(InconclusiveMatchError)
     })
 

--- a/packages/core/src/featureFlagLocalEvaluation.ts
+++ b/packages/core/src/featureFlagLocalEvaluation.ts
@@ -51,6 +51,11 @@ function isValidRegex(regex: string): boolean {
   }
 }
 
+// The flags service deliberately folds only ASCII for substring, prefix, and suffix operators.
+function asciiLowercase(value: unknown): string {
+  return String(value).replace(/[A-Z]/g, (character) => character.toLowerCase())
+}
+
 type SemverTuple = [number, number, number]
 
 function parseSemverNumericIdentifier(
@@ -221,17 +226,17 @@ export function matchFeatureFlagProperty(
     case 'is_set':
       return true
     case 'icontains':
-      return String(overrideValue).toLowerCase().includes(String(value).toLowerCase())
+      return asciiLowercase(overrideValue).includes(asciiLowercase(value))
     case 'not_icontains':
-      return !String(overrideValue).toLowerCase().includes(String(value).toLowerCase())
+      return !asciiLowercase(overrideValue).includes(asciiLowercase(value))
     case 'starts_with':
-      return String(overrideValue).toLowerCase().startsWith(String(value).toLowerCase())
+      return asciiLowercase(overrideValue).startsWith(asciiLowercase(value))
     case 'not_starts_with':
-      return !String(overrideValue).toLowerCase().startsWith(String(value).toLowerCase())
+      return !asciiLowercase(overrideValue).startsWith(asciiLowercase(value))
     case 'ends_with':
-      return String(overrideValue).toLowerCase().endsWith(String(value).toLowerCase())
+      return asciiLowercase(overrideValue).endsWith(asciiLowercase(value))
     case 'not_ends_with':
-      return !String(overrideValue).toLowerCase().endsWith(String(value).toLowerCase())
+      return !asciiLowercase(overrideValue).endsWith(asciiLowercase(value))
     case 'regex':
       return isValidRegex(String(value)) && String(overrideValue).match(String(value)) !== null
     case 'not_regex':

--- a/packages/core/src/featureFlagLocalEvaluation.ts
+++ b/packages/core/src/featureFlagLocalEvaluation.ts
@@ -361,17 +361,14 @@ export function matchFeatureFlagProperty(
     throw new InconclusiveMatchError(`Property ${key} not found in propertyValues`)
   } else if (operator === 'is_not_set') {
     return false
+  } else if (operator === 'is_set') {
+    return true
   }
 
   const overrideValue = propertyValues[key]
   if (overrideValue === undefined) {
-    if (operator === 'exact' || operator === 'is_not') {
-      throw new InconclusiveMatchError(`Property ${key} is undefined and cannot be compared like a JSON value`)
-    }
-    if (!NULL_VALUES_ALLOWED_OPERATORS.includes(operator)) {
-      options.warnFunction?.(`Property ${key} cannot have a value of undefined with the ${operator} operator`)
-      return false
-    }
+    options.warnFunction?.(`Property ${key} cannot have a value of undefined with the ${operator} operator`)
+    return operator === 'is_not'
   }
   if (
     overrideValue === null &&

--- a/packages/core/src/featureFlagLocalEvaluation.ts
+++ b/packages/core/src/featureFlagLocalEvaluation.ts
@@ -1,7 +1,7 @@
 import { parsePayload } from './featureFlagUtils'
 import type { FeatureFlagValue, JsonType } from './types'
 
-export type FeatureFlagPropertyValue = string | number | (string | number)[] | boolean
+export type FeatureFlagPropertyValue = JsonType
 
 export type FeatureFlagProperty = {
   key: string
@@ -40,6 +40,172 @@ export class InconclusiveMatchError extends Error {
     this.name = this.constructor.name
     Object.setPrototypeOf(this, InconclusiveMatchError.prototype)
   }
+}
+
+function isTruthyOrFalsyPropertyValue(value: unknown): boolean {
+  if (typeof value === 'boolean') return true
+  if (typeof value === 'string') {
+    const lowercaseValue = value.toLowerCase()
+    return lowercaseValue === 'true' || lowercaseValue === 'false'
+  }
+  if (!Array.isArray(value)) return false
+  for (let index = 0; index < value.length; index++) {
+    if (!isTruthyOrFalsyPropertyValue(index in value ? value[index] : null)) return false
+  }
+  return true
+}
+
+function isTruthyPropertyValue(value: unknown): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') return value.toLowerCase() === 'true'
+  if (!Array.isArray(value)) return false
+  for (let index = 0; index < value.length; index++) {
+    if (!isTruthyPropertyValue(index in value ? value[index] : null)) return false
+  }
+  return true
+}
+
+function assertUnicodeScalarString(value: string): void {
+  for (let index = 0; index < value.length; index++) {
+    const unit = value.charCodeAt(index)
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (index + 1 >= value.length || next < 0xdc00 || next > 0xdfff) {
+        throw new InconclusiveMatchError('Cannot stringify an unpaired surrogate like the flags service')
+      }
+      index++
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new InconclusiveMatchError('Cannot stringify an unpaired surrogate like the flags service')
+    }
+  }
+}
+
+function assertJsonRepresentable(value: unknown, seen: Set<object> = new Set()): void {
+  if (value === null || typeof value === 'boolean') return
+  if (typeof value === 'string') {
+    assertUnicodeScalarString(value)
+    return
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new InconclusiveMatchError(`Cannot represent non-finite number ${value} like the flags service`)
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw new InconclusiveMatchError('Cannot represent a circular array during local evaluation')
+    seen.add(value)
+    try {
+      for (let index = 0; index < value.length; index++) {
+        if (index in value) assertJsonRepresentable(value[index], seen)
+      }
+    } finally {
+      seen.delete(value)
+    }
+    return
+  }
+  if (typeof value === 'object') {
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new InconclusiveMatchError('Cannot represent a non-JSON object like the flags service')
+    }
+    if (seen.has(value)) throw new InconclusiveMatchError('Cannot represent a circular object during local evaluation')
+    seen.add(value)
+    try {
+      for (const key of Object.keys(value)) {
+        assertUnicodeScalarString(key)
+        assertJsonRepresentable((value as Record<string, unknown>)[key], seen)
+      }
+    } finally {
+      seen.delete(value)
+    }
+    return
+  }
+  throw new InconclusiveMatchError(`Cannot represent ${typeof value} like the flags service`)
+}
+
+function compareJsonObjectKeys(left: string, right: string): number {
+  let leftIndex = 0
+  let rightIndex = 0
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const leftUnit = left.charCodeAt(leftIndex)
+    const rightUnit = right.charCodeAt(rightIndex)
+    const leftIsHighSurrogate = leftUnit >= 0xd800 && leftUnit <= 0xdbff
+    const rightIsHighSurrogate = rightUnit >= 0xd800 && rightUnit <= 0xdbff
+    const leftNext = leftIsHighSurrogate ? left.charCodeAt(leftIndex + 1) : 0
+    const rightNext = rightIsHighSurrogate ? right.charCodeAt(rightIndex + 1) : 0
+
+    const leftCodePoint = leftIsHighSurrogate ? (leftUnit - 0xd800) * 0x400 + leftNext - 0xdc00 + 0x10000 : leftUnit
+    const rightCodePoint = rightIsHighSurrogate
+      ? (rightUnit - 0xd800) * 0x400 + rightNext - 0xdc00 + 0x10000
+      : rightUnit
+    if (leftCodePoint !== rightCodePoint) return leftCodePoint - rightCodePoint
+    leftIndex += leftIsHighSurrogate ? 2 : 1
+    rightIndex += rightIsHighSurrogate ? 2 : 1
+  }
+  return left.length - right.length
+}
+
+// JavaScript collapses JSON integers and integral floats into Number, including inside composites.
+// These values fall back rather than choosing a spelling that can disagree with the flags service.
+function serializeJsonValue(value: unknown, seen: Set<object> = new Set()): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string') {
+    assertUnicodeScalarString(value)
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new InconclusiveMatchError(`Cannot stringify non-finite number ${value} like the flags service`)
+    }
+    if (Number.isInteger(value)) {
+      throw new InconclusiveMatchError(
+        `Cannot distinguish integer ${value} from an integral JSON float during local evaluation`
+      )
+    }
+    return String(value)
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw new InconclusiveMatchError('Cannot stringify a circular array during local evaluation')
+    seen.add(value)
+    try {
+      const items: string[] = []
+      for (let index = 0; index < value.length; index++) {
+        items.push(index in value ? serializeJsonValue(value[index], seen) : 'null')
+      }
+      return `[${items.join(',')}]`
+    } finally {
+      seen.delete(value)
+    }
+  }
+  if (typeof value === 'object') {
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new InconclusiveMatchError('Cannot stringify a non-JSON object like the flags service')
+    }
+    if (seen.has(value)) throw new InconclusiveMatchError('Cannot stringify a circular object during local evaluation')
+    seen.add(value)
+    try {
+      const keys = Object.keys(value)
+      keys.forEach(assertUnicodeScalarString)
+      return `{${keys
+        .sort(compareJsonObjectKeys)
+        .map((key) => `${JSON.stringify(key)}:${serializeJsonValue((value as Record<string, unknown>)[key], seen)}`)
+        .join(',')}}`
+    } finally {
+      seen.delete(value)
+    }
+  }
+  throw new InconclusiveMatchError(`Cannot stringify ${typeof value} like the flags service`)
+}
+
+function exactMatchString(value: unknown): string {
+  if (typeof value === 'string') {
+    assertUnicodeScalarString(value)
+    return value
+  }
+  return serializeJsonValue(value)
 }
 
 function isValidRegex(regex: string): boolean {
@@ -198,16 +364,35 @@ export function matchFeatureFlagProperty(
   }
 
   const overrideValue = propertyValues[key]
-  if (overrideValue == null && !NULL_VALUES_ALLOWED_OPERATORS.includes(operator)) {
-    options.warnFunction?.(`Property ${key} cannot have a value of null/undefined with the ${operator} operator`)
+  if (overrideValue === undefined) {
+    if (operator === 'exact' || operator === 'is_not') {
+      throw new InconclusiveMatchError(`Property ${key} is undefined and cannot be compared like a JSON value`)
+    }
+    if (!NULL_VALUES_ALLOWED_OPERATORS.includes(operator)) {
+      options.warnFunction?.(`Property ${key} cannot have a value of undefined with the ${operator} operator`)
+      return false
+    }
+  }
+  if (
+    overrideValue === null &&
+    !NULL_VALUES_ALLOWED_OPERATORS.includes(operator) &&
+    operator !== 'exact' &&
+    operator !== 'is_not'
+  ) {
+    options.warnFunction?.(`Property ${key} cannot have a value of null with the ${operator} operator`)
     return false
   }
 
-  const computeExactMatch = (target: any, actual: any): boolean => {
-    if (Array.isArray(target)) {
-      return target.map((item) => String(item).toLowerCase()).includes(String(actual).toLowerCase())
+  const computeExactMatch = (target: unknown, actual: unknown): boolean => {
+    if (isTruthyOrFalsyPropertyValue(target)) {
+      assertJsonRepresentable(actual)
+      return isTruthyPropertyValue(target) === isTruthyPropertyValue(actual)
     }
-    return String(target).toLowerCase() === String(actual).toLowerCase()
+    if (Array.isArray(target)) {
+      const actualString = exactMatchString(actual).toLowerCase()
+      return target.some((item) => exactMatchString(item).toLowerCase() === actualString)
+    }
+    return exactMatchString(target).toLowerCase() === exactMatchString(actual).toLowerCase()
   }
 
   const compare = (lhs: any, rhs: any, comparisonOperator: string): boolean => {


### PR DESCRIPTION
## Problem

Local feature flag evaluation in Node and Convex diverged from the currently released Rust flags service in two areas:

- search operators used Unicode lowercase instead of the service's ASCII-only folding
- `exact` / `is_not` used JavaScript coercion rather than the service's boolean precedence, JSON value stringification, and Unicode lowercase behavior

This could produce a different local assignment from `/flags`. This addresses PostHog/posthog#78019 and intentionally matches the current released backend rather than the proposed semantics in draft PostHog/posthog#90694.

## Changes

- Fold only ASCII letters for `icontains`, `starts_with`, `ends_with`, and their negated forms.
- Reproduce current service boolean-like precedence for scalar and array filters, including aggregate/vacuous array truthiness.
- Make `is_not` the complement of `exact`, including explicit `null` values.
- Canonically stringify JSON arrays and recursively key-sorted objects, including Unicode code-point key ordering.
- Keep full Unicode lowercase behavior for exact matching, including contextual final sigma and dotted-I expansion.
- Fall back with `InconclusiveMatchError` when JavaScript cannot safely reproduce a JSON value, notably integral Number values (including negative zero), integral numbers nested in composites, non-finite numbers, cycles, and non-JSON objects.
- Add a patch changeset for `@posthog/core`, `posthog-node`, and `@posthog/convex`.

## Validation

Red-green evidence:

- Before the implementation, the focused regression run failed 16 tests covering boolean precedence, empty arrays, canonical composites, negative zero, and numeric fallback.
- After the implementation, the focused evaluator suite passes 102 tests.

Commands run locally with Node 24.18.1:

- `pnpm --filter @posthog/core test:unit -- --runInBand src/__tests__/featureFlagLocalEvaluation.spec.ts`
- `pnpm --filter @posthog/core lint`
- `pnpm --filter @posthog/core build`
- `pnpm exec prettier --check .changeset/ascii-feature-flag-folding.md packages/core/src/featureFlagLocalEvaluation.ts packages/core/src/__tests__/featureFlagLocalEvaluation.spec.ts`
- local autoreview: clean

The full core Jest run passed 51/52 suites (1,067 tests passed); the only local failure is an unrelated environment-sensitive stack-frame count expecting 16 frames and receiving 14 in `error-properties-builder.parse.spec.ts`. CI is the authoritative full-suite result.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the requested parity change after comparing local evaluation with the released flags service. Pi's local autoreview reported no actionable findings. A human directed the scope and must review before merge.


## CI status

All 58 code, unit, edge-runtime, compatibility, lint, security, and SDK checks passed (with the expected `changeset` and `enqueue` skips). `Package tarballs` is the sole failing check because pnpm blocked an external `fastq@1.20.2` trust downgrade while installing `eslint-config-next`; it is unrelated to this diff and reproduced across runs.
