### PR TITLE
fix(ai): report tokens used by an interrupted stream instead of zero

### DIFF
--- a/.changeset/ai-report-usage-on-interrupted-streams.md
+++ b/.changeset/ai-report-usage-on-interrupted-streams.md
@@ -1,0 +1,9 @@
+---
+'@posthog/ai': minor
+---
+
+Report the tokens an interrupted stream actually used, instead of zero.
+
+When a stream failed or was cancelled partway, the OpenAI wrapper discarded the token counts it had already accumulated and reported zero, so a call that consumed a large prompt appeared to cost nothing. It now reports what it collected, along with the real latency.
+
+Token counts are also omitted entirely when the provider never reported them, rather than being sent as `$ai_input_tokens: 0`. This is a minor rather than a patch because `$ai_input_tokens` was previously always present on a generation event; anything reading it now needs to handle it being absent. Zero remains a valid value and still means the model consumed nothing.

--- a/.changeset/ai-report-usage-on-interrupted-streams.md
+++ b/.changeset/ai-report-usage-on-interrupted-streams.md
@@ -7,3 +7,5 @@ Report the tokens an interrupted stream actually used, instead of zero.
 When a stream failed or was cancelled partway, the wrappers discarded the token counts they had already accumulated and reported zero, so a call that consumed a large prompt appeared to cost nothing. They now report what they collected, along with the real latency. This covers the OpenAI chat, Responses and transcription streams, and the Anthropic, Gemini, Azure and Vercel wrappers.
 
 Token counts are also omitted entirely when the provider never reported them, rather than being sent as `$ai_input_tokens: 0`. Zero remains a valid value and still means the model consumed nothing. The package API does not change, but `$ai_input_tokens` was previously always present on a generation event, so anything reading that property downstream needs to handle it being absent.
+
+Cost overrides follow the same rule: a configured price is applied only to the token counts the provider reported, so an interrupted stream no longer claims a `$0` cost just because a `costOverride` was set.

--- a/.changeset/ai-report-usage-on-interrupted-streams.md
+++ b/.changeset/ai-report-usage-on-interrupted-streams.md
@@ -8,4 +8,4 @@ When a stream failed or was cancelled partway, the wrappers discarded the token 
 
 Token counts are also omitted entirely when the provider never reported them, rather than being sent as `$ai_input_tokens: 0`. Zero remains a valid value and still means the model consumed nothing. The package API does not change, but `$ai_input_tokens` was previously always present on a generation event, so anything reading that property downstream needs to handle it being absent.
 
-Cost overrides follow the same rule: a configured price is applied only to the token counts the provider reported, so an interrupted stream no longer claims a `$0` cost just because a `costOverride` was set.
+Cost overrides follow the same rule: a configured price is applied only to the token counts the provider reported, so an interrupted stream no longer claims a `$0` cost just because a `costOverride` was set. When only one side was reported, `$ai_total_cost_usd` is the cost of the known side alone, a lower bound on the true total rather than an assertion of it.

--- a/.changeset/ai-report-usage-on-interrupted-streams.md
+++ b/.changeset/ai-report-usage-on-interrupted-streams.md
@@ -4,6 +4,6 @@
 
 Report the tokens an interrupted stream actually used, instead of zero.
 
-When a stream failed or was cancelled partway, the OpenAI wrapper discarded the token counts it had already accumulated and reported zero, so a call that consumed a large prompt appeared to cost nothing. It now reports what it collected, along with the real latency.
+When a stream failed or was cancelled partway, the wrappers discarded the token counts they had already accumulated and reported zero, so a call that consumed a large prompt appeared to cost nothing. They now report what they collected, along with the real latency. This covers the OpenAI chat, Responses and transcription streams, and the Anthropic, Gemini, Azure and Vercel wrappers.
 
 Token counts are also omitted entirely when the provider never reported them, rather than being sent as `$ai_input_tokens: 0`. This is a minor rather than a patch because `$ai_input_tokens` was previously always present on a generation event; anything reading it now needs to handle it being absent. Zero remains a valid value and still means the model consumed nothing.

--- a/.changeset/ai-report-usage-on-interrupted-streams.md
+++ b/.changeset/ai-report-usage-on-interrupted-streams.md
@@ -1,9 +1,9 @@
 ---
-'@posthog/ai': minor
+'@posthog/ai': patch
 ---
 
 Report the tokens an interrupted stream actually used, instead of zero.
 
 When a stream failed or was cancelled partway, the wrappers discarded the token counts they had already accumulated and reported zero, so a call that consumed a large prompt appeared to cost nothing. They now report what they collected, along with the real latency. This covers the OpenAI chat, Responses and transcription streams, and the Anthropic, Gemini, Azure and Vercel wrappers.
 
-Token counts are also omitted entirely when the provider never reported them, rather than being sent as `$ai_input_tokens: 0`. This is a minor rather than a patch because `$ai_input_tokens` was previously always present on a generation event; anything reading it now needs to handle it being absent. Zero remains a valid value and still means the model consumed nothing.
+Token counts are also omitted entirely when the provider never reported them, rather than being sent as `$ai_input_tokens: 0`. Zero remains a valid value and still means the model consumed nothing. The package API does not change, but `$ai_input_tokens` was previously always present on a generation event, so anything reading that property downstream needs to handle it being absent.

--- a/.changeset/ai-report-usage-on-interrupted-streams.md
+++ b/.changeset/ai-report-usage-on-interrupted-streams.md
@@ -2,10 +2,4 @@
 '@posthog/ai': patch
 ---
 
-Report the tokens an interrupted stream actually used, instead of zero.
-
-When a stream failed or was cancelled partway, the wrappers discarded the token counts they had already accumulated and reported zero, so a call that consumed a large prompt appeared to cost nothing. They now report what they collected, along with the real latency. This covers the OpenAI chat, Responses and transcription streams, and the Anthropic, Gemini, Azure and Vercel wrappers.
-
-Token counts are also omitted entirely when the provider never reported them, rather than being sent as `$ai_input_tokens: 0`. Zero remains a valid value and still means the model consumed nothing. The package API does not change, but `$ai_input_tokens` was previously always present on a generation event, so anything reading that property downstream needs to handle it being absent.
-
-Cost overrides follow the same rule: a configured price is applied only to the token counts the provider reported, so an interrupted stream no longer claims a `$0` cost just because a `costOverride` was set. When only one side was reported, `$ai_total_cost_usd` is the cost of the known side alone, a lower bound on the true total rather than an assertion of it.
+Interrupted or cancelled streams now report the token usage and latency they actually observed, instead of zeros, across the OpenAI, Anthropic, Gemini, Azure and Vercel wrappers. When usage was never reported, token counts and override costs are omitted entirely, so `$ai_input_tokens` can be absent where it was previously always `0`.

--- a/packages/ai/src/anthropic/index.ts
+++ b/packages/ai/src/anthropic/index.ts
@@ -81,9 +81,6 @@ export class WrappedMessages extends AnthropicOriginal.Messages {
         let firstTokenTime: number | undefined
         let stopReason: string | undefined
 
-        // Token counts stay undefined until an event reports them. Anthropic
-        // sends input tokens on message_start and output tokens on message_delta,
-        // so a stream cut short still carries whatever arrived before the cut.
         const usage: {
           inputTokens?: number
           outputTokens?: number
@@ -264,8 +261,6 @@ export class WrappedMessages extends AnthropicOriginal.Messages {
                 latency: (Date.now() - startTime) / 1000,
                 baseURL: this.baseURL,
                 modelParameters: getModelParams(body),
-                // Whatever the stream reported before it failed, rather than a
-                // zero that would read as a call which consumed nothing.
                 usage,
                 error: error,
               })
@@ -323,13 +318,10 @@ export class WrappedMessages extends AnthropicOriginal.Messages {
             provider: 'anthropic',
             input: sanitizeAnthropic(mergeSystemPrompt(anthropicParams, 'anthropic'), this.phClient),
             output: [],
-            latency: 0,
+            latency: (Date.now() - startTime) / 1000,
             baseURL: this.baseURL,
             modelParameters: getModelParams(body),
             httpStatus: error?.status ? error.status : 500,
-            // The call returned no usage, and a failure this side of a response
-            // can still have consumed the prompt, so report no counts rather
-            // than zero.
             usage: {},
             error: error,
           })

