### PR TITLE
fix: sanitize legacy product tour content

### DIFF
--- a/.changeset/calm-tours-sanitize.md
+++ b/.changeset/calm-tours-sanitize.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Sanitize legacy product tour HTML before rendering

--- a/packages/browser/src/__tests__/extensions/product-tours-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/product-tours-utils.test.ts
@@ -1,5 +1,6 @@
 import {
     calculateTooltipPosition,
+    getStepHtml,
     getSpotlightStyle,
     renderTipTapContent,
     normalizeUrl,
@@ -240,6 +241,24 @@ describe('renderTipTapContent', () => {
             ],
         }
         expect(renderTipTapContent(content)).toBe('<p>First paragraph</p><p>Second paragraph</p>')
+    })
+})
+
+describe('getStepHtml', () => {
+    it('sanitizes HTML rendered from legacy TipTap content', () => {
+        const step = {
+            content: {
+                type: 'heading',
+                attrs: { level: '1><img src=x onerror=alert(document.cookie)><h1' },
+                content: [{ type: 'text', text: 'Test' }],
+            },
+        } as ProductTourStep
+
+        const html = getStepHtml(step)
+
+        expect(html).toContain('Test')
+        expect(html).not.toContain('onerror')
+        expect(html).not.toContain('alert')
     })
 })
 

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -351,15 +351,14 @@ export function getStepImageUrls(step: ProductTourStep): string[] {
 }
 
 export function getStepHtml(step: ProductTourStep): string {
-    if (step.contentHtml) {
-        return DOMPurify.sanitize(step.contentHtml, {
-            ADD_TAGS: ['iframe'],
-            ADD_ATTR: ['allowfullscreen', 'frameborder', 'referrerpolicy'],
-        })
-    }
+    // Fall back to rendering legacy TipTap content when pre-rendered HTML is unavailable.
+    // Both paths must be sanitized because TipTap node attributes can contain untrusted values.
+    const html = step.contentHtml || renderTipTapContent(step.content)
 
-    // backwards compat, will be deprecated
-    return renderTipTapContent(step.content)
+    return DOMPurify.sanitize(html, {
+        ADD_TAGS: ['iframe'],
+        ADD_ATTR: ['allowfullscreen', 'frameborder', 'referrerpolicy'],
+    })
 }
 
 export function hasTourWaitPeriodPassed(seenTourWaitPeriod?: ProductTourWaitPeriod): boolean {


### PR DESCRIPTION
## Problem

Legacy product tours can fall back to rendering structured editor content when precomputed HTML is unavailable. That compatibility path did not apply the same sanitization policy as the precomputed HTML path.

## Changes

Render either content source first, then sanitize the result with the existing DOMPurify policy. Adds regression coverage for unsafe values in legacy editor attributes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran pnpm changeset to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app implemented the requested hardening. We retained legacy rendering for compatibility and applied the existing sanitization policy uniformly to both rendering paths. The focused regression test, browser dependency build, and browser lint pass.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0428JHABK2/p1788260272394409?thread_ts=1788260272.394409&cid=C0428JHABK2)*