### PR TITLE
fix: honor a fallback of 0 in clampToRange

### DIFF
--- a/.changeset/clamp-to-range-zero-fallback.md
+++ b/.changeset/clamp-to-range-zero-fallback.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Fix `clampToRange` discarding a valid fallback value of `0`. It used `fallbackValue || max`, so a `0` fallback (a legitimate value) was treated as absent and replaced by `max`; it now uses `??` so `0` is honored.

--- a/packages/core/src/utils/number-utils.spec.ts
+++ b/packages/core/src/utils/number-utils.spec.ts
@@ -67,6 +67,26 @@ describe('number-utils', () => {
         },
       ],
       [
+        'honors a fallback of 0 instead of falling back to max',
+        {
+          value: 'invalid',
+          min: 0,
+          max: 100,
+          expected: 0,
+          fallback: 0,
+        },
+      ],
+      [
+        'clamps a fallback of 0 up to min',
+        {
+          value: 'invalid',
+          min: 10,
+          max: 100,
+          expected: 10,
+          fallback: 0,
+        },
+      ],
+      [
         'returns the max value when fallback is not valid',
         {
           value: 'invalid',

--- a/packages/core/src/utils/number-utils.ts
+++ b/packages/core/src/utils/number-utils.ts
@@ -17,7 +17,9 @@ export function clampToRange(value: unknown, min: number, max: number, logger: L
 
   if (!isNumber(value)) {
     logger.warn(' must be a number. using max or fallback. max: ' + max + ', fallback: ' + fallbackValue)
-    return clampToRange(fallbackValue || max, min, max, logger)
+    // Use ?? so a valid fallback of 0 is honored instead of being treated as
+    // absent and replaced by max.
+    return clampToRange(fallbackValue ?? max, min, max, logger)
   } else if (value > max) {
     logger.warn(' cannot be  greater than max: ' + max + '. Using max value instead.')
     return max


### PR DESCRIPTION
## Problem

`clampToRange` (in `@posthog/core`) discards a valid fallback value of `0`. When the input value is not a number, it recurses with `fallbackValue || max`, so a `0` fallback — a legitimate value — is treated as absent and replaced by `max`:

```ts
clampToRange('invalid', 0, 100, logger, 0) // returned 100, expected 0
clampToRange('invalid', 10, 100, logger, 0) // returned 100, expected 10 (0 clamped to min)
```

`clampToRange` is consumed with a fallback in several published paths (session recorder canvas fps/quality, `request-queue` flush timeout, `sessionid`), so a config value of `0` used as a fallback would silently become `max`.

## Changes

- `clampToRange` now uses `fallbackValue ?? max` instead of `fallbackValue || max`, so a `0` fallback is honored. Truthy fallbacks and the `undefined` (→ `max`) case are unchanged, so there is no behavior change for existing callers.
- Added two regression cases to `number-utils.spec.ts` covering a `0` fallback (honored when in range; clamped up to `min` when below it).
- Added a changeset targeting `@posthog/core` (patch).

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

<!-- The fix is in @posthog/core; the changeset patches @posthog/core, which cascades a patch to its dependents (posthog-js web, node, react-native, etc.) via updateInternalDependencies. -->

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Claude Opus 4.8). A human directed the goal of contributing a small, well-scoped fix; the agent found and implemented it.
- How the bug was found: reviewing the pure utility functions in `packages/core/src/utils`, `clampToRange`'s `fallbackValue || max` stood out as a classic `||`-vs-`??` bug that drops a valid `0`.
- Testing: I could not run the repo's Jest suite locally because its Babel `.mjs` config requires Node ≥ 22.13 and this machine has Node 20/21. Instead I verified the **actual edited module** by bundling `number-utils.ts` with the repo's esbuild and executing `clampToRange` against the cases above — all pass (`0`→`0`, `0`/min 10→`10`, `20`→`20`, `undefined`→`max`, valid value passes through). The added Jest cases will run in CI on the proper Node version. I have not performed browser/manual testing beyond this.
- This is a latent-bug fix (I did not find a current caller passing exactly `0`), so behavior for existing usage is unchanged; happy to drop the changeset if you'd prefer to treat it as non-publishable.
