### PR TITLE
fix(replay): follow session rotation while _isIdle is unknown

### DIFF
--- a/.changeset/replay-restart-on-rotation-while-idle-unknown.md
+++ b/.changeset/replay-restart-on-rotation-while-idle-unknown.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix session replay recordings being unplayable after the session rotated in a tab with no user interaction. When a session expired and rotated (for example in a long-lived background tab), a recorder that had not yet seen user interaction kept attributing snapshots — including full snapshots — to the previous session, so the new session never received a playable full snapshot. The recorder now restarts on rotation in this state, re-syncs its session id from the session manager if they ever diverge, and flushes its buffer on the normal cadence before the first user interaction instead of holding data until the next rotation or page unload.

--- a/packages/browser/playwright/mocked/session-recording/session-rotation-scenarios.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-rotation-scenarios.spec.ts
@@ -477,12 +477,20 @@ test.describe('Session rotation without user interaction', () => {
                 )
                 .toBe(true)
 
+            // allow a further flush cycle to land so a duplicated restart would be visible below
+            await page.waitForTimeout(2500)
+
             const snapshots = (await page.capturedEvents()).filter((e) => e.event === '$snapshot')
             const newSessionSnapshotData = snapshots
                 .filter((s) => s.properties.$session_id === newSessionId)
                 .flatMap((s: any) => s.properties.$snapshot_data)
 
-            // the new session must open with Meta then FullSnapshot so it is playable
+            // the new session must open with Meta then FullSnapshot so it is playable,
+            // and the rotation must restart the recorder exactly once — a single pair
+            const metaEvents = newSessionSnapshotData.filter((e: any) => e.type === 4)
+            const fullSnapshotEvents = newSessionSnapshotData.filter((e: any) => e.type === 2)
+            expect(metaEvents.length).toEqual(1)
+            expect(fullSnapshotEvents.length).toEqual(1)
             const renderable = newSessionSnapshotData.filter((e: any) => e.type === 4 || e.type === 2)
             expect(renderable[0]?.type).toEqual(4)
             expect(renderable[1]?.type).toEqual(2)

--- a/packages/browser/playwright/mocked/session-recording/session-rotation-scenarios.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-rotation-scenarios.spec.ts
@@ -422,3 +422,59 @@ test.describe('Session rotation scenarios', () => {
         expect(allCustomTags).not.toContain('$session_id_change')
     })
 })
+
+test.describe('Session rotation without user interaction', () => {
+    // Regression test for #4202: a tab with no user interaction keeps the recorder in the
+    // 'unknown' idle state. An analytics-driven activity-timeout rotation must still restart
+    // the recorder and ship a full snapshot under the new session id, with no interaction at all.
+    test('ships a full snapshot for the new session after rotation with no user interaction', async ({
+        page,
+        context,
+    }) => {
+        await page.waitingForNetworkCausedBy({
+            urlPatternsToWaitFor: ['**/*recorder.js*'],
+            action: async () => {
+                await start(startOptions, page, context)
+            },
+        })
+        await waitForSessionRecordingToStart(page)
+        await page.resetCapturedEvents()
+
+        const initialSessionId = await getSessionId(page)
+
+        await simulateFrozenTabIdle(page)
+
+        // an analytics event (e.g. a background tab capturing a network failure) rotates the session
+        await page.evaluate(() => {
+            ;(window as WindowWithPostHog).posthog?.capture('background_tab_event')
+        })
+
+        const newSessionId = await getSessionId(page)
+        expect(newSessionId).not.toEqual(initialSessionId)
+
+        const capturedAnalytics = await page.capturedEvents()
+        const backgroundEvent = capturedAnalytics.find((e) => e.event === 'background_tab_event')
+        expect(backgroundEvent?.properties.$session_id).toEqual(newSessionId)
+
+        // without any further interaction, replay data for the new session must still flush
+        await expect
+            .poll(
+                async () => {
+                    const snapshots = (await page.capturedEvents()).filter((e) => e.event === '$snapshot')
+                    return snapshots.some((s) => s.properties.$session_id === newSessionId)
+                },
+                { timeout: 10000 }
+            )
+            .toBe(true)
+
+        const snapshots = (await page.capturedEvents()).filter((e) => e.event === '$snapshot')
+        const newSessionSnapshotData = snapshots
+            .filter((s) => s.properties.$session_id === newSessionId)
+            .flatMap((s: any) => s.properties.$snapshot_data)
+
+        // the new session must open with Meta then FullSnapshot so it is playable
+        const renderable = newSessionSnapshotData.filter((e: any) => e.type === 4 || e.type === 2)
+        expect(renderable[0]?.type).toEqual(4)
+        expect(renderable[1]?.type).toEqual(2)
+    })
+})

