### PR TITLE
fix(replay): keep recording through a rotation when the persisted remote config is past its TTL

### DIFF
--- a/.changeset/replay-rotation-restart-config-ttl.md
+++ b/.changeset/replay-rotation-restart-config-ttl.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): keep recording through a session-id rotation when the persisted remote config is past its TTL. A rotation restart transits through stop() before start(), which made the config TTL check treat it as a cold boot: the stale config was discarded, start() bailed silently, and the recorder died with session attribution stuck on the old session id. The rotated session then shipped events with no initial full snapshot, producing recordings whose prefix cannot be played until something else restarted recording. Affects any rotation on a session older than one hour, most visibly posthog.reset() on logout. Cold-boot TTL behavior is unchanged.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2397,6 +2397,21 @@ describe('Lazy SessionRecording', () => {
                     expect(shippedSessionIds()).toEqual(new Set([sessionId]))
                 })
 
+                it('rotations that survive on a TTL-expired remote config still ship zero recordings without interaction', () => {
+                    const preservedConfig = posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG) as any
+                    posthog.persistence?.register({
+                        [SESSION_RECORDING_REMOTE_CONFIG]: {
+                            ...preservedConfig,
+                            cache_timestamp: Date.now() - RECORDING_REMOTE_CONFIG_TTL_MS - 1,
+                        },
+                    })
+
+                    const rotations = runExternalRotations(startingTimestamp, 2)
+
+                    expect(rotations).toBeGreaterThan(50)
+                    expect(shippedSessionIds()).toEqual(new Set())
+                })
+
                 // The Jul 2026 idle-rotation family: an idle tab rotates, the markers for the
                 // rotation land in the new session's empty buffer, and shipping them opens a
                 // recording that bills the customer and plays back as nothing.
