### PR TITLE
fix(nextjs-config): snapshot dist files before invoking sourcemap CLI

### DIFF
--- a/.changeset/nextjs-config-dist-snapshot.md
+++ b/.changeset/nextjs-config-dist-snapshot.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nextjs-config': patch
+---
+
+fix: snapshot build outputs into an explicit file list before invoking the sourcemap CLI, so Turbopack's background filesystem-cache writes on Next.js 16.3+ can no longer race the CLI's inject/upload passes and fail the build with "Chunk ID not found". The bundler cache directory (`<distDir>/cache`) is no longer scanned.

--- a/packages/nextjs-config/src/utils.spec.ts
+++ b/packages/nextjs-config/src/utils.spec.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { runSourcemapCli } from '@posthog/plugin-utils'
+import type { ResolvedPluginConfig } from '@posthog/webpack-plugin'
+
+import { collectDistFiles, processSourceMaps } from './utils'
+
+jest.mock('@posthog/plugin-utils', () => ({
+  runSourcemapCli: jest.fn().mockResolvedValue(undefined),
+}))
+
+describe('collectDistFiles', () => {
+  let distDir: string
+
+  beforeEach(async () => {
+    distDir = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-nextjs-config-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(distDir, { recursive: true, force: true })
+  })
+
+  async function writeFile(relativePath: string): Promise<string> {
+    const fullPath = path.join(distDir, relativePath)
+    await fs.mkdir(path.dirname(fullPath), { recursive: true })
+    await fs.writeFile(fullPath, '')
+    return fullPath
+  }
+
+  it('collects files recursively, excluding the top-level cache directory', async () => {
+    const chunk = await writeFile('static/chunks/page.js')
+    const map = await writeFile('static/chunks/page.js.map')
+    const buildId = await writeFile('BUILD_ID')
+    // A route directory that happens to be named `cache` is build output, not
+    // a bundler cache, and must stay included.
+    const nestedCacheRoute = await writeFile('server/app/cache/route.js')
+    await writeFile('cache/turbopack/blob.js')
+    await writeFile('cache/webpack/index.pack')
+
+    const files = await collectDistFiles(distDir)
+
+    expect(files.sort()).toEqual([buildId, nestedCacheRoute, chunk, map].sort())
+  })
+
+  it('passes the snapshot as an explicit file list to the CLI', async () => {
+    const chunk = await writeFile('static/chunks/page.js')
+    await writeFile('cache/turbopack/blob.js')
+    const config = {} as ResolvedPluginConfig
+
+    await processSourceMaps(config, distDir)
+
+    expect(runSourcemapCli).toHaveBeenCalledWith(config, { filePaths: [chunk] })
+  })
+})

--- a/packages/nextjs-config/src/utils.ts
+++ b/packages/nextjs-config/src/utils.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
 import nextPackage from 'next/package.json' with { type: 'json' }
 import semver from 'semver'
 
@@ -14,7 +17,49 @@ export function hasCompilerHook(): boolean {
 }
 
 export async function processSourceMaps(posthogOptions: ResolvedPluginConfig, directory: string) {
-  await runSourcemapCli(posthogOptions, { directory })
+  await runSourcemapCli(posthogOptions, { filePaths: await collectDistFiles(directory) })
+}
+
+// Snapshot the build outputs into an explicit file list instead of handing the
+// CLI a directory. The CLI's `process` command re-walks directory roots once
+// for inject and again for upload, while Next.js 16.3+ (Turbopack filesystem
+// cache) keeps writing into distDir in the background during
+// runAfterProductionCompile — so the upload walk can find chunks the inject
+// walk never stamped and abort the build with "Chunk ID not found". A frozen
+// file list makes both passes see the same set.
+// See https://github.com/PostHog/posthog-js/issues/4667
+//
+// The top-level `cache` directory only holds bundler caches (Turbopack
+// filesystem cache, webpack cache), never deployable chunks, and is written
+// concurrently by design — skip it. Deeper directories named `cache` are
+// route output and stay included.
+export async function collectDistFiles(directory: string): Promise<string[]> {
+  const files: string[] = []
+  await collectFilesInto(directory, files, new Set(['cache']))
+  return files
+}
+
+async function collectFilesInto(directory: string, files: string[], skipNames?: Set<string>): Promise<void> {
+  let entries
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true })
+  } catch {
+    // A directory vanished or became unreadable mid-walk (the bundler writes
+    // concurrently) — skip it rather than failing the build, matching the
+    // CLI's own tolerant directory walker.
+    return
+  }
+  for (const entry of entries) {
+    if (skipNames?.has(entry.name)) {
+      continue
+    }
+    const fullPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      await collectFilesInto(fullPath, files)
+    } else if (entry.isFile()) {
+      files.push(fullPath)
+    }
+  }
 }
 
 // Helper to detect if Turbopack is enabled


### PR DESCRIPTION
## Problem

Fixes #4667.

On Next.js 16.3+, `next build` with `withPostHogConfig` can abort with `Chunk ID not found` (exit 1). Next 16.3 enables `turbopackFileSystemCacheForBuild` by default, and Turbopack keeps writing into `distDir` in the background while `runAfterProductionCompile` is running (the cache-persisting shutdown promise is only awaited at the very end of the build, after the compiler hook).

`@posthog/nextjs-config` hands the whole `distDir` to `posthog-cli sourcemap process`, whose two passes (inject, then upload) each re-walk directory roots independently. A chunk pair that materializes between the two walks is found by the upload pass without an injected chunk ID, and the CLI hard-fails the whole build.

## Changes

- `processSourceMaps` now snapshots the build outputs into an explicit file list and passes it to the CLI via the existing stdin file-path mode (the same mechanism `@posthog/webpack-plugin` already uses). The CLI resolves stdin once and reuses the identical set for both inject and upload, so late-appearing files can no longer fail the build.
- The snapshot prunes the top-level `<distDir>/cache` directory before descending: it only holds bundler caches (Turbopack filesystem cache, webpack cache), never deployable chunks, and is concurrently written by design. Deeper directories that happen to be named `cache` (route output) stay included.
- The walker tolerates directories vanishing mid-walk (concurrent bundler writes) instead of failing the build, matching the CLI's own tolerant traversal.
- Added unit tests for the collector and the CLI invocation contract.

Note: this makes the processed set deterministic; files Turbopack flushes after the snapshot are consistently untouched by both passes. The root-boundary CLI fix (materializing the walk once inside `sourcemap process`) is being addressed separately in the PostHog monorepo.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5) investigated issue #4667: verified the CLI double-walk race against current CLI source, and verified the Next.js 16.3.3 ordering (`runAfterProductionCompile` runs before the Turbopack shutdown/cache-flush promise is awaited; unchanged on canary; no Next hook exists that runs after the flush).
- Chose the existing stdin file-list mode over a directory-mode CLI flag change so the fix ships to users immediately and works with already-installed CLI versions.
- Structured second-model review (Codex) ran to clean; it caught that a `readdir({ recursive: true })` snapshot would still traverse (and could reject on) the concurrently-written cache directory, which led to the pruning walker.
