### PR TITLE
feat(web): use shared browser detection in posthog-js-lite

### DIFF
--- a/.changeset/lite-reuse-core-browser-detection.md
+++ b/.changeset/lite-reuse-core-browser-detection.md
@@ -1,0 +1,7 @@
+---
+'posthog-js-lite': minor
+---
+
+Use the shared `@posthog/core` browser detection instead of a separate copy. `$browser` and `$browser_version` now match posthog-js.
+
+This reattributes some events. Browsers the old copy missed (Vivaldi, Yandex, Whale, DuckDuckGo, Brave on iOS, Pale Moon, Waterfox, Oculus Browser) now report their own name instead of `Chrome` or `Safari`. User agents that only contain `Gecko` now report `Firefox` instead of `Mozilla`. Opera versions older than 15 are no longer detected.

--- a/packages/web/src/context.ts
+++ b/packages/web/src/context.ts
@@ -1,4 +1,4 @@
-import { currentTimestamp, stripUrlHash } from '@posthog/core'
+import { currentTimestamp, detectBrowser, detectBrowserVersion, stripUrlHash } from '@posthog/core'
 import { version } from './version'
 
 export function getContext(window: Window | undefined, disableCaptureUrlHashes: boolean = false): any {
@@ -9,14 +9,14 @@ export function getContext(window: Window | undefined, disableCaptureUrlHashes: 
     context = {
       ...context,
       ...(osValue !== undefined && { $os: osValue }),
-      $browser: browser(userAgent, window.navigator.vendor, !!(window as any).opera),
+      $browser: detectBrowser(userAgent, window.navigator.vendor),
       $referrer: window.document.referrer,
       $referring_domain: referringDomain(window.document.referrer),
       $device: device(userAgent),
       $current_url: disableCaptureUrlHashes ? stripUrlHash(window.location.href) : window.location.href,
       $host: window.location.host,
       $pathname: window.location.pathname,
-      $browser_version: browserVersion(userAgent, window.navigator.vendor, !!(window as any).opera),
+      $browser_version: detectBrowserVersion(userAgent, window.navigator.vendor),
       $screen_height: window.screen.height,
       $screen_width: window.screen.width,
       $screen_dpr: window.devicePixelRatio,
@@ -31,98 +31,6 @@ export function getContext(window: Window | undefined, disableCaptureUrlHashes: 
     $time: currentTimestamp() / 1000, // epoch time in seconds
   }
   return context // TODO: strip empty props?
-}
-
-function includes(haystack: string, needle: string): boolean {
-  return haystack.indexOf(needle) >= 0
-}
-
-function browser(userAgent: string, vendor: string, opera: boolean): string {
-  vendor = vendor || '' // vendor is undefined for at least IE9
-  if (opera || includes(userAgent, ' OPR/')) {
-    if (includes(userAgent, 'Mini')) {
-      return 'Opera Mini'
-    }
-    return 'Opera'
-  } else if (/(BlackBerry|PlayBook|BB10)/i.test(userAgent)) {
-    return 'BlackBerry'
-  } else if (includes(userAgent, 'IEMobile') || includes(userAgent, 'WPDesktop')) {
-    return 'Internet Explorer Mobile'
-  } else if (includes(userAgent, 'SamsungBrowser/')) {
-    // https://developer.samsung.com/internet/user-agent-string-format
-    return 'Samsung Internet'
-  } else if (includes(userAgent, 'Edge') || includes(userAgent, 'Edg/')) {
-    return 'Microsoft Edge'
-  } else if (includes(userAgent, 'FBIOS')) {
-    return 'Facebook Mobile'
-  } else if (includes(userAgent, 'Claude/')) {
-    return 'Claude'
-  } else if (includes(userAgent, 'Codex/')) {
-    return 'Codex'
-  } else if (includes(userAgent, 'ChatGPT/')) {
-    return 'ChatGPT'
-  } else if (includes(userAgent, 'Chrome')) {
-    return 'Chrome'
-  } else if (includes(userAgent, 'CriOS')) {
-    return 'Chrome iOS'
-  } else if (includes(userAgent, 'UCWEB') || includes(userAgent, 'UCBrowser')) {
-    return 'UC Browser'
-  } else if (includes(userAgent, 'FxiOS')) {
-    return 'Firefox iOS'
-  } else if (includes(vendor, 'Apple')) {
-    if (includes(userAgent, 'Mobile')) {
-      return 'Mobile Safari'
-    }
-    return 'Safari'
-  } else if (includes(userAgent, 'Android')) {
-    return 'Android Mobile'
-  } else if (includes(userAgent, 'Konqueror')) {
-    return 'Konqueror'
-  } else if (includes(userAgent, 'Firefox')) {
-    return 'Firefox'
-  } else if (includes(userAgent, 'MSIE') || includes(userAgent, 'Trident/')) {
-    return 'Internet Explorer'
-  } else if (includes(userAgent, 'Gecko')) {
-    return 'Mozilla'
-  } else {
-    return ''
-  }
-}
-
-const browserVersionRegexList = {
-  'Internet Explorer Mobile': /rv:(\d+(\.\d+)?)/,
-  'Microsoft Edge': /Edge?\/(\d+(\.\d+)?)/,
-  Claude: /Claude\/(\d+(\.\d+)?)/,
-  Codex: /Codex\/(\d+(\.\d+)?)/,
-  ChatGPT: /ChatGPT\/(\d+(\.\d+)?)/,
-  Chrome: /Chrome\/(\d+(\.\d+)?)/,
-  'Chrome iOS': /CriOS\/(\d+(\.\d+)?)/,
-  'UC Browser': /(UCBrowser|UCWEB)\/(\d+(\.\d+)?)/,
-  Safari: /Version\/(\d+(\.\d+)?)/,
-  'Mobile Safari': /Version\/(\d+(\.\d+)?)/,
-  Opera: /(Opera|OPR)\/(\d+(\.\d+)?)/,
-  Firefox: /Firefox\/(\d+(\.\d+)?)/,
-  'Firefox iOS': /FxiOS\/(\d+(\.\d+)?)/,
-  Konqueror: /Konqueror:(\d+(\.\d+)?)/,
-  BlackBerry: /BlackBerry (\d+(\.\d+)?)/,
-  'Android Mobile': /android\s(\d+(\.\d+)?)/,
-  'Samsung Internet': /SamsungBrowser\/(\d+(\.\d+)?)/,
-  'Internet Explorer': /(rv:|MSIE )(\d+(\.\d+)?)/,
-  Mozilla: /rv:(\d+(\.\d+)?)/,
-}
-
-function browserVersion(userAgent: string, vendor: string, opera: boolean): number | null {
-  const browserString = browser(userAgent, vendor, opera) as keyof typeof browserVersionRegexList
-  const regex: RegExp = browserVersionRegexList[browserString] || undefined
-
-  if (regex === undefined) {
-    return null
-  }
-  const matches = userAgent.match(regex)
-  if (!matches) {
-    return null
-  }
-  return parseFloat(matches[matches.length - 2])
 }
 
 function os(window: Window | undefined): string | undefined {

--- a/packages/web/test/context.spec.ts
+++ b/packages/web/test/context.spec.ts
@@ -32,6 +32,14 @@ describe('getContext', () => {
       expectedBrowser: 'ChatGPT',
       expectedVersion: 3.4,
     },
+    {
+      // detected by the shared @posthog/core detector; the old local detector reported Chrome
+      name: 'Vivaldi',
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Vivaldi/6.8.3381.48',
+      expectedBrowser: 'Vivaldi',
+      expectedVersion: 6.8,
+    },
   ])('detects $name', ({ userAgent, expectedBrowser, expectedVersion }) => {
     expect(getContext(windowWithUserAgent(userAgent), false)).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
> 🤖 This pull request was created by a coding agent.

## Problem

- posthog-js-lite reports Vivaldi, Yandex, DuckDuckGo, iOS Brave, and other self-identifying browsers as Chrome or Safari. posthog-js detects them correctly.
- The lite SDK keeps its own copy of browser detection, and that copy missed every marker the shared detector gained since 2023.
- Review of #4663 flagged the fork: that PR had to add the same three markers in two places.

## Changes

- posthog-js-lite events now report the same `$browser` and `$browser_version` as posthog-js: the lite context uses `detectBrowser` and `detectBrowserVersion` from `@posthog/core`.
- The local copy of the detectors is deleted (95 lines removed, 18 added).

> [!WARNING]
> This reattributes some events, as listed in the changeset:
>
> - Vivaldi, Yandex, Whale, DuckDuckGo, iOS Brave, Pale Moon, Waterfox, and Oculus Browser now report their own names instead of `Chrome` or `Safari`.
> - User agents that only contain `Gecko` now report `Firefox` instead of `Mozilla`.
> - Opera versions older than 15 (detected via `window.opera`) are no longer detected.

Bundle size: lite's own unminified module shrinks from 14.3 kB to 11.1 kB. Consumers now bundle core's user-agent module in place of the deleted copy. Not measured: the minified consumer delta.

> [!NOTE]
> Builds on #4663 and is based on its branch. Merge after that PR lands.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [x] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Generated a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code made this change as the follow-up flagged while addressing review on #4663. A new test pins that Vivaldi, which the old copy reported as Chrome, now reports `Vivaldi`. The existing AI app browser tests pass unchanged.

Rejected alternative: passing browser hints (`navigator.brave`) into the shared detector. That would also reattribute desktop Brave and is left for a separate decision.