--- a/packages/ai/src/anthropic/index.ts
+++ b/packages/ai/src/anthropic/index.ts
@@ -81,18 +81,17 @@ export class WrappedMessages extends AnthropicOriginal.Messages {
         let firstTokenTime: number | undefined
         let stopReason: string | undefined
 
+        // Token counts stay undefined until an event reports them. Anthropic
+        // sends input tokens on message_start and output tokens on message_delta,
+        // so a stream cut short still carries whatever arrived before the cut.
         const usage: {
-          inputTokens: number
-          outputTokens: number
+          inputTokens?: number
+          outputTokens?: number
           cacheCreationInputTokens?: number
           cacheReadInputTokens?: number
           webSearchCount?: number
           rawUsage?: unknown
         } = {
-          inputTokens: 0,
-          outputTokens: 0,
-          cacheCreationInputTokens: 0,
-          cacheReadInputTokens: 0,
           webSearchCount: 0,
         }
         let rawUsage: Record<string, unknown> = {}
@@ -262,13 +261,12 @@ export class WrappedMessages extends AnthropicOriginal.Messages {
                 provider: 'anthropic',
                 input: sanitizeAnthropic(mergeSystemPrompt(anthropicParams, 'anthropic'), this.phClient),
                 output: [],
-                latency: 0,
+                latency: (Date.now() - startTime) / 1000,
                 baseURL: this.baseURL,
                 modelParameters: getModelParams(body),
-                usage: {
-                  inputTokens: 0,
-                  outputTokens: 0,
-                },
+                // Whatever the stream reported before it failed, rather than a
+                // zero that would read as a call which consumed nothing.
+                usage,
                 error: error,
               })
               throw error
@@ -329,10 +327,10 @@ export class WrappedMessages extends AnthropicOriginal.Messages {
             baseURL: this.baseURL,
             modelParameters: getModelParams(body),
             httpStatus: error?.status ? error.status : 500,
-            usage: {
-              inputTokens: 0,
-              outputTokens: 0,
-            },
+            // The call returned no usage, and a failure this side of a response
+            // can still have consumed the prompt, so report no counts rather
+            // than zero.
+            usage: {},
             error: error,
           })
           throw error

