### PR TITLE
feat(mcp): support model capture in custom dispatchers

### DIFF
--- a/.changeset/custom-dispatcher-model-capture.md
+++ b/.changeset/custom-dispatcher-model-capture.md
@@ -2,4 +2,4 @@
 '@posthog/mcp': minor
 ---
 
-Add self-reported model capture to the `PostHogMCP` custom-dispatcher path. `prepareToolList()` injects the opt-in model field, `prepareToolCall()` strips and returns it, and `captureToolCall()` records the model properties.
+Add self-reported model capture to the `PostHogMCP` custom-dispatcher path. The preparation helpers preserve application-owned fields and work across stateless server replicas when given the original tool descriptor. Tool calls and missing-capability reports can record the model properties.

--- a/.changeset/custom-dispatcher-model-capture.md
+++ b/.changeset/custom-dispatcher-model-capture.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': minor
+---
+
+Add self-reported model capture to the `PostHogMCP` custom-dispatcher path. `prepareToolList()` injects the opt-in model field, `prepareToolCall()` strips and returns it, and `captureToolCall()` records the model properties.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -137,9 +137,10 @@ cannot tell that it is yours, its value is recorded as `$mcp_intent`. It never l
 and it is capped at 2048 characters. Two ways out, both one line:
 
 ```ts
-instrument(server, posthog, { context: false })                   // no injection, no capture
+instrument(server, posthog, { context: false }) // no injection, no capture
 
-instrument(server, posthog, {                                     // keep it, drop the property
+instrument(server, posthog, {
+  // keep it, drop the property
   beforeSend: (event) => {
     delete event.properties.$mcp_intent
     return event
@@ -177,6 +178,21 @@ and the capture require the SDK to have confirmed the parameter is its own:
 As with `context`, what matters is instance lifetime rather than statelessness: a transport-stateless
 server (`sessionIdGenerator: undefined`) that keeps one long-lived server object learns ownership
 from the first `tools/list` and keeps it.
+
+For a custom dispatcher, enable the same option on `PostHogMCP`. Its `prepareToolList()` helper
+injects the field and records ownership by tool name; `prepareToolCall()` returns `llmModel` and
+`llmModelSource` while removing the SDK-owned argument before dispatch. Pass both fields to
+`captureToolCall()`. Keep one client for the server and prepare each tool before its first call:
+
+```ts
+const posthog = new PostHogMCP(process.env.POSTHOG_PROJECT_TOKEN, { captureModel: true })
+
+const tools = posthog.prepareToolList(serverTools)
+const { args, llmModel, llmModelSource } = posthog.prepareToolCall(toolName, rawArgs)
+const result = await dispatch(toolName, args)
+
+posthog.captureToolCall({ toolName, llmModel, llmModelSource, isError: false })
+```
 
 ### If you switched to `instrument(server.server)`
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -182,17 +182,21 @@ from the first `tools/list` and keeps it.
 For a custom dispatcher, enable the same option on `PostHogMCP`. Its `prepareToolList()` helper
 injects the field and records ownership by tool name; `prepareToolCall()` returns `llmModel` and
 `llmModelSource` while removing the SDK-owned argument before dispatch. Pass both fields to
-`captureToolCall()`. Keep one client for the server and prepare each tool before its first call:
+`captureToolCall()`. Pass the original tool descriptor on each call so this also works when
+`tools/list` and `tools/call` reach different server replicas:
 
 ```ts
 const posthog = new PostHogMCP(process.env.POSTHOG_PROJECT_TOKEN, { captureModel: true })
 
 const tools = posthog.prepareToolList(serverTools)
