### PR TITLE
feat(browser): add os.name and os.version to logs, and share one OTLP resource builder

### DIFF
--- a/.changeset/browser-os-resource-attributes.md
+++ b/.changeset/browser-os-resource-attributes.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/core': patch
+---
+
+Add `os.name` and `os.version` resource attributes to logs from the browser SDK, overridable via `logs.resourceAttributes`

--- a/packages/browser/src/__tests__/logs-defaults.test.ts
+++ b/packages/browser/src/__tests__/logs-defaults.test.ts
@@ -110,4 +110,62 @@ describe('resolveLogsConfig', () => {
 
         expect(resolved.serviceName).toBe('from-named')
     })
+    describe('OS resource attributes', () => {
+        const setUserAgent = (value: string | undefined): void => {
+            Object.defineProperty(window.navigator, 'userAgent', { value, configurable: true })
+        }
+
+        afterEach(() => {
+            // @ts-expect-error restoring the jsdom prototype getter
+            delete window.navigator.userAgent
+        })
+
+        it('attaches the detected OS under the name the other PostHog SDKs use', () => {
+            setUserAgent(
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+            )
+
+            // `detectOS` reads the user agent's "Mac OS X"; posthog-ios reports the
+            // same OS as "macOS", and one filter has to match both.
+            expect(resolveLogsConfig(undefined).resourceAttributes).toEqual({
+                'os.name': 'macOS',
+                'os.version': '10.15.7',
+            })
+        })
+
+        it.each([
+            ['Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15', 'iOS'],
+            ['Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile', 'Android'],
+            ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0', 'Windows'],
+        ])('reports %s as os.name %s, matching the native SDKs', (userAgent, expected) => {
+            setUserAgent(userAgent)
+
+            expect(resolveLogsConfig(undefined).resourceAttributes?.['os.name']).toBe(expected)
+        })
+
+        it('lets user resourceAttributes override the detected OS', () => {
+            setUserAgent(
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+            )
+
+            expect(
+                resolveLogsConfig({ resourceAttributes: { 'os.name': 'my-os', 'os.version': '1.2.3' } })
+                    .resourceAttributes
+            ).toEqual({ 'os.name': 'my-os', 'os.version': '1.2.3' })
+        })
+
+        it('omits a key the user agent cannot supply rather than emitting it empty', () => {
+            setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0')
+
+            expect(resolveLogsConfig(undefined).resourceAttributes).toEqual({ 'os.name': 'Linux' })
+        })
+
+        it('resolves without OS keys when there is no user agent', () => {
+            setUserAgent(undefined)
+
+            expect(resolveLogsConfig({ resourceAttributes: { 'host.name': 'web-01' } }).resourceAttributes).toEqual({
+                'host.name': 'web-01',
+            })
+        })
+    })
 })

--- a/packages/browser/src/__tests__/posthog-logs.test.ts
+++ b/packages/browser/src/__tests__/posthog-logs.test.ts
@@ -764,6 +764,30 @@ describe('posthog-logs', () => {
                 expect(attrsMap['deployment.environment']).toEqual({ stringValue: 'production' })
             })
 