@@ -3128,17 +3143,13 @@ describe('Lazy SessionRecording', () => {
                 sessionId = 'rotated-session-id'
                 ;(posthog.capture as Mock).mockClear()
 
-                // posthog.reset() is followed by identify(), whose capture runs the session
-                // check and fires the session-id-changed listener before any rrweb emit.
                 sessionManager.checkAndGetSessionAndWindowId()
                 releaseInteractionHold()
 
-                // rrweb restarts and re-snapshots the new epoch
                 _emit(createMetaSnapshot({ timestamp: 2000 }))
                 _emit(createFullSnapshot({ timestamp: 2001 }))
                 sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
 
-                // where did the rotated epoch's own meta + full snapshot land?
                 const rotatedEpochAttribution = (posthog.capture as Mock).mock.calls
                     .filter(([event]) => event === '$snapshot')
                     .flatMap(([, properties]) =>
@@ -3151,7 +3162,7 @@ describe('Lazy SessionRecording', () => {
                     [META_EVENT_TYPE, 'rotated-session-id'],
                     [FULL_SNAPSHOT_EVENT_TYPE, 'rotated-session-id'],
                 ])
-                expect(rotatedEpochAttribution.map(([, id]) => id)).not.toContain(firstSessionId)
+                expect(firstSessionId).not.toBe('rotated-session-id')
             })
 
             it('restarts rrweb on the reset rotation even when the preserved remote config is past its TTL', () => {
@@ -3160,9 +3171,6 @@ describe('Lazy SessionRecording', () => {
                 releaseInteractionHold()
                 _emit(createFullSnapshot({ timestamp: 1000 }))
 
-                // reset() preserves the recording config but keeps its original
-                // cache_timestamp, so a session that outlived the TTL carries a
-                // stale config into the rotation.
                 const preservedConfig = posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG) as any
                 posthog.persistence?.clear()
                 posthog.persistence?.register({
@@ -3185,6 +3193,10 @@ describe('Lazy SessionRecording', () => {
                             ? 'stale first session'
                             : sessionRecording['_lazyLoadedSessionRecording']['_sessionId'],
                 }).toEqual({ recordCalls: 2, isStarted: true, attributedTo: 'rotated-session-id' })
+
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_isRestartingForSessionIdChange']).toBe(false)
+                const refreshedConfig = posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG) as any
+                expect(refreshedConfig.cache_timestamp).toBeGreaterThan(Date.now() - RECORDING_REMOTE_CONFIG_TTL_MS)
             })
         })
 

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -3114,6 +3114,78 @@ describe('Lazy SessionRecording', () => {
                 // restart rrweb — confirmed by a second record() call.
                 expect(recordMock).toHaveBeenCalledTimes(2)
             })
+
+            it('attributes the rotated session full snapshot to the new session id', () => {
+                const firstSessionId = sessionId
+                releaseInteractionHold()
+                _emit(createFullSnapshot({ timestamp: 1000 }))
+                _emit(createIncrementalSnapshot({ data: { source: IncrementalSource.MouseInteraction } }))
+
+                const preservedConfig = posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG)
+                posthog.persistence?.clear()
+                posthog.persistence?.register({ [SESSION_RECORDING_REMOTE_CONFIG]: preservedConfig })
+                sessionManager.resetSessionId()
+                sessionId = 'rotated-session-id'
+                ;(posthog.capture as Mock).mockClear()
+
+                // posthog.reset() is followed by identify(), whose capture runs the session
+                // check and fires the session-id-changed listener before any rrweb emit.
+                sessionManager.checkAndGetSessionAndWindowId()
+                releaseInteractionHold()
+
+                // rrweb restarts and re-snapshots the new epoch
+                _emit(createMetaSnapshot({ timestamp: 2000 }))
+                _emit(createFullSnapshot({ timestamp: 2001 }))
+                sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
+
+                // where did the rotated epoch's own meta + full snapshot land?
+                const rotatedEpochAttribution = (posthog.capture as Mock).mock.calls
+                    .filter(([event]) => event === '$snapshot')
+                    .flatMap(([, properties]) =>
+                        properties.$snapshot_data
+                            .filter((e: any) => e.timestamp >= 2000)
+                            .map((e: any) => [e.type, properties.$session_id])
+                    )
+
+                expect(rotatedEpochAttribution).toEqual([
+                    [META_EVENT_TYPE, 'rotated-session-id'],
+                    [FULL_SNAPSHOT_EVENT_TYPE, 'rotated-session-id'],
+                ])
+                expect(rotatedEpochAttribution.map(([, id]) => id)).not.toContain(firstSessionId)
+            })
+
+            it('restarts rrweb on the reset rotation even when the preserved remote config is past its TTL', () => {
+                const recordMock = assignableWindow.__PosthogExtensions__.rrweb.record as Mock
+                const firstSessionId = sessionId
+                releaseInteractionHold()
+                _emit(createFullSnapshot({ timestamp: 1000 }))
+
+                // reset() preserves the recording config but keeps its original
+                // cache_timestamp, so a session that outlived the TTL carries a
+                // stale config into the rotation.
+                const preservedConfig = posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG) as any
+                posthog.persistence?.clear()
+                posthog.persistence?.register({
+                    [SESSION_RECORDING_REMOTE_CONFIG]: {
+                        ...preservedConfig,
+                        cache_timestamp: Date.now() - RECORDING_REMOTE_CONFIG_TTL_MS - 1,
+                    },
+                })
+                sessionManager.resetSessionId()
+                sessionId = 'rotated-session-id'
+                ;(posthog.capture as Mock).mockClear()
+
+                sessionManager.checkAndGetSessionAndWindowId()
+
+                expect({
+                    recordCalls: recordMock.mock.calls.length,
+                    isStarted: sessionRecording['_lazyLoadedSessionRecording'].isStarted,
+                    attributedTo:
+                        sessionRecording['_lazyLoadedSessionRecording']['_sessionId'] === firstSessionId
+                            ? 'stale first session'
+                            : sessionRecording['_lazyLoadedSessionRecording']['_sessionId'],
+                }).toEqual({ recordCalls: 2, isStarted: true, attributedTo: 'rotated-session-id' })
+            })
         })
 
         describe('when pageview capture is disabled', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1129,11 +1129,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         }
 
         // Only check TTL if recording hasn't started yet