--- a/packages/ai/src/anthropic/index.ts
+++ b/packages/ai/src/anthropic/index.ts
@@ -252,6 +252,11 @@ export class WrappedMessages extends AnthropicOriginal.Messages {
                 tools: availableTools,
               })
             } catch (error: unknown) {
+              // The final usage delta may never arrive; whatever raw usage did
+              // still belongs on the event.
+              if (Object.keys(rawUsage).length > 0) {
+                usage.rawUsage = rawUsage
+              }
               await captureAiGeneration(this.phClient, {
                 ...posthogParams,
                 model: anthropicParams.model,

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -151,14 +151,21 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
     }
     httpStatus = httpStatus ?? 200
 
-    let costOverrideData: Record<string, number> = {}
+    // A price times an unknown token count is unknown, not zero: a cancelled
+    // stream still consumed its prompt. Each component is priced only when its
+    // count exists, and the total sums the priced components, so a call with no
+    // reported usage sends no cost instead of asserting $0.
+    const costOverrideData: Record<string, number> = {}
     if (options.costOverride) {
-      const inputCostUSD = (options.costOverride.inputCost ?? 0) * (usage.inputTokens ?? 0)
-      const outputCostUSD = (options.costOverride.outputCost ?? 0) * (usage.outputTokens ?? 0)
-      costOverrideData = {
-        $ai_input_cost_usd: inputCostUSD,
-        $ai_output_cost_usd: outputCostUSD,
-        $ai_total_cost_usd: inputCostUSD + outputCostUSD,
+      if (usage.inputTokens !== undefined) {
+        costOverrideData.$ai_input_cost_usd = (options.costOverride.inputCost ?? 0) * usage.inputTokens
+      }
+      if (usage.outputTokens !== undefined) {
+        costOverrideData.$ai_output_cost_usd = (options.costOverride.outputCost ?? 0) * usage.outputTokens
+      }
+      if (Object.keys(costOverrideData).length > 0) {
+        costOverrideData.$ai_total_cost_usd =
+          (costOverrideData.$ai_input_cost_usd ?? 0) + (costOverrideData.$ai_output_cost_usd ?? 0)
       }
     }
 

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -151,10 +151,10 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
     }
     httpStatus = httpStatus ?? 200
 
-    // A price times an unknown token count is unknown, not zero: a cancelled
-    // stream still consumed its prompt. Each component is priced only when its
-    // count exists, and the total sums the priced components, so a call with no
-    // reported usage sends no cost instead of asserting $0.
+    // A configured price applies only to a count the provider reported, so a call with no
+    // reported usage sends no cost instead of asserting $0. $ai_total_cost_usd sums the sides
+    // that were priced, which makes it the cost of the known side alone when the other side
+    // went unreported: a lower bound on the true total, not an assertion of it.
     const costOverrideData: Record<string, number> = {}
     if (options.costOverride) {
       if (usage.inputTokens !== undefined) {
@@ -202,9 +202,6 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
       $ai_input: safeInput,
       $ai_output_choices: safeOutput,
       $ai_http_status: httpStatus,
-      // Omitted rather than defaulted to 0 when the provider never reported it,
-      // matching $ai_output_tokens below. A cancelled stream still consumed its
-      // input, so reporting 0 would state a cost we know to be wrong.
       ...(usage.inputTokens !== undefined ? { $ai_input_tokens: usage.inputTokens } : {}),
       ...(usage.outputTokens !== undefined ? { $ai_output_tokens: usage.outputTokens } : {}),
       ...additionalTokenValues,

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -195,7 +195,10 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
       $ai_input: safeInput,
       $ai_output_choices: safeOutput,
       $ai_http_status: httpStatus,
-      $ai_input_tokens: usage.inputTokens ?? 0,
+      // Omitted rather than defaulted to 0 when the provider never reported it,
+      // matching $ai_output_tokens below. A cancelled stream still consumed its
+      // input, so reporting 0 would state a cost we know to be wrong.
+      ...(usage.inputTokens !== undefined ? { $ai_input_tokens: usage.inputTokens } : {}),
       ...(usage.outputTokens !== undefined ? { $ai_output_tokens: usage.outputTokens } : {}),
       ...additionalTokenValues,
       ...(options.latency !== undefined ? { $ai_latency: options.latency } : {}),

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -152,9 +152,9 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
     httpStatus = httpStatus ?? 200
 
     // A configured price applies only to a count the provider reported, so a call with no
-    // reported usage sends no cost instead of asserting $0. $ai_total_cost_usd sums the sides
-    // that were priced, which makes it the cost of the known side alone when the other side
-    // went unreported: a lower bound on the true total, not an assertion of it.
+    // reported usage sends no cost instead of asserting $0. The total is written only when
+    // both sides were priced: $ai_total_cost_usd reads downstream as the whole cost, and one
+    // known side is a lower bound, not a total. A partial call sends its components alone.
     const costOverrideData: Record<string, number> = {}
     if (options.costOverride) {
       if (usage.inputTokens !== undefined) {
@@ -163,9 +163,8 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
       if (usage.outputTokens !== undefined) {
         costOverrideData.$ai_output_cost_usd = (options.costOverride.outputCost ?? 0) * usage.outputTokens
       }
-      if (Object.keys(costOverrideData).length > 0) {
-        costOverrideData.$ai_total_cost_usd =
-          (costOverrideData.$ai_input_cost_usd ?? 0) + (costOverrideData.$ai_output_cost_usd ?? 0)
+      if (costOverrideData.$ai_input_cost_usd !== undefined && costOverrideData.$ai_output_cost_usd !== undefined) {
+        costOverrideData.$ai_total_cost_usd = costOverrideData.$ai_input_cost_usd + costOverrideData.$ai_output_cost_usd
       }
     }
 

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -152,9 +152,9 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
     httpStatus = httpStatus ?? 200
 
     // A configured price applies only to a count the provider reported, so a call with no
-    // reported usage sends no cost instead of asserting $0. The total is written only when
-    // both sides were priced: $ai_total_cost_usd reads downstream as the whole cost, and one
-    // known side is a lower bound, not a total. A partial call sends its components alone.
+    // reported usage sends no cost instead of asserting $0. $ai_total_cost_usd sums the sides
+    // that were priced, which makes it the cost of the known side alone when the other side
+    // went unreported: a lower bound on the true total, not an assertion of it.
     const costOverrideData: Record<string, number> = {}
     if (options.costOverride) {
       if (usage.inputTokens !== undefined) {
@@ -163,8 +163,9 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
       if (usage.outputTokens !== undefined) {
         costOverrideData.$ai_output_cost_usd = (options.costOverride.outputCost ?? 0) * usage.outputTokens
       }
-      if (costOverrideData.$ai_input_cost_usd !== undefined && costOverrideData.$ai_output_cost_usd !== undefined) {
-        costOverrideData.$ai_total_cost_usd = costOverrideData.$ai_input_cost_usd + costOverrideData.$ai_output_cost_usd
+      if (Object.keys(costOverrideData).length > 0) {
+        costOverrideData.$ai_total_cost_usd =
+          (costOverrideData.$ai_input_cost_usd ?? 0) + (costOverrideData.$ai_output_cost_usd ?? 0)
       }
     }
 

--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -104,10 +104,9 @@ export class WrappedModels {
         latency,
         baseURL: 'https://generativelanguage.googleapis.com',
         modelParameters: getModelParams(params as GenerateContentParameters & MonitoringParams),
-        usage: {
-          inputTokens: 0,
-          outputTokens: 0,
-        },
+        // The call returned no usage, and a failure this side of a response can
+        // still have consumed the prompt, so report no counts rather than zero.
+        usage: {},
         error,
       })
       throw error
@@ -122,9 +121,9 @@ export class WrappedModels {
     const accumulatedContent: FormattedContent = []
     let firstTokenTime: number | undefined
     let stopReason: string | undefined
+    // Token counts stay undefined until a chunk carries usageMetadata, so a
+    // stream that ends before one arrives is not reported as having used nothing.
     let usage: TokenUsage = {
-      inputTokens: 0,
-      outputTokens: 0,
       webSearchCount: 0,
       rawUsage: undefined,
     }
@@ -249,10 +248,9 @@ export class WrappedModels {
         latency,
         baseURL: 'https://generativelanguage.googleapis.com',
         modelParameters: getModelParams(params as GenerateContentParameters & MonitoringParams),
-        usage: {
-          inputTokens: 0,
-          outputTokens: 0,
-        },
+        // Whatever the stream reported before it failed. Gemini sends
+        // usageMetadata on chunks, so a stream cut short often has real counts.
+        usage,
         error,
       })
       throw error
@@ -298,9 +296,9 @@ export class WrappedModels {
         latency,
         baseURL: 'https://generativelanguage.googleapis.com',
         modelParameters: getModelParams(params as EmbedContentParameters & MonitoringParams),
-        usage: {
-          inputTokens: 0,
-        },
+        // The call returned no usage, and a failure this side of a response can
+        // still have consumed the input, so report no count rather than zero.
+        usage: {},
         error,
       })
       throw error

--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -104,8 +104,6 @@ export class WrappedModels {
         latency,
         baseURL: 'https://generativelanguage.googleapis.com',
         modelParameters: getModelParams(params as GenerateContentParameters & MonitoringParams),
-        // The call returned no usage, and a failure this side of a response can
-        // still have consumed the prompt, so report no counts rather than zero.
         usage: {},
         error,
       })
@@ -121,8 +119,6 @@ export class WrappedModels {
     const accumulatedContent: FormattedContent = []
     let firstTokenTime: number | undefined
     let stopReason: string | undefined
-    // Token counts stay undefined until a chunk carries usageMetadata, so a
-    // stream that ends before one arrives is not reported as having used nothing.
     let usage: TokenUsage = {
       webSearchCount: 0,
       rawUsage: undefined,
@@ -248,8 +244,6 @@ export class WrappedModels {
         latency,
         baseURL: 'https://generativelanguage.googleapis.com',
         modelParameters: getModelParams(params as GenerateContentParameters & MonitoringParams),
-        // Whatever the stream reported before it failed. Gemini sends
-        // usageMetadata on chunks, so a stream cut short often has real counts.
         usage,
         error,
       })
@@ -296,8 +290,6 @@ export class WrappedModels {
         latency,
         baseURL: 'https://generativelanguage.googleapis.com',
         modelParameters: getModelParams(params as EmbedContentParameters & MonitoringParams),
-        // The call returned no usage, and a failure this side of a response can
-        // still have consumed the input, so report no count rather than zero.
         usage: {},
         error,
       })

--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -123,6 +123,7 @@ export class WrappedModels {
       webSearchCount: 0,
       rawUsage: undefined,
     }
+    let errored = false
 
     try {
       const stream = await this.client.models.generateContentStream(geminiParams as GenerateContentParameters)
@@ -205,35 +206,8 @@ export class WrappedModels {
         }
         yield chunk
       }
-
-      const latency = (Date.now() - startTime) / 1000
-      const timeToFirstToken = firstTokenTime !== undefined ? (firstTokenTime - startTime) / 1000 : undefined
-
-      const availableTools = extractAvailableToolCalls('gemini', geminiParams)
-
-      // Format output similar to formatResponseGemini
-      const output = accumulatedContent.length > 0 ? [{ role: 'assistant', content: accumulatedContent }] : []
-
-      await captureAiGeneration(this.phClient, {
-        ...posthogParams,
-        model: geminiParams.model,
-        provider: 'gemini',
-        input: this.formatInputForPostHog(geminiParams),
-        output,
-        latency,
-        timeToFirstToken,
-        baseURL: 'https://generativelanguage.googleapis.com',
-        modelParameters: getModelParams(params as GenerateContentParameters & MonitoringParams),
-        httpStatus: 200,
-        usage: {
-          ...usage,
-          webSearchCount: usage.webSearchCount,
-          rawUsage: usage.rawUsage,
-        },
-        stopReason,
-        tools: availableTools,
-      })
     } catch (error: unknown) {
+      errored = true
       const latency = (Date.now() - startTime) / 1000
       await captureAiGeneration(this.phClient, {
         ...posthogParams,
@@ -248,6 +222,39 @@ export class WrappedModels {
         error,
       })
       throw error
+    } finally {
+      // A consumer that stops iterating resumes the pending yield as a return,
+      // skipping both the loop tail and the catch. Only a finally runs then, so
+      // the success capture lives here to cover completion and cancellation.
+      if (!errored) {
+        const latency = (Date.now() - startTime) / 1000
+        const timeToFirstToken = firstTokenTime !== undefined ? (firstTokenTime - startTime) / 1000 : undefined
+
+        const availableTools = extractAvailableToolCalls('gemini', geminiParams)
+
+        // Format output similar to formatResponseGemini
+        const output = accumulatedContent.length > 0 ? [{ role: 'assistant', content: accumulatedContent }] : []
+
+        await captureAiGeneration(this.phClient, {
+          ...posthogParams,
+          model: geminiParams.model,
+          provider: 'gemini',
+          input: this.formatInputForPostHog(geminiParams),
+          output,
+          latency,
+          timeToFirstToken,
+          baseURL: 'https://generativelanguage.googleapis.com',
+          modelParameters: getModelParams(params as GenerateContentParameters & MonitoringParams),
+          httpStatus: 200,
+          usage: {
+            ...usage,
+            webSearchCount: usage.webSearchCount,
+            rawUsage: usage.rawUsage,
+          },
+          stopReason,
+          tools: availableTools,
+        })
+      }
     }
   }
 

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -394,7 +394,11 @@ export class WrappedResponses extends AzureOpenAI.Responses {
                     modelParametersSource: body,
                   },
                   error,
-                  accumulated.completionId
+                  {
+                    completionId: accumulated.completionId,
+                    usage: accumulated.usage,
+                    latency: (Date.now() - startTime) / 1000,
+                  }
                 )
               )
               throw error

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -173,6 +173,8 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                   {
                     completionId: accumulated.completionId,
                     systemFingerprint: accumulated.systemFingerprint,
+                    usage: accumulated.usage,
+                    latency: (Date.now() - startTime) / 1000,
                   }
                 )
               )
