### PR TITLE
fix(core): skip OTLP attributes with an empty key

### DIFF
--- a/.changeset/otlp-skip-empty-attribute-keys.md
+++ b/.changeset/otlp-skip-empty-attribute-keys.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Drop attributes with an empty key from exported logs and metrics instead of sending them. OTLP requires a non-empty key, and the server stored one verbatim, where it appeared as a nameless attribute that filters could not match.

--- a/packages/core/src/utils/otlp-any-value.spec.ts
+++ b/packages/core/src/utils/otlp-any-value.spec.ts
@@ -357,5 +357,20 @@ describe('otlp-any-value', () => {
         })
       ).toEqual([{ key: 'kept', value: { stringValue: 'yes' } }])
     })
+
+    it('skips an empty key, which OTLP does not allow', () => {
+      expect(toOtlpKeyValueList({ '': 'nameless', kept: 'yes' })).toEqual([
+        { key: 'kept', value: { stringValue: 'yes' } },
+      ])
+    })
+
+    it('skips an empty key nested inside a value', () => {
+      expect(toOtlpKeyValueList({ outer: { '': 'nameless', kept: 'yes' } })).toEqual([
+        {
+          key: 'outer',
+          value: { kvlistValue: { values: [{ key: 'kept', value: { stringValue: 'yes' } }] } },
+        },
+      ])
+    })
   })
 })

--- a/packages/core/src/utils/otlp-any-value.ts
+++ b/packages/core/src/utils/otlp-any-value.ts
@@ -204,6 +204,12 @@ function encodeKeyValueList(
     if (!propertyIsEnumerable.call(attrs, key)) {
       continue
     }
+    if (!key) {
+      // OTLP requires a non-empty key. The server stores one verbatim, where it
+      // shows up as a nameless attribute nothing can filter on.
+      logger?.debug('Dropping an attribute with an empty key')
+      continue
+    }
     if (result.length >= MAX_JSON_SAFE_VALUE_ITEMS || state.remainingNodes <= 0) {
       // Reported rather than written into the attributes: a synthetic key would
       // land in the user's own namespace and could collide with a real one.


### PR DESCRIPTION
## Problem

An attribute whose key is the empty string ships to OTLP as `{ "key": "" }`. The OTel spec requires a non-empty key, and the ingestion service stores it verbatim, so it lands in the product as a nameless attribute that no filter can match — the value is there but unreachable.

Raised by @jonmcwest reviewing #4579. It is not specific to spans: logs, metrics and (once #4579 lands) traces all encode their attributes through the same `toOtlpKeyValueList`, so the hole is already shipped in the logs and metrics pipelines today. That is why this branches off `main` rather than off the traces stack.

## Changes

`encodeKeyValueList` skips an entry whose key is empty, with a debug log, in the same place it already skips non-enumerable keys and nullish values. Nested keys inside a `kvlistValue` go through the same function, so an empty key one level down is dropped too.

Two tests: a top-level empty key, and one nested inside an object value.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

`@posthog/core` is bumped (patch); it has no checkbox above. Every SDK that sends logs or metrics picks it up.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

An empty-keyed attribute was unusable in the product, so dropping it removes no working behaviour.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @turnipdabeets, from review feedback on #4579.

The fix deliberately lives in the shared encoder rather than in the traces encoder: all three signals produce their attributes there, and fixing it once means logs and metrics — both already shipped — stop emitting nameless attributes as well.

`packages/core` 1113 pass (56 suites), lint clean.
