### PR TITLE
fix(ai): only capture terminal Responses statuses as stop reasons

### DIFF
--- a/.changeset/responses-terminal-stop-reason.md
+++ b/.changeset/responses-terminal-stop-reason.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Only terminal Responses API statuses become `$ai_stop_reason` (a queued or in-progress background run no longer records a lifecycle state as its stop reason), and the native OpenAI wrapper now names a truncated run by `incomplete_details.reason` (e.g. `max_output_tokens`) instead of the bare `incomplete`, matching the LangChain callback

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -13,6 +13,7 @@ import { sanitizeLangChain } from '../sanitization'
 import { stringifyError } from '../serializeError'
 import { warnIfPostHogAiGateway } from '../gatewayWarning'
 import { isObject } from '../typeGuards'
+import { responsesStopReason } from '../openai/utils'
 import { captureAiEvent } from '../captureAiEvent'
 
 // Mirror LangGraph's isGraphBubbleUp guard without adding LangGraph as a dependency. Every
@@ -721,13 +722,11 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
       generationResponseMetadata?.stop_reason ||
       generationResponseMetadata?.finish_reason ||
       gen.generationInfo?.stop_reason ||
-      // The Responses API reports no finish_reason. An early stop is named by
-      // `incomplete_details.reason`, and `status` covers the rest, matching the
-      // native OpenAI Responses wrapper.
-      messageResponseMetadata?.incomplete_details?.reason ||
-      generationResponseMetadata?.incomplete_details?.reason ||
-      messageResponseMetadata?.status ||
-      generationResponseMetadata?.status
+      // The Responses API reports no finish_reason: an incomplete run is named
+      // by what cut it short, and only terminal statuses count as stop reasons.
+      // Shared with the native OpenAI Responses wrapper.
+      responsesStopReason(messageResponseMetadata) ||
+      responsesStopReason(generationResponseMetadata)
 
     return stopReason != null ? String(stopReason) : undefined
   }

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -348,7 +348,6 @@ export class WrappedResponses extends AzureOpenAI.Responses {
                 accumulated.terminalResponse ?? {
                   id: accumulated.completionId ?? '',
                   model: accumulated.model ?? openAIParams.model,
-                  status: accumulated.stopReason as OpenAIOrignal.Responses.Response['status'],
                   service_tier: accumulated.serviceTier,
                 }
               await captureAiGeneration(

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -358,7 +358,6 @@ export class WrappedResponses extends Responses {
                 accumulated.terminalResponse ?? {
                   id: accumulated.completionId ?? '',
                   model: accumulated.model ?? openAIParams.model,
-                  status: accumulated.stopReason as OpenAIOrignal.Responses.Response['status'],
                   service_tier: accumulated.serviceTier,
                 }
               await captureAiGeneration(

--- a/packages/ai/src/openai/stream-accumulators.ts
+++ b/packages/ai/src/openai/stream-accumulators.ts
@@ -1,7 +1,7 @@
 import type OpenAI from 'openai'
 import type { FormattedContent, FormattedMessage, TokenUsage } from '../types'
 import { calculateWebSearchCount } from '../utils'
-import { extractCacheWriteTokens, isResponseTokenChunk, isTerminalResponse } from './utils'
+import { extractCacheWriteTokens, isResponseTokenChunk, isTerminalResponse, responsesStopReason } from './utils'
 
 export interface OpenAIChatStreamResult {
   output: FormattedMessage[]
@@ -172,7 +172,7 @@ export class OpenAIResponsesStreamAccumulator {
     if (isTerminalResponse(response)) {
       this.terminalResponse = response
       this.output = response.output ?? []
-      this.stopReason = response.status
+      this.stopReason = responsesStopReason(response)
     }
   }
 

--- a/packages/ai/src/openai/telemetry.ts
+++ b/packages/ai/src/openai/telemetry.ts
@@ -15,7 +15,13 @@ import {
 import { sanitizeOpenAI, sanitizeOpenAIResponse } from '../sanitization'
 import { captureAiGeneration } from './capture'
 import { getBackgroundResponseLatency } from './background-responses'
-import { buildProviderMetadata, extractCacheWriteTokens, extractRequestId, getResponseFailure, responsesStopReason } from './utils'
+import {
+  buildProviderMetadata,
+  extractCacheWriteTokens,
+  extractRequestId,
+  getResponseFailure,
+  responsesStopReason,
+} from './utils'
 
 export type OpenAICompatibleProvider = 'openai' | 'azure'
 type ChatParams = OpenAI.Chat.Completions.ChatCompletionCreateParams

--- a/packages/ai/src/openai/telemetry.ts
+++ b/packages/ai/src/openai/telemetry.ts
@@ -15,7 +15,7 @@ import {
 import { sanitizeOpenAI, sanitizeOpenAIResponse } from '../sanitization'
 import { captureAiGeneration } from './capture'
 import { getBackgroundResponseLatency } from './background-responses'
-import { buildProviderMetadata, extractCacheWriteTokens, extractRequestId, getResponseFailure } from './utils'
+import { buildProviderMetadata, extractCacheWriteTokens, extractRequestId, getResponseFailure, responsesStopReason } from './utils'
 
 export type OpenAICompatibleProvider = 'openai' | 'azure'
 type ChatParams = OpenAI.Chat.Completions.ChatCompletionCreateParams
@@ -177,7 +177,7 @@ export function buildResponsesSuccessOptions(
     modelParameters: getModelParams(context.modelParametersSource, response.service_tier),
     httpStatus: 200,
     usage: result.usage ?? buildResponsesUsage(response.usage, response),
-    stopReason: response.status ?? undefined,
+    stopReason: responsesStopReason(response),
     tools: result.includeTools ? extractAvailableToolCalls('openai', context.params) : undefined,
     completionId: response.id,
     providerMetadata: buildProviderMetadata({

--- a/packages/ai/src/openai/utils.ts
+++ b/packages/ai/src/openai/utils.ts
@@ -75,6 +75,28 @@ export function isTerminalResponse(response: { status?: string | null } | null |
 }
 
 /**
+ * Maps a Responses API outcome to a `$ai_stop_reason`. An incomplete run is
+ * named by what cut it short (`incomplete_details.reason`, e.g.
+ * `max_output_tokens`); the other terminal statuses stand for themselves.
+ * Non-terminal lifecycle statuses (`queued`, `in_progress`) are not stop
+ * reasons, so they yield undefined.
+ */
+export function responsesStopReason(
+  response:
+    | { status?: string | null; incomplete_details?: { reason?: string | null } | null }
+    | null
+    | undefined
+): string | undefined {
+  if (!response || !isTerminalResponse(response)) {
+    return undefined
+  }
+  if (response.status === 'incomplete' && response.incomplete_details?.reason) {
+    return response.incomplete_details.reason
+  }
+  return response.status ?? undefined
+}
+
+/**
  * Returns an isolated copy of a failed Responses API error for `$ai_error`, or
  * creates a fallback error when the provider omitted failure details.
  */

--- a/packages/ai/src/openai/utils.ts
+++ b/packages/ai/src/openai/utils.ts
@@ -82,10 +82,7 @@ export function isTerminalResponse(response: { status?: string | null } | null |
  * reasons, so they yield undefined.
  */
 export function responsesStopReason(
-  response:
-    | { status?: string | null; incomplete_details?: { reason?: string | null } | null }
-    | null
-    | undefined
+  response: { status?: string | null; incomplete_details?: { reason?: string | null } | null } | null | undefined
 ): string | undefined {
   if (!response || !isTerminalResponse(response)) {
     return undefined

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -1246,7 +1246,7 @@ describe('PostHogAzureOpenAI - Responses terminal statuses', () => {
 
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
     const properties = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
-    expect(properties['$ai_stop_reason']).toBe(status)
+    expect(properties['$ai_stop_reason']).toBe(status === 'incomplete' ? 'max_output_tokens' : status)
     expect(properties['$ai_input_tokens']).toBe(11)
     expect(properties['$ai_output_tokens']).toBe(7)
     expect(properties['$ai_output_choices']).toEqual([
@@ -1289,7 +1289,7 @@ describe('PostHogAzureOpenAI - Responses terminal statuses', () => {
 
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
     const properties = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
-    expect(properties['$ai_stop_reason']).toBe(status)
+    expect(properties['$ai_stop_reason']).toBe(status === 'incomplete' ? 'max_output_tokens' : status)
     expect(properties['$ai_input_tokens']).toBe(11)
     expect(properties['$ai_output_tokens']).toBe(7)
     expect(properties['$ai_output_choices']).toEqual(response.output ?? [])

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -246,7 +246,7 @@ describe('LangChainCallbackHandler', () => {
             output_tokens: 10,
             total_tokens: 40,
           },
-          response_metadata: { status: 'completed' },
+          response_metadata: { status: 'completed', incomplete_details: null },
         }),
       },
       expectedInputTokens: 30,
@@ -273,6 +273,27 @@ describe('LangChainCallbackHandler', () => {
       expectedInputTokens: 33,
       expectedOutputTokens: 11,
       expectedStopReason: 'max_output_tokens',
+    },
+    {
+      name: 'Responses API non-terminal status is not a stop reason',
+      serializedId: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
+      runId: 'run_responses_api_queued',
+      model: 'gpt-4o',
+      provider: 'openai',
+      generation: {
+        message: new AIMessage({
+          content: '',
+          usage_metadata: {
+            input_tokens: 5,
+            output_tokens: 0,
+            total_tokens: 5,
+          },
+          response_metadata: { status: 'queued', incomplete_details: null },
+        }),
+      },
+      expectedInputTokens: 5,
+      expectedOutputTokens: 0,
+      expectedStopReason: undefined,
     },
     {
       name: 'finish_reason over a Responses-style status',

--- a/packages/ai/tests/openai-background-responses.test.ts
+++ b/packages/ai/tests/openai-background-responses.test.ts
@@ -319,7 +319,7 @@ describe.each(providerCases)('$provider background Responses', ({ provider, crea
       $ai_input_tokens: 12,
       $ai_output_tokens: 7,
       $ai_usage: usage,
-      $ai_stop_reason: status,
+      $ai_stop_reason: status === 'incomplete' ? 'max_output_tokens' : status,
       $ai_provider_metadata: {
         request_id: `req_background_${status}`,
         ...(status === 'incomplete' ? { incomplete_details: { reason: 'max_output_tokens' } } : {}),

--- a/packages/ai/tests/openai-stream-accumulators.test.ts
+++ b/packages/ai/tests/openai-stream-accumulators.test.ts
@@ -162,7 +162,7 @@ describe('OpenAI-compatible stream accumulators', () => {
       completionId: 'resp-1',
       serviceTier: 'flex',
       firstTokenTime: 150,
-      stopReason: 'incomplete',
+      stopReason: 'max_output_tokens',
       usage: {
         inputTokens: 9,
         outputTokens: 5,

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -1234,7 +1234,7 @@ describe('PostHogOpenAI - Jest test suite', () => {
 
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const properties = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
-      expect(properties['$ai_stop_reason']).toBe(status)
+      expect(properties['$ai_stop_reason']).toBe(status === 'incomplete' ? 'max_output_tokens' : status)
       expect(properties['$ai_input_tokens']).toBe(11)
       expect(properties['$ai_output_tokens']).toBe(7)
       expect(properties['$ai_output_choices']).toEqual([
@@ -1288,7 +1288,7 @@ describe('PostHogOpenAI - Jest test suite', () => {
 
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const properties = (mockPostHogClient.capture as jest.Mock).mock.calls[0][0].properties
-      expect(properties['$ai_stop_reason']).toBe(status)
+      expect(properties['$ai_stop_reason']).toBe(status === 'incomplete' ? 'max_output_tokens' : status)
       expect(properties['$ai_input_tokens']).toBe(11)
       expect(properties['$ai_output_tokens']).toBe(7)
       expect(properties['$ai_output_choices']).toEqual(response.output ?? [])


### PR DESCRIPTION
## Problem

- A LangChain Responses run started with `background: true` returns while still queued, and the callback records `$ai_stop_reason: 'queued'` - a lifecycle state, not a stop reason.
- The same truncated run gets two spellings: the LangChain callback reports `max_output_tokens`, the native OpenAI wrapper reports `incomplete`. The PostHog trace view only recognizes the first, so native-wrapper truncations render as normal endings.
- A comment in the callback claims the two surfaces already match.

Follow-up to #4700, from its post-merge review.

## Changes

- Runs that OpenAI truncated or ended abnormally now carry the same `$ai_stop_reason` from both the LangChain callback and the native wrapper, and queued or in-progress background runs carry none.
- One shared `responsesStopReason` helper does the mapping: non-terminal statuses yield nothing, an incomplete run is named by `incomplete_details.reason` (e.g. `max_output_tokens`), the other terminal statuses stand for themselves.
- The LangChain callback, the native telemetry builder, and the stream accumulator route through the helper.
- Mechanical: the callback comment now states what the code does; changeset added.

> [!NOTE]
> Behavior change: the native wrapper reports a truncated run as `max_output_tokens` instead of `incomplete`. Dashboards grouping on `$ai_stop_reason` see the new value after this ships. Cancelled runs stay `cancelled`.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## Testing

- New LangChain row: `status: 'queued'` produces no stop reason - fails without the terminal gate.
- The completed-run row now carries `incomplete_details: null`, the shape every real completed run has.
- The native `openai`, `azure-openai`, `openai-stream-accumulators`, and `openai-background-responses` suites expect `max_output_tokens` for the incomplete status.
- The streaming fallback response object drops its `status` field: `stopReason` is set only alongside `terminalResponse` now, so the old cast could never hold a real status.
- Not run: the integration suites, because they need provider API keys.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code from the confirmed findings of a max-level review of #4700: the missing terminal-status gate, the stop-reason vocabulary split between the two wrappers, and the stale comment. The remaining review findings (streamed truncations on @langchain/openai <=1.4.6, untested generation-level metadata legs) were left out as lower priority. Skills invoked: code-review, writing-pr-descriptions.