@@ -233,7 +235,8 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 monitoring: posthogParams,
                 modelParametersSource: body,
               },
-              error
+              error,
+              { latency: (Date.now() - startTime) / 1000 }
             )
           )
           throw error
@@ -458,7 +461,8 @@ export class WrappedResponses extends AzureOpenAI.Responses {
                 monitoring: posthogParams,
                 modelParametersSource: body,
               },
-              error
+              error,
+              { latency: (Date.now() - startTime) / 1000 }
             )
           )
           throw error
@@ -599,7 +603,8 @@ export class WrappedResponses extends AzureOpenAI.Responses {
               monitoring: posthogParams,
               modelParametersSource: body,
             },
-            error
+            error,
+            { latency: (Date.now() - startTime) / 1000 }
           )
         )
         throw error
@@ -659,7 +664,8 @@ export class WrappedEmbeddings extends AzureOpenAI.Embeddings {
               monitoring: posthogParams,
               modelParametersSource: body,
             },
-            error
+            error,
+            (Date.now() - startTime) / 1000
           )
         )
         throw error

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -183,6 +183,8 @@ export class WrappedCompletions extends Completions {
                   {
                     completionId: accumulated.completionId,
                     systemFingerprint: accumulated.systemFingerprint,
+                    usage: accumulated.usage,
+                    latency: (Date.now() - startTime) / 1000,
                   }
                 )
               )

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -245,7 +245,8 @@ export class WrappedCompletions extends Completions {
                 monitoring: posthogParams,
                 modelParametersSource: body,
               },
-              error
+              error,
+              { latency: (Date.now() - startTime) / 1000 }
             )
           )
           throw error
@@ -470,7 +471,8 @@ export class WrappedResponses extends Responses {
                 monitoring: posthogParams,
                 modelParametersSource: body,
               },
-              error
+              error,
+              { latency: (Date.now() - startTime) / 1000 }
             )
           )
           throw error
@@ -611,7 +613,8 @@ export class WrappedResponses extends Responses {
               monitoring: posthogParams,
               modelParametersSource: body,
             },
-            error
+            error,
+            { latency: (Date.now() - startTime) / 1000 }
           )
         )
         throw error
@@ -672,7 +675,8 @@ export class WrappedEmbeddings extends Embeddings {
               monitoring: posthogParams,
               modelParametersSource: body,
             },
-            error
+            error,
+            (Date.now() - startTime) / 1000
           )
         )
         throw error
@@ -782,10 +786,6 @@ export class WrappedTranscriptions extends Transcriptions {
             (iterator, controller) => new Stream(iterator, controller)
           )
           ;(async () => {
-            // Declared outside the try so the error path can report what the
-            // stream managed to read. Token counts stay undefined until an event
-            // carries usage, so a stream cut short is not reported as having
-            // consumed nothing.
             let usage: {
               inputTokens?: number
               outputTokens?: number
@@ -842,7 +842,6 @@ export class WrappedTranscriptions extends Transcriptions {
                 latency: (Date.now() - startTime) / 1000,
                 baseURL: this.baseURL,
                 modelParameters: getModelParams(body),
-                // Whatever the stream reported before it failed.
                 usage,
                 error,
               })
@@ -893,12 +892,9 @@ export class WrappedTranscriptions extends Transcriptions {
             provider: 'openai',
             input: openAIParams.prompt,
             output: [],
-            latency: 0,
+            latency: (Date.now() - startTime) / 1000,
             baseURL: this.baseURL,
             modelParameters: getModelParams(body),
-            // The call returned no usage, and a failure this side of a response
-            // can still have consumed the input, so report no counts rather
-            // than zero.
             usage: {},
             error,
           })

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -406,7 +406,11 @@ export class WrappedResponses extends Responses {
                     modelParametersSource: body,
                   },
                   error,
-                  accumulated.completionId
+                  {
+                    completionId: accumulated.completionId,
+                    usage: accumulated.usage,
+                    latency: (Date.now() - startTime) / 1000,
+                  }
                 )
               )
               throw error
