### PR TITLE
feat(conversations): make widget ticket recovery text customizable

### DIFF
--- a/.changeset/widget-ticket-recovery-text.md
+++ b/.changeset/widget-ticket-recovery-text.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/browser-common': minor
+---
+
+The conversations widget footer text ("Don't see your previous tickets?" and "Recover them here") can now be customized from the in-app widget settings, via the `ticketRecoveryText` and `ticketRecoveryLinkText` remote config values.

--- a/packages/browser-common/src/types/remote-config.ts
+++ b/packages/browser-common/src/types/remote-config.ts
@@ -113,6 +113,10 @@ export interface ConversationsRemoteConfig {
     color?: string
     /** Placeholder text for the message input. */
     placeholderText?: string
+    /** Text shown before the ticket recovery link in the widget footer. */
+    ticketRecoveryText?: string
+    /** Label for the ticket recovery link in the widget footer. */
+    ticketRecoveryLinkText?: string
     /** Whether to require an email address before starting a conversation. */
     requireEmail?: boolean
     /** Whether to show the name field in the identification form. */

--- a/packages/browser/src/extensions/conversations/external/components/ConversationsWidget.tsx
+++ b/packages/browser/src/extensions/conversations/external/components/ConversationsWidget.tsx
@@ -702,13 +702,13 @@ export class ConversationsWidget extends Component<WidgetProps, WidgetState> {
 
                     {showRecoverFooter && (
                         <div style={styles.recoverFooter}>
-                            Don't see your previous tickets?{' '}
+                            {config.ticketRecoveryText || "Don't see your previous tickets?"}{' '}
                             <button
                                 type="button"
                                 style={styles.recoverFooterLink}
                                 onClick={this._handleOpenRestoreRequest}
                             >
-                                Recover them here
+                                {config.ticketRecoveryLinkText || 'Recover them here'}
                             </button>
                         </div>
                     )}


### PR DESCRIPTION
## Problem

The conversations widget footer ("Don't see your previous tickets? Recover them here") is hardcoded in English. Teams that run the widget in another language can customize the greeting and placeholder, but not this footer.

## Changes

- The widget renders `ticketRecoveryText` and `ticketRecoveryLinkText` from the conversations remote config, falling back to the current strings.
- `ConversationsRemoteConfig` declares the two new optional keys.
- PostHog serves the values from the new widget settings in PostHog/posthog#90802 (companion PR).

## Screenshots

| Before (defaults) | After (custom text set) |
| --- | --- |
| ![widget-default](https://raw.githubusercontent.com/PostHog/pr-assets/5116da2725193604acb21379f25a7aa434a188df/2026/08/03fd68da-7c96-4768-bfa3-4943498ab5af.png) | ![widget-custom](https://raw.githubusercontent.com/PostHog/pr-assets/13303a9f1a475b1320458a8ff3105d4959bb468d/2026/08/2f5b530a-f02d-411c-91e3-f41538e2700b.png) |

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- Existing widget tests exercise the default footer strings (`conversations-widget.test.tsx`, 8 tests, pass locally).
- No new test: the change is a `config.x || default` substitution, matching how `greetingText` and `placeholderText` are consumed without dedicated render tests.

