### PR TITLE
refactor(traces): keep the traces plumbing off the public API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,7 +45,6 @@ export {
 } from './logs/logs-utils'
 export { toOtlpAnyValue, toOtlpKeyValueList } from './utils/otlp-any-value'
 export { osResourceAttributes } from './utils/otlp-resource'
-export { assignUserAttributes } from './traces/sanitize'
 export { PostHogLogs } from './logs'
 export type {
   BeforeSendLogFn,
@@ -90,7 +89,8 @@ export type {
 } from './metrics/types'
 export { PostHogTraces } from './traces'
 export { SyncSpanContextManager } from './traces/context'
-export { NOOP_SPAN, inertSpan } from './traces/span'
+export { inertSpan, runWithActiveSpan } from './traces/span'
+export { resolveTracesConfig } from './traces/config'
 export type { ResolvedTracesConfig, SpanContextManager, TraceSdkContext } from './traces/types'
 // Same barrel convention as logs and metrics for the user-facing tracing types.
 export type {

--- a/packages/core/src/traces/config.spec.ts
+++ b/packages/core/src/traces/config.spec.ts
@@ -1,4 +1,4 @@
-import { resolveTracesConfig } from '../traces-defaults'
+import { resolveTracesConfig } from './config'
 
 describe('resolveTracesConfig', () => {
   it('applies the documented defaults', () => {

--- a/packages/core/src/traces/config.ts
+++ b/packages/core/src/traces/config.ts
@@ -1,5 +1,6 @@
-import { assignUserAttributes } from '@posthog/core'
-import type { ResolvedTracesConfig, TracesConfig } from '@posthog/core'
+import { assignUserAttributes } from '../utils/json-utils'
+import type { ResolvedTracesConfig } from './types'
+import type { TracesConfig } from '@posthog/types'
 
 // OpenTelemetry's BatchSpanProcessor defaults, which sit comfortably under the
 // server's 2 MB body cap.

--- a/packages/core/src/traces/index.ts
+++ b/packages/core/src/traces/index.ts
@@ -8,10 +8,11 @@ import type {
   TraceSdkContext,
   TracesHost,
 } from './types'
-import { NOOP_SPAN, PostHogSpan, describeError, inertSpan, monotonicNow } from './span'
+import { NOOP_SPAN, PostHogSpan, describeError, inertSpan, monotonicNow, runWithActiveSpan } from './span'
 import { newSpanId, newTraceId } from './ids'
 import { parseTraceparent, sanitizeTracestate } from './traceparent'
-import { assignUserAttributes, resolveStartTime, sanitizeName } from './sanitize'
+import { resolveStartTime, sanitizeName } from './sanitize'
+import { assignUserAttributes } from '../utils/json-utils'
 import { buildOtlpSpan, buildOtlpTracesPayload, buildTracesResourceAttributes } from './otlp'
 import { isPromise, safeSetTimeout } from '../utils'
 
@@ -180,11 +181,7 @@ export class PostHogTraces {
     const span = this.startSpan(name, options)
 
     try {
-      // The shared no-op is never activated, so `getActiveSpan()` inside the
-      // callback reads null — callbacks should use the handle they're given. A
-      // pass-through handle is activated, so `getActiveSpan()?.traceparent()`
-      // still propagates an inbound trace through a service with tracing off.
-      const result = span === NOOP_SPAN ? fn(span) : this._contextManager.with(span, () => fn(span))
+      const result = runWithActiveSpan(this._contextManager, span, fn)
 
       if (isPromise(result)) {
         return result.then(

--- a/packages/core/src/traces/sanitize.ts
+++ b/packages/core/src/traces/sanitize.ts
@@ -6,7 +6,6 @@
 
 import type { Logger } from '../types'
 import type { SpanAttributes, SpanTimeInput } from '@posthog/types'
-import { UNSERIALIZABLE_VALUE } from '../utils/json-utils'
 
 const FALLBACK_SPAN_NAME = 'unknown'
 
@@ -107,39 +106,4 @@ export function resolveSuppliedTime(
     return derived
   }
   return supplied
-}
-
-/**
- * Copies caller-supplied attributes onto `target`, own enumerable keys only.
- *
- * Read key by key rather than spread: a getter over a disposed resource or a
- * revoked proxy throws on the read itself, before the encoder's guards see it.
- *
- * @internal Exposed for cross-package use within this SDK; not part of the stable public API.
- */
-export function assignUserAttributes<T extends Record<string, any>>(
-  target: T,
-  source: Record<string, unknown> | undefined
-): T {
-  if (!source) {
-    return target
-  }
-  let keys: string[] = []
-  try {
-    keys = Object.keys(source)
-  } catch {
-    keys = []
-  }
-  for (const key of keys) {
-    let value: unknown
-    try {
-      value = source[key]
-    } catch {
-      value = UNSERIALIZABLE_VALUE
-    }
-    // defineProperty, not assignment: `attributes['__proto__'] = v` hits the
-    // prototype setter and the attribute vanishes.
-    Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true })
-  }
-  return target
 }

--- a/packages/core/src/traces/span.ts
+++ b/packages/core/src/traces/span.ts
@@ -1,8 +1,9 @@
 import type { Span, SpanAttributes, SpanAttributeValue, SpanKind, SpanStatusCode, SpanTimeInput } from '@posthog/types'
 import type { Logger } from '../types'
-import type { SpanEventRecord, SpanRecord } from './types'
+import type { SpanContextManager, SpanEventRecord, SpanRecord } from './types'
 import { formatTraceparent, normalizeTraceparent, sanitizeTracestate, TRACE_FLAGS_SAMPLED } from './traceparent'
-import { assignUserAttributes, clampEndTime, resolveSuppliedTime, sanitizeName } from './sanitize'
+import { clampEndTime, resolveSuppliedTime, sanitizeName } from './sanitize'
+import { assignUserAttributes } from '../utils/json-utils'
 import { isError } from '../utils'
 
 /**
@@ -273,6 +274,18 @@ export function inertSpan(options?: { parent?: unknown; tracestate?: unknown }):
     return NOOP_SPAN
   }
   return new PassThroughSpan(traceparent, sanitizeTracestate(options?.tracestate))
+}
+
+/**
+ * Runs `fn` with `span` active, which every scoped helper does the same way.
+ *
+ * The shared no-op is never activated, so `getActiveSpan()` inside the callback
+ * reads null — callbacks should use the handle they're given. A pass-through
+ * handle is activated, so `getActiveSpan()?.traceparent()` still propagates an
+ * inbound trace through a service with tracing off.
+ */
+export function runWithActiveSpan<T>(contextManager: SpanContextManager, span: Span, fn: (span: Span) => T): T {
+  return span === NOOP_SPAN ? fn(span) : contextManager.with(span, () => fn(span))
 }
 
 /**

--- a/packages/core/src/utils/json-utils.ts
+++ b/packages/core/src/utils/json-utils.ts
@@ -153,3 +153,36 @@ export function toJsonSafeValue(value: unknown): unknown {
 
   return convert(value, 0)
 }
+
+/**
+ * Copies caller-supplied attributes onto `target`, own enumerable keys only.
+ *
+ * Read key by key rather than spread: a getter over a disposed resource or a
+ * revoked proxy throws on the read itself, before the encoder's guards see it.
+ */
+export function assignUserAttributes<T extends Record<string, any>>(
+  target: T,
+  source: Record<string, unknown> | undefined
+): T {
+  if (!source) {
+    return target
+  }
+  let keys: string[] = []
+  try {
+    keys = Object.keys(source)
+  } catch {
+    keys = []
+  }
+  for (const key of keys) {
+    let value: unknown
+    try {
+      value = source[key]
+    } catch {
+      value = UNSERIALIZABLE_VALUE
+    }
+    // defineProperty, not assignment: `attributes['__proto__'] = v` hits the
+    // prototype setter and the attribute vanishes.
+    Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true })
+  }
+  return target
+}

--- a/packages/core/src/utils/otlp-resource.ts
+++ b/packages/core/src/utils/otlp-resource.ts
@@ -1,4 +1,4 @@
-import { assignUserAttributes } from '../traces/sanitize'
+import { assignUserAttributes } from './json-utils'
 
 /**
  * Shape the logs, metrics and traces resolved configs share for resource

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -18,10 +18,11 @@ import {
   PostHogMetrics,
   PostHogPersistedProperty,
   PostHogTraces,
-  NOOP_SPAN,
   inertSpan,
   Properties,
   resolveMetricsConfig,
+  resolveTracesConfig,
+  runWithActiveSpan,
   RetriableOptions,
   raceWithTimeout,
   safeSetTimeout,
@@ -29,7 +30,6 @@ import {
   uuidv7,
 } from '@posthog/core'
 import type { Metrics, Span, SpanContextManager, StartSpanOptions, TraceSdkContext } from '@posthog/core'
-import { resolveTracesConfig } from './traces-defaults'
 import {
   AllFlagsOptions,
   EventMessage,
@@ -747,8 +747,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       // Tracing off: still run the callback exactly once, with an inert handle.
       // A handle carrying an inbound `parent` is activated, so `getActiveSpan()`
       // inside the callback can propagate the trace onward.
-      const span = inertSpan(options)
-      return span === NOOP_SPAN ? fn(span) : this._spanContextManager.with(span, () => fn(span))
+      return runWithActiveSpan(this._spanContextManager, inertSpan(options), fn)
     }
     return options ? pipeline.withSpan(name, options, fn) : pipeline.withSpan(name, fn)
   }


### PR DESCRIPTION
## Problem

Three symbols became permanent exports of `@posthog/core` in #4579, none of them things a developer should ever import:

- **`assignUserAttributes`** — a generic safe-copy utility, tagged `@internal` in its own docstring, exported only so `packages/node/src/traces-defaults.ts` could reach it across the package boundary.
- **`NOOP_SPAN`** — a sentinel, exported only so `packages/node/src/client.ts` could reproduce `PostHogTraces.withSpan`'s activation rule with an identity check.
- **`inertSpan`** — legitimate, but paired with the sentinel above.

Reaching for `assignUserAttributes` also made `packages/core/src/utils/` depend on `packages/core/src/traces/`, while `traces/otlp.ts` imports `buildOtlpResourceAttributes` back out of `utils/`. Two directories that point at each other, and `traces/sanitize.ts` pulled into every browser bundle even though the browser has no traces host yet.

None of this has shipped — the stack hasn't released — so it's still cheap to fix. Once it releases, the export surface is permanent.

Found by a pre-PR review pass on #4579, and stacked directly on it, since it is #4579's own code being cleaned up.

## Changes

**`resolveTracesConfig` moves to `packages/core/src/traces/config.ts`**, next to `resolveMetricsConfig` in `packages/core/src/metrics/config.ts`, which is the precedent it should have followed: metrics resolves its config in core and is consumed by both `packages/browser` and `packages/node`. It was already host-agnostic — the runtime-detected OS attributes arrive as a `hostResourceAttributes` parameter — so the move is a file move plus import rewiring. Its 39 tests move with it.

This matters beyond tidiness: the defaults (`5000`, `512`, `2048`, `10000`, `3_600_000`) are promised to every SDK by the `@default` doc comments on the public `TracesConfig`. With the resolver in `packages/node`, the next traces host either copies the file or picks different numbers and silently falsifies those docs.

**`assignUserAttributes` moves to `packages/core/src/utils/json-utils.ts`**, where `UNSERIALIZABLE_VALUE`, its only dependency, already lives. `utils/` no longer imports from `traces/`.

**`runWithActiveSpan(contextManager, span, fn)`** replaces the duplicated activation rule. `PostHogTraces.withSpan` and `PostHogBackendClient.withSpan` had the same `span === NOOP_SPAN ? … : …` line, and nothing failed if only one of them were updated. Now the rule lives once and `NOOP_SPAN` stays internal.

Net public surface: three exports out, one in (`resolveTracesConfig`, matching `resolveMetricsConfig`), and one renamed in purpose (`runWithActiveSpan` instead of the raw sentinel).

### Reviewer notes

- **No behavior change anywhere.** No production logic is edited — this is moves, import rewiring, and one extracted function. The suites are the check: `packages/core` 1390 pass (64 suites, up 29 as the config tests arrive), `packages/node` 988 pass (35 suites, down 29 as they leave). Same totals as the base branch, just relocated.
- **The browser bundle is unchanged**, at 281,076 B for `array.js` — byte-identical to the base. `buildOtlpResourceAttributes` still calls `assignUserAttributes`, so the function stays in the bundle; what leaves is the *dependency direction*, not the bytes. Worth being precise about: breaking the cycle is what a future code-split traces host would need, not something that pays off today.
- **API references regenerate with no drift.** None of the removed exports were reaching the generated `packages/{node,react-native}/references/*-latest.json` — they were public through the `@posthog/core` barrel only, which is exactly the surface that has no doc-level guard on it.
- **No changeset.** Everything here is internal to the traces feature #4579 introduces, which has not shipped, so there is no outcome to describe to an external developer.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

`@posthog/core` is also touched; both packages are already bumped by the changesets on this stack.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

The removed exports have never appeared in a published version, so nothing external can be depending on them.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

Deliberately none — see the reviewer note above.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @turnipdabeets.

Came out of a pre-PR review loop on #4579: two independent fresh-context reviewers, one on correctness and spec conformance, one on public API surface and maintainability. This PR is the second reviewer's public-surface findings. The first reviewer's one material finding — the retry budget being spent by a caller-driven `flush()` — is fixed in #4726 instead, where the retry semantics already live.

Decisions worth flagging:

- **`runWithActiveSpan` over exporting a predicate.** An `isActivatable(span)` helper would have kept the sentinel internal too, but left the two-line rule duplicated in both hosts. Exporting the whole rule is the version that can't drift.
- **Cost to #4584, measured rather than assumed.** #4584 also edits `traces-defaults.ts`, so this move touches a file it has changes in. Merging this into #4584 was simulated: git follows the rename, so all 45 lines #4584 adds (`resolveBeforeSpanSend`, the per-span constants, the extra `logger` parameter) land in the new `core/traces/config.ts` path automatically. The whole conflict is one hunk of five lines — the import block, where both sides edited the same two lines.
- **`SendTracesBatchOutcome` in the react-native reference is left alone.** It surfaces there because it's the return type of a public method on the shared core client, which is #4579's design rather than a leak this PR introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8eFZB35NExUZyq5hGgh43