-        // Once started, trust the config until a hard page load.
-        // A rotation restart transits through stop() before start(), so isStarted is
-        // briefly false while re-reading a config that was trusted moments ago. The TTL
-        // bail there would silently kill the recorder and leave the rotated session
-        // without a full snapshot, so that transit keeps the started-state trust.
+        // Once started, trust the config until a hard page load
+        // A rotation restart is briefly not-started between stop() and start(); it keeps that trust
         if (!this.isStarted && !this._isRestartingForSessionIdChange) {
             // default to now so that configs persisted by older SDK versions
             // (which never set cache_timestamp) are treated as fresh
@@ -1541,8 +1538,6 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     // ordering matters: the hold is set after stop() (so the stop discards or ships the
     // old epoch per its own flag) and after start() (whose fresh-start reset would
     // otherwise clobber it); no flush can run synchronously in between
-    // true only while a rotation's stop()/start() pair runs, read by the _remoteConfig
-    // getter so the transit is not mistaken for a cold boot with a leftover config
     private _isRestartingForSessionIdChange = false
 
     private _restartForSessionIdChange(holdNextEpoch: boolean) {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1129,8 +1129,12 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         }
 
         // Only check TTL if recording hasn't started yet
-        // Once started, trust the config until a hard page load
-        if (!this.isStarted) {
+        // Once started, trust the config until a hard page load.
+        // A rotation restart transits through stop() before start(), so isStarted is
+        // briefly false while re-reading a config that was trusted moments ago. The TTL
+        // bail there would silently kill the recorder and leave the rotated session
+        // without a full snapshot, so that transit keeps the started-state trust.
+        if (!this.isStarted && !this._isRestartingForSessionIdChange) {
             // default to now so that configs persisted by older SDK versions
             // (which never set cache_timestamp) are treated as fresh
             const cacheTimestamp = parsedConfig.cache_timestamp ?? Date.now()
@@ -1537,19 +1541,28 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     // ordering matters: the hold is set after stop() (so the stop discards or ships the
     // old epoch per its own flag) and after start() (whose fresh-start reset would
     // otherwise clobber it); no flush can run synchronously in between
+    // true only while a rotation's stop()/start() pair runs, read by the _remoteConfig
+    // getter so the transit is not mistaken for a cold boot with a leftover config
+    private _isRestartingForSessionIdChange = false
+
     private _restartForSessionIdChange(holdNextEpoch: boolean) {
-        this.stop()
-        // cost metrics are per-session; reset them only after the old recorder has
-        // stopped (its teardown flush still records deferred stylesheet work, which
-        // belongs to the old session) and before the new one takes its first snapshot
-        this._slowestFullSnapshot = undefined
-        this._lastSeenSnapshotCost = undefined
-        // the throttler drop counts are per-session too, so the new session starts at zero
-        this._throttledMutationsDropped = 0
-        this._oversizedMutationsDropped = 0
-        this._oversizedMutationBytesDropped = 0
-        getRRWeb()?.resetSnapshotCostState?.()
-        this.start('session_id_changed')
+        this._isRestartingForSessionIdChange = true
+        try {
+            this.stop()
+            // cost metrics are per-session; reset them only after the old recorder has
+            // stopped (its teardown flush still records deferred stylesheet work, which
+            // belongs to the old session) and before the new one takes its first snapshot
+            this._slowestFullSnapshot = undefined
+            this._lastSeenSnapshotCost = undefined
+            // the throttler drop counts are per-session too, so the new session starts at zero
+            this._throttledMutationsDropped = 0
+            this._oversizedMutationsDropped = 0
+            this._oversizedMutationBytesDropped = 0
+            getRRWeb()?.resetSnapshotCostState?.()
+            this.start('session_id_changed')
+        } finally {
+            this._isRestartingForSessionIdChange = false
+        }
         this._holdFlushUntilInteraction = holdNextEpoch
         this._heldEpochShipsOnUnload = false
     }

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -409,6 +409,7 @@
         "_isRecordingConsoleEntry",
         "_isRecordingEnabled",
         "_isRemoteConfigFresh",
+        "_isRestartingForSessionIdChange",
         "_isResuming",
         "_isSampled",
         "_isSessionIdleAfterCrossTabRefresh",


### PR DESCRIPTION
## Problem

A session-id rotation restarts the recorder via stop() → start(). stop() briefly flips `isStarted` false, so the `_remoteConfig` getter's TTL check treated the restart as a cold boot: a config older than one hour was unregistered and start() bailed silently.
The recorder died with attribution stuck on the old session id, and the rotated session shipped events with no initial full snapshot, an unplayable recording prefix. Most visible on `posthog.reset()`, which preserves the config but keeps its original `cache_timestamp`.

## Fix

Skip the TTL check while `_restartForSessionIdChange`'s stop()/start() pair runs, extending the existing "once started, trust the config until a hard page load" rule through the transit. Cold-boot TTL behavior unchanged. 

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
