### PR TITLE
fix(nextjs-config): snapshot sourcemap inputs for Turbopack

### DIFF
--- a/packages/nextjs-config/src/utils.spec.ts
+++ b/packages/nextjs-config/src/utils.spec.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { runSourcemapCli } from '@posthog/plugin-utils'
+import type { ResolvedPluginConfig } from '@posthog/webpack-plugin'
+
+import { processSourceMaps } from './utils'
+
+jest.mock('@posthog/plugin-utils', () => ({
+  runSourcemapCli: jest.fn(),
+}))
+
+const mockedRunSourcemapCli = runSourcemapCli as jest.MockedFunction<typeof runSourcemapCli>
+const posthogOptions = {} as ResolvedPluginConfig
+
+describe('processSourceMaps', () => {
+  let distDir: string
+
+  beforeEach(async () => {
+    mockedRunSourcemapCli.mockReset()
+    distDir = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-nextjs-config-utils-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(distDir, { recursive: true, force: true })
+  })
+
+  async function writeFile(relativePath: string, content = ''): Promise<string> {
+    const fullPath = path.join(distDir, relativePath)
+    await fs.mkdir(path.dirname(fullPath), { recursive: true })
+    await fs.writeFile(fullPath, content)
+    return fullPath
+  }
+
+  it('passes an explicit snapshot of JavaScript files to the sourcemap CLI', async () => {
+    const js = await writeFile('static/chunks/a.js')
+    const mjs = await writeFile('server/app/b.mjs')
+    const cjs = await writeFile('server/c.cjs')
+    await writeFile('static/chunks/a.js.map', '{}')
+    await writeFile('BUILD_ID', 'build-id')
+
+    await processSourceMaps(posthogOptions, distDir)
+
+    expect(mockedRunSourcemapCli).toHaveBeenCalledTimes(1)
+    expect(mockedRunSourcemapCli).toHaveBeenCalledWith(posthogOptions, {
+      filePaths: [cjs, mjs, js].sort(),
+    })
+  })
+
+  it('does not let files created during CLI processing enter the same run', async () => {
+    const initial = await writeFile('static/chunks/initial.js')
+    let late: string | undefined
+    mockedRunSourcemapCli.mockImplementationOnce(async () => {
+      late = await writeFile('static/chunks/late.js')
+    })
+
+    await processSourceMaps(posthogOptions, distDir)
+
+    expect(mockedRunSourcemapCli).toHaveBeenCalledWith(posthogOptions, { filePaths: [initial] })
+    expect(late).toBeDefined()
+    expect(mockedRunSourcemapCli.mock.calls[0]?.[1]).not.toEqual({ filePaths: [initial, late] })
+  })
+
+  it('skips the CLI when the output directory contains no JavaScript files', async () => {
+    await writeFile('static/chunks/page.js.map', '{}')
+
+    await processSourceMaps(posthogOptions, distDir)
+
+    expect(mockedRunSourcemapCli).not.toHaveBeenCalled()
+  })
+
+  it('treats a missing output directory as an empty snapshot', async () => {
+    await fs.rm(distDir, { recursive: true, force: true })
+
+    await processSourceMaps(posthogOptions, distDir)
+
+    expect(mockedRunSourcemapCli).not.toHaveBeenCalled()
+  })
+})

--- a/packages/nextjs-config/src/utils.ts
+++ b/packages/nextjs-config/src/utils.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
 import nextPackage from 'next/package.json' with { type: 'json' }
 import semver from 'semver'
 
@@ -14,7 +17,44 @@ export function hasCompilerHook(): boolean {
 }
 
 export async function processSourceMaps(posthogOptions: ResolvedPluginConfig, directory: string) {
-  await runSourcemapCli(posthogOptions, { directory })
+  // Snapshot the compiler output before invoking the CLI. Next.js 16.3+
+  // Turbopack can continue flushing its filesystem cache after
+  // runAfterProductionCompile starts. Passing the directory lets the CLI scan
+  // once while injecting and again while uploading, so a chunk created between
+  // those scans has no injected chunk id and aborts the build. Feeding the CLI
+  // an explicit file list makes both phases operate on the same immutable set.
+  const filePaths = await listJavaScriptFiles(directory)
+  if (filePaths.length === 0) {
+    return
+  }
+  await runSourcemapCli(posthogOptions, { filePaths })
+}
+
+async function listJavaScriptFiles(directory: string): Promise<string[]> {
+  const files: string[] = []
+  await visit(directory, files)
+  return files.sort()
+}
+
+async function visit(directory: string, files: string[]): Promise<void> {
+  let entries: Awaited<ReturnType<typeof fs.readdir>>
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return
+    }
+    throw error
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      await visit(fullPath, files)
+    } else if (entry.isFile() && /\.[mc]?js$/.test(entry.name)) {
+      files.push(fullPath)
+    }
+  }
 }
 
 // Helper to detect if Turbopack is enabled


### PR DESCRIPTION
## Problem

Fixes #4667.

Next.js 16.3+ can continue flushing Turbopack's filesystem cache after `runAfterProductionCompile` starts. `@posthog/nextjs-config` currently passes the entire `.next` directory to `posthog-cli sourcemap process`, so the CLI can observe one set of chunks during injection and a larger set during upload. Chunks created between those scans have no injected chunk ID and can fail the production build with `Chunk ID not found`.

## Changes

- Snapshot the JavaScript files under the compilation output before invoking the PostHog CLI.
- Pass that explicit file list over the CLI's existing stdin mode so injection and upload operate on the same set of chunks.
- Ignore files that materialize after the snapshot for that run instead of letting them invalidate the already-started sourcemap transaction.
- Add regression coverage for a file appearing while CLI processing is in progress, plus `.js`/`.mjs`/`.cjs`, empty-output, and missing-output cases.

This avoids timing sleeps/retries and keeps the fix local to the integration lifecycle race.

## Testing

CI requested via this draft PR. The focused unit tests are in `packages/nextjs-config/src/utils.spec.ts`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
