### PR TITLE
feat(plugins): default release mode to event

### DIFF
--- a/.changeset/event-release-mode-default.md
+++ b/.changeset/event-release-mode-default.md
@@ -5,8 +5,6 @@
 '@posthog/nextjs-config': minor
 ---
 
-Change the default `sourcemaps.releaseMode` to `event`: set `sourcemaps.releaseMode: 'symbol-set'`, or `POSTHOG_RELEASE_MODE=symbol-set`, to keep binding uploaded symbol sets to a release.
-
-A build now injects the release id into each chunk as `_posthogReleaseId`, and it uploads the symbol sets release-independent. Two releases that ship the same chunk keep one symbol set instead of colliding on the release that uploaded it first. The new default reaches the rollup plugin, the webpack plugin and `@posthog/nextjs-config`, because all three resolve their config through the same function. The `@posthog/plugin-utils` bump is major so an already-installed plugin cannot pick the new default up through its `^1.x` range.
+Change the default `sourcemaps.releaseMode` to `event`: set `sourcemaps.releaseMode: 'symbol-set'`, or `POSTHOG_RELEASE_MODE=symbol-set`, to keep binding uploaded symbol sets to a release. The `@posthog/plugin-utils` bump is major, so an installed plugin keeps the old default until the plugin itself is upgraded.
 
 `event` mode requires a posthog-cli with `release resolve` and `--release-mode`, and `posthog-js` 1.409.0, `posthog-node` 5.47.0, or `@posthog/core` 1.46.0 at runtime. An older CLI fails a rollup build and skips the upload on webpack and Next.js. An older SDK reports no release on exceptions.

--- a/.changeset/event-release-mode-default.md
+++ b/.changeset/event-release-mode-default.md
@@ -2,6 +2,11 @@
 '@posthog/plugin-utils': minor
 '@posthog/rollup-plugin': minor
 '@posthog/webpack-plugin': minor
+'@posthog/nextjs-config': minor
 ---
 
-Default `sourcemaps.releaseMode` to `event`. A build now injects the release id into each chunk as `_posthogReleaseId` and uploads its symbol sets release-independent, so two releases that ship the same chunk keep one symbol set instead of colliding on the release that uploaded it first. Set `sourcemaps.releaseMode: 'symbol-set'`, or `POSTHOG_RELEASE_MODE=symbol-set`, to keep binding the uploaded symbol sets to a release. Event mode needs a posthog-cli that supports `release resolve` and `--release-mode`; an older binary now fails the build with that message instead of falling back.
+Default `sourcemaps.releaseMode` to `event`. A build now injects the release id into each chunk as `_posthogReleaseId`, and it uploads the symbol sets release-independent. Two releases that ship the same chunk keep one symbol set instead of colliding on the release that uploaded it first. The new default reaches the rollup plugin, the webpack plugin and `@posthog/nextjs-config`, because all three resolve their config through the same function.
+
+Set `sourcemaps.releaseMode: 'symbol-set'`, or `POSTHOG_RELEASE_MODE=symbol-set`, to keep binding the uploaded symbol sets to a release.
+
+Event mode needs a posthog-cli that supports `release resolve` and `--release-mode`. An older binary stops a rollup build, because the plugin resolves the release while it renders each chunk. A webpack or Next.js build prints the error from the CLI and then completes without uploading source maps, because those uploads run after the build and do not fail it.

--- a/.changeset/event-release-mode-default.md
+++ b/.changeset/event-release-mode-default.md
@@ -1,0 +1,7 @@
+---
+'@posthog/plugin-utils': minor
+'@posthog/rollup-plugin': minor
+'@posthog/webpack-plugin': minor
+---
+
+Default `sourcemaps.releaseMode` to `event`. A build now injects the release id into each chunk as `_posthogReleaseId` and uploads its symbol sets release-independent, so two releases that ship the same chunk keep one symbol set instead of colliding on the release that uploaded it first. Set `sourcemaps.releaseMode: 'symbol-set'`, or `POSTHOG_RELEASE_MODE=symbol-set`, to keep binding the uploaded symbol sets to a release. Event mode needs a posthog-cli that supports `release resolve` and `--release-mode`; an older binary now fails the build with that message instead of falling back.

--- a/.changeset/event-release-mode-default.md
+++ b/.changeset/event-release-mode-default.md
@@ -1,12 +1,12 @@
 ---
