### PR TITLE
feat(conversations): forward signed identity claims

### DIFF
--- a/.changeset/signed-identity-claims.md
+++ b/.changeset/signed-identity-claims.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+Forward generic server-signed identity claims with conversations widget requests.

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -1890,7 +1890,7 @@
         {
           "category": "",
           "description": "Set HMAC-based identity verification.",
-          "details": "When set, products like conversations use server-verified identity (distinct_id + HMAC hash) instead of anonymous session identifiers. The hash should be computed server-side as HMAC-SHA256 of the distinct_id using the project's API secret.",
+          "details": "When set, products like conversations use server-verified identity (distinct_id + HMAC hash) instead of anonymous session identifiers. The hash should be computed server-side as HMAC-SHA256 of the distinct_id using the project's API secret. Any additional signed identity claims are cleared because they are bound to the previously configured distinct_id.",
           "id": "setIdentity",
           "showDocs": true,
           "title": "setIdentity",
@@ -3164,6 +3164,11 @@
           "description": "HMAC-SHA256 of `identity_distinct_id` using the project's API secret.\nMust be provided together with `identity_distinct_id`.",
           "type": "string",
           "name": "identity_hash"
+        },
+        {
+          "description": "Additional server-signed identity claims.\n\nClaims are forwarded to products such as conversations only when\n`identity_distinct_id` and `identity_hash` are also present. Claim\nverification and consumption happen server-side.",
+          "type": "Record<string, { value: string; hash: string; }>",
+          "name": "identity_claims"
         },
         {
           "description": "Determines whether PostHog should disable web experiments.\n\nCurrently disabled while we're in BETA. It will be toggled to `true` in a future release.",

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-identity-manager.test.tsx
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-identity-manager.test.tsx
@@ -205,6 +205,82 @@ describe('ConversationsManager Identity Verification', () => {
             expect(url).toContain('widget_session_id')
             expect(url).not.toContain('identity_hash')
         })
+
+        it('should use widget_session_id when only the base hash is set', async () => {
+            ;(mockPosthog as any).config.identity_hash = 'abc123hash'
+
+            manager = new ConversationsManager(mockConfig, mockPosthog)
+            jest.clearAllMocks()
+
+            await act(async () => {
+                await manager.getTickets()
+            })
+
+            const call = (mockPosthog._send_request as jest.Mock).mock.calls.find(
+                (c: any) => c[0].url?.includes('/widget/tickets') && c[0].method === 'GET'
+            )
+            const url = call[0].url as string
+            expect(url).toContain('widget_session_id')
+            expect(url).not.toContain('identity_distinct_id')
+            expect(url).not.toContain('identity_hash')
+        })
+
+        it('should not use claims without the base identity pair', async () => {
+            ;(mockPosthog as any).config.identity_claims = {
+                email: { value: 'viewer@example.com', hash: 'email-claim-hash' },
+            }
+
+            manager = new ConversationsManager(mockConfig, mockPosthog)
+            jest.clearAllMocks()
+
+            await act(async () => {
+                await manager.getTickets()
+            })
+
+            const call = (mockPosthog._send_request as jest.Mock).mock.calls.find(
+                (c: any) => c[0].url?.includes('/widget/tickets') && c[0].method === 'GET'
+            )
+            const url = call[0].url as string
+            expect(url).toContain('widget_session_id')
+            expect(url).not.toContain('identity_email')
+            expect(url).not.toContain('identity_hash_email')
+        })
+
+        it('should ignore incomplete and reserved claims while forwarding valid claims generically', async () => {
+            ;(mockPosthog as any).config.identity_distinct_id = 'user_123'
+            ;(mockPosthog as any).config.identity_hash = 'abc123hash'
+            ;(mockPosthog as any).config.identity_claims = {
+                organization: { value: 'posthog', hash: 'organization-claim-hash' },
+                email: { value: 'viewer@example.com' },
+                empty_value: { value: '', hash: 'empty-value-hash' },
+                empty_hash: { value: 'ignored', hash: '' },
+                distinct_id: { value: 'other-user', hash: 'other-user-hash' },
+                hash: { value: 'other-base-hash', hash: 'hash-claim-hash' },
+                hash_organization: { value: 'other-organization-hash', hash: 'nested-hash-claim-hash' },
+            }
+
+            manager = new ConversationsManager(mockConfig, mockPosthog)
+            jest.clearAllMocks()
+
+            await act(async () => {
+                await manager.getTickets()
+            })
+
+            const call = (mockPosthog._send_request as jest.Mock).mock.calls.find(
+                (c: any) => c[0].url?.includes('/widget/tickets') && c[0].method === 'GET'
+            )
+            const url = call[0].url as string
+            expect(url).toContain('identity_organization=posthog')
+            expect(url).toContain('identity_hash_organization=organization-claim-hash')
+            expect(url).toContain('identity_distinct_id=user_123')
+            expect(url).toContain('identity_hash=abc123hash')
+            expect(url).not.toContain('identity_email')
+            expect(url).not.toContain('identity_empty_value')
+            expect(url).not.toContain('identity_empty_hash')
+            expect(url).not.toContain('other-user')
+            expect(url).not.toContain('other-base-hash')
+            expect(url).not.toContain('other-organization-hash')
+        })
     })
 
     describe('setIdentity / clearIdentity', () => {
@@ -253,6 +329,10 @@ describe('ConversationsManager Identity Verification', () => {
         beforeEach(() => {
             ;(mockPosthog as any).config.identity_distinct_id = 'user_123'
             ;(mockPosthog as any).config.identity_hash = 'abc123hash'
+            ;(mockPosthog as any).config.identity_claims = {
+                email: { value: 'viewer@example.com', hash: 'email-claim-hash' },
+                organization: { value: 'posthog', hash: 'organization-claim-hash' },
+            }
             manager = new ConversationsManager(mockConfig, mockPosthog)
             jest.clearAllMocks()
         })
@@ -269,6 +349,10 @@ describe('ConversationsManager Identity Verification', () => {
             const data = call[0].data
             expect(data.identity_distinct_id).toBe('user_123')
             expect(data.identity_hash).toBe('abc123hash')
+            expect(data.identity_email).toBe('viewer@example.com')
+            expect(data.identity_hash_email).toBe('email-claim-hash')
+            expect(data.identity_organization).toBe('posthog')
+            expect(data.identity_hash_organization).toBe('organization-claim-hash')
             expect(data.distinct_id).toBe('user_123')
             expect(data.widget_session_id).toBeUndefined()
         })
@@ -285,6 +369,10 @@ describe('ConversationsManager Identity Verification', () => {
             const url = call[0].url as string
             expect(url).toContain('identity_distinct_id=user_123')
             expect(url).toContain('identity_hash=abc123hash')
+            expect(url).toContain('identity_email=viewer%40example.com')
+            expect(url).toContain('identity_hash_email=email-claim-hash')
+            expect(url).toContain('identity_organization=posthog')
+            expect(url).toContain('identity_hash_organization=organization-claim-hash')
             expect(url).not.toContain('widget_session_id')
         })
 
@@ -300,6 +388,10 @@ describe('ConversationsManager Identity Verification', () => {
             const data = call[0].data
             expect(data.identity_distinct_id).toBe('user_123')
             expect(data.identity_hash).toBe('abc123hash')
+            expect(data.identity_email).toBe('viewer@example.com')
+            expect(data.identity_hash_email).toBe('email-claim-hash')
+            expect(data.identity_organization).toBe('posthog')
+            expect(data.identity_hash_organization).toBe('organization-claim-hash')
             expect(data.widget_session_id).toBeUndefined()
         })
 
@@ -315,7 +407,61 @@ describe('ConversationsManager Identity Verification', () => {
             const url = call[0].url as string
             expect(url).toContain('identity_distinct_id=user_123')
             expect(url).toContain('identity_hash=abc123hash')
+            expect(url).toContain('identity_email=viewer%40example.com')
+            expect(url).toContain('identity_hash_email=email-claim-hash')
+            expect(url).toContain('identity_organization=posthog')
+            expect(url).toContain('identity_hash_organization=organization-claim-hash')
             expect(url).not.toContain('widget_session_id')
+        })
+    })
+
+    describe('API calls with base identity and no claims', () => {
+        beforeEach(() => {
+            ;(mockPosthog as any).config.identity_distinct_id = 'user_123'
+            ;(mockPosthog as any).config.identity_hash = 'abc123hash'
+            manager = new ConversationsManager(mockConfig, mockPosthog)
+            jest.clearAllMocks()
+        })
+
+        it('should preserve the existing request shape for all endpoints', async () => {
+            await act(async () => {
+                await manager.sendMessage('Hello!')
+                await manager.getMessages('ticket-123')
+                await manager.markAsRead('ticket-123')
+                await manager.getTickets()
+            })
+
+            const calls = (mockPosthog._send_request as jest.Mock).mock.calls.map((call: any[]) => call[0])
+            const sendMessageCall = calls.find(
+                (call: any) => call.url?.endsWith('/widget/message') && call.method === 'POST'
+            )
+            const getMessagesCall = calls.find(
+                (call: any) => call.url?.includes('/widget/messages/ticket-123?') && call.method === 'GET'
+            )
+            const markAsReadCall = calls.find((call: any) => call.url?.includes('/read') && call.method === 'POST')
+            const getTicketsCall = calls.find(
+                (call: any) => call.url?.includes('/widget/tickets') && call.method === 'GET'
+            )
+
+            expect(sendMessageCall.data).toEqual(
+                expect.objectContaining({
+                    identity_distinct_id: 'user_123',
+                    identity_hash: 'abc123hash',
+                    distinct_id: 'user_123',
+                })
+            )
+            expect(sendMessageCall.data.identity_email).toBeUndefined()
+            expect(markAsReadCall.data).toEqual({
+                identity_distinct_id: 'user_123',
+                identity_hash: 'abc123hash',
+            })
+
+            for (const call of [getMessagesCall, getTicketsCall]) {
+                expect(call.url).toContain('identity_distinct_id=user_123')
+                expect(call.url).toContain('identity_hash=abc123hash')
+                expect(call.url).not.toContain('identity_email')
+                expect(call.url).not.toContain('widget_session_id')
+            }
         })
     })
 
@@ -354,6 +500,31 @@ describe('ConversationsManager Identity Verification', () => {
             expect(url).toContain('widget_session_id=test-widget-session-id')
             expect(url).not.toContain('identity_distinct_id')
             expect(url).not.toContain('identity_hash')
+        })
+
+        it('getMessages should include widget_session_id in query params', async () => {
+            await act(async () => {
+                await manager.getMessages('ticket-123')
+            })
+
+            const call = (mockPosthog._send_request as jest.Mock).mock.calls.find(
+                (c: any) => c[0].url?.includes('/widget/messages/ticket-123') && c[0].method === 'GET'
+            )
+            const url = call[0].url as string
+            expect(url).toContain('widget_session_id=test-widget-session-id')
+            expect(url).not.toContain('identity_distinct_id')
+            expect(url).not.toContain('identity_hash')
+        })
+
+        it('markAsRead should include widget_session_id in the body', async () => {
+            await act(async () => {
+                await manager.markAsRead('ticket-123')
+            })
+
+            const call = (mockPosthog._send_request as jest.Mock).mock.calls.find(
+                (c: any) => c[0].url?.includes('/read') && c[0].method === 'POST'
+            )
+            expect(call[0].data).toEqual({ widget_session_id: 'test-widget-session-id' })
         })
     })
 })

