### PR TITLE
fix(rrweb): release DOM node references when a mutation batch is empty

### DIFF
--- a/.changeset/rrweb-mutation-buffer-empty-payload-leak.md
+++ b/.changeset/rrweb-mutation-buffer-empty-payload-leak.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rrweb': patch
+---
+
+Fix a memory leak in Session Replay recording: `MutationBuffer` skipped its own cleanup whenever a mutation batch normalized to an empty payload (e.g. a node added and removed within the same task), leaving the buffer holding strong references to DOM nodes indefinitely.

--- a/.changeset/rrweb-mutation-buffer-empty-payload-leak.md
+++ b/.changeset/rrweb-mutation-buffer-empty-payload-leak.md
@@ -1,5 +1,5 @@
 ---
-'@posthog/rrweb': patch
+'posthog-js': patch
 ---
 
 Fix a memory leak in Session Replay recording: `MutationBuffer` skipped its own cleanup whenever a mutation batch normalized to an empty payload (e.g. a node added and removed within the same task), leaving the buffer holding strong references to DOM nodes indefinitely.

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -604,10 +604,8 @@ export default class MutationBuffer {
       adds,
     };
 
-    // reset — must happen unconditionally (even when the payload below is
-    // empty) since these collections can strongly reference DOM nodes;
-    // `payload` was already built above from independent array/map
-    // references, so resetting here doesn't affect it.
+    // Reset before the empty-payload return: these collections strongly
+    // reference DOM nodes, and payload holds its own references.
     this.texts = [];
     this.attributes = [];
     this.attributeMap = new WeakMap<Node, attributeCursor>();

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -603,17 +603,11 @@ export default class MutationBuffer {
       removes: this.removes,
       adds,
     };
-    // payload may be empty if the mutations happened in some blocked elements
-    if (
-      !payload.texts.length &&
-      !payload.attributes.length &&
-      !payload.removes.length &&
-      !payload.adds.length
-    ) {
-      return;
-    }
 
-    // reset
+    // reset — must happen unconditionally (even when the payload below is
+    // empty) since these collections can strongly reference DOM nodes;
+    // `payload` was already built above from independent array/map
+    // references, so resetting here doesn't affect it.
     this.texts = [];
     this.attributes = [];
     this.attributeMap = new WeakMap<Node, attributeCursor>();
@@ -624,6 +618,16 @@ export default class MutationBuffer {
     this.droppedSet = new Set<Node>();
     this.removesSubTreeCache = new Set<Node>();
     this.movedMap = {};
+
+    // payload may be empty if the mutations happened in some blocked elements
+    if (
+      !payload.texts.length &&
+      !payload.attributes.length &&
+      !payload.removes.length &&
+      !payload.adds.length
+    ) {
+      return;
+    }
 
     this.mutationCb(payload);
   };

