### PR TITLE
fix(react-native): bump android gradle plugin to 1.5.2 and native SDKs

### DIFF
--- a/.changeset/bump-android-gradle-plugin.md
+++ b/.changeset/bump-android-gradle-plugin.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix Android builds failing to resolve a Kotlin compiler plugin when `uploadNativeSymbols` is enabled, by picking up `com.posthog:posthog-android-gradle-plugin` 1.5.2. Re-run `expo prebuild` to apply it.

--- a/.changeset/bump-native-sdks.md
+++ b/.changeset/bump-native-sdks.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Update the native SDKs to `posthog-ios` 3.70.1 and `posthog-android` 3.61.0, fixing session replay masks drifting off their content during scroll, a crash when replay console-log capture tears down on iOS, and web-scoped surveys showing on native Android.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,7 +85,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.60.7"
+  implementation "com.posthog:posthog-android:3.61.0"
 
   testImplementation "junit:junit:4.13.2"
 }

--- a/packages/react-native-plugin/ios/Package.swift
+++ b/packages/react-native-plugin/ios/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: reactNativeDependencies + [
         .package(
             url: "https://github.com/PostHog/posthog-ios.git",
-            .upToNextMinor(from: "3.69.10")
+            .upToNextMinor(from: "3.70.1")
         ),
     ],
     targets: [

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.69.10'
+posthog_ios_version = '3.70.1'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -9,7 +9,7 @@ const { withAppBuildGradle, withBaseMod, withGradleProperties, withProjectBuildG
 // crash stack traces can be deobfuscated. The injected version has to read every gradle
 // property the plugin writes, or that half of the build ignores the option: 1.4.0 is the first
 // version that reads posthog.dotenvFile, and 1.5.0 the first that reads posthog.releaseMode.
-const POSTHOG_ANDROID_GRADLE_PLUGIN_VERSION = '1.5.1'
+const POSTHOG_ANDROID_GRADLE_PLUGIN_VERSION = '1.5.2'
 
 const resolvePostHogReactNativePackageJsonPath =
   "[\"node\", \"--print\", \"require('path').join(require('path').dirname(require.resolve('posthog-react-native')), '..', 'tooling', 'posthog.gradle')\"].execute().text.trim()"


### PR DESCRIPTION
## Problem

Two things, both in the React Native native layer.

**1. Expo/Android builds fail with `uploadNativeSymbols` enabled** (#4674):

```
Could not find io.github.lukmccall.pika:pika-compiler:0.3.2-2.1.21.
```

`com.posthog:posthog-android-gradle-plugin` 1.5.1 publishes `org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21` as a **runtime** dependency. The Expo config plugin injects that classpath into the consumer's root `buildscript`, which every module shares and where Gradle takes the highest version — so it raises the Kotlin version the whole build compiles with. Expo pins 2.1.20 and resolves its compiler plugins by coordinates that embed that version, so it asks for `pika-compiler:0.3.2-2.1.21`, which was never published.

Fixed upstream in PostHog/posthog-android#737, which stops the plugin publishing any dependencies. This bump is what delivers it: `expoconfig.ts` pins the injected coordinate, so Expo users keep resolving 1.5.1 until it changes.

**2. The native SDK pins are behind.** RN drives session replay and error tracking through them.

| Pin | Was | Now |
|---|---|---|
| `posthog-android-gradle-plugin` (`expoconfig.ts:12`) | 1.5.1 | 1.5.2 |
| `posthog-ios` (`posthog-react-native-plugin.podspec:9`) | 3.69.10 | 3.70.1 |
| `posthog-android` (`android/build.gradle:88`) | 3.60.7 | 3.61.0 |

What RN gains from the native bumps:

- **ios 3.70.1** — session replay masks no longer drift off the content they cover while a screen scrolls or animates. RN sets `maskAllTextInputs` / `maskAllImages` through the native plugin, so this is a privacy fix for RN.
- **ios 3.69.11** — fixes a fatal SIGPIPE when replay console-log capture tears down, e.g. backgrounding with log capture on. RN passes `captureLog` in its native replay config.
- **ios 3.69.12** — posthog-cli ≥ 0.15.1 reads release metadata from the app Info.plist when uploading debug symbols; touches the RN dSYM upload path.
- **android 3.60.8** — surveys scoped to web by CSS selector or URL no longer leak onto native.
- **android 3.61.0** — republish so `posthog-android` resolves core 6.34.0.

`ios 3.70.0` adds a native survey intro screen. RN renders surveys in JS, so it is not expected to surface there.

## Changes

Three version constants and two changesets. No source changes.

**Do not merge until `posthog-android-gradle-plugin` 1.5.2 is on Maven Central** — CI will fail to resolve it until then. Confirm the version and re-run once posthog-android#737 releases.

Users with a checked-in `android/` keep whatever gradle-plugin version their `build.gradle` already pins — the injector returns early when the coordinate is present — so they need `expo prebuild --clean`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @turnipdabeets. Tools: Bash (gradle, adb, curl, gh), file edits.

- The gradle-plugin root cause was reproduced with real Gradle resolution in an Expo 57 app (which pins Kotlin 2.1.20, the reporter's setup): published 1.5.1 resolves KGP to 2.1.21, the patched plugin leaves it at 2.1.20. Confirmed on an emulator — app builds, installs, launches, and PostHog captures and flushes events.
- A fix was first built here instead, adding `exclude group: "org.jetbrains.kotlin", module: "kotlin-gradle-plugin"` to the injected classpath. It works, but it patches one consumer of a dependency published wrong for everyone, so it was dropped for the upstream fix and this bump.
- The native bumps were briefly split into their own PR (#4678, now closed) so the shippable replay fixes would not wait on an unreleased artifact. Folded back here at the author's request, for a single RN release.
- `patch` for the native bumps rather than `minor`: the two upstream minors are `posthog-ios` 3.70.0 and `posthog-android` 3.61.0, both survey-appearance features in the native survey UI. RN renders surveys in JS, so no new RN-facing API arrives. Everything RN-observable here is a fix.
- Existing `expoconfig` tests assert the classpath coordinate without its version, so they neither cover nor break on the gradle-plugin bump. Not run locally (no `node_modules` in the worktree used to prepare this); CI runs them. No simulator or device build for the native bumps — those are dependency coordinates resolved at consumer build time.