-'@posthog/plugin-utils': minor
+'@posthog/plugin-utils': major
 '@posthog/rollup-plugin': minor
 '@posthog/webpack-plugin': minor
 '@posthog/nextjs-config': minor
 ---
 
-Default `sourcemaps.releaseMode` to `event`. A build now injects the release id into each chunk as `_posthogReleaseId`, and it uploads the symbol sets release-independent. Two releases that ship the same chunk keep one symbol set instead of colliding on the release that uploaded it first. The new default reaches the rollup plugin, the webpack plugin and `@posthog/nextjs-config`, because all three resolve their config through the same function.
+Change the default `sourcemaps.releaseMode` to `event`: set `sourcemaps.releaseMode: 'symbol-set'`, or `POSTHOG_RELEASE_MODE=symbol-set`, to keep binding uploaded symbol sets to a release.
 
-Set `sourcemaps.releaseMode: 'symbol-set'`, or `POSTHOG_RELEASE_MODE=symbol-set`, to keep binding the uploaded symbol sets to a release.
+A build now injects the release id into each chunk as `_posthogReleaseId`, and it uploads the symbol sets release-independent. Two releases that ship the same chunk keep one symbol set instead of colliding on the release that uploaded it first. The new default reaches the rollup plugin, the webpack plugin and `@posthog/nextjs-config`, because all three resolve their config through the same function. The `@posthog/plugin-utils` bump is major so an already-installed plugin cannot pick the new default up through its `^1.x` range.
 
-Event mode needs a posthog-cli that supports `release resolve` and `--release-mode`. An older binary stops a rollup build, because the plugin resolves the release while it renders each chunk. A webpack or Next.js build prints the error from the CLI and then completes without uploading source maps, because those uploads run after the build and do not fail it.
+`event` mode requires a posthog-cli with `release resolve` and `--release-mode`, and `posthog-js` 1.409.0, `posthog-node` 5.47.0, or `@posthog/core` 1.46.0 at runtime. An older CLI fails a rollup build and skips the upload on webpack and Next.js. An older SDK reports no release on exceptions.