--- a/packages/browser/playwright/mocked/session-recording/session-rotation-scenarios.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-rotation-scenarios.spec.ts
@@ -427,54 +427,65 @@ test.describe('Session rotation without user interaction', () => {
     // Regression test for #4202: a tab with no user interaction keeps the recorder in the
     // 'unknown' idle state. An analytics-driven activity-timeout rotation must still restart
     // the recorder and ship a full snapshot under the new session id, with no interaction at all.
-    test('ships a full snapshot for the new session after rotation with no user interaction', async ({
-        page,
-        context,
-    }) => {
-        await page.waitingForNetworkCausedBy({
-            urlPatternsToWaitFor: ['**/*recorder.js*'],
-            action: async () => {
-                await start(startOptions, page, context)
-            },
-        })
-        await waitForSessionRecordingToStart(page)
-        await page.resetCapturedEvents()
-
-        const initialSessionId = await getSessionId(page)
-
-        await simulateFrozenTabIdle(page)
-
-        // an analytics event (e.g. a background tab capturing a network failure) rotates the session
-        await page.evaluate(() => {
-            ;(window as WindowWithPostHog).posthog?.capture('background_tab_event')
-        })
-
-        const newSessionId = await getSessionId(page)
-        expect(newSessionId).not.toEqual(initialSessionId)
-
-        const capturedAnalytics = await page.capturedEvents()
-        const backgroundEvent = capturedAnalytics.find((e) => e.event === 'background_tab_event')
-        expect(backgroundEvent?.properties.$session_id).toEqual(newSessionId)
-
-        // without any further interaction, replay data for the new session must still flush
-        await expect
-            .poll(
-                async () => {
-                    const snapshots = (await page.capturedEvents()).filter((e) => e.event === '$snapshot')
-                    return snapshots.some((s) => s.properties.$session_id === newSessionId)
+    // Runs in both compression modes: the restart happens mid-stream, so it exercises the
+    // rotation + compression-queue interaction as well.
+    for (const compressEvents of [false, true]) {
+        test(`ships a full snapshot for the new session after rotation with no user interaction (compress_events: ${compressEvents})`, async ({
+            page,
+            context,
+        }) => {
+            const variantStartOptions = {
+                ...startOptions,
+                options: {
+                    ...startOptions.options,
+                    session_recording: { compress_events: compressEvents },
                 },
-                { timeout: 10000 }
-            )
-            .toBe(true)
+            }
+            await page.waitingForNetworkCausedBy({
+                urlPatternsToWaitFor: ['**/*recorder.js*'],
+                action: async () => {
+                    await start(variantStartOptions, page, context)
+                },
+            })
+            await waitForSessionRecordingToStart(page)
+            await page.resetCapturedEvents()
 
-        const snapshots = (await page.capturedEvents()).filter((e) => e.event === '$snapshot')
-        const newSessionSnapshotData = snapshots
-            .filter((s) => s.properties.$session_id === newSessionId)
-            .flatMap((s: any) => s.properties.$snapshot_data)
+            const initialSessionId = await getSessionId(page)
 
-        // the new session must open with Meta then FullSnapshot so it is playable
-        const renderable = newSessionSnapshotData.filter((e: any) => e.type === 4 || e.type === 2)
-        expect(renderable[0]?.type).toEqual(4)
-        expect(renderable[1]?.type).toEqual(2)
-    })
+            await simulateFrozenTabIdle(page)
+
+            // an analytics event (e.g. a background tab capturing a network failure) rotates the session
+            await page.evaluate(() => {
+                ;(window as WindowWithPostHog).posthog?.capture('background_tab_event')
+            })
+
+            const newSessionId = await getSessionId(page)
+            expect(newSessionId).not.toEqual(initialSessionId)
+
+            const capturedAnalytics = await page.capturedEvents()
+            const backgroundEvent = capturedAnalytics.find((e) => e.event === 'background_tab_event')
+            expect(backgroundEvent?.properties.$session_id).toEqual(newSessionId)
+
+            // without any further interaction, replay data for the new session must still flush
+            await expect
+                .poll(
+                    async () => {
+                        const snapshots = (await page.capturedEvents()).filter((e) => e.event === '$snapshot')
+                        return snapshots.some((s) => s.properties.$session_id === newSessionId)
+                    },
+                    { timeout: 10000 }
+                )
+                .toBe(true)
+
+            const snapshots = (await page.capturedEvents()).filter((e) => e.event === '$snapshot')
+            const newSessionSnapshotData = snapshots
+                .filter((s) => s.properties.$session_id === newSessionId)
+                .flatMap((s: any) => s.properties.$snapshot_data)
+
+            // the new session must open with Meta then FullSnapshot so it is playable
+            const renderable = newSessionSnapshotData.filter((e: any) => e.type === 4 || e.type === 2)
+            expect(renderable[0]?.type).toEqual(4)
+            expect(renderable[1]?.type).toEqual(2)
+        })
+    }
 })

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording-compression.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording-compression.test.ts
@@ -280,6 +280,8 @@ describe('LazyLoadedSessionRecording compression paths', () => {
         })
 
         // an idle rotation adopts the new session id before any user interaction clears the idle state
+        // (the session manager must agree, or the recorder re-syncs the stale id from it on the next event)
+        posthog.sessionManager['_setSessionId']('rotated-session-id', 123, 123)
         lazyLoadedSessionRecording['_isIdle'] = 'unknown'
         lazyLoadedSessionRecording['_sessionId'] = 'rotated-session-id'
 
@@ -310,6 +312,7 @@ describe('LazyLoadedSessionRecording compression paths', () => {
         const originalGetStatus = strategy.getStatus.bind(strategy)
         strategy.getStatus = () => 'buffering'
 
+        posthog.sessionManager['_setSessionId']('rotated-session-id', 123, 123)
         lazyLoadedSessionRecording['_isIdle'] = 'unknown'
         lazyLoadedSessionRecording['_sessionId'] = 'rotated-session-id'
         emit(createFullSnapshot({ content: 'post-rotation snapshot' }))
@@ -331,7 +334,7 @@ describe('LazyLoadedSessionRecording compression paths', () => {
     })
 
     it('requests a full snapshot when an incremental ships for a rotated session without one', async () => {
-        const { emit, lazyLoadedSessionRecording } = await setupLazyLoadedSessionRecording({
+        const { emit, posthog, lazyLoadedSessionRecording } = await setupLazyLoadedSessionRecording({
             gzipSupported: true,
         })
         const { assignableWindow } = require('../../../utils/globals')
@@ -343,6 +346,7 @@ describe('LazyLoadedSessionRecording compression paths', () => {
         expect(takeFullSnapshot).not.toHaveBeenCalled()
 
         // an idle rotation adopts the new session id whose full snapshot never ships (the rotation bug), so the next incremental must trigger a healing snapshot
+        posthog.sessionManager['_setSessionId']('rotated-session-id', 123, 123)
         lazyLoadedSessionRecording['_isIdle'] = 'unknown'
         lazyLoadedSessionRecording['_sessionId'] = 'rotated-session-id'
         emit(createIncrementalSnapshot(100))

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -54,6 +54,7 @@ import { SessionRecording } from '../../../extensions/replay/session-recording'
 import {
     LazyLoadedSessionRecording,
     RECORDING_IDLE_THRESHOLD_MS,
+    RECORDING_BUFFER_TIMEOUT,
     RECORDING_MAX_EVENT_SIZE,
     RECORDING_REMOTE_CONFIG_TTL_MS,
 } from '../../../extensions/replay/external/lazy-loaded-session-recorder'
@@ -1308,6 +1309,121 @@ describe('Lazy SessionRecording', () => {
                 expect(recordMock).toHaveBeenCalledTimes(2)
                 expect(sessionRecording['_lazyLoadedSessionRecording']['_sessionId']).toEqual(rotatedSessionId)
                 expect(sessionRecording['_lazyLoadedSessionRecording']['isStarted']).toEqual(true)
+            })
+
+            it('restarts recorder when session rotates externally while _isIdle is unknown', () => {
+                // Regression test for #4202: a tab that never sees user interaction keeps
+                // _isIdle === 'unknown'. An analytics event can still rotate the session via
+                // activityTimeout; the recorder must follow the rotation or every later event
+                // ships under the old session id and the new session never gets a full snapshot.
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual('unknown')
+                const firstSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
+                const recordMock = assignableWindow.__PosthogExtensions__.rrweb.record as Mock
+                expect(recordMock).toHaveBeenCalledTimes(1)
+
+                sessionIdGeneratorMock.mockClear()
+                const rotatedSessionId = 'unknown-idle-rotated-session-id'
+                sessionIdGeneratorMock.mockImplementation(() => rotatedSessionId)
+
+                const rotationTimestamp = sessionManager['_sessionTimeoutMs'] + startingTimestamp + 1000
+                jest.useFakeTimers().setSystemTime(new Date(rotationTimestamp))
+                const { sessionId: newSessionId } = sessionManager.checkAndGetSessionAndWindowId(
+                    false,
+                    rotationTimestamp
+                )
+                expect(newSessionId).toEqual(rotatedSessionId)
+                expect(newSessionId).not.toEqual(firstSessionId)
+
+                // the session-id callback restarts the recorder immediately
+                expect(recordMock).toHaveBeenCalledTimes(2)
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_sessionId']).toEqual(rotatedSessionId)
+
+                // and post-rotation events are attributed to the new session
+                emitInactiveEvent(rotationTimestamp + 100, 'unknown')
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_buffer'].sessionId).toEqual(rotatedSessionId)
+            })
+
+            it('takes a full snapshot for the new session on a second idle rotation without user interaction', () => {
+                // Regression test for #4202, reported production sequence: interaction, idle,
+                // rotation (restart leaves _isIdle 'unknown'), no further interaction, second
+                // rotation. The second rotation must also restart the recorder.
+                const recordMock = assignableWindow.__PosthogExtensions__.rrweb.record as Mock
+                const lazyRecorder = sessionRecording['_lazyLoadedSessionRecording']
+
+                emitActiveEvent(startingTimestamp + 100)
+                emitInactiveEvent(startingTimestamp + RECORDING_IDLE_THRESHOLD_MS + 1000, true)
+
+                sessionIdGeneratorMock.mockClear()
+                sessionIdGeneratorMock.mockImplementation(() => 'second-session-id')
+                const firstRotationTimestamp = sessionManager['_sessionTimeoutMs'] + startingTimestamp + 1000
+                jest.useFakeTimers().setSystemTime(new Date(firstRotationTimestamp))
+                sessionManager.checkAndGetSessionAndWindowId(false, firstRotationTimestamp)
+
+                // first rotation while confirmed idle restarts and leaves _isIdle 'unknown'
+                expect(lazyRecorder['_sessionId']).toEqual('second-session-id')
+                expect(recordMock).toHaveBeenCalledTimes(2)
+                expect(lazyRecorder['_isIdle']).toEqual('unknown')
+
+                // the restarted rrweb ships its initial full snapshot; still no user interaction
+                _emit(createFullSnapshot({ timestamp: firstRotationTimestamp + 10 }))
+                emitInactiveEvent(firstRotationTimestamp + 20, 'unknown')
+                expect(lazyRecorder['_buffer'].sessionId).toEqual('second-session-id')
+
+                sessionIdGeneratorMock.mockImplementation(() => 'third-session-id')
+                const secondRotationTimestamp = sessionManager['_sessionTimeoutMs'] + firstRotationTimestamp + 1000
+                jest.useFakeTimers().setSystemTime(new Date(secondRotationTimestamp))
+                const { sessionId: newSessionId } = sessionManager.checkAndGetSessionAndWindowId(
+                    false,
+                    secondRotationTimestamp
+                )
+                expect(newSessionId).toEqual('third-session-id')
+
+                // the second rotation must restart the recorder too
+                expect(recordMock).toHaveBeenCalledTimes(3)
+                expect(lazyRecorder['_sessionId']).toEqual('third-session-id')
+
+                // and the new session's full snapshot is attributed to it
+                _emit(createFullSnapshot({ timestamp: secondRotationTimestamp + 10 }))
+                expect(lazyRecorder['_buffer'].sessionId).toEqual('third-session-id')
+                const fullSnapshotSessions = lazyRecorder['_fullSnapshotTimestamps'].map(
+                    ([sid]: [string, number]) => sid
+                )
+                expect(fullSnapshotSessions).toContain('third-session-id')
+            })
+
+            it('re-syncs a stale session id from the session manager while _isIdle is unknown', () => {
+                // If the recorder's session id ever diverges from the session manager while no
+                // user interaction has confirmed activity, the next event must re-sync and
+                // restart rather than shipping events under the stale id.
+                const lazyRecorder = sessionRecording['_lazyLoadedSessionRecording']
+                const recordMock = assignableWindow.__PosthogExtensions__.rrweb.record as Mock
+                expect(lazyRecorder['_isIdle']).toEqual('unknown')
+                const realSessionId = lazyRecorder['_sessionId']
+                lazyRecorder['_sessionId'] = 'stale-session-id'
+
+                emitInactiveEvent(startingTimestamp + 100, 'unknown')
+
+                expect(lazyRecorder['_sessionId']).toEqual(realSessionId)
+                expect(recordMock).toHaveBeenCalledTimes(2)
+            })
+
+            it('schedules a buffer flush while _isIdle is unknown so background tabs ship their data', () => {
+                jest.useFakeTimers().setSystemTime(new Date(startingTimestamp + 100))
+
+                const snapshot = emitInactiveEvent(startingTimestamp + 100, 'unknown')
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data).toContain(snapshot)
+                expect(posthog.capture).not.toHaveBeenCalled()
+
+                jest.advanceTimersByTime(RECORDING_BUFFER_TIMEOUT)
+
+                expect(posthog.capture).toHaveBeenCalledWith(
+                    '$snapshot',
+                    expect.objectContaining({
+                        $session_id: sessionId,
+                        $snapshot_data: [snapshot],
+                    }),
+                    expect.any(Object)
+                )
             })
 
             it('recorder follows an adopted sibling-tab session id (does not record under the stale id)', () => {
@@ -4333,6 +4449,9 @@ describe('Lazy SessionRecording', () => {
 
         it('emits session linking events on activity timeout', () => {
             const tryAddCustomEvent = sessionRecording['_lazyLoadedSessionRecording']['_tryAddCustomEvent'] as any
+            // confirm user activity so the rotation callback defers the restart to
+            // _updateWindowAndSessionIds and only the linking events are captured below
+            _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: Date.now() }))
             tryAddCustomEvent.mockClear()
 
             const newSessionId = 'new-session-id'
@@ -4388,6 +4507,9 @@ describe('Lazy SessionRecording', () => {
 
         it('emits session linking events on session past maximum length', () => {
             const tryAddCustomEvent = sessionRecording['_lazyLoadedSessionRecording']['_tryAddCustomEvent'] as any
+            // confirm user activity so the rotation callback defers the restart to
+            // _updateWindowAndSessionIds and only the linking events are captured below
+            _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: Date.now() }))
             tryAddCustomEvent.mockClear()
 
             const newSessionId = 'new-session-id-2'
@@ -4483,6 +4605,9 @@ describe('Lazy SessionRecording', () => {
 
         it('does NOT emit linking events when only noSessionId is true (like after reset)', () => {
             const tryAddCustomEvent = sessionRecording['_lazyLoadedSessionRecording']['_tryAddCustomEvent'] as any
+            // confirm user activity so the rotation callback defers the restart to
+            // _updateWindowAndSessionIds and only the linking events are captured below
+            _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: Date.now() }))
             tryAddCustomEvent.mockClear()
 
             const newSessionId = 'new-session-after-reset'

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1407,6 +1407,53 @@ describe('Lazy SessionRecording', () => {
                 expect(recordMock).toHaveBeenCalledTimes(2)
             })
 
+            it('restarts only once when the $session_id_change emit drives the restart re-entrantly', () => {
+                // Production rrweb delivers addCustomEvent synchronously through emit, so the
+                // $session_id_change custom event emitted inside _onSessionIdCallback re-enters
+                // _updateWindowAndSessionIds, which adopts the rotated ids and restarts. The
+                // callback must then not restart a second time.
+                _addCustomEvent.mockImplementation((tag: string, payload: any) => {
+                    _emit({ type: EventType.Custom, data: { tag, payload }, timestamp: Date.now() })
+                })
+                try {
+                    const recordMock = assignableWindow.__PosthogExtensions__.rrweb.record as Mock
+                    expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual('unknown')
+                    expect(recordMock).toHaveBeenCalledTimes(1)
+
+                    sessionIdGeneratorMock.mockClear()
+                    const rotatedSessionId = 'reentrant-rotated-session-id'
+                    sessionIdGeneratorMock.mockImplementation(() => rotatedSessionId)
+
+                    const rotationTimestamp = sessionManager['_sessionTimeoutMs'] + startingTimestamp + 1000
+                    jest.useFakeTimers().setSystemTime(new Date(rotationTimestamp))
+                    sessionManager.checkAndGetSessionAndWindowId(false, rotationTimestamp)
+
+                    expect(sessionRecording['_lazyLoadedSessionRecording']['_sessionId']).toEqual(rotatedSessionId)
+                    expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual('unknown')
+                    // exactly one restart: the initial start plus a single re-record for the rotation
+                    expect(recordMock).toHaveBeenCalledTimes(2)
+                } finally {
+                    _addCustomEvent.mockReset()
+                }
+            })
+
+            it('flushes the buffer while _isIdle is unknown when it exceeds the max event size', () => {
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual('unknown')
+
+                sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
+
+                // fake having a large buffer, as the idle === true counterpart test does
+                sessionRecording['_lazyLoadedSessionRecording']['_buffer'].size = RECORDING_MAX_EVENT_SIZE - 1
+                sessionRecording.onRRwebEmit(createCustomSnapshot({}) as eventWithTime)
+
+                // unlike confirmed idle, the unknown state must respect the size cap and flush
+                expect(posthog.capture).toHaveBeenCalledWith(
+                    '$snapshot',
+                    expect.objectContaining({ $session_id: sessionId }),
+                    expect.any(Object)
+                )
+            })
+
             it('schedules a buffer flush while _isIdle is unknown so background tabs ship their data', () => {
                 jest.useFakeTimers().setSystemTime(new Date(startingTimestamp + 100))
 

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1208,11 +1208,16 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         this._clearConditionalRecordingPersistence()
 
-        // _updateWindowAndSessionIds only drives the restart while rrweb is running and the
-        // recorder has confirmed activity (_isIdle === false), so restart here in every other
-        // state — idle, stopped, or 'unknown' (a tab with no user interaction since rrweb
-        // started stays 'unknown' indefinitely).
-        if (this._isIdle !== false || !this.isStarted) {
+        // The $session_id_change emit above can synchronously re-enter
+        // _updateWindowAndSessionIds (rrweb delivers addCustomEvent through emit), which
+        // adopts the new ids and restarts the recorder itself. Restart here only when the
+        // ids are still stale — confirmed idle, stopped, or states where that emit never
+        // reached the session check (blocked URL, queued emit) — so a rotation restarts
+        // exactly once.
+        if (
+            (this._isIdle !== false || !this.isStarted) &&
+            (this._sessionId !== sessionId || this._windowId !== windowId)
+        ) {
             this._isIdle = 'unknown'
             this.stop()
             this.start('session_id_changed')

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1208,9 +1208,11 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         this._clearConditionalRecordingPersistence()
 
-        // When rrweb isn't running _updateWindowAndSessionIds can't drive the restart,
-        // so we restart here. Otherwise it handles the restart after this callback returns.
-        if (this._isIdle === true || !this.isStarted) {
+        // _updateWindowAndSessionIds only drives the restart while rrweb is running and the
+        // recorder has confirmed activity (_isIdle === false), so restart here in every other
+        // state — idle, stopped, or 'unknown' (a tab with no user interaction since rrweb
+        // started stays 'unknown' indefinitely).
+        if (this._isIdle !== false || !this.isStarted) {
             this._isIdle = 'unknown'
             this.stop()
             this.start('session_id_changed')
@@ -1828,8 +1830,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         if (
             sessionChanged ||
-            // we never want to flush a healthy same-session buffer while idle
-            (!this._isIdle &&
+            // we never want to flush a healthy same-session buffer while confirmed idle, but
+            // 'unknown' still captures so its buffer must respect the size cap or it grows unbounded
+            (this._isIdle !== true &&
                 this._buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE)
         ) {
             this._buffer = this._flushBuffer()
@@ -1846,7 +1849,10 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         this._buffer.data.push(properties.$snapshot_data)
         this._buffer.sizes.push(properties.$snapshot_bytes)
 
-        if (!this._flushBufferTimer && !this._isIdle) {
+        // Schedule the flush unless confirmed idle: a tab that never sees user interaction stays
+        // 'unknown' indefinitely, and without a timer its captured events (including the initial
+        // full snapshot after a session rotation) would never ship until the next rotation or unload.
+        if (!this._flushBufferTimer && this._isIdle !== true) {
             this._flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()
             }, RECORDING_BUFFER_TIMEOUT)
@@ -2002,7 +2008,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             }
         }
 
-        if (this._isIdle) {
+        // Only bail on confirmed idle: while 'unknown' the recorder still captures, so it must
+        // also keep checking for session changes or its events are stamped with a stale session id.
+        if (this._isIdle === true) {
             return
         }
 


### PR DESCRIPTION
## Problem

Fixes #4202.

In a tab with no user interaction, the session recorder sits in the `'unknown'` idle state (`_isIdle: boolean | 'unknown'`). Several guards treat that truthy string as "idle", so when the analytics session rotates via activity timeout (e.g. a long-lived background tab capturing an event), the recorder:

- never restarts — `_onSessionIdCallback` only restarted when `_isIdle === true`, and `_updateWindowAndSessionIds` (the "otherwise" restart path its comment relies on) bailed early on truthy `_isIdle`
- keeps stamping every event, including periodic full snapshots, with the **old** session id
- never schedules a buffer flush, so data accumulates unbounded and ships nothing

Net effect, exactly as reported in #4202: the new session's only ingested blob is the `$session_starting` lifecycle event, there is no FullSnapshot under the new session id, and the replay is unplayable while `get_session_replay_url()` happily points at it.

## Changes

Four one-line guard fixes in `lazy-loaded-session-recorder.ts`, all the same `'unknown'`-truthiness family:

1. `_onSessionIdCallback` restarts the recorder when `_isIdle !== false` (was `=== true`), so a rotation in the `'unknown'` state restarts immediately and the new session gets its own FullSnapshot.
2. `_updateWindowAndSessionIds` bails only on confirmed idle (`=== true`), so a recorder in `'unknown'` keeps checking for session changes on every event and self-heals a stale `_sessionId`. This revives the approach from #3511, which was approved but closed unmerged.
3. The flush timer in `_captureSnapshotBuffered` is scheduled while `'unknown'`, so a no-interaction tab ships its buffer (including the post-rotation FullSnapshot) on the normal 2s cadence instead of holding it until the next rotation or unload. `$snapshot` capture returns before the session check in `_calculate_event_properties`, so flushing cannot extend the session, and `_flushBuffer`'s own gating (buffering/paused/minimum duration) still applies.
4. The buffer size cap likewise applies during `'unknown'`, so the buffer can no longer grow unbounded in memory.
5. The restart guard in `_onSessionIdCallback` also requires the ids to still be stale: with real rrweb, the `$session_id_change` custom event is delivered synchronously through `emit` and re-enters `_updateWindowAndSessionIds`, which (after change 2) adopts the new ids and restarts the recorder itself — without the staleness check, every rotation in the `'unknown'` state restarted twice, shipping two full DOM serializations. A rotation now restarts the recorder exactly once, and degraded paths (queued emit, blocked URL, stopped recorder) still fall back to the callback restart.

Capture (`onRRwebEmit`) and periodic snapshot scheduling already treated only `=== true` as idle; this brings the remaining guards in line.

Test changes:

- Unit regression tests for the bootup-`'unknown'` rotation, the reported two-rotation background-tab sequence, the stale-session-id re-sync, and the `'unknown'`-state flush (red on the old code, green now).
- A real-rrweb Playwright spec (both compression modes): rotation with zero user interaction must ship **exactly one** Meta + FullSnapshot pair under the new session id with no further activity. Verified failing against the unfixed bundle and passing with the fix.
- A re-entrancy unit test with `addCustomEvent` forwarded into `emit` the way real rrweb delivers it, pinning the exactly-one-restart behavior of change 5 (red before that change, green after), plus a size-cap-while-`'unknown'` test for change 4.
- Six existing tests re-staged: three session-linking tests now confirm user activity first (they implicitly relied on no-restart-during-`'unknown'`), and three #4104 compression tests staged rotation by writing `_sessionId` without telling the session manager — a divergence the recorder now corrects — so they stage the manager too.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] `@posthog/react-native-plugin`
- [ ] `@posthog/react`
- [ ] `@posthog/ai`
- [ ] `@posthog/convex`
- [ ] `@posthog/next`
- [ ] `@posthog/nextjs-config`
- [ ] `@posthog/nuxt`
- [ ] `@posthog/openfeature-node-provider`
- [ ] `@posthog/openfeature-web-provider`
- [ ] `@posthog/rollup-plugin`
- [ ] `@posthog/webpack-plugin`
- [ ] `@posthog/types`
- [ ] `@posthog/browser-common`

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Investigation started from the #4202 report: reproduced the failure in unit tests against the real `SessionIdManager` → recorder callback chain before touching any code, then verified the fix end-to-end by rebuilding the bundle with and without the change and running the new Playwright spec against both (fails on the old bundle with exactly the reported symptom — only the `$session_starting` blob ships for the new session).
- Considered fixing only the missed restart, but that leaves the new session's snapshot sitting in an unflushed buffer for up to the next rotation/unload (the reporter's "flushed size stayed 0 for over an hour"), so the flush guards were included; verified `$snapshot` capture cannot extend the session before making flushing more eager.