--- a/packages/rrweb/rrweb/test/record/memory-leaks.test.ts
+++ b/packages/rrweb/rrweb/test/record/memory-leaks.test.ts
@@ -145,43 +145,88 @@ describe('memory leak prevention', () => {
 
       const stopRecording = record({ emit });
 
-      // Let the initial full snapshot settle.
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      try {
+        // Let the initial full snapshot settle.
+        await new Promise((resolve) => setTimeout(resolve, 10));
 
-      const buffer = mutationBuffers[0] as unknown as {
-        addedSet: Set<Node>;
-        movedSet: Set<Node>;
-        droppedSet: Set<Node>;
-        texts: unknown[];
-        attributes: unknown[];
+        const buffer = mutationBuffers[0] as unknown as {
+          addedSet: Set<Node>;
+          movedSet: Set<Node>;
+          droppedSet: Set<Node>;
+          texts: unknown[];
+          attributes: unknown[];
+        };
+        expect(buffer).toBeDefined();
+
+        const eventCountBefore = events.length;
+
+        // Append then remove the same node within a single synchronous task,
+        // so the MutationObserver callback sees both records in one batch.
+        // Net effect: no add, no remove, no text/attribute change — the
+        // payload normalizes to fully empty (adds/removes/texts/attributes
+        // all length 0) — but the node passes through MutationBuffer's
+        // addedSet/droppedSet bookkeeping along the way.
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        document.body.removeChild(el);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        // An empty payload must not be emitted.
+        expect(events.length).toBe(eventCountBefore);
+
+        // The buffer must still release its node references.
+        expect(buffer.addedSet.size).toBe(0);
+        expect(buffer.movedSet.size).toBe(0);
+        expect(buffer.droppedSet.size).toBe(0);
+        expect(buffer.texts.length).toBe(0);
+        expect(buffer.attributes.length).toBe(0);
+      } finally {
+        stopRecording?.();
+      }
+    });
+
+    it('releases text/attribute buffer entries for nodes that never reached the mirror', async () => {
+      const emit = (event: eventWithTime) => {
+        events.push(event);
       };
-      expect(buffer).toBeDefined();
 
-      const eventCountBefore = events.length;
+      const stopRecording = record({ emit });
 
-      // Append then remove the same node within a single synchronous task,
-      // so the MutationObserver callback sees both records in one batch.
-      // Net effect: no add, no remove, no text/attribute change — the
-      // payload normalizes to fully empty (adds/removes/texts/attributes
-      // all length 0) — but the node passes through MutationBuffer's
-      // addedSet/droppedSet bookkeeping along the way.
-      const el = document.createElement('div');
-      document.body.appendChild(el);
-      document.body.removeChild(el);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 10));
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+        const buffer = mutationBuffers[0] as unknown as {
+          texts: unknown[];
+          attributes: unknown[];
+        };
+        expect(buffer).toBeDefined();
 
-      // An empty payload must not be emitted.
-      expect(events.length).toBe(eventCountBefore);
+        const eventCountBefore = events.length;
 
-      // The buffer must still release its node references.
-      expect(buffer.addedSet.size).toBe(0);
-      expect(buffer.movedSet.size).toBe(0);
-      expect(buffer.droppedSet.size).toBe(0);
-      expect(buffer.texts.length).toBe(0);
-      expect(buffer.attributes.length).toBe(0);
+        // Add a node, mutate its attribute and its child text node's data,
+        // then remove it -- all within one synchronous task. The node is
+        // never serialized (no mirror id), so both mutations get pushed to
+        // `texts`/`attributes` but are filtered out of the emitted payload
+        // by the mirror-membership check, leaving the payload empty even
+        // though the pre-filter buffer entries are non-empty going into the
+        // reset this test exercises.
+        const el = document.createElement('div');
+        const textNode = document.createTextNode('before');
+        el.appendChild(textNode);
+        document.body.appendChild(el);
+        el.setAttribute('data-x', '1');
+        textNode.data = 'after';
+        document.body.removeChild(el);
 
-      stopRecording?.();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(events.length).toBe(eventCountBefore);
+        expect(buffer.texts.length).toBe(0);
+        expect(buffer.attributes.length).toBe(0);
+      } finally {
+        stopRecording?.();
+      }
     });
   });
 

--- a/packages/rrweb/rrweb/test/record/memory-leaks.test.ts
+++ b/packages/rrweb/rrweb/test/record/memory-leaks.test.ts
@@ -137,6 +137,54 @@ describe('memory leak prevention', () => {
     });
   });
 