--- a/packages/plugin-utils/src/config.spec.ts
+++ b/packages/plugin-utils/src/config.spec.ts
@@ -43,8 +43,8 @@ describe('resolveConfig', () => {
         })
 
         it.each([
-            { name: 'defaults to symbol-set', option: undefined, env: undefined, expected: 'symbol-set' },
-            { name: 'reads POSTHOG_RELEASE_MODE', option: undefined, env: 'event', expected: 'event' },
+            { name: 'defaults to event', option: undefined, env: undefined, expected: 'event' },
+            { name: 'reads POSTHOG_RELEASE_MODE', option: undefined, env: 'symbol-set', expected: 'symbol-set' },
             { name: 'prefers the explicit option', option: 'symbol-set', env: 'event', expected: 'symbol-set' },
             {
                 name: 'takes the explicit option without an env var',

--- a/packages/plugin-utils/src/config.ts
+++ b/packages/plugin-utils/src/config.ts
@@ -16,8 +16,9 @@ export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'
 /**
  * How an exception gets associated with a release, mirroring posthog-cli's `--release-mode`.
  *
- * `symbol-set` binds the uploaded symbol sets to a release. `event` leaves them unbound and
- * injects the release id into each chunk instead, so the release is resolved per exception.
+ * `event`, the default, leaves the uploaded symbol sets unbound and injects the release id into
+ * each chunk, so the release is resolved per exception. `symbol-set` binds the uploaded symbol
+ * sets to a release instead.
  */
 export type ReleaseMode = 'symbol-set' | 'event'
 
@@ -25,7 +26,7 @@ const RELEASE_MODES: ReleaseMode[] = ['symbol-set', 'event']
 
 function normalizeReleaseMode(value: string | undefined): ReleaseMode {
     if (value === undefined || value === '') {
-        return 'symbol-set'
+        return 'event'
     }
     if (!(RELEASE_MODES as string[]).includes(value)) {
         throw new Error(`sourcemaps.releaseMode must be one of ${RELEASE_MODES.join(', ')}, got '${value}'`)
@@ -53,9 +54,10 @@ export interface PluginConfig {
         deleteAfterUpload?: boolean
         batchSize?: number
         /**
-         * EXPERIMENTAL. Defaults to the `POSTHOG_RELEASE_MODE` env var, the same one posthog-cli
-         * reads, then to `symbol-set`. Event mode needs a posthog-cli that supports
-         * `release resolve` and `--release-mode`.
+         * Defaults to the `POSTHOG_RELEASE_MODE` env var, the same one posthog-cli reads, then to
+         * `event`. Event mode needs a posthog-cli that supports `release resolve` and
+         * `--release-mode`. Set `symbol-set` to bind the uploaded symbol sets to a release
+         * instead.
          */
         releaseMode?: ReleaseMode
     }

--- a/packages/rollup-plugin/src/index.spec.ts
+++ b/packages/rollup-plugin/src/index.spec.ts
@@ -22,6 +22,8 @@ const options = {
     projectId: '1',
 }
 
+const symbolSetOptions = { ...options, sourcemaps: { releaseMode: 'symbol-set' as const } }
+
 type RenderChunkResult = { code: string; map: unknown } | null
 
 type TestPlugin = {
@@ -79,9 +81,9 @@ describe('posthogRollupPlugin', () => {
     describe('renderChunk', () => {
         const code = 'console.log("chunk one");console.log("chunk two");'
 
-        it('injects the chunk id snippet and trailing comment in-memory', () => {
+        it('injects the chunk id snippet and trailing comment in-memory', async () => {
             const plugin = testPlugin(options)
-            const result = plugin.renderChunk.handler(code, { fileName: 'index-abc123.js' })
+            const result = await plugin.renderChunk.handler(code, { fileName: 'index-abc123.js' })
 
             expect(result).not.toBeNull()
             expect(result!.code.startsWith('!function(){try{var e=')).toBe(true)
@@ -89,13 +91,16 @@ describe('posthogRollupPlugin', () => {
             expect(result!.code).toMatch(/\n\/\/# chunkId=[0-9a-f-]{36}$/)
             expect(result!.map).toBeDefined()
 
+            // The default is event mode, so the chunk carries the release id.
+            expect(result!.code).toContain('e._posthogReleaseId=e._posthogReleaseId||"release-id-1"')
+
             // the runtime snippet and the CLI-facing comment carry the same id
             const commentId = result!.code.match(/\/\/# chunkId=(\S+)$/)![1]
             expect(determineChunkIdFromSource(result!.code)).toBe(commentId)
         })
 
-        it('mints a fresh chunk id per injection', () => {
-            const plugin = testPlugin(options)
+        it('mints a fresh chunk id per injection in symbol-set mode', () => {
+            const plugin = testPlugin(symbolSetOptions)
             const first = plugin.renderChunk.handler(code, { fileName: 'a.js' })
             const second = plugin.renderChunk.handler(code, { fileName: 'b.js' })
 
@@ -103,14 +108,14 @@ describe('posthogRollupPlugin', () => {
         })
 
         it('does not re-inject already injected code', () => {
-            const plugin = testPlugin(options)
+            const plugin = testPlugin(symbolSetOptions)
             const injected = plugin.renderChunk.handler(code, { fileName: 'index.js' })!.code
 
             expect(plugin.renderChunk.handler(injected, { fileName: 'index.js' })).toBeNull()
         })
 
         it('keeps a "use strict" directive in effect by injecting after it', () => {
-            const plugin = testPlugin(options)
+            const plugin = testPlugin(symbolSetOptions)
             const result = plugin.renderChunk.handler('"use strict";console.log("app");', {
                 fileName: 'index.cjs',
             })
@@ -119,7 +124,7 @@ describe('posthogRollupPlugin', () => {
         })
 
         it('does not split a leading string-literal expression', () => {
-            const plugin = testPlugin(options)
+            const plugin = testPlugin(symbolSetOptions)
             const cases = [
                 '"undefined"!=typeof window&&console.log(1);',
                 '"undefined"\n!=typeof window&&console.log(1);',
@@ -137,7 +142,7 @@ describe('posthogRollupPlugin', () => {
         })
 
         it('honors semicolonless ASI directives', () => {
-            const plugin = testPlugin(options)
+            const plugin = testPlugin(symbolSetOptions)
             const result = plugin.renderChunk.handler('"use strict"\n!function(){console.log(1)}();', {
                 fileName: 'index.js',
             })
@@ -147,7 +152,7 @@ describe('posthogRollupPlugin', () => {
         })
 
         it('injects after a full directive prologue like "use client"', () => {
-            const plugin = testPlugin(options)
+            const plugin = testPlugin(symbolSetOptions)
             const result = plugin.renderChunk.handler('"use client";\n"use strict";\nconsole.log("app");', {
                 fileName: 'index.js',
             })
@@ -212,7 +217,7 @@ describe('posthogRollupPlugin', () => {
             })
 
             it('does not resolve a release in symbol-set mode', async () => {
-                const plugin = testPlugin(options)
+                const plugin = testPlugin(symbolSetOptions)
 
                 await plugin.renderChunk.handler(code, { fileName: 'index.js' })
 
@@ -234,9 +239,9 @@ describe('posthogRollupPlugin', () => {
         const preliminaryFileName = 'index-!~{001}~.js'
         const fileName = 'index-abc123.js'
 
-        it('restores a chunk id comment removed after renderChunk', () => {
+        it('restores a chunk id comment removed after renderChunk', async () => {
             const plugin = testPlugin(options)
-            const rendered = plugin.renderChunk.handler(code, { fileName: preliminaryFileName })!
+            const rendered = (await plugin.renderChunk.handler(code, { fileName: preliminaryFileName }))!
             const chunkId = determineChunkIdFromSource(rendered.code)!
             const minifiedCode = rendered.code.replace(createChunkIdComment(chunkId), '')
             const bundle = {
@@ -248,9 +253,9 @@ describe('posthogRollupPlugin', () => {
             expect(determineChunkIdFromSource(bundle[fileName].code)).toBe(chunkId)
         })
 
-        it('does not duplicate a chunk id comment that survived output minification', () => {
+        it('does not duplicate a chunk id comment that survived output minification', async () => {
             const plugin = testPlugin(options)
-            const rendered = plugin.renderChunk.handler(code, { fileName: preliminaryFileName })!
+            const rendered = (await plugin.renderChunk.handler(code, { fileName: preliminaryFileName }))!
             const bundle = {
                 [fileName]: { type: 'chunk', fileName, preliminaryFileName, code: rendered.code },
             }


### PR DESCRIPTION
## Related PRs

Event mode is live today, and it is opt-in. These PRs settle where it stays and where it goes.

**Deprecating the mobile knobs.** The symbol id on these paths is already a content hash, so two releases collide only when they ship a byte-identical artifact. An ordinary release that changes code gets its own symbol set and never collides. The dSYM path also lost release attribution for embedded targets, because one upload covers every target while it creates one release. Review asked for deprecation instead of removal, so every knob stays accepted as a warned no-op.

- PostHog/posthog#92401
- PostHog/posthog-android#747
- PostHog/posthog-ios#791

**Making it the default.**

- PostHog/posthog#91823 (stacked on PostHog/posthog#92401)
- PostHog/posthog-js#4705 ← this PR

**React Native.** Removes the iOS and Android propagation, and makes event mode the default for the Hermes upload. That is the one path where two releases really do ship the same artifact.

- PostHog/posthog-js#4717

## Problem

- Two web releases that ship the same chunk report their exceptions on one release.
- The release that uploads the symbol set first takes them.

## Changes

- `sourcemaps.releaseMode` defaults to `event` for the rollup plugin, the webpack plugin and `@posthog/nextjs-config`.
- All three resolve their config through `normalizeReleaseMode`, so one line moves them together.
- The plugin injects the release id into each chunk as `_posthogReleaseId`.
- The plugin uploads the symbol sets without a release.
- `sourcemaps.releaseMode: 'symbol-set'` keeps the old behavior. `POSTHOG_RELEASE_MODE=symbol-set` does the same.

One function holds the default: `normalizeReleaseMode` in `@posthog/plugin-utils`. The rest of the diff is test setup.

An old posthog-cli behaves differently per bundler. It stops a rollup build, because the plugin resolves the release while it renders each chunk. It does not stop a webpack or Next.js build. Those uploads run after the build, and the plugin logs the error from the CLI instead of failing. The changeset states both. Making webpack fail would change how it treats every upload error, which is a wider decision than this PR.

## How did you test this code?

- `jest` in `packages/plugin-utils`, `packages/rollup-plugin` and `packages/webpack-plugin`.
- One test pins the new default. The symbol-set tests now name `symbolSetOptions`.
- Not run: a bundler build against a real project.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`.

Rollup's `renderChunk` returns a promise in event mode, because it waits for the release. Six tests read `.code` off that promise. The tests for mode-independent behavior moved to explicit symbol-set config and stayed synchronous.






