### PR TITLE
chore(react-native-plugin): update native SDKs to ios 3.70.1 and android 3.61.0

### DIFF
--- a/.changeset/bump-native-sdks.md
+++ b/.changeset/bump-native-sdks.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Update the native SDKs to `posthog-ios` 3.70.1 and `posthog-android` 3.61.0, fixing session replay masks drifting off their content during scroll, a crash when replay console-log capture tears down on iOS, and web-scoped surveys showing on native Android.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -85,7 +85,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.60.7"
+  implementation "com.posthog:posthog-android:3.61.0"
 
   testImplementation "junit:junit:4.13.2"
 }

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.69.10'
+posthog_ios_version = '3.70.1'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"


### PR DESCRIPTION
## Problem

The native SDK pins in `@posthog/react-native-plugin` are behind. RN drives session replay and error tracking through them, so RN users are missing fixes that shipped upstream weeks ago.

| Pin | Was | Now |
|---|---|---|
| `posthog-ios` (`posthog-react-native-plugin.podspec:9`) | 3.69.10 | 3.70.1 |
| `posthog-android` (`android/build.gradle:88`) | 3.60.7 | 3.61.0 |

What RN actually gains:

- **ios 3.70.1** — session replay masks no longer drift off the content they cover while a screen scrolls or animates. RN sets `maskAllTextInputs` / `maskAllImages` through the native plugin, so this is a privacy fix for RN.
- **ios 3.69.11** — fixes a fatal SIGPIPE when replay console-log capture tears down, e.g. backgrounding with log capture on. RN passes `captureLog` in its native replay config.
- **ios 3.69.12** — posthog-cli ≥ 0.15.1 reads release metadata from the app Info.plist when uploading debug symbols; touches the RN dSYM upload path.
- **android 3.60.8** — surveys scoped to web by CSS selector or URL no longer leak onto native.
- **android 3.61.0** — republish so `posthog-android` resolves core 6.34.0.

`ios 3.70.0` adds a native survey intro screen. RN renders surveys in JS, so it is not expected to surface there.

## Changes

Two version constants and a changeset. No source changes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @turnipdabeets. Tools: Bash (gh, curl), file edits.

- Kept separate from #4677 on purpose. That one bumps the injected Android Gradle plugin and cannot merge until `posthog-android-gradle-plugin` 1.5.2 is on Maven Central; this one is unblocked. Bundling them would hold a shippable fix behind an unreleased artifact, and a regression in either would take both down.
- `patch` rather than `minor`: the two upstream minors are `posthog-ios` 3.70.0 and `posthog-android` 3.61.0, both survey-appearance features in the native survey UI. RN renders surveys in JS, so no new RN-facing API arrives with this. Everything RN-observable here is a fix.
- Not built against a device or simulator. The changes are two dependency coordinates; the native pods and Gradle artifacts resolve at consumer build time, so CI resolution is the meaningful check.
