### PR TITLE
ci: Run replay incident check only for browser changes

### DIFF
--- a/.github/workflows/replay-incident-risk.yml
+++ b/.github/workflows/replay-incident-risk.yml
@@ -15,6 +15,11 @@ jobs:
     uses: ./.github/workflows/check-affected.yml
     with:
       package-name: posthog-js
+      additional-paths: |
+        .agents/skills/replay-incident-risk/
+        .github/workflows/replay-incident-risk.yml
+        .github/workflows/check-affected.yml
+        .github/actions/is-affected/action.yaml
 
   check:
     needs: affected

--- a/.github/workflows/replay-incident-risk.yml
+++ b/.github/workflows/replay-incident-risk.yml
@@ -11,7 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  affected:
+    uses: ./.github/workflows/check-affected.yml
+    with:
+      package-name: posthog-js
+
   check:
+    needs: affected
+    if: needs.affected.outputs.is-affected == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
 


### PR DESCRIPTION
## Problem

The replay incident risk workflow runs for every pull request. Its release workflow rule posts replay warnings on unrelated changes, such as React Native CI updates, even when the browser SDK and its replay dependencies are unaffected.

## Changes

The workflow now uses the existing affected-package check for `posthog-js`. The incident check runs when the browser package or one of its dependencies, including rrweb, is affected.

Changes to the incident checker, risk map, workflow, or shared affected-package gate also run the check so updates to this CI behavior still validate themselves.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using the replay incident risk guidance. The existing Turbo affected-package check was chosen instead of a static browser path list so changes to rrweb dependencies still run the incident check. Explicit CI paths keep the checker and its gate self-validating. The workflow passed `actionlint`, and the risk map validation passed.
