### PR TITLE
feat(consent): check navigator.globalPrivacyControl in getDnt()

### DIFF
--- a/.changeset/respect-global-privacy-control.md
+++ b/.changeset/respect-global-privacy-control.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Respect `navigator.globalPrivacyControl` when `respect_dnt` is enabled

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,3 @@ CLAUDE.md
 
 # Ignore Ralph's local configuration directory
 .ralph/
-
-# Ignore people with wonky pnpm configurations
-.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ CLAUDE.md
 
 # Ignore Ralph's local configuration directory
 .ralph/
+
+# Ignore people with wonky pnpm configurations
+.pnpm-store

--- a/packages/browser/src/__tests__/consent.test.ts
+++ b/packages/browser/src/__tests__/consent.test.ts
@@ -300,12 +300,42 @@ describe('consentManager', () => {
             ;(navigator as any).doNotTrack = '1'
         })
 
+        afterEach(() => {
+            ;(navigator as any).doNotTrack = undefined
+        })
+
         it('should respect it if explicitly set', async () => {
             posthog = await createPostHog({ respect_dnt: true })
             expect(posthog.has_opted_in_capturing()).toBe(false)
         })
 
         it('should not respect it if not explicitly set', () => {
+            expect(posthog.has_opted_in_capturing()).toBe(true)
+        })
+    })
+
+    describe('with global privacy control setting', () => {
+        beforeEach(() => {
+            ;(navigator as any).globalPrivacyControl = true
+        })
+
+        afterEach(() => {
+            ;(navigator as any).globalPrivacyControl = undefined
+        })
+
+        it('should respect it if respect_dnt is explicitly set', async () => {
+            posthog = await createPostHog({ respect_dnt: true })
+            expect(posthog.has_opted_in_capturing()).toBe(false)
+            expect(posthog.get_explicit_consent_status()).toBe('denied')
+        })
+
+        it('should not respect it if respect_dnt is not explicitly set', () => {
+            expect(posthog.has_opted_in_capturing()).toBe(true)
+        })
+
+        it('should not treat globalPrivacyControl false as opted out', async () => {
+            ;(navigator as any).globalPrivacyControl = false
+            posthog = await createPostHog({ respect_dnt: true })
             expect(posthog.has_opted_in_capturing()).toBe(true)
         })
     })

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -21,7 +21,7 @@ export type ConsentStatus = (typeof ConsentStatus)[keyof typeof ConsentStatus]
 export class ConsentManager {
     private _persistentStore?: PersistentStore
 
-    constructor(private _instance: PostHog) { }
+    constructor(private _instance: PostHog) {}
 
     private get _config() {
         return this._instance.config

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -128,7 +128,7 @@ export class ConsentManager {
             navigator?.doNotTrack, // standard
             (navigator as any)?.['msDoNotTrack'],
             assignableWindow['doNotTrack'],
-            navigator.globalPrivacyControl, // FireFox 120+ DNT replacement, CA/DE legal enforcement
+            navigator?.globalPrivacyControl, // FireFox 120+ DNT replacement, CA/DE legal enforcement
         ].some((dntValue) => isYesLike(dntValue))
     }
 }

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -128,6 +128,7 @@ export class ConsentManager {
             navigator?.doNotTrack, // standard
             (navigator as any)?.['msDoNotTrack'],
             assignableWindow['doNotTrack'],
+            navigator.globalPrivacyControl, // FireFox 120+ DNT replacement, CA/DE legal enforcement
         ].some((dntValue) => isYesLike(dntValue))
     }
 }

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -21,7 +21,7 @@ export type ConsentStatus = (typeof ConsentStatus)[keyof typeof ConsentStatus]
 export class ConsentManager {
     private _persistentStore?: PersistentStore
 
-    constructor(private _instance: PostHog) {}
+    constructor(private _instance: PostHog) { }
 
     private get _config() {
         return this._instance.config
@@ -128,7 +128,8 @@ export class ConsentManager {
             navigator?.doNotTrack, // standard
             (navigator as any)?.['msDoNotTrack'],
             assignableWindow['doNotTrack'],
-            navigator?.globalPrivacyControl, // FireFox 120+ DNT replacement, CA/DE legal enforcement
+            // DNT replacement, EFF Privacy Badger, Firefox 120+. Possibly legally required
+            (navigator as any)?.globalPrivacyControl,
         ].some((dntValue) => isYesLike(dntValue))
     }
 }


### PR DESCRIPTION
## Problem

`getDnt()` currently only checks the browser's Do Not Track signal, which is non-binding and has been deprecated/ignored by most of the ad industry. A growing number of state privacy laws require businesses to honor Global Privacy Control (`navigator.globalPrivacyControl`) as a valid consumer opt-out request, not merely a soft preference:

- **CA** — Cal. Civ. Code § 1798.135; 11 CCR § 7025 (eff. 2026-01-01): must process GPC as a valid Do-Not-Sell/Share request.
- **CO** — Colo. Rev. Stat. § 6-1-1306; 4 CCR 904-3: mandatory since 2024-07-01 for AG-recognized universal opt-out mechanisms (GPC is currently the only one on that list).
- **CT** — Conn. Gen. Stat. § 42-520 (eff. 2025-01-01)
- **DE** — Del. Code tit. 6 § 12D-106 (eff. 2026-01-01)

Similar requirements are enacted or pending in roughly 20 other states. Customers operating in these states need PostHog to recognize GPC so they can stay compliant.

GPC is natively supported in Firefox and Brave, and available via extension in other browsers — support isn't Firefox-only, but that's the most common native case today.

## Changes

- Extend `getDnt()` to also check `navigator.globalPrivacyControl === true`, alongside the existing DNT check.
- This is **not on by default** — it only takes effect for consumers of `getDnt()` who already opt into that check today. (Worth flagging for reviewers: since GPC is a legal opt-out signal in several states, teams relying on `getDnt()` being off by default may need to reconsider that default separately — this PR doesn't change the default, just adds recognition of the signal when the check is invoked.)

## Release info

### Sub-libraries affected

- [x] posthog-js (web)

### Libraries affected

_(mark others if `getDnt` is shared/re-exported elsewhere, e.g. browser-common)_

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Used Claude (via Midpage Legal Research) to research which state privacy statutes require honoring GPC/opt-out-preference-signals, to ground the rationale for this change in current law rather than general assumption.
- Decision: extend the existing `getDnt()` function rather than adding a separate GPC-specific function, since GPC and DNT serve the same purpose (a browser-level opt-out signal) and downstream consumers of `getDnt()` want a single check.
- Left the default-off behavior of `getDnt()`'s caller untouched in this PR — flagged as a follow-up discussion since several of the cited statutes arguably require GPC recognition regardless of local config, which may warrant a separate change to defaults.