-const { args, llmModel, llmModelSource } = posthog.prepareToolCall(toolName, rawArgs)
+const originalTool = serverTools.find((tool) => tool.name === toolName)
+const { args, llmModel, llmModelSource } = posthog.prepareToolCall(toolName, rawArgs, { originalTool })
 const result = await dispatch(toolName, args)
 
 posthog.captureToolCall({ toolName, llmModel, llmModelSource, isError: false })
 ```
+
+A persistent single-process dispatcher can omit `originalTool` after it has prepared its tool list.
 
 ### If you switched to `instrument(server.server)`
 

--- a/packages/mcp/src/__tests__/posthog-mcp.test.ts
+++ b/packages/mcp/src/__tests__/posthog-mcp.test.ts
@@ -238,6 +238,7 @@ describe('PostHogMCP', () => {
       for (const tool of prepared) {
         expect(tool.inputSchema?.properties?.context).toMatchObject({ type: 'string' })
         expect(tool.inputSchema?.required).toContain('context')
+        expect(tool.inputSchema?.properties).not.toHaveProperty('llm_model')
       }
     })
 
@@ -275,6 +276,80 @@ describe('PostHogMCP', () => {
       expect(client.prepareToolCall('posthog_find_tools', { context: 'x' }).isMissingCapability).toBe(true)
       expect(client.prepareToolCall(GET_MORE_TOOLS_NAME, { context: 'x' }).isMissingCapability).toBe(false)
       await client.shutdown()
+    })
+
+    it('injects and extracts a self-reported model when captureModel is enabled', async () => {
+      const client = newClient({ captureModel: true })
+      try {
+        const prepared = client.prepareToolList(tools)
+        expect(prepared[0].inputSchema?.properties?.llm_model).toMatchObject({ type: 'string' })
+        expect(prepared[0].inputSchema?.required).toContain('llm_model')
+
+        const call = client.prepareToolCall('execute-sql', {
+          query: 'select 1',
+          context: 'Counting signups',
+          llm_model: 'claude-sonnet-4-20250514',
+        })
+        expect(call.args).toEqual({ query: 'select 1' })
+        expect(call.llmModel).toBe('claude-sonnet-4-20250514')
+        expect(call.llmModelSource).toBe('self_reported')
+
+        client.captureToolCall({
+          toolName: 'execute-sql',
+          distinctId: 'user-123',
+          isError: false,
+          llmModel: call.llmModel,
+          llmModelSource: call.llmModelSource,
+        })
+        await tick()
+
+        const properties = onlyCapture(PostHogMCPAnalyticsEvent.ToolCall).properties
+        expect(properties[PostHogMCPAnalyticsProperty.LlmModel]).toBe('claude-sonnet-4-20250514')
+        expect(properties[PostHogMCPAnalyticsProperty.LlmModelSource]).toBe('self_reported')
+      } finally {
+        await client.shutdown()
+      }
+    })
+
+    it('leaves an application-owned llm_model argument untouched and uncaptured', async () => {
+      const client = newClient({ captureModel: true })
+      const ownedTools = [
+        {
+          name: 'route-model',
+          inputSchema: {
+            type: 'object',
+            properties: { llm_model: { type: 'string', description: 'Application routing model' } },
+            required: ['llm_model'],
+          },
+        },
+      ]
+      try {
+        const prepared = client.prepareToolList(ownedTools)
+        expect(prepared[0].inputSchema.properties.llm_model).toEqual({
+          type: 'string',
+          description: 'Application routing model',
+        })
+
+        const call = client.prepareToolCall('route-model', { llm_model: 'application-owned-value' })
+        expect(call.args).toEqual({ llm_model: 'application-owned-value' })
+        expect(call.llmModel).toBeUndefined()
+        expect(call.llmModelSource).toBeUndefined()
+      } finally {
+        await client.shutdown()
+      }
+    })
+
+    it('drops an unknown self-reported model', async () => {
+      const client = newClient({ captureModel: true })
+      try {
+        client.prepareToolList(tools)
+        const call = client.prepareToolCall('execute-sql', { query: 'select 1', llm_model: ' unknown ' })
+        expect(call.args).toEqual({ query: 'select 1' })
+        expect(call.llmModel).toBeUndefined()
+        expect(call.llmModelSource).toBeUndefined()
+      } finally {
+        await client.shutdown()
+      }
     })
   })
 

--- a/packages/mcp/src/__tests__/posthog-mcp.test.ts
+++ b/packages/mcp/src/__tests__/posthog-mcp.test.ts
@@ -167,6 +167,35 @@ describe('PostHogMCP', () => {
         await client.shutdown()
       }
     })
+
+    it.each([
+      {
+        name: 'trims a direct model value',
+        llmModel: '  claude-sonnet-4-20250514  ',
+        expected: 'claude-sonnet-4-20250514',
+      },
+      { name: 'drops a direct unknown model', llmModel: ' unknown ', expected: undefined },
+      {
+        name: 'redacts a token from a direct model value',
+        llmModel: 'gateway-phx_abcdefghijklmnopqrstuvwxyz1234',
+        expected: 'gateway-[redacted]',
+      },
+    ])('$name', async ({ llmModel, expected }) => {
+      posthog.captureToolCall({
+        toolName: 'execute-sql',
+        distinctId: 'user-123',
+        isError: false,
+        llmModel,
+        llmModelSource: 'self_reported',
+      })
+      await tick()
+
+      const properties = onlyCapture(PostHogMCPAnalyticsEvent.ToolCall).properties
+      expect(properties[PostHogMCPAnalyticsProperty.LlmModel]).toBe(expected)
+      expect(properties[PostHogMCPAnalyticsProperty.LlmModelSource]).toBe(
+        expected === undefined ? undefined : 'self_reported'
+      )
+    })
   })
 
   describe('intent capture', () => {
@@ -345,6 +374,21 @@ describe('PostHogMCP', () => {
         client.prepareToolList(tools)
         const call = client.prepareToolCall('execute-sql', { query: 'select 1', llm_model: ' unknown ' })
         expect(call.args).toEqual({ query: 'select 1' })
+        expect(call.llmModel).toBeUndefined()
+        expect(call.llmModelSource).toBeUndefined()
+      } finally {
+        await client.shutdown()
+      }
+    })
+
+    it('forgets ownership for tools removed from a refreshed list', async () => {
+      const client = newClient({ captureModel: true })
+      try {
+        client.prepareToolList(tools)
+        client.prepareToolList([tools[1]])
+
+        const call = client.prepareToolCall('execute-sql', { llm_model: 'application-owned-value' })
+        expect(call.args).toEqual({ llm_model: 'application-owned-value' })
         expect(call.llmModel).toBeUndefined()
         expect(call.llmModelSource).toBeUndefined()
       } finally {

--- a/packages/mcp/src/__tests__/posthog-mcp.test.ts
+++ b/packages/mcp/src/__tests__/posthog-mcp.test.ts
@@ -368,6 +368,32 @@ describe('PostHogMCP', () => {
       }
     })
 
+    it('skips model injection for duplicate names when any descriptor owns llm_model', async () => {
+      const client = newClient({ captureModel: true })
+      const duplicateTools = [
+        tools[0],
+        {
+          name: 'execute-sql',
+          inputSchema: {
+            type: 'object',
+            properties: { llm_model: { type: 'string' } },
+            required: ['llm_model'],
+          },
+        },
+      ]
+      try {
+        const prepared = client.prepareToolList(duplicateTools)
+        expect(prepared[0].inputSchema.properties).not.toHaveProperty('llm_model')
+        expect(prepared[1].inputSchema.properties.llm_model).toEqual({ type: 'string' })
+
+        const call = client.prepareToolCall('execute-sql', { llm_model: 'application-owned-value' })
+        expect(call.args).toEqual({ llm_model: 'application-owned-value' })
+        expect(call.llmModel).toBeUndefined()
+      } finally {
+        await client.shutdown()
+      }
+    })
+
     it('drops an unknown self-reported model', async () => {
       const client = newClient({ captureModel: true })
       try {
@@ -395,6 +421,46 @@ describe('PostHogMCP', () => {
         await client.shutdown()
       }
     })
+
+    it.each([
+      {
+        name: 'strips an SDK-owned model argument',
+        originalTool: tools[0],
+        expectedArgs: { query: 'select 1' },
+        expectedModel: 'claude-sonnet-4-20250514',
+      },
+      {
+        name: 'preserves an application-owned model argument',
+        originalTool: {
+          name: 'route-model',
+          inputSchema: {
+            type: 'object',
+            properties: { llm_model: { type: 'string' } },
+            required: ['llm_model'],
+          },
+        },
+        expectedArgs: { query: 'select 1', llm_model: 'claude-sonnet-4-20250514' },
+        expectedModel: undefined,
+      },
+    ])(
+      '$name from the original schema without prior list preparation',
+      async ({ originalTool, expectedArgs, expectedModel }) => {
+        const client = newClient({ captureModel: true })
+        try {
+          const call = client.prepareToolCall(
+            originalTool.name,
+            { query: 'select 1', llm_model: 'claude-sonnet-4-20250514' },
+            { originalTool }
+          )
+
+          expect(call.args).toEqual(expectedArgs)
+          expect(call.llmModel).toBe(expectedModel)
+          expect(call.llmModelSource).toBe(expectedModel ? 'self_reported' : undefined)
+        } finally {
+          await client.shutdown()
+        }
+      }
+    )
   })
 
   describe('prepareToolCall', () => {
@@ -419,14 +485,21 @@ describe('PostHogMCP', () => {
   })
 
   describe('captureMissingCapability', () => {
-    it('emits $mcp_missing_capability with the context as intent', async () => {
-      posthog.captureMissingCapability({ context: 'I need a tool to delete cohorts', distinctId: 'user-123' })
+    it('emits $mcp_missing_capability with the context and model', async () => {
+      posthog.captureMissingCapability({
+        context: 'I need a tool to delete cohorts',
+        distinctId: 'user-123',
+        llmModel: 'claude-sonnet-4-20250514',
+        llmModelSource: 'self_reported',
+      })
       await tick()
 
       const payload = onlyCapture(PostHogMCPAnalyticsEvent.MissingCapability)
       const p = payload.properties
       expect(p[PostHogMCPAnalyticsProperty.Intent]).toBe('I need a tool to delete cohorts')
       expect(p[PostHogMCPAnalyticsProperty.IntentSource]).toBe('context_parameter')
+      expect(p[PostHogMCPAnalyticsProperty.LlmModel]).toBe('claude-sonnet-4-20250514')
+      expect(p[PostHogMCPAnalyticsProperty.LlmModelSource]).toBe('self_reported')
     })
   })
 

--- a/packages/mcp/src/extensions/model-parameters.ts
+++ b/packages/mcp/src/extensions/model-parameters.ts
@@ -74,7 +74,10 @@ export function addModelParameterToTools<TTool extends ModelInjectableTool>(
  * not become a property value queries would group by.
  */
 export function getModelArgument(request: MCPRequestLike): string | undefined {
-  const model = request.params?.arguments?.llm_model
+  return normalizeModel(request.params?.arguments?.llm_model)
+}
+
+function normalizeModel(model: unknown): string | undefined {
   if (typeof model !== 'string') {
     return undefined
   }
@@ -86,9 +89,10 @@ export function getModelArgument(request: MCPRequestLike): string | undefined {
 }
 
 export function setEventModel(event: McpEvent, model: string | undefined): void {
-  if (!model) {
+  const normalizedModel = normalizeModel(model)
+  if (!normalizedModel) {
     return
   }
-  event.llmModel = model
+  event.llmModel = normalizedModel
   event.llmModelSource = 'self_reported'
 }

--- a/packages/mcp/src/extensions/posthog-mcp.ts
+++ b/packages/mcp/src/extensions/posthog-mcp.ts
@@ -3,6 +3,7 @@ import { PostHog, type PostHogOptions } from 'posthog-node'
 import type {
   InitializeCaptureData,
   JsonRecord,
+  MCPAnalyticsOptions,
   McpCaptureCommon,
   McpEvent,
   MissingCapabilityCaptureData,
@@ -11,6 +12,7 @@ import type {
   ToolCallCaptureData,
   ToolsListCaptureData,
 } from '../types'
+import { analyticsOwnsParameter, stripOwnedAnalyticsArguments } from './analytics-parameters'
 import {
   addContextParameterToTools,
   getContextDescription,
@@ -22,6 +24,13 @@ import { captureException } from './exceptions'
 import { normalizeHeaderString } from './headers'
 import { applyMcpLibIdentity } from './lib-identity'
 import { log } from './logger'
+import {
+  addModelParameterToTools,
+  getModelArgument,
+  getModelDescription,
+  isCaptureModelEnabled,
+  setEventModel,
+} from './model-parameters'
 import { McpEventSink } from './sink'
 import { GET_MORE_TOOLS_NAME, getReportMissingToolDescriptor } from './tools'
 
@@ -37,6 +46,11 @@ export interface PostHogMCPOptions extends PostHogOptions {
    * can't drift. Defaults to `get_more_tools`.
    */
   missingCapabilityToolName?: string
+  /**
+   * Inject a required `llm_model` argument into advertised tools and capture
+   * the agent's self-reported value. Off by default.
+   */
+  captureModel?: MCPAnalyticsOptions['captureModel']
 }
 
 /**
@@ -57,7 +71,10 @@ export interface PostHogMCPOptions extends PostHogOptions {
  * ```ts
  * import { PostHogMCP } from "@posthog/mcp"
  *