--- a/packages/browser/src/__tests__/posthog-core.identity.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.identity.test.ts
@@ -1,0 +1,48 @@
+import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
+
+import { PostHog } from '../posthog-core'
+import { createPosthogInstance } from './helpers/posthog-instance'
+
+describe('HMAC identity lifecycle', () => {
+    let instance: PostHog
+
+    beforeEach(async () => {
+        instance = await createPosthogInstance(uuidv7(), {
+            api_host: 'https://test.com',
+            token: 'test-token',
+        })
+        instance.config.identity_claims = {
+            email: { value: 'viewer@example.com', hash: 'email-claim-hash' },
+        }
+    })
+
+    it('clears claims when setting a base identity', () => {
+        instance.setIdentity('user_123', 'base-identity-hash')
+
+        expect(instance.config.identity_distinct_id).toBe('user_123')
+        expect(instance.config.identity_hash).toBe('base-identity-hash')
+        expect(instance.config.identity_claims).toBeUndefined()
+    })
+
+    it('clears claims with the base identity', () => {
+        instance.config.identity_distinct_id = 'user_123'
+        instance.config.identity_hash = 'base-identity-hash'
+
+        instance.clearIdentity()
+
+        expect(instance.config.identity_distinct_id).toBeUndefined()
+        expect(instance.config.identity_hash).toBeUndefined()
+        expect(instance.config.identity_claims).toBeUndefined()
+    })
+
+    it('clears claims on reset', () => {
+        instance.config.identity_distinct_id = 'user_123'
+        instance.config.identity_hash = 'base-identity-hash'
+
+        instance.reset()
+
+        expect(instance.config.identity_distinct_id).toBeUndefined()
+        expect(instance.config.identity_hash).toBeUndefined()
+        expect(instance.config.identity_claims).toBeUndefined()
+    })
+})

