### PR TITLE
chore: bump @posthog/cli to 0.16.2

### DIFF
--- a/.changeset/bump-cli-for-process-race.md
+++ b/.changeset/bump-cli-for-process-race.md
@@ -1,0 +1,8 @@
+---
+'@posthog/nextjs-config': patch
+'@posthog/nuxt': patch
+'@posthog/rollup-plugin': patch
+'@posthog/webpack-plugin': patch
+---
+
+Bump `@posthog/cli` to `~0.16.2`, which fixes a race in `sourcemap process`: inject and upload used to walk the directory roots separately, so a bundler still writing into the output directory mid-run (e.g. Turbopack's background filesystem-cache flush on Next.js 16.3+) could hand upload a chunk inject never stamped and abort the build with "Chunk ID not found". The CLI now uploads exactly the pairs it injected, and `--delete-after` cleanup skips files that vanished or changed after upload instead of failing the build.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^7.27.1
       version: 7.28.5
     '@posthog/cli':
-      specifier: ~0.14.1
-      version: 0.14.1
+      specifier: ~0.16.2
+      version: 0.16.2
     '@rslib/core':
       specifier: 0.10.6
       version: 0.10.6
@@ -787,7 +787,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.14.1
+        version: 0.16.2
       '@posthog/plugin-utils':
         specifier: workspace:^
         version: link:../plugin-utils
@@ -864,7 +864,7 @@ importers:
         version: 4.1.3(magicast@0.5.3)
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.14.1
+        version: 0.16.2
       '@posthog/core':
         specifier: workspace:^
         version: link:../core
@@ -1206,7 +1206,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.14.1
+        version: 0.16.2
       '@posthog/plugin-utils':
         specifier: workspace:^
         version: link:../plugin-utils
@@ -1765,7 +1765,7 @@ importers:
     dependencies:
       '@posthog/cli':
         specifier: 'catalog:'
-        version: 0.14.1
+        version: 0.16.2
       '@posthog/core':
         specifier: workspace:^
         version: link:../core
@@ -6153,8 +6153,8 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@posthog/cli@0.14.1':
-    resolution: {integrity: sha512-gTzcKpl9TZLf0LrlLHEjChlPc9LIK1gdQG0alMnX6+b+W1mTD+6nTN0W/MeEzjT4DiKDeK8FPhc1n7dT1tWKFw==}
+  '@posthog/cli@0.16.2':
+    resolution: {integrity: sha512-h8bpf9ffBUH/Z9IoyGV+wiI+vS8rIPorKT3eKQXuzuwawO0G7Qvy+hDd7HQ9YJjHByYZ77yPPQvrSs4WsqTUCg==}
     engines: {node: '>=14.14', npm: '>=6'}
     hasBin: true
 
@@ -25286,7 +25286,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@posthog/cli@0.14.1':
+  '@posthog/cli@0.16.2':
     dependencies:
       detect-libc: 2.1.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@babel/preset-env': ^7.27.1
   '@babel/preset-react': ^7.27.1
   '@babel/preset-typescript': ^7.27.1
-  '@posthog/cli': ~0.14.1
+  '@posthog/cli': ~0.16.2
   '@rslib/core': 0.10.6
   '@testing-library/dom': ^10.4.1
   '@testing-library/jest-dom': ^6.9.1


### PR DESCRIPTION
## Problem

On Next.js 16.3+, `next build` with `withPostHogConfig` can abort with `Chunk ID not found` (#4667). Turbopack's filesystem cache keeps writing into `distDir` while `@posthog/nextjs-config` runs `posthog-cli sourcemap process`, and CLI versions up to 0.16.1 walked the directory once for inject and again for upload, so a chunk that appeared between the two walks reached upload unstamped and failed the build.

The root fix landed in the CLI (PostHog/posthog#91427, released as `@posthog/cli` 0.16.2): `process` now uploads exactly the pairs it injected. The build plugins still pin the CLI to `~0.14.1`, so users do not get it until the catalog moves.

## Changes

- Bump the shared `@posthog/cli` catalog range to `~0.16.2` and regenerate the root lockfile.
- Patch changesets for the four packages that publish the CLI dependency: `@posthog/nextjs-config`, `@posthog/nuxt`, `@posthog/rollup-plugin`, `@posthog/webpack-plugin`.

No code changes. CLI 0.15.x and 0.16.x add Info.plist release metadata and Hermes `--release-mode`; nothing the plugins invoke changed shape. Supersedes #4681, which worked around the race on the JS side by snapshotting `distDir` into a stdin file list.

Independent example and playground lockfiles still resolve 0.11.1 and are left alone, as in #4563.

## How did you test this code?

`pnpm install --frozen-lockfile --lockfile-only` passes on the regenerated lockfile. No unit tests run: dependency-only change, CI covers the plugin packages.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/nextjs-config
- [x] @posthog/nuxt
- [x] @posthog/rollup-plugin
- [x] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