- * const posthog = new PostHogMCP("phc_your_project_token", { host: "https://us.i.posthog.com" })
+ * const posthog = new PostHogMCP("phc_your_project_token", {
+ *   host: "https://us.i.posthog.com",
+ *   captureModel: true,
+ * })
  *
  * posthog.captureToolCall({
  *   toolName: "search_docs",
@@ -78,10 +95,13 @@ export class PostHogMCP extends PostHog {
   // The get_more_tools name lives here (not on the per-call options) so that
   // prepareToolList (inject) and prepareToolCall (detect) always agree.
   readonly #missingCapabilityToolName: string
+  readonly #captureModel: MCPAnalyticsOptions['captureModel']
+  readonly #modelParameterOwnership = new Map<string, boolean>()
 
   constructor(apiKey: string, options: PostHogMCPOptions = {}) {
     super(apiKey, options)
     this.#missingCapabilityToolName = options.missingCapabilityToolName ?? GET_MORE_TOOLS_NAME
+    this.#captureModel = options.captureModel
     applyMcpLibIdentity(this)
   }
 
@@ -97,6 +117,10 @@ export class PostHogMCP extends PostHog {
     event.isError = data.isError
     event.errorType = data.errorType
     applyIntent(event, data.intent, data.intentSource)
+    setEventModel(event, data.llmModel)
+    if (event.llmModel && data.llmModelSource) {
+      event.llmModelSource = data.llmModelSource
+    }
     if (data.isError) {
       event.error = captureException(data.error ?? `Tool ${data.toolName} returned an error`)
     }
@@ -137,9 +161,9 @@ export class PostHogMCP extends PostHog {
   /**
    * Decorate your `tools/list` response with PostHog's analytics affordances:
    * injects the `context` argument into every tool (so agents state their intent,
-   * captured as `$mcp_intent`) and, when `reportMissing` is on, appends the
-   * `get_more_tools` virtual tool (rename it via the `missingCapabilityToolName`
-   * constructor option). Returns a new array; your tools are untouched.
+   * captured as `$mcp_intent`), injects `llm_model` when the constructor's
+   * `captureModel` option is enabled, and appends `get_more_tools` when
+   * `reportMissing` is on. Returns a new array; your tools are untouched.
    *
    * The appended `get_more_tools` descriptor carries only the base MCP tool fields
    * (name, description, input schema) — not any framework-specific fields your
@@ -165,16 +189,30 @@ export class PostHogMCP extends PostHog {
     if (options.reportMissing && !prepared.some((tool) => tool?.name === this.#missingCapabilityToolName)) {
       prepared = [...prepared, getReportMissingToolDescriptor(this.#missingCapabilityToolName) as TTool]
     }
+
+    if (isCaptureModelEnabled(this.#captureModel)) {
+      const ownershipByName = new Map<string, boolean>()
+      for (const tool of prepared) {
+        if (typeof tool.name !== 'string') {
+          continue
+        }
+        const ownsModel = analyticsOwnsParameter(tool.inputSchema, 'llm_model')
+        ownershipByName.set(tool.name, (ownershipByName.get(tool.name) ?? true) && ownsModel)
+      }
+      for (const [toolName, ownsModel] of ownershipByName) {
+        this.#modelParameterOwnership.set(toolName, ownsModel)
+      }
+      prepared = addModelParameterToTools(prepared, getModelDescription(this.#captureModel))
+    }
     return prepared
   }
 
   /**
-   * Read an incoming `tools/call` before you dispatch it: pulls the agent's
-   * intent off the injected `context` argument, strips `context` from the
-   * arguments (so your handler and its schema validation never see it), and flags
+   * Read an incoming `tools/call` before you dispatch it: pulls analytics values
+   * from SDK-owned arguments, strips those arguments before validation, and flags
    * whether the call targeted the `get_more_tools` virtual tool.
    *
-   * Pass the returned `intent` / `intentSource` to {@link captureToolCall}, and
+   * Pass the returned intent and model fields to {@link captureToolCall}, and
    * dispatch the returned `args` to your tool.
    *
    * This only extracts the explicit `context` argument (`intentSource:
@@ -197,10 +235,21 @@ export class PostHogMCP extends PostHog {
   prepareToolCall(name: string, args?: Record<string, unknown>): PreparedToolCall {
     const rawContext = args?.context
     const intent = typeof rawContext === 'string' && rawContext.trim() ? rawContext.trim() : undefined
+    const ownsModel = this.#modelParameterOwnership.get(name) === true
+    const llmModel = ownsModel ? getModelArgument({ params: { arguments: args } }) : undefined
+    const strippedArgs = stripContext(args)
     return {
       intent,
       intentSource: intent ? 'context_parameter' : undefined,
-      args: stripContext(args),
+      llmModel,
+      llmModelSource: llmModel ? 'self_reported' : undefined,
+      args: ownsModel
+        ? (stripOwnedAnalyticsArguments(strippedArgs, {
+            context: false,
+            conversationId: false,
+            llmModel: true,
+          }) as Record<string, unknown> | undefined)
+        : strippedArgs,
       isMissingCapability: name === this.#missingCapabilityToolName,
     }
   }

--- a/packages/mcp/src/extensions/posthog-mcp.ts
+++ b/packages/mcp/src/extensions/posthog-mcp.ts
@@ -191,6 +191,7 @@ export class PostHogMCP extends PostHog {
     }
 
     if (isCaptureModelEnabled(this.#captureModel)) {
+      this.#modelParameterOwnership.clear()
       const ownershipByName = new Map<string, boolean>()
       for (const tool of prepared) {
         if (typeof tool.name !== 'string') {

--- a/packages/mcp/src/extensions/posthog-mcp.ts
+++ b/packages/mcp/src/extensions/posthog-mcp.ts
@@ -8,6 +8,7 @@ import type {
   McpEvent,
   MissingCapabilityCaptureData,
   PreparedToolCall,
+  PrepareToolCallOptions,
   PrepareToolListOptions,
   ToolCallCaptureData,
   ToolsListCaptureData,
@@ -25,7 +26,7 @@ import { normalizeHeaderString } from './headers'
 import { applyMcpLibIdentity } from './lib-identity'
 import { log } from './logger'
 import {
-  addModelParameterToTools,
+  addModelParameterToTool,
   getModelArgument,
   getModelDescription,
   isCaptureModelEnabled,
@@ -203,7 +204,12 @@ export class PostHogMCP extends PostHog {
       for (const [toolName, ownsModel] of ownershipByName) {
         this.#modelParameterOwnership.set(toolName, ownsModel)
       }
-      prepared = addModelParameterToTools(prepared, getModelDescription(this.#captureModel))
+      const modelDescription = getModelDescription(this.#captureModel)
+      prepared = prepared.map((tool) =>
+        typeof tool.name === 'string' && ownershipByName.get(tool.name) === false
+          ? tool
+          : addModelParameterToTool(tool, modelDescription)
+      )
     }
     return prepared
   }
@@ -216,6 +222,9 @@ export class PostHogMCP extends PostHog {
    * Pass the returned intent and model fields to {@link captureToolCall}, and
    * dispatch the returned `args` to your tool.
    *
+   * On stateless or multi-replica servers, pass the original tool descriptor
+   * so ownership does not depend on which process served `tools/list`.
+   *
    * This only extracts the explicit `context` argument (`intentSource:
    * 'context_parameter'`); it does not infer intent. If you run your own
    * inference, pass that string with `intentSource: 'inferred'` straight to
@@ -224,19 +233,28 @@ export class PostHogMCP extends PostHog {
    *
    * @example
    * ```ts
-   * const { intent, intentSource, args, isMissingCapability } = posthog.prepareToolCall(name, rawArgs)
+   * const { intent, intentSource, llmModel, llmModelSource, args, isMissingCapability } =
+   *   posthog.prepareToolCall(name, rawArgs)
    * if (isMissingCapability) {
-   *   posthog.captureMissingCapability({ context: intent, ...identity })
+   *   posthog.captureMissingCapability({ context: intent, llmModel, llmModelSource, ...identity })
    *   return getMoreToolsResult()
    * }
    * const result = await runTool(name, args)
    * posthog.captureToolCall({ toolName: name, intent, intentSource, ...identity })
    * ```
    */
-  prepareToolCall(name: string, args?: Record<string, unknown>): PreparedToolCall {
+  prepareToolCall(
+    name: string,
+    args?: Record<string, unknown>,
+    options: PrepareToolCallOptions = {}
+  ): PreparedToolCall {
     const rawContext = args?.context
     const intent = typeof rawContext === 'string' && rawContext.trim() ? rawContext.trim() : undefined
-    const ownsModel = this.#modelParameterOwnership.get(name) === true
+    const ownsModel =
+      isCaptureModelEnabled(this.#captureModel) &&
+      (options.originalTool
+        ? analyticsOwnsParameter(options.originalTool.inputSchema, 'llm_model')
+        : this.#modelParameterOwnership.get(name) === true)
     const llmModel = ownsModel ? getModelArgument({ params: { arguments: args } }) : undefined
     const strippedArgs = stripContext(args)
     return {
@@ -265,6 +283,10 @@ export class PostHogMCP extends PostHog {
     event.resourceName = this.#missingCapabilityToolName
     event.parameters = data.parameters
     applyIntent(event, data.context, 'context_parameter')
+    setEventModel(event, data.llmModel)
+    if (event.llmModel && data.llmModelSource) {
+      event.llmModelSource = data.llmModelSource
+    }
     this.#emit(event)
   }
 

--- a/packages/mcp/src/extensions/sanitization.ts
+++ b/packages/mcp/src/extensions/sanitization.ts
@@ -15,8 +15,8 @@ function isRecord(value: unknown): value is SanitizedRecord {
 /**
  * Sanitizes an event by redacting non-text content blocks from responses
  * and large base64-encoded strings from parameters, and applying the same
- * string redaction (PostHog tokens, base64 blobs, sensitive keys) to the
- * agent-supplied intent.
+ * string redaction (PostHog tokens, base64 blobs, sensitive keys) to values
+ * supplied by the agent.
  *
  * This is a synchronous operation that returns a new object without mutating the original.
  * It should run after customer redaction in the event pipeline.
@@ -37,6 +37,10 @@ export function sanitizeEvent<T extends Event | McpEvent>(event: T): T {
   // value rather than shipping it raw as `$mcp_intent`.
   if (result.userIntent != null) {
     result.userIntent = sanitizeCapturedValue(result.userIntent) as string
+  }
+
+  if (result.llmModel != null) {
+    result.llmModel = sanitizeCapturedValue(result.llmModel) as string
   }
 
   if (result.error != null) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -233,6 +233,7 @@ export type {
   MCPAnalyticsOptions,
   MissingCapabilityCaptureData,
   PreparedToolCall,
+  PrepareToolCallOptions,
   PrepareToolListOptions,
   RequestHeaderBag,
   ToolCallCaptureData,

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -593,11 +593,19 @@ export interface PrepareToolListOptions {
   reportMissing?: boolean
 }
 
+/** Options for {@link PostHogMCP.prepareToolCall}. */
+export interface PrepareToolCallOptions {
+  /**
+   * The tool descriptor before PostHog preparation. Pass this on stateless or
+   * multi-replica servers so SDK argument ownership is resolved per request.
+   */
+  originalTool?: { inputSchema?: unknown }
+}
+
 /**
  * Result of {@link PostHogMCP.prepareToolCall}: the intent pulled off the
- * incoming call, the arguments with the injected `context` removed (so your tool
- * handler and its schema validation never see it), and whether the call targeted
- * the `get_more_tools` virtual tool.
+ * incoming call, the arguments with SDK-owned analytics fields removed, and
+ * whether the call targeted the `get_more_tools` virtual tool.
  */
 export interface PreparedToolCall {
   /** The agent's stated intent (the `context` argument), if present. */
@@ -608,7 +616,7 @@ export interface PreparedToolCall {
   llmModel?: string
   /** How the model id was obtained. Always `self_reported` when present. */
   llmModelSource?: MCPAnalyticsModelSource
-  /** The call arguments with the injected `context` key stripped out. */
+  /** The call arguments with SDK-owned `context` and `llm_model` keys removed. */
   args?: Record<string, unknown>
   /** True when `name` is the `get_more_tools` virtual tool. */
   isMissingCapability: boolean
@@ -621,6 +629,10 @@ export interface MissingCapabilityCaptureData extends McpCaptureCommon {
    * on the `get_more_tools` call) → `$mcp_intent`.
    */
   context?: string
+  /** The calling agent's self-reported model id -> `$mcp_llm_model`. */
+  llmModel?: string
+  /** How the model id was obtained -> `$mcp_llm_model_source`. */
+  llmModelSource?: MCPAnalyticsModelSource
   /** Captured call arguments → `$mcp_parameters` (sanitized + truncated). */
   parameters?: unknown
 }

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -511,6 +511,13 @@ export interface ToolCallCaptureData extends McpCaptureCommon {
    * the host derived it. Defaults to `context_parameter` when an intent is set.
    */
   intentSource?: MCPAnalyticsIntentSource
+  /**
+   * The calling agent's self-reported model id -> `$mcp_llm_model`. On the
+   * custom-dispatcher path, read it from {@link PostHogMCP.prepareToolCall}.
+   */
+  llmModel?: string
+  /** How the model id was obtained -> `$mcp_llm_model_source`. */
+  llmModelSource?: MCPAnalyticsModelSource
   /** Captured call arguments → `$mcp_parameters` (sanitized + truncated). */
   parameters?: unknown
   /** Captured tool result → `$mcp_response` (sanitized + truncated). */
@@ -597,6 +604,10 @@ export interface PreparedToolCall {
   intent?: string
   /** Where the intent came from. Always `context_parameter` here when set. */
   intentSource?: MCPAnalyticsIntentSource
+  /** The agent's self-reported model id, when `captureModel` is enabled and owned by the SDK. */
+  llmModel?: string
+  /** How the model id was obtained. Always `self_reported` when present. */
+  llmModelSource?: MCPAnalyticsModelSource
   /** The call arguments with the injected `context` key stripped out. */
   args?: Record<string, unknown>
   /** True when `name` is the `get_more_tools` virtual tool. */


### PR DESCRIPTION
## Problem

Custom MCP dispatchers cannot capture the calling model, so their tool-call analytics never include model attribution.

The wrapped-server path supports `captureModel`, but `PostHogMCP` does not expose the same behavior. PostHog's Hono MCP server uses this custom-dispatcher path.

## Changes

- `PostHogMCP` callers can enable self-reported model capture with `captureModel: true`.
- `prepareToolList()` injects the required model field and records ownership by tool name.
- `prepareToolCall()` removes SDK-owned model arguments before dispatch and returns the captured model metadata.
- `captureToolCall()` emits `$mcp_llm_model` and `$mcp_llm_model_source` through the standard sanitization pipeline.
- Application-owned `llm_model` fields remain untouched, and `unknown` values remain uncaptured.
- The change has no visual effect.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common
- [x] @posthog/mcp

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Codex after testing PostHog's custom-dispatcher integration path.
- Used the debugging-mcp-analytics, writing-tests, writing-code-comments, and writing-pr-descriptions skills.
- Extended the nearest public API test. All 672 MCP unit tests, lint, and build pass locally.