--- a/packages/browser/src/extensions/conversations/external/index.tsx
+++ b/packages/browser/src/extensions/conversations/external/index.tsx
@@ -228,8 +228,7 @@ export class ConversationsManager implements ConversationsManagerInterface {
             }
 
             if (identity) {
-                payload.identity_distinct_id = identity.identity_distinct_id
-                payload.identity_hash = identity.identity_hash
+                Object.assign(payload, identity)
                 payload.distinct_id = identity.identity_distinct_id
             } else {
                 payload.widget_session_id = this._widgetSessionId
@@ -354,8 +353,7 @@ export class ConversationsManager implements ConversationsManagerInterface {
             }
 
             if (identity) {
-                queryParams.identity_distinct_id = identity.identity_distinct_id
-                queryParams.identity_hash = identity.identity_hash
+                Object.assign(queryParams, identity)
             } else {
                 queryParams.widget_session_id = this._widgetSessionId
             }
@@ -416,9 +414,7 @@ export class ConversationsManager implements ConversationsManagerInterface {
         // eslint-disable-next-line compat/compat
         return new Promise((resolve, reject) => {
             const identity = this._identityFields()
-            const data = identity
-                ? { identity_distinct_id: identity.identity_distinct_id, identity_hash: identity.identity_hash }
-                : { widget_session_id: this._widgetSessionId }
+            const data = identity || { widget_session_id: this._widgetSessionId }
 
             this._posthog._send_request({
                 url: this._posthog.requestRouter.endpointFor(
@@ -1358,8 +1354,7 @@ export class ConversationsManager implements ConversationsManagerInterface {
         }
 
         if (identity) {
-            queryParams.identity_distinct_id = identity.identity_distinct_id
-            queryParams.identity_hash = identity.identity_hash
+            Object.assign(queryParams, identity)
         } else {
             queryParams.widget_session_id = this._widgetSessionId
         }
@@ -1493,13 +1488,38 @@ export class ConversationsManager implements ConversationsManagerInterface {
         return this._widgetSessionId
     }
 
-    private _identityFields(): { identity_distinct_id: string; identity_hash: string } | null {
+    private _identityFields(): Record<string, string> | null {
         const id = this._posthog.config.identity_distinct_id
         const hash = this._posthog.config.identity_hash
         if (!id || !hash) {
             return null
         }
-        return { identity_distinct_id: id, identity_hash: hash }
+
+        const fields: Record<string, string> = {
+            identity_distinct_id: id,
+            identity_hash: hash,
+        }
+
+        const claims = this._posthog.config.identity_claims
+        if (claims) {
+            Object.entries(claims).forEach(([field, claim]) => {
+                const isReservedField = field === 'distinct_id' || field === 'hash' || field.startsWith('hash_')
+                if (
+                    field &&
+                    !isReservedField &&
+                    claim &&
+                    typeof claim.value === 'string' &&
+                    claim.value.length > 0 &&
+                    typeof claim.hash === 'string' &&
+                    claim.hash.length > 0
+                ) {
+                    fields[`identity_${field}`] = claim.value
+                    fields[`identity_hash_${field}`] = claim.hash
+                }
+            })
+        }
+
+        return fields
     }
 
     setIdentity(): void {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3533,6 +3533,7 @@ export class PostHog implements PostHogInterface {
             // Clear HMAC identity verification fields
             delete this.config.identity_distinct_id
             delete this.config.identity_hash
+            delete this.config.identity_claims
             resetCompleted = true
         } finally {
             if (cookieSyncSuppressionStarted) {
@@ -3607,6 +3608,8 @@ export class PostHog implements PostHogInterface {
      * (distinct_id + HMAC hash) instead of anonymous session identifiers.
      * The hash should be computed server-side as HMAC-SHA256 of the
      * distinct_id using the project's API secret.
+     * Any additional signed identity claims are cleared because they are
+     * bound to the previously configured distinct_id.
      *
      * @param distinctId - The verified user distinct_id
      * @param hash - HMAC-SHA256 of distinctId using the project API secret
@@ -3619,6 +3622,7 @@ export class PostHog implements PostHogInterface {
      * @public
      */
     setIdentity(distinctId: string, hash: string): void {
+        delete this.config.identity_claims
         this.config.identity_distinct_id = distinctId
         this.config.identity_hash = hash
         this.alias(distinctId)
@@ -3638,6 +3642,7 @@ export class PostHog implements PostHogInterface {
     clearIdentity(): void {
         delete this.config.identity_distinct_id
         delete this.config.identity_hash
+        delete this.config.identity_claims
         this.conversations?._onIdentityCleared()
     }
 

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -323,6 +323,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "undefined",
     "string"
   ],
+  "identity_claims": [
+    "undefined",
+    "Record<string, { value: string; hash: string; }>"
+  ],
   "disable_web_experiments": [
     "false",
     "true"

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1562,6 +1562,15 @@ export interface PostHogConfig {
     identity_hash?: string
 
     /**
+     * Additional server-signed identity claims.
+     *
+     * Claims are forwarded to products such as conversations only when
+     * `identity_distinct_id` and `identity_hash` are also present. Claim
+     * verification and consumption happen server-side.
+     */
+    identity_claims?: Record<string, { value: string; hash: string }>
+
+    /**
      * Determines whether PostHog should disable web experiments.
      *
      * Currently disabled while we're in BETA. It will be toggled to `true` in a future release.


### PR DESCRIPTION
## Summary

- Add optional generic signed identity claims to the browser SDK configuration.
- Forward claims as `identity_<field>` and `identity_hash_<field>` on all Conversations widget requests.
- Require the existing verified distinct ID pair before forwarding claims.
- Clear claims when identity changes or resets to prevent stale identity data.

## Why

The Conversations ticket bridge needs a server-attested email rather than the mutable `person.properties.email`. The SDK transports signed claims generically while verification and explicit claim consumption remain backend responsibilities.

## Deployment safety

- Existing integrations without claims keep their current request shape and behavior.
- Claims without the base identity pair fall back to widget-session authentication.
- Older backends ignore the additional claim fields.
- Older SDKs simply omit claims, leaving the bridge disabled until upgraded.

## Test plan

- [x] Tickets and messages query parameters
- [x] Send-message and mark-read bodies
- [x] Base identity without claims
- [x] No identity configuration
- [x] Partial, empty, and reserved claims
- [x] Identity clearing and reset lifecycle
- [x] Typecheck, lint, and formatting