+            it('should include the detected OS in OTLP resource attributes', () => {
+                Object.defineProperty(window.navigator, 'userAgent', {
+                    value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0',
+                    configurable: true,
+                })
+
+                try {
+                    logs = new PostHogLogs(mockPostHog)
+                    logs.captureLog({ body: 'test' })
+                    jest.advanceTimersByTime(3000)
+
+                    const call = (mockPostHog._send_request as jest.Mock).mock.calls[0][0]
+                    const attrsMap = Object.fromEntries(
+                        call.data.resourceLogs[0].resource.attributes.map((a: any) => [a.key, a.value])
+                    )
+
+                    expect(attrsMap['os.name']).toEqual({ stringValue: 'Windows' })
+                    expect(attrsMap['os.version']).toEqual({ stringValue: '10' })
+                } finally {
+                    // @ts-expect-error restoring the jsdom prototype getter
+                    delete window.navigator.userAgent
+                }
+            })
+
             it('should allow resourceAttributes to override named fields', () => {
                 ;(mockPostHog.config as any).logs = {
                     ...mockPostHog.config.logs,

--- a/packages/browser/src/logs-defaults.ts
+++ b/packages/browser/src/logs-defaults.ts
@@ -1,6 +1,7 @@
 import type { LogCaptureOptions } from '@posthog/types'
 import type { ResolvedPostHogLogsConfig } from '@posthog/core'
-import { isUndefined } from '@posthog/core'
+import { detectOS, isUndefined, osResourceAttributes } from '@posthog/core'
+import { navigator } from '@posthog/browser-common/utils/globals'
 
 const DEFAULT_FLUSH_INTERVAL_MS = 3000
 const DEFAULT_MAX_BUFFER_SIZE = 100
@@ -8,6 +9,27 @@ const DEFAULT_MAX_LOGS_PER_INTERVAL = 1000
 // Console runs uncapped, so this buffer depth is its only drop protection.
 const DEFAULT_CONSOLE_MAX_QUEUE_SIZE = 2048
 const DEFAULT_MAX_BATCH_RECORDS_PER_POST = 100
+
+/**
+ * Browser resource attribute defaults. Identifies the visitor's OS so logs can
+ * be filtered by platform (e.g. "only errors on Windows" in the PostHog UI).
+ * User-supplied `resourceAttributes` merges last so these stay overridable.
+ *
+ * `detectOS` returns empty strings for a user agent it can't place, and there is
+ * no `navigator` in an SSR or worker-like context — either way the key is
+ * omitted rather than emitted empty, and resolution never throws.
+ */
+function defaultResourceAttributes(): Record<string, string> {
+    let osName = ''
+    let osVersion = ''
+    try {
+        const userAgent = navigator?.userAgent
+        if (userAgent) {
+            ;[osName, osVersion] = detectOS(userAgent)
+        }
+    } catch {}
+    return osResourceAttributes(osName, osVersion)
+}
 
 /**
  * Resolves the public `logs` config into the shape core `PostHogLogs` consumes.
@@ -31,7 +53,7 @@ export function resolveLogsConfig(
         ? Math.max(maxBufferSize, DEFAULT_CONSOLE_MAX_QUEUE_SIZE)
         : Math.max(maxBufferSize, maxLogsPerInterval)
     // OTLP keys in `resourceAttributes` take precedence over the named config fields.
-    const resourceAttributes = config?.resourceAttributes
+    const resourceAttributes = { ...defaultResourceAttributes(), ...config?.resourceAttributes }
     return {
         serviceName:
             (resourceAttributes?.['service.name'] as string | undefined) ??

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
   getOtlpSeverityText,
 } from './logs/logs-utils'
 export { toOtlpAnyValue, toOtlpKeyValueList } from './utils/otlp-any-value'
+export { osResourceAttributes } from './utils/otlp-resource'
 export { PostHogLogs } from './logs'
 export type {
   BeforeSendLogFn,

--- a/packages/core/src/logs/logs-utils.ts
+++ b/packages/core/src/logs/logs-utils.ts
@@ -12,6 +12,7 @@ import type { LogSdkContext, ResolvedPostHogLogsConfig } from './types'
 import { isNullish, isNumber, isUndefined } from '../utils'
 import { sanitizeString, UNSERIALIZABLE_VALUE } from '../utils/json-utils'
 import { toOtlpKeyValueList } from '../utils/otlp-any-value'
+import { buildOtlpResourceAttributes } from '../utils/otlp-resource'
 
 // ============================================================================
 // Severity mapping
@@ -185,14 +186,7 @@ export function buildResourceAttributes(
   sdkName: string,
   sdkVersion: string
 ): Record<string, LogAttributeValue> {
-  return {
-    ...config.resourceAttributes,
-    'service.name': config.serviceName || 'unknown_service',
-    ...(config.environment && { 'deployment.environment': config.environment }),
-    ...(config.serviceVersion && { 'service.version': config.serviceVersion }),
-    'telemetry.sdk.name': sdkName,
-    'telemetry.sdk.version': sdkVersion,
-  }
+  return buildOtlpResourceAttributes(config, sdkName, sdkVersion)
 }
 
 /**

--- a/packages/core/src/metrics/metrics-utils.ts
+++ b/packages/core/src/metrics/metrics-utils.ts
@@ -1,5 +1,6 @@
 import type { MetricAttributeValue, OtlpMetric, OtlpMetricsPayload } from '@posthog/types'
 import { toOtlpKeyValueList } from '../utils/otlp-any-value'
+import { buildOtlpResourceAttributes } from '../utils/otlp-resource'
 import type { ResolvedPostHogMetricsConfig } from './types'
 
 /**
@@ -59,14 +60,7 @@ export function buildMetricsResourceAttributes(
   scopeName: string,
   scopeVersion: string
 ): Record<string, MetricAttributeValue> {
-  return {
-    ...config.resourceAttributes,
-    'service.name': config.serviceName || 'unknown_service',
-    ...(config.environment && { 'deployment.environment': config.environment }),
-    ...(config.serviceVersion && { 'service.version': config.serviceVersion }),
-    'telemetry.sdk.name': scopeName,
-    'telemetry.sdk.version': scopeVersion,
-  }
+  return buildOtlpResourceAttributes(config, scopeName, scopeVersion)
 }
 
 /**

--- a/packages/core/src/utils/otlp-resource.spec.ts
+++ b/packages/core/src/utils/otlp-resource.spec.ts
@@ -1,0 +1,125 @@
+import { buildResourceAttributes } from '../logs/logs-utils'
+import type { ResolvedPostHogLogsConfig } from '../logs/types'
+import { buildMetricsResourceAttributes } from '../metrics/metrics-utils'
+import type { ResolvedPostHogMetricsConfig } from '../metrics/types'
+import { normalizeOsName, osResourceAttributes } from './otlp-resource'
+
+const shared = {
+  serviceName: 'checkout',
+  serviceVersion: '2.1.0',
+  environment: 'production',
+  resourceAttributes: { 'host.name': 'web-01' },
+}
+
+const conflicting = {
+  serviceName: 'checkout',
+  serviceVersion: '2.1.0',
+  environment: 'production',
+  resourceAttributes: {
+    'service.name': 'hijacked',
+    'service.version': '0.0.0',
+    'deployment.environment': 'hijacked-env',
+    'telemetry.sdk.name': 'hijacked-sdk',
+    'telemetry.sdk.version': '0.0.0',
+    'host.name': 'web-01',
+  },
+}
+
+const bothSignals = (partial: object): Record<string, unknown>[] => [
+  buildResourceAttributes(partial as ResolvedPostHogLogsConfig, 'posthog-node', '1.0.0'),
+  buildMetricsResourceAttributes(partial as ResolvedPostHogMetricsConfig, 'posthog-node', '1.0.0'),
+]
+
+describe('shared OTLP resource attributes', () => {
+  it.each([
+    ['a fully populated config', shared],
+    ['a config with conflicting user attributes', conflicting],
+    ['an empty config', {}],
+  ])('produces the same attributes for logs and metrics given %s', (_label, config) => {
+    const [logs, metrics] = bothSignals(config)
+    expect(metrics).toEqual(logs)
+    expect(Object.keys(metrics)).toEqual(Object.keys(logs))
+  })
+
+  it('layers the identity keys over user resource attributes', () => {
+    for (const attributes of bothSignals(conflicting)) {
+      expect(attributes).toEqual({
+        'service.name': 'checkout',
+        'service.version': '2.1.0',
+        'deployment.environment': 'production',
+        'telemetry.sdk.name': 'posthog-node',
+        'telemetry.sdk.version': '1.0.0',
+        'host.name': 'web-01',
+      })
+    }
+  })
+
+  it('keeps user resource attributes that do not collide', () => {
+    for (const attributes of bothSignals(shared)) {
+      expect(attributes).toEqual({
+        'host.name': 'web-01',
+        'service.name': 'checkout',
+        'deployment.environment': 'production',
+        'service.version': '2.1.0',
+        'telemetry.sdk.name': 'posthog-node',
+        'telemetry.sdk.version': '1.0.0',
+      })
+    }
+  })
+
+  it('falls back to unknown_service and omits unset optional keys', () => {
+    for (const attributes of bothSignals({})) {
+      expect(attributes).toEqual({
+        'service.name': 'unknown_service',
+        'telemetry.sdk.name': 'posthog-node',
+        'telemetry.sdk.version': '1.0.0',
+      })
+    }
+  })
+})
+
+describe('osResourceAttributes', () => {
+  it.each([
+    // node:os platform() identifiers rather than os.name values
+    ['darwin', 'macOS'],
+    ['win32', 'Windows'],
+    ['linux', 'Linux'],
+    ['android', 'Android'],
+    ['freebsd', 'FreeBSD'],
+    // detectOS spellings
+    ['Mac OS X', 'macOS'],
+    ['iOS', 'iOS'],
+    ['Android', 'Android'],
+    ['Windows', 'Windows'],
+    ['Linux', 'Linux'],
+  ])('normalizes %s to %s', (raw, expected) => {
+    expect(normalizeOsName(raw)).toBe(expected)
+  })
+
+  it('passes an unmapped name through rather than dropping it', () => {
+    expect(normalizeOsName('Haiku')).toBe('Haiku')
+    expect(normalizeOsName('constructor')).toBe('constructor')
+  })
+
+  it.each([undefined, ''])('returns undefined for %p', (raw) => {
+    expect(normalizeOsName(raw)).toBeUndefined()
+  })
+
+  it('agrees with the names posthog-ios and posthog-android already send', () => {
+    // Both SDKs ship these values today; a divergence here splits one filter in two.
+    expect(normalizeOsName('darwin')).toBe('macOS')
+    expect(normalizeOsName('Mac OS X')).toBe('macOS')
+    expect(normalizeOsName('iOS')).toBe('iOS')
+    expect(normalizeOsName('Android')).toBe('Android')
+  })
+
+  it('omits either key rather than emitting it empty', () => {
+    expect(osResourceAttributes('darwin', undefined)).toEqual({ 'os.name': 'macOS' })
+    expect(osResourceAttributes(undefined, '14.0')).toEqual({ 'os.version': '14.0' })
+    expect(osResourceAttributes('', '')).toEqual({})
+    expect(osResourceAttributes('win32', '10.0.26100')).toEqual({
+      'os.name': 'Windows',
+      'os.version': '10.0.26100',
+    })
+  })
+})

--- a/packages/core/src/utils/otlp-resource.ts
+++ b/packages/core/src/utils/otlp-resource.ts
@@ -1,0 +1,89 @@
+/**
+ * Shape the logs and metrics resolved configs share for resource
+ * attribution. Generic over the attribute value type so each signal keeps its
+ * own value union.
+ */
+export interface OtlpResourceConfig<TAttributeValue> {
+  serviceName?: string
+  serviceVersion?: string
+  environment?: string
+  resourceAttributes?: Record<string, TAttributeValue>
+}
+
+/**
+ * OTLP resource attributes shared by the logs and metrics envelopes.
+ *
+ * User `resourceAttributes` are spread first, then SDK-controlled keys on top so
+ * a stray user key can't clobber the ingestion-attribution ones; the dedicated
+ * `serviceName` / `environment` / `serviceVersion` fields are how you override
+ * those three.
+ *
+ * @internal Shared within this SDK; not part of the stable public API.
+ */
+export function buildOtlpResourceAttributes<TAttributeValue>(
+  config: OtlpResourceConfig<TAttributeValue>,
+  sdkName: string,
+  sdkVersion: string
+): Record<string, TAttributeValue | string> {
+  return {
+    ...config.resourceAttributes,
+    'service.name': config.serviceName || 'unknown_service',
+    ...(config.environment && { 'deployment.environment': config.environment }),
+    ...(config.serviceVersion && { 'service.version': config.serviceVersion }),
+    'telemetry.sdk.name': sdkName,
+    'telemetry.sdk.version': sdkVersion,
+  }
+}
+
+/**
+ * OTLP `os.name` values, keyed by the spellings the JS SDKs detect natively:
+ * `node:os` `platform()` identifiers and the names `detectOS` reads out of a
+ * user agent.
+ *
+ * OpenTelemetry defines `os.name` as the human-readable OS name; the lowercase
+ * identifiers (`darwin`, `win32`) are `node:os` `platform()` values, not
+ * `os.name` values.
+ * The values match what `posthog-ios` and `posthog-android` send for the
+ * platforms they cover.
+ */
+const OS_NAMES: Record<string, string> = {
+  // node:os platform()
+  darwin: 'macOS',
+  win32: 'Windows',
+  linux: 'Linux',
+  android: 'Android',
+  freebsd: 'FreeBSD',
+  openbsd: 'OpenBSD',
+  sunos: 'SunOS',
+  aix: 'AIX',
+  // detectOS
+  'Mac OS X': 'macOS',
+}
+
+/**
+ * Normalizes a natively-detected OS name against the table above.
+ * Unrecognized names pass through: a wrong-looking value beats dropping an OS
+ * we have not mapped yet.
+ *
+ * @internal Shared within this SDK; not part of the stable public API.
+ */
+export function normalizeOsName(name: string | undefined): string | undefined {
+  if (!name) {
+    return undefined
+  }
+  return Object.prototype.hasOwnProperty.call(OS_NAMES, name) ? OS_NAMES[name] : name
+}
+
+/**
+ * The `os.name` / `os.version` resource attribute pair, with either key omitted
+ * rather than emitted empty when the host cannot determine it.
+ *
+ * @internal Exposed for cross-package use within this SDK; not part of the stable public API.
+ */
+export function osResourceAttributes(name: string | undefined, version: string | undefined): Record<string, string> {
+  const osName = normalizeOsName(name)
+  return {
+    ...(osName ? { 'os.name': osName } : {}),
+    ...(version ? { 'os.version': version } : {}),
+  }
+}


### PR DESCRIPTION
## Problem

**Logs from the web SDK don't record what OS the visitor was on.** You can't answer "show me errors on Windows only" — the OS is simply absent from every logs payload `posthog-js` produces.

Logs are sent as OTLP, and every batch carries a set of *resource attributes*: key/value pairs describing where the logs came from (service name, SDK version, and so on). The [logs spec](https://github.com/PostHog/sdk-specs/blob/main/openspec/specs/logs/spec.md) lists `os.name` and `os.version` among the ones the envelope SHALL carry. `posthog-react-native`, `posthog-ios` and `posthog-android` all send them; `posthog-js` never has.

**Separately, the code that builds those resource attributes existed twice.** `buildResourceAttributes` (logs) and `buildMetricsResourceAttributes` (metrics) had byte-identical bodies; only the return-type spelling differed.

## Changes

**One builder.** `packages/core/src/utils/otlp-resource.ts` holds `buildOtlpResourceAttributes`, generic over each signal's attribute value type. Both existing functions keep their exported names, parameter lists and return types and now delegate to it — `buildResourceAttributes` is a public `@posthog/core` export with a shipped call site in `packages/browser`, so nothing about its surface moves.

**The OS attributes** on `posthog-js` logs, from `detectOS(navigator.userAgent)`, merged *before* user `resourceAttributes` so a user-supplied value still wins. Either key is omitted rather than emitted empty when it can't be determined, and the path cannot throw out of client construction.

**`os.name` is normalized to one cross-SDK vocabulary.** This is the part worth a look. The raw detected spellings disagree across SDKs for the same OS:

| OS | `detectOS` | posthog-ios | posthog-android | posthog-rn |
|---|---|---|---|---|
| macOS | `Mac OS X` | `macOS` | — | `macos` |
| iOS | `iOS` | `iOS` | — | `ios` |
| Android | `Android` | — | `Android` | `android` |
| Windows | `Windows` | — | — | `windows` |

`detectOS` already agrees with the native SDKs on iOS, Android and watchOS — macOS was the only real disagreement, so `normalizeOsName` maps `Mac OS X` → `macOS`. OpenTelemetry defines `os.name` as the human-readable name, which is what iOS and Android already send; the lowercase identifiers belong to `os.type`, a different attribute.

The table also covers `node:os` `platform()` identifiers (`darwin`, `win32`, …) so `posthog-node` can reuse `osResourceAttributes` without inventing a third spelling. That consumer is #4679 — `feat(node): emit os.name and os.version on spans` — which is the PR this one was split out of, and it is why the `node:os` keys are in the table now rather than bolted on later. Node reaches them through `osResourceAttributes` alone, which is why that is the only symbol exported. React Native is deliberately untouched — its lowercase values are already shipped, so realigning them is a data-migration conversation and shouldn't block this.

### Reviewer notes

- **Behavior preservation was checked by output, not by reading.** The pre-refactor bodies were re-implemented from the base commit and diffed against the new builder across 3,888 combinations: 9 user-attribute shapes (empty, collisions on all five SDK-controlled keys, integer-like keys, prototype-inherited keys, and non-string values including `null`, `undefined`, booleans and numbers) x 6 values for each of `serviceName`/`environment`/`serviceVersion` x 2 SDK name/version pairs — asserting `toEqual`, `Object.keys` order **and** `JSON.stringify` equality. Identical every time. Key order matters because `toOtlpKeyValueList` iterates the object.
- **One new `@posthog/core` export, tagged `@internal`.** `osResourceAttributes` is added to core's entry point because `packages/browser` can only reach core through its published entry points. It appears in `dist/index.d.ts` and carries `@internal Exposed for cross-package use within this SDK; not part of the stable public API.` — the same idiom `createNamedError` already uses. `buildOtlpResourceAttributes` and `normalizeOsName` stay module-internal and are absent from `dist/index.d.ts`. No `posthog-js` public API changes.
- **Browser metrics deliberately don't get the OS attributes** — only logs. No spec covers metrics resource attributes, and widening that is out of scope here.

### Verification

`packages/core`: 56 suites, 1111 pass. `packages/browser`: `posthog-logs` 157 pass (was 156 — one added here asserts `os.*` reaches the emitted payload), `logs-defaults` 17 pass. `eslint` clean on all changed files. `tsc --noEmit` on core reports 37 errors both with and without this change — all pre-existing in unrelated `__tests__` files, none naming a file touched here.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

`@posthog/core` is also bumped (patch); it has no checkbox above.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

Two new resource attributes appear on logs batches from the web SDK — new behavior on an already-shipped payload, hence the minor bump. `os.name` is emitted whenever the user agent can be placed; `os.version` is absent where the user agent does not carry one (Android and desktop Linux). Both keys are overridable and both are omitted when undetectable. Nothing is removed or renamed.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @turnipdabeets.

Split out of #4679 during a pre-PR review pass: that PR sat three deep in a stack behind the traces MVP, but only ~10 of its lines actually needed traces. The `os.name` vocabulary divergence was found by comparing the emitted values against `posthog-ios`, `posthog-android` and `posthog-react-native` source — the original change would have shipped a fourth spelling for macOS.


A later review pass added the two follow-up commits: `normalizeOsName` was un-exported after a rebuild showed it reaching the published `dist/index.d.ts` with no cross-package caller, and the changeset was corrected — it had claimed one `os.name` filter matches every SDK, which `posthog-react-native`'s already-shipped lowercase `ios`/`android` falsifies. That parity gap is left for a separate spec proposal, since realigning it changes a shipped attribute value.


