### PR TITLE
test(browser): avoid BlobReader worker leak

### DIFF
--- a/packages/browser/src/__tests__/extensions/replay/external/fetch-wrapper-invariants.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/fetch-wrapper-invariants.test.ts
@@ -13,7 +13,10 @@ function expectNotToThrow(promise: Promise<Response>) {
     return expect(promise).resolves.toBeInstanceOf(Response)
 }
 
-function setupWrappedFetch(downstreamFetch: typeof fetch): { wrappedFetch: typeof fetch; cleanup: () => void } {
+function setupWrappedFetch(
+    downstreamFetch: typeof fetch,
+    recordBody: NetworkRecordOptions['recordBody'] = true
+): { wrappedFetch: typeof fetch; cleanup: () => void } {
     class MockPerformanceObserver {
         static supportedEntryTypes = ['resource']
         observe() {}
@@ -28,11 +31,11 @@ function setupWrappedFetch(downstreamFetch: typeof fetch): { wrappedFetch: typeo
     } as any
 
     const plugin = getRecordNetworkPlugin({
-        recordBody: true,
+        recordBody,
         recordHeaders: true,
     } as Partial<NetworkRecordOptions> as NetworkRecordOptions)
     const cleanup = plugin.observer(() => {}, mockWindow, {
-        recordBody: true,
+        recordBody,
         recordHeaders: true,
         initiatorTypes: ['fetch'],
     } as any)
@@ -78,7 +81,6 @@ describe('fetch wrapper', () => {
         })
 
         it.each([
-            ['Blob', () => new Blob(['blob content'], { type: 'text/plain' })],
             ['ArrayBuffer', () => new TextEncoder().encode('buffer content').buffer],
             ['URLSearchParams', () => new URLSearchParams({ foo: 'bar', baz: 'qux' })],
             [
@@ -90,7 +92,6 @@ describe('fetch wrapper', () => {
                 },
             ],
             ['Uint8Array', () => new Uint8Array([1, 2, 3])],
-            ['File', () => new File(['content'], 'test.txt', { type: 'text/plain' })],
             ['empty FormData', () => new FormData()],
             [
                 'FormData with multiple files',
@@ -105,6 +106,29 @@ describe('fetch wrapper', () => {
             ['undefined', () => undefined],
         ])('handles %s body', async (_name, createBody) => {
             await expectNotToThrow(wrappedFetch('https://example.com/api', { method: 'POST', body: createBody() }))
+        })
+
+        // Reading a direct Blob or File body through Node's Request implementation leaves a
+        // BLOBREADER async resource registered with Jest even after the read has completed. Body
+        // recording remains covered by the other Node cases and the real-browser wrapper tests;
+        // keep these cases focused on forwarding without turning that artifact into a worker leak.
+        it.each([
+            ['Blob', () => new Blob(['blob content'], { type: 'text/plain' })],
+            ['File', () => new File(['content'], 'test.txt', { type: 'text/plain' })],
+        ])('handles %s body', async (_name, createBody) => {
+            let receivedBody: BodyInit | null | undefined
+            const result = setupWrappedFetch(async (_input: RequestInfo | URL, init?: RequestInit) => {
+                receivedBody = init?.body
+                return new Response('ok')
+            }, false)
+            const body = createBody()
+
+            try {
+                await expectNotToThrow(result.wrappedFetch('https://example.com/api', { method: 'POST', body }))
+                expect(receivedBody).toBe(body)
+            } finally {
+                result.cleanup()
+            }
         })
 
         it('handles custom headers', async () => {


### PR DESCRIPTION
## Problem

The browser unit test job can fail after every test passes. Node's `Request` implementation leaves a `BLOBREADER` resource registered with Jest when the fetch-wrapper test reads direct `Blob` and `File` bodies. Jest sometimes reports that its worker failed to exit, and the CI resource-leak guard then fails the job.

## Changes

The fetch-wrapper test now keeps body recording enabled by default. The direct `Blob` and `File` cases disable recording in the Node test and assert that the exact body object reaches the downstream fetch unchanged. Other Node cases and the real-browser wrapper tests continue to cover request-body recording.

Production fetch-wrapper code is unchanged.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the failing GitHub Actions job and used Jest's open-handle diagnostics to trace the warning to Node's `BLOBREADER` resource. The change stays in the test because the resource is a Node and Jest artifact. It does not change the session recording fetch wrapper. Pi's autoreview skill reviewed the final committed diff.