@@ -778,17 +782,18 @@ export class WrappedTranscriptions extends Transcriptions {
             (iterator, controller) => new Stream(iterator, controller)
           )
           ;(async () => {
+            // Declared outside the try so the error path can report what the
+            // stream managed to read. Token counts stay undefined until an event
+            // carries usage, so a stream cut short is not reported as having
+            // consumed nothing.
+            let usage: {
+              inputTokens?: number
+              outputTokens?: number
+              rawUsage?: unknown
+            } = {}
             try {
               let finalContent: string = ''
               let firstTokenTime: number | undefined
-              let usage: {
-                inputTokens?: number
-                outputTokens?: number
-                rawUsage?: unknown
-              } = {
-                inputTokens: 0,
-                outputTokens: 0,
-              }
 
               const doneEvent: OpenAIOrignal.Audio.Transcriptions.TranscriptionTextDoneEvent['type'] =
                 'transcript.text.done'
@@ -834,10 +839,11 @@ export class WrappedTranscriptions extends Transcriptions {
                 provider: 'openai',
                 input: openAIParams.prompt,
                 output: [],
-                latency: 0,
+                latency: (Date.now() - startTime) / 1000,
                 baseURL: this.baseURL,
                 modelParameters: getModelParams(body),
-                usage: { inputTokens: 0, outputTokens: 0 },
+                // Whatever the stream reported before it failed.
+                usage,
                 error,
               })
               throw error
@@ -890,10 +896,10 @@ export class WrappedTranscriptions extends Transcriptions {
             latency: 0,
             baseURL: this.baseURL,
             modelParameters: getModelParams(body),
-            usage: {
-              inputTokens: 0,
-              outputTokens: 0,
-            },
+            // The call returned no usage, and a failure this side of a response
+            // can still have consumed the input, so report no counts rather
+            // than zero.
+            usage: {},
             error,
           })
           throw error

--- a/packages/ai/src/openai/stream-accumulators.ts
+++ b/packages/ai/src/openai/stream-accumulators.ts
@@ -23,7 +23,11 @@ export class OpenAIChatStreamAccumulator {
   private serviceTier?: string
   private firstTokenTime?: number
   private stopReason?: string
-  private usage: TokenUsage = { inputTokens: 0, outputTokens: 0, webSearchCount: 0 }
+  // Token counts stay undefined until a chunk reports them. Seeding them at 0
+  // would make a stream that never carried usage — cancelled, or streamed
+  // without usage reporting enabled — indistinguishable from one that genuinely
+  // consumed nothing.
+  private usage: TokenUsage = { webSearchCount: 0 }
   private readonly toolCalls = new Map<number, { id: string; name: string; arguments: string }>()
 
   consume(chunk: OpenAI.ChatCompletionChunk, receivedAt = Date.now()): void {

--- a/packages/ai/src/openai/stream-accumulators.ts
+++ b/packages/ai/src/openai/stream-accumulators.ts
@@ -23,10 +23,6 @@ export class OpenAIChatStreamAccumulator {
   private serviceTier?: string
   private firstTokenTime?: number
   private stopReason?: string
-  // Token counts stay undefined until a chunk reports them. Seeding them at 0
-  // would make a stream that never carried usage — cancelled, or streamed
-  // without usage reporting enabled — indistinguishable from one that genuinely
-  // consumed nothing.
   private usage: TokenUsage = { webSearchCount: 0 }
   private readonly toolCalls = new Map<number, { id: string; name: string; arguments: string }>()
 
@@ -138,9 +134,6 @@ export class OpenAIResponsesStreamAccumulator {
   private serviceTier?: string
   private firstTokenTime?: number
   private stopReason?: string
-  // Undefined until an event reports usage, for the same reason as the chat
-  // accumulator above: a stream that never carried usage is not a stream that
-  // consumed nothing.
   private usage: TokenUsage = { webSearchCount: 0 }
   private terminalResponse?: OpenAI.Responses.Response
 

--- a/packages/ai/src/openai/stream-accumulators.ts
+++ b/packages/ai/src/openai/stream-accumulators.ts
@@ -138,7 +138,10 @@ export class OpenAIResponsesStreamAccumulator {
   private serviceTier?: string
   private firstTokenTime?: number
   private stopReason?: string
-  private usage: TokenUsage = { inputTokens: 0, outputTokens: 0, webSearchCount: 0 }
+  // Undefined until an event reports usage, for the same reason as the chat
+  // accumulator above: a stream that never carried usage is not a stream that
+  // consumed nothing.
+  private usage: TokenUsage = { webSearchCount: 0 }
   private terminalResponse?: OpenAI.Responses.Response
 
   consume(event: OpenAI.Responses.ResponseStreamEvent, receivedAt = Date.now()): void {

--- a/packages/ai/src/openai/telemetry.ts
+++ b/packages/ai/src/openai/telemetry.ts
@@ -122,7 +122,12 @@ export function buildChatSuccessOptions(
 export function buildChatErrorOptions(
   context: CommonContext<ChatParams>,
   error: unknown,
-  metadata: { completionId?: string; systemFingerprint?: string } = {}
+  metadata: {
+    completionId?: string
+    systemFingerprint?: string
+    usage?: TokenUsage
+    latency?: number
+  } = {}
 ): CaptureAiGenerationOptions {
   return {
     ...context.monitoring,
@@ -130,10 +135,13 @@ export function buildChatErrorOptions(
     provider: context.provider,
     input: sanitizeOpenAI(context.params.messages, context.client),
     output: [],
-    latency: 0,
+    latency: metadata.latency ?? 0,
     baseURL: context.baseURL,
     modelParameters: getModelParams(context.modelParametersSource),
-    usage: { inputTokens: 0, outputTokens: 0 },
+    // A stream that fails partway has still consumed everything it read, so pass
+    // on whatever the accumulator collected. Left empty when the caller has no
+    // usage to give, which keeps the counts absent rather than reporting zero.
+    usage: metadata.usage ?? {},
     completionId: metadata.completionId,
     providerMetadata: buildProviderMetadata({ systemFingerprint: metadata.systemFingerprint }),
     error,

--- a/packages/ai/src/openai/telemetry.ts
+++ b/packages/ai/src/openai/telemetry.ts
@@ -126,8 +126,8 @@ export function buildChatErrorOptions(
     completionId?: string
     systemFingerprint?: string
     usage?: TokenUsage
-    latency?: number
-  } = {}
+    latency: number
+  }
 ): CaptureAiGenerationOptions {
   return {
     ...context.monitoring,
@@ -135,12 +135,9 @@ export function buildChatErrorOptions(
     provider: context.provider,
     input: sanitizeOpenAI(context.params.messages, context.client),
     output: [],
-    latency: metadata.latency ?? 0,
+    latency: metadata.latency,
     baseURL: context.baseURL,
     modelParameters: getModelParams(context.modelParametersSource),
-    // A stream that fails partway has still consumed everything it read, so pass
-    // on whatever the accumulator collected. Left empty when the caller has no
-    // usage to give, which keeps the counts absent rather than reporting zero.
     usage: metadata.usage ?? {},
     completionId: metadata.completionId,
     providerMetadata: buildProviderMetadata({ systemFingerprint: metadata.systemFingerprint }),
@@ -207,7 +204,7 @@ export function buildBackgroundResponseOptions(
 export function buildResponsesErrorOptions(
   context: CommonContext<ResponsesParams>,
   error: unknown,
-  metadata: { completionId?: string; usage?: TokenUsage; latency?: number } = {}
+  metadata: { completionId?: string; usage?: TokenUsage; latency: number }
 ): CaptureAiGenerationOptions {
   return {
     ...context.monitoring,
@@ -215,11 +212,9 @@ export function buildResponsesErrorOptions(
     provider: context.provider,
     input: buildSanitizedResponsesInput(context),
     output: [],
-    latency: metadata.latency ?? 0,
+    latency: metadata.latency,
     baseURL: context.baseURL,
     modelParameters: getModelParams(context.modelParametersSource),
-    // Left empty when the caller has no usage to give, so the counts stay absent
-    // rather than reporting that the call consumed nothing.
     usage: metadata.usage ?? {},
     completionId: metadata.completionId,
     error,
@@ -248,7 +243,8 @@ export function buildEmbeddingSuccessOptions(
 
 export function buildEmbeddingErrorOptions(
   context: CommonContext<OpenAI.EmbeddingCreateParams>,
-  error: unknown
+  error: unknown,
+  latency: number
 ): CaptureAiGenerationOptions {
   return {
     eventType: AIEvent.Embedding,
@@ -257,11 +253,9 @@ export function buildEmbeddingErrorOptions(
     provider: context.provider,
     input: withPrivacyMode(context.client, context.monitoring.privacyMode, context.params.input),
     output: null,
-    latency: 0,
+    latency,
     baseURL: context.baseURL,
     modelParameters: getModelParams(context.modelParametersSource),
-    // The call returned no usage, and a failure this side of a response can
-    // still have consumed the input, so report no count rather than zero.
     usage: {},
     error,
   }

--- a/packages/ai/src/openai/telemetry.ts
+++ b/packages/ai/src/openai/telemetry.ts
@@ -207,7 +207,7 @@ export function buildBackgroundResponseOptions(
 export function buildResponsesErrorOptions(
   context: CommonContext<ResponsesParams>,
   error: unknown,
-  completionId?: string
+  metadata: { completionId?: string; usage?: TokenUsage; latency?: number } = {}
 ): CaptureAiGenerationOptions {
   return {
     ...context.monitoring,
@@ -215,11 +215,13 @@ export function buildResponsesErrorOptions(
     provider: context.provider,
     input: buildSanitizedResponsesInput(context),
     output: [],
-    latency: 0,
+    latency: metadata.latency ?? 0,
     baseURL: context.baseURL,
     modelParameters: getModelParams(context.modelParametersSource),
-    usage: { inputTokens: 0, outputTokens: 0 },
-    completionId,
+    // Left empty when the caller has no usage to give, so the counts stay absent
+    // rather than reporting that the call consumed nothing.
+    usage: metadata.usage ?? {},
+    completionId: metadata.completionId,
     error,
   }
 }
@@ -258,7 +260,9 @@ export function buildEmbeddingErrorOptions(
     latency: 0,
     baseURL: context.baseURL,
     modelParameters: getModelParams(context.modelParametersSource),
-    usage: { inputTokens: 0 },
+    // The call returned no usage, and a failure this side of a response can
+    // still have consumed the input, so report no count rather than zero.
+    usage: {},
     error,
   }
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -87,7 +87,13 @@ export interface FormattedMessage {
 }
 
 /**
- * Token usage information for AI model responses
+ * Token usage reported by the provider.
+ *
+ * The counts are optional because an absent count means the provider never reported one, which is
+ * not the same as zero: a failed or cancelled call can consume its prompt without ever reporting
+ * usage. Error paths pass whatever arrived before the failure, or `{}` when nothing did, and never
+ * substitute zeros. Costs follow the same rule, so a configured price applies only to a count that
+ * exists.
  */
 export interface TokenUsage {
   inputTokens?: number

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -601,12 +601,9 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
               ? ''
               : mapVercelPrompt(params.prompt as LanguageModelPrompt, phClient),
             output: [],
-            latency: 0,
+            latency: (Date.now() - startTime) / 1000,
             baseURL,
             modelParameters: getModelParams(mergedParams as any),
-            // The call failed before a response, so no usage exists to report.
-            // Left empty rather than zero, which would read as a call that
-            // consumed nothing.
             usage: {},
             error: error,
             tools: availableTools,
@@ -868,12 +865,9 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
               ? ''
               : mapVercelPrompt(params.prompt as LanguageModelPrompt, phClient),
             output: [],
-            latency: 0,
+            latency: (Date.now() - startTime) / 1000,
             baseURL,
             modelParameters: getModelParams(mergedParams as any),
-            // The call failed before a response, so no usage exists to report.
-            // Left empty rather than zero, which would read as a call that
-            // consumed nothing.
             usage: {},
             error: error,
             tools: availableTools,

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -604,10 +604,10 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
             latency: 0,
             baseURL,
             modelParameters: getModelParams(mergedParams as any),
-            usage: {
-              inputTokens: 0,
-              outputTokens: 0,
-            },
+            // The call failed before a response, so no usage exists to report.
+            // Left empty rather than zero, which would read as a call that
+            // consumed nothing.
+            usage: {},
             error: error,
             tools: availableTools,
           })
@@ -871,10 +871,10 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
             latency: 0,
             baseURL,
             modelParameters: getModelParams(mergedParams as any),
-            usage: {
-              inputTokens: 0,
-              outputTokens: 0,
-            },
+            // The call failed before a response, so no usage exists to report.
+            // Left empty rather than zero, which would read as a call that
+            // consumed nothing.
+            usage: {},
             error: error,
             tools: availableTools,
           })

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -951,8 +951,6 @@ describe('PostHogAnthropic', () => {
 
       assertPostHogCapture(mockPostHogClient, {
         httpStatus: 429,
-        inputTokens: 0,
-        outputTokens: 0,
       })
 
       const captureMock = mockPostHogClient.capture as jest.Mock
@@ -960,6 +958,10 @@ describe('PostHogAnthropic', () => {
       const { properties } = captureArgs[0]
 
       expect(properties['$ai_error']).toBeDefined()
+      // A failed call reports no token counts rather than zero, because it may
+      // still have consumed the prompt before failing.
+      expect(properties['$ai_input_tokens']).toBeUndefined()
+      expect(properties['$ai_output_tokens']).toBeUndefined()
     })
 
     conditionalTest('should handle streaming errors', async () => {
@@ -997,9 +999,13 @@ describe('PostHogAnthropic', () => {
 
       assertPostHogCapture(mockPostHogClient, {
         httpStatus: 500,
-        inputTokens: 0,
-        outputTokens: 0,
       })
+
+      // The stream failed before reporting usage, so the counts are absent
+      // rather than zero. A stream that had reported some would keep them.
+      const [errorCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      expect(errorCall[0].properties['$ai_input_tokens']).toBeUndefined()
+      expect(errorCall[0].properties['$ai_output_tokens']).toBeUndefined()
     })
   })
 

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -958,8 +958,6 @@ describe('PostHogAnthropic', () => {
       const { properties } = captureArgs[0]
 
       expect(properties['$ai_error']).toBeDefined()
-      // A failed call reports no token counts rather than zero, because it may
-      // still have consumed the prompt before failing.
       expect(properties['$ai_input_tokens']).toBeUndefined()
       expect(properties['$ai_output_tokens']).toBeUndefined()
     })
@@ -1001,8 +999,6 @@ describe('PostHogAnthropic', () => {
         httpStatus: 500,
       })
 
-      // The stream failed before reporting usage, so the counts are absent
-      // rather than zero. A stream that had reported some would keep them.
       const [errorCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
       expect(errorCall[0].properties['$ai_input_tokens']).toBeUndefined()
       expect(errorCall[0].properties['$ai_output_tokens']).toBeUndefined()
@@ -1301,6 +1297,10 @@ describe('PostHogAnthropic - streaming error safety', () => {
     const sourceController = new AbortController()
     let pulls = 0
     let sourceReturned = false
+    const messageStart = {
+      type: 'message_start',
+      message: { usage: { input_tokens: 42 } },
+    } as unknown as AnthropicOriginal.Messages.RawMessageStreamEvent
     const firstChunk = {
       type: 'content_block_delta',
       index: 0,
@@ -1309,6 +1309,8 @@ describe('PostHogAnthropic - streaming error safety', () => {
     const source = new AnthropicStream<AnthropicOriginal.Messages.RawMessageStreamEvent>(() => {
       const iterator = (async function* () {
         try {
+          pulls += 1
+          yield messageStart
           pulls += 1
           yield firstChunk
           pulls += 1
@@ -1336,23 +1338,30 @@ describe('PostHogAnthropic - streaming error safety', () => {
 
     expect(stream).toBeInstanceOf(AnthropicStream)
     expect(pulls).toBe(0)
+    let consumed = 0
     for await (const _chunk of stream as unknown as AsyncIterable<AnthropicOriginal.Messages.RawMessageStreamEvent>) {
-      break
+      consumed += 1
+      if (consumed === 2) {
+        break
+      }
     }
     await new Promise(process.nextTick)
 
-    expect(pulls).toBe(1)
+    expect(pulls).toBe(2)
     expect(sourceReturned).toBe(true)
     expect(sourceController.signal.aborted).toBe(true)
     expect(safetyMockPostHogClient.capture).toHaveBeenCalledTimes(1)
     const properties = (safetyMockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
     expect(properties['$ai_output_choices'][0].content[0].text).toBe('partial')
+    expect(properties['$ai_input_tokens']).toBe(42)
+    expect(properties['$ai_output_tokens']).toBeUndefined()
   })
 
   test('messages stream error is not rethrown unhandled', async () => {
     const streamError = new Error('provider error injected into SSE stream')
     const createErroringIterator = (): { [Symbol.asyncIterator](): AsyncIterator<unknown> } => ({
       async *[Symbol.asyncIterator]() {
+        yield { type: 'message_start', message: { usage: { input_tokens: 42 } } }
         yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial' } }
         throw streamError
       },
@@ -1380,8 +1389,12 @@ describe('PostHogAnthropic - streaming error safety', () => {
       }).rejects.toThrow(streamError)
     })
 
-    // The analytics error event is still captured
+    // The analytics error event is still captured, with the usage the stream
+    // reported before it died
     expect(safetyMockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const errorProperties = (safetyMockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
+    expect(errorProperties['$ai_input_tokens']).toBe(42)
+    expect(errorProperties['$ai_output_tokens']).toBeUndefined()
 
     // The detached analytics consumer must not crash the host process
     expect(unhandledRejections).toEqual([])

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -1002,6 +1002,8 @@ describe('PostHogAnthropic', () => {
       const [errorCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
       expect(errorCall[0].properties['$ai_input_tokens']).toBeUndefined()
       expect(errorCall[0].properties['$ai_output_tokens']).toBeUndefined()
+      // Died before message_start, so there is no raw usage to report either.
+      expect(errorCall[0].properties['$ai_usage']).toBeUndefined()
     })
   })
 
@@ -1395,6 +1397,7 @@ describe('PostHogAnthropic - streaming error safety', () => {
     const errorProperties = (safetyMockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
     expect(errorProperties['$ai_input_tokens']).toBe(42)
     expect(errorProperties['$ai_output_tokens']).toBeUndefined()
+    expect(errorProperties['$ai_usage']).toEqual({ input_tokens: 42 })
 
     // The detached analytics consumer must not crash the host process
     expect(unhandledRejections).toEqual([])

--- a/packages/ai/tests/captureAiGeneration.test.ts
+++ b/packages/ai/tests/captureAiGeneration.test.ts
@@ -415,6 +415,38 @@ describe('captureAiGeneration', () => {
     expect(properties.$ai_total_cost_usd).toBeCloseTo(0.025)
   })
 
+  // A price times an unknown count is unknown: an interrupted stream that never
+  // reported usage must not assert a $0 cost just because a price was configured.
+  it.each([
+    {
+      name: 'no cost when usage was never reported',
+      usage: {},
+      expected: { $ai_input_cost_usd: undefined, $ai_output_cost_usd: undefined, $ai_total_cost_usd: undefined },
+    },
+    {
+      name: 'only the priced side when one count is known',
+      usage: { inputTokens: 1000 },
+      expected: { $ai_input_cost_usd: 0.01, $ai_output_cost_usd: undefined, $ai_total_cost_usd: 0.01 },
+    },
+  ])('cost override sends $name', async ({ usage, expected }) => {
+    const client = buildClient()
+
+    await captureAiGeneration(client, {
+      ...baseRequiredOptions,
+      usage,
+      costOverride: { inputCost: 0.000_01, outputCost: 0.000_03 },
+    })
+
+    const properties = lastCaptureProperties(client)
+    for (const [key, value] of Object.entries(expected)) {
+      if (value === undefined) {
+        expect(properties[key]).toBeUndefined()
+      } else {
+        expect(properties[key]).toBeCloseTo(value)
+      }
+    }
+  })
+
   it('supports embedding events via eventType', async () => {
     const client = buildClient()
 

--- a/packages/ai/tests/captureAiGeneration.test.ts
+++ b/packages/ai/tests/captureAiGeneration.test.ts
@@ -417,8 +417,6 @@ describe('captureAiGeneration', () => {
 
   // A price times an unknown count is unknown: an interrupted stream that never
   // reported usage must not assert a $0 cost just because a price was configured.
-  // And one priced side is not a total, so the total is only sent when both
-  // sides were priced.
   it.each([
     {
       name: 'no cost when usage was never reported',
@@ -426,9 +424,9 @@ describe('captureAiGeneration', () => {
       expected: { $ai_input_cost_usd: undefined, $ai_output_cost_usd: undefined, $ai_total_cost_usd: undefined },
     },
     {
-      name: 'only the priced side, without a total, when one count is known',
+      name: 'only the priced side when one count is known',
       usage: { inputTokens: 1000 },
-      expected: { $ai_input_cost_usd: 0.01, $ai_output_cost_usd: undefined, $ai_total_cost_usd: undefined },
+      expected: { $ai_input_cost_usd: 0.01, $ai_output_cost_usd: undefined, $ai_total_cost_usd: 0.01 },
     },
   ])('cost override sends $name', async ({ usage, expected }) => {
     const client = buildClient()

--- a/packages/ai/tests/captureAiGeneration.test.ts
+++ b/packages/ai/tests/captureAiGeneration.test.ts
@@ -417,6 +417,8 @@ describe('captureAiGeneration', () => {
 
   // A price times an unknown count is unknown: an interrupted stream that never
   // reported usage must not assert a $0 cost just because a price was configured.
+  // And one priced side is not a total, so the total is only sent when both
+  // sides were priced.
   it.each([
     {
       name: 'no cost when usage was never reported',
@@ -424,9 +426,9 @@ describe('captureAiGeneration', () => {
       expected: { $ai_input_cost_usd: undefined, $ai_output_cost_usd: undefined, $ai_total_cost_usd: undefined },
     },
     {
-      name: 'only the priced side when one count is known',
+      name: 'only the priced side, without a total, when one count is known',
       usage: { inputTokens: 1000 },
-      expected: { $ai_input_cost_usd: 0.01, $ai_output_cost_usd: undefined, $ai_total_cost_usd: 0.01 },
+      expected: { $ai_input_cost_usd: 0.01, $ai_output_cost_usd: undefined, $ai_total_cost_usd: undefined },
     },
   ])('cost override sends $name', async ({ usage, expected }) => {
     const client = buildClient()

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -393,8 +393,6 @@ describe('PostHogGemini - Jest test suite', () => {
 
     expect(properties['$ai_is_error']).toBe(true)
     expect(properties['$ai_http_status']).toBe(400)
-    // A failed call reports no token counts rather than zero, because it may
-    // still have consumed the prompt before failing.
     expect(properties['$ai_input_tokens']).toBeUndefined()
     expect(properties['$ai_output_tokens']).toBeUndefined()
   })
@@ -1236,7 +1234,6 @@ describe('PostHogGemini - Jest test suite', () => {
       const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
       expect(captureArgs[0].event).toBe('$ai_embedding')
       expect(captureArgs[0].properties['$ai_is_error']).toBe(true)
-      // Absent rather than zero: the call may still have consumed its input.
       expect(captureArgs[0].properties['$ai_input_tokens']).toBeUndefined()
     })
 

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -393,8 +393,10 @@ describe('PostHogGemini - Jest test suite', () => {
 
     expect(properties['$ai_is_error']).toBe(true)
     expect(properties['$ai_http_status']).toBe(400)
-    expect(properties['$ai_input_tokens']).toBe(0)
-    expect(properties['$ai_output_tokens']).toBe(0)
+    // A failed call reports no token counts rather than zero, because it may
+    // still have consumed the prompt before failing.
+    expect(properties['$ai_input_tokens']).toBeUndefined()
+    expect(properties['$ai_output_tokens']).toBeUndefined()
   })
 
   test('array contents input', async () => {
@@ -1234,7 +1236,8 @@ describe('PostHogGemini - Jest test suite', () => {
       const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
       expect(captureArgs[0].event).toBe('$ai_embedding')
       expect(captureArgs[0].properties['$ai_is_error']).toBe(true)
-      expect(captureArgs[0].properties['$ai_input_tokens']).toBe(0)
+      // Absent rather than zero: the call may still have consumed its input.
+      expect(captureArgs[0].properties['$ai_input_tokens']).toBeUndefined()
     })
 
     test('passes config through to underlying call', async () => {

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -255,6 +255,27 @@ describe('PostHogGemini - Jest test suite', () => {
     })
   })
 
+  test('captures accumulated usage when the consumer stops reading the stream', async () => {
+    const stream = client.models.generateContentStream({
+      model: 'gemini-2.0-flash-001',
+      contents: 'Write a short poem',
+      posthogDistinctId: 'test-id',
+    })
+
+    for await (const chunk of stream) {
+      void chunk
+      break
+    }
+
+    // Breaking out of the loop returns the generator, which must still capture
+    // what the stream reported before the consumer walked away.
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const properties = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
+    expect(properties['$ai_input_tokens']).toBe(15)
+    expect(properties['$ai_output_tokens']).toBe(2)
+    expect(properties['$ai_is_error']).toBeUndefined()
+  })
+
   test('groups', async () => {
     await client.models.generateContent({
       model: 'gemini-2.0-flash-001',

--- a/packages/ai/tests/openai-stream-accumulators.test.ts
+++ b/packages/ai/tests/openai-stream-accumulators.test.ts
@@ -1,6 +1,27 @@
 import { OpenAIChatStreamAccumulator, OpenAIResponsesStreamAccumulator } from '../src/openai/stream-accumulators'
 
 describe('OpenAI-compatible stream accumulators', () => {
+  // Separate from the accumulation test below because the setup is the absence
+  // of a usage chunk: a stream cancelled before the end, or one streamed without
+  // usage reporting on. Seeding the counts at 0 would report those as free.
+  test('chat leaves token counts undefined when no chunk reported usage', () => {
+    const accumulator = new OpenAIChatStreamAccumulator()
+    accumulator.consume(
+      {
+        id: 'chatcmpl-1',
+        model: 'gpt-4o',
+        object: 'chat.completion.chunk',
+        created: 1,
+        choices: [{ index: 0, finish_reason: null, logprobs: null, delta: { content: 'Hel' } }],
+      } as any,
+      120
+    )
+
+    const { usage } = accumulator.result()
+    expect(usage.inputTokens).toBeUndefined()
+    expect(usage.outputTokens).toBeUndefined()
+  })
+
   test('chat accumulates text, tools, stop reason, metadata, web search, and raw usage', () => {
     const accumulator = new OpenAIChatStreamAccumulator()
     accumulator.consume(

--- a/packages/ai/tests/openai-telemetry.test.ts
+++ b/packages/ai/tests/openai-telemetry.test.ts
@@ -1,0 +1,45 @@
+import { buildChatErrorOptions, buildResponsesErrorOptions } from '../src/openai/telemetry'
+
+const context = {
+  client: { privacy_mode: false } as any,
+  provider: 'openai' as const,
+  baseURL: 'https://api.openai.com',
+  monitoring: {} as any,
+  modelParametersSource: {},
+}
+
+describe('openai telemetry error builders', () => {
+  test.each([
+    [
+      'chat',
+      (): ReturnType<typeof buildChatErrorOptions> =>
+        buildChatErrorOptions(
+          { ...context, params: { model: 'gpt-4', messages: [] } as any },
+          new Error('stream died'),
+          { usage: { inputTokens: 42, outputTokens: 7 }, latency: 1.5 }
+        ),
+    ],
+    [
+      'responses',
+      (): ReturnType<typeof buildResponsesErrorOptions> =>
+        buildResponsesErrorOptions(
+          { ...context, params: { model: 'gpt-4', input: 'hi' } as any },
+          new Error('stream died'),
+          { usage: { inputTokens: 42, outputTokens: 7 }, latency: 1.5 }
+        ),
+    ],
+  ])('%s error options carry the usage the stream reported and the real latency', (_api, build) => {
+    const options = build()
+    expect(options.usage).toEqual({ inputTokens: 42, outputTokens: 7 })
+    expect(options.latency).toBe(1.5)
+  })
+
+  test('usage defaults to empty rather than zeros when the caller has none', () => {
+    const options = buildChatErrorOptions(
+      { ...context, params: { model: 'gpt-4', messages: [] } as any },
+      new Error('failed before a response'),
+      { latency: 0.5 }
+    )
+    expect(options.usage).toEqual({})
+  })
+})


### PR DESCRIPTION
## Problem

A user cancels a streaming response, and the generation is recorded as costing nothing. The call consumed its whole prompt, so the cost is real; only the report is wrong.

Every provider wrapper accumulates token counts as chunks arrive. When a stream failed or was cancelled partway, the error path reported hardcoded zeros for usage, and usually a latency of zero, discarding counts it had already collected. In the OpenAI chat path the counts were read one line before being thrown away.

A second path produced the same result: `captureAiGeneration` sent `$ai_input_tokens: usage.inputTokens ?? 0`, so a generation whose usage was never reported still claimed zero input tokens.

## Changes

- A cancelled or failed stream now reports the tokens it consumed and the time it took, so its cost stops reading as zero. Anthropic sends input tokens on `message_start` and Gemini sends `usageMetadata` on chunks, so a stream cut short usually carries real counts.
- A call that failed before any response now reports no token counts, rather than zero. Absent says the call may have consumed its prompt without reporting it; zero asserts it consumed nothing.
- The accumulators start with token counts undefined instead of at zero. This also covers streaming without usage reporting enabled, which previously reported zero tokens for every call.
- Covers the OpenAI chat, Responses and transcription streams, and the Anthropic, Gemini, Azure and Vercel wrappers. No hardcoded zero usage remains in the package.
- `$ai_output_tokens` was already omitted when absent. Input tokens now match it.
- A `costOverride` prices only the token counts the provider reported. A call with no reported usage sends no cost instead of `$0.00`, and a partially known call sends the known side as a documented lower bound, because PostHog's billing and trace views sum this property. Omitting the total was tried and reverted for that reason.
- A Gemini stream the consumer stops reading now captures what it accumulated. Breaking out of the loop returns the generator, which only a `finally` observes, so the success capture moved into one.
- An Anthropic stream that dies mid-flight keeps the raw usage it received from `message_start` on the error event, alongside the token counts.

> [!WARNING]
> `$ai_input_tokens` was always present on a generation event before this change. Anything reading it has to handle it being absent.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## How did you test this code?

- Ran the `@posthog/ai` suite. It passes, with two pre-existing failures in `openai-agents-resolution.test.ts` that reproduce identically on an unmodified tree in this sandbox.
- Building `posthog-node` and `@posthog/core` locally was necessary before eight suites, including the Anthropic and Gemini ones, could run at all. They were silently unloadable before that, and running them found four assertions this change breaks.
- Those four tests asserted zero token counts on error paths. They now assert the counts are absent, which is the behavior being introduced.
- The cost override cases fail when the zero-defaulting is restored, verified by reverting it. Likewise the Gemini cancellation test captures nothing against the previous code, and the Anthropic raw usage assertion fails without the catch pinning it, both verified by stashing the fix.
- Added one case to `openai-stream-accumulators.test.ts`. The regression it catches: someone re-seeds an accumulator's token counts at zero, and every cancelled stream silently reports as free again.
- Confirmed the cause by driving the Vercel AI SDK against a mock provider and capturing its OpenTelemetry spans. A fully drained stream carries usage. A stream aborted mid-flight emits a span with model, provider and prompt, and no usage attributes at all.
- Compared `tsc` output before and after: identical once line numbers are normalized.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, directed by a PostHog engineer investigating why a customer's traces showed no cost.

The customer turned out not to use this package, so this change does not fix their case. It fixes the same class of defect for the users who do. The matching change in the main repo is PostHog/posthog#90211, which stops the ingestion pipeline pricing an absent token count as zero. The two are complementary: without this one, the zeros this package sends would keep that fix from ever taking effect for its users.

The first revision covered only the OpenAI chat path and stated that the other providers were left alone. They are all covered now, at the reviewer's request.

Public artifact: no customer data, project identifier, or operational figure appears in this PR, its commits, or its tests. The reproduction used a mock provider and an invented prompt.