+  describe('MutationBuffer empty-payload cleanup', () => {
+    it('releases node references even when a batch normalizes to an empty payload', async () => {
+      const emit = (event: eventWithTime) => {
+        events.push(event);
+      };
+
+      const stopRecording = record({ emit });
+
+      // Let the initial full snapshot settle.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const buffer = mutationBuffers[0] as unknown as {
+        addedSet: Set<Node>;
+        movedSet: Set<Node>;
+        droppedSet: Set<Node>;
+        texts: unknown[];
+        attributes: unknown[];
+      };
+      expect(buffer).toBeDefined();
+
+      const eventCountBefore = events.length;
+
+      // Append then remove the same node within a single synchronous task,
+      // so the MutationObserver callback sees both records in one batch.
+      // Net effect: no add, no remove, no text/attribute change — the
+      // payload normalizes to fully empty (adds/removes/texts/attributes
+      // all length 0) — but the node passes through MutationBuffer's
+      // addedSet/droppedSet bookkeeping along the way.
+      const el = document.createElement('div');
+      document.body.appendChild(el);
+      document.body.removeChild(el);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // An empty payload must not be emitted.
+      expect(events.length).toBe(eventCountBefore);
+
+      // The buffer must still release its node references.
+      expect(buffer.addedSet.size).toBe(0);
+      expect(buffer.movedSet.size).toBe(0);
+      expect(buffer.droppedSet.size).toBe(0);
+      expect(buffer.texts.length).toBe(0);
+      expect(buffer.attributes.length).toBe(0);
+
+      stopRecording?.();
+    });
+  });
+
   describe('IframeManager cleanup', () => {
     it('should remove window message listener when recording stops', () => {
       const emit = (event: eventWithTime) => {

--- a/packages/rrweb/rrweb/test/record/memory-leaks.test.ts
+++ b/packages/rrweb/rrweb/test/record/memory-leaks.test.ts
@@ -160,12 +160,8 @@ describe('memory leak prevention', () => {
 
         const eventCountBefore = events.length;
 
-        // Append then remove the same node within a single synchronous task,
-        // so the MutationObserver callback sees both records in one batch.
-        // Net effect: no add, no remove, no text/attribute change — the
-        // payload normalizes to fully empty (adds/removes/texts/attributes
-        // all length 0) — but the node passes through MutationBuffer's
-        // addedSet/droppedSet bookkeeping along the way.
+        // Append and remove in one task so the batch becomes empty after
+        // addedSet/droppedSet bookkeeping.
         const el = document.createElement('div');
         document.body.appendChild(el);
         document.body.removeChild(el);
@@ -204,13 +200,8 @@ describe('memory leak prevention', () => {
 
         const eventCountBefore = events.length;
 
-        // Add a node, mutate its attribute and its child text node's data,
-        // then remove it -- all within one synchronous task. The node is
-        // never serialized (no mirror id), so both mutations get pushed to
-        // `texts`/`attributes` but are filtered out of the emitted payload
-        // by the mirror-membership check, leaving the payload empty even
-        // though the pre-filter buffer entries are non-empty going into the
-        // reset this test exercises.
+        // Mutate a new node before removing it in the same task. The missing
+        // mirror id filters its text and attribute entries from the payload.
         const el = document.createElement('div');
         const textNode = document.createTextNode('before');
         el.appendChild(textNode);


### PR DESCRIPTION
## Problem

Fixes #4688.

`MutationBuffer.processBufferedMutations()` (`packages/rrweb/rrweb/src/record/mutation.ts`) builds a `payload` object, then returns immediately if it normalizes to empty — *before* reaching the cleanup block a few lines below that clears `texts`, `attributes`, `addedSet`, `movedSet`, `droppedSet`, and `removesSubTreeCache`. Several of those are `Set<Node>`/array entries holding strong references to DOM nodes.

The most direct way to hit an empty payload while still populating those collections: append a node and remove it again within the same synchronous task (e.g. a component that mounts and immediately unmounts before the observer callback fires). Both mutation records land in the same `MutationObserver` callback batch — the node passes through `addedSet`/`droppedSet` bookkeeping, nets out to no emitted mutation, and the early return skips the reset that would otherwise release it.

## Changes

`packages/rrweb/rrweb/src/record/mutation.ts`: moved the reset block above the empty-payload check, so it always runs regardless of whether `mutationCb(payload)` ends up getting called. `payload`'s `texts`/`attributes` fields are already-computed `.map()` results and `removes`/`adds` are independent array references built earlier in the function, so reassigning `this.texts = []` etc. afterward doesn't touch `payload` — only whether the (unrelated) early return skips cleanup changes.

## Testing

Added a regression test in `test/record/memory-leaks.test.ts` that starts recording, appends then immediately removes a node in one synchronous task, and asserts:
- no `close`/mutation event is emitted for the net-zero change (unchanged behavior), and
- `MutationBuffer`'s `addedSet`/`movedSet`/`droppedSet`/`texts`/`attributes` are all empty afterward (the actual leak check).

Negative control: reverted the source change locally and reran the new test — it fails with `addedSet.size` at 2 instead of 0, matching the described leak. Restored the fix and confirmed it passes again.

Ran the full suite locally (Windows, after installing the missing `@rollup/rollup-win32-x64-msvc` optional dependency and a local Puppeteer Chrome, and building `@posthog/rrweb-snapshot`/`-types`/`-utils`/`rrdom`/`rrweb` from source — none of that is part of this diff):
- `test/record/memory-leaks.test.ts` — 35/35 passing
- `test/record/**` (full directory, including the Puppeteer-driven browser tests) — 22 files, 303/305 passing, 2 pre-existing skips
- `eslint` on both changed files — clean

Added a changeset (`patch` on `@posthog/rrweb`).

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Fully autonomous

I picked this up from the existing `posthog-watcher-action` triage comment on #4688, which had already localized the root cause correctly (same file, same function, same early-return-skips-cleanup diagnosis) and opened a draft PR (#4689) that says "No validation command configured" — i.e. unverified. I independently re-read the source to confirm the diagnosis before touching anything, then implemented the fix, wrote the regression test above, and ran the negative control and full local suite described in Testing. No prior agent session/transcript to link beyond that triage comment.
