### PR TITLE
fix(ai): capture the stop reason from LangChain Responses API runs

### DIFF
--- a/.changeset/ai-langchain-responses-api-stop-reason.md
+++ b/.changeset/ai-langchain-responses-api-stop-reason.md
@@ -1,0 +1,7 @@
+---
+'@posthog/ai': patch
+---
+
+Capture `$ai_stop_reason` from LangChain runs that use the OpenAI Responses API.
+
+The callback only understood Chat Completions vocabulary (`finish_reason` / `stop_reason`), so Responses API runs, which report `status` and `incomplete_details.reason` instead, never carried a stop reason. The Chat Completions keys keep priority, and `incomplete_details.reason` outranks `status`, so an early stop names its cause (for example `max_output_tokens`) instead of just `incomplete`.

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -720,7 +720,14 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
       gen.generationInfo?.finish_reason ||
       generationResponseMetadata?.stop_reason ||
       generationResponseMetadata?.finish_reason ||
-      gen.generationInfo?.stop_reason
+      gen.generationInfo?.stop_reason ||
+      // The Responses API reports no finish_reason. An early stop is named by
+      // `incomplete_details.reason`, and `status` covers the rest, matching the
+      // native OpenAI Responses wrapper.
+      messageResponseMetadata?.incomplete_details?.reason ||
+      generationResponseMetadata?.incomplete_details?.reason ||
+      messageResponseMetadata?.status ||
+      generationResponseMetadata?.status
 
     return stopReason != null ? String(stopReason) : undefined
   }

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -233,6 +233,69 @@ describe('LangChainCallbackHandler', () => {
       expectedStopReason: 'stop',
     },
     {
+      name: 'Responses API status when no finish_reason exists',
+      serializedId: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
+      runId: 'run_responses_api_status',
+      model: 'gpt-4o',
+      provider: 'openai',
+      generation: {
+        message: new AIMessage({
+          content: 'Test response',
+          usage_metadata: {
+            input_tokens: 30,
+            output_tokens: 10,
+            total_tokens: 40,
+          },
+          response_metadata: { status: 'completed' },
+        }),
+      },
+      expectedInputTokens: 30,
+      expectedOutputTokens: 10,
+      expectedStopReason: 'completed',
+    },
+    {
+      name: 'Responses API incomplete_details.reason over its status',
+      serializedId: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
+      runId: 'run_responses_api_incomplete',
+      model: 'gpt-4o',
+      provider: 'openai',
+      generation: {
+        message: new AIMessage({
+          content: 'Test response',
+          usage_metadata: {
+            input_tokens: 33,
+            output_tokens: 11,
+            total_tokens: 44,
+          },
+          response_metadata: { status: 'incomplete', incomplete_details: { reason: 'max_output_tokens' } },
+        }),
+      },
+      expectedInputTokens: 33,
+      expectedOutputTokens: 11,
+      expectedStopReason: 'max_output_tokens',
+    },
+    {
+      name: 'finish_reason over a Responses-style status',
+      serializedId: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
+      runId: 'run_responses_api_precedence',
+      model: 'gpt-4o',
+      provider: 'openai',
+      generation: {
+        message: new AIMessage({
+          content: 'Test response',
+          usage_metadata: {
+            input_tokens: 36,
+            output_tokens: 12,
+            total_tokens: 48,
+          },
+          response_metadata: { finish_reason: 'stop', status: 'completed' },
+        }),
+      },
+      expectedInputTokens: 36,
+      expectedOutputTokens: 12,
+      expectedStopReason: 'stop',
+    },
+    {
       name: 'generationInfo response_metadata Bedrock invocation metrics',
       serializedId: ['langchain', 'chat_models', 'bedrock', 'ChatBedrock'],
       runId: 'run_generation_info_bedrock_invocation_metrics',


### PR DESCRIPTION
## Problem

The LangChain callback resolves `$ai_stop_reason` only from Chat Completions vocabulary (`finish_reason` / `stop_reason`). Runs through the OpenAI Responses API report `status` and `incomplete_details.reason` instead, so those generations never carry a stop reason — and downstream surfaces that explain why a response ended (for example the trace view's empty-output notice) have nothing to work with. The SDK's native OpenAI Responses wrapper already maps `status`; the LangChain callback simply lacked the same fallback.

## Changes

- `_extractStopReason` falls back to `incomplete_details.reason`, then `status`, from both the message-level and generation-level `response_metadata`.
- Chat Completions keys keep priority, so existing providers are unaffected.
- `incomplete_details.reason` outranks `status`, so an early stop names its cause (for example `max_output_tokens`) instead of just `incomplete`.

Three new rows in the existing `callbacks.test.ts` stop-reason table: the `status` fallback, `incomplete_details.reason` over `status`, and `finish_reason` over a Responses-style `status`. Reverting the source leaves exactly the first two red.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
