### PR TITLE
ci: Run bundle size checks only for browser changes

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -7,7 +7,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  affected_posthog_js:
+    uses: ./.github/workflows/check-affected.yml
+    with:
+      package-name: posthog-js
+      additional-paths: |
+        .github/workflows/bundled-size.yaml
+        .github/workflows/check-affected.yml
+        .github/actions/is-affected/action.yaml
+
+  affected_browser:
+    uses: ./.github/workflows/check-affected.yml
+    with:
+      package-name: "@posthog/browser"
+      additional-paths: |
+        .github/workflows/bundled-size.yaml
+        .github/workflows/check-affected.yml
+        .github/actions/is-affected/action.yaml
+
   build:
+    needs: [affected_posthog_js, affected_browser]
+    if: needs.affected_posthog_js.outputs.is-affected == 'true' || needs.affected_browser.outputs.is-affected == 'true'
     runs-on: ubuntu-22.04
 
     permissions:

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -2,6 +2,9 @@ name: Bundled Size
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Problem

The bundled size workflow builds the full monorepo for every pull request, including changes that cannot affect either browser package. This wastes CI time and allows unrelated package build failures to fail the bundle size check.

## Changes

The workflow now checks whether `posthog-js` or `@posthog/browser` is affected before running the bundle size build. Changes to either package or its dependencies run the check.

Changes to the bundle size workflow, reusable affected-package workflow, or affected-package action also run the check so CI updates validate themselves.

The workflow defaults to `contents: read`. The build job keeps the write permissions required to post bundle size comments.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi. The existing Turbo affected-package workflow was reused so changes to dependencies of either browser package still run the bundle size check. The workflow passed `actionlint`, and representative Turbo queries confirmed that React Native-only changes skip the build while changes to either browser package run it.
