### PR TITLE
fix(traces): reject a traceparent W3C requires a vendor to ignore

### DIFF
--- a/.changeset/traceparent-w3c-strictness.md
+++ b/.changeset/traceparent-w3c-strictness.md
@@ -1,0 +1,6 @@
+---
+'posthog-node': patch
+'@posthog/core': patch
+---
+
+Start a fresh trace on an inbound `traceparent` that W3C requires a vendor to ignore, rather than continuing it. Two headers were being accepted: a version `00` header carrying fields beyond `trace-id`, `parent-id` and `trace-flags`, and one whose ids are uppercase hex. Both were continued here while a conformant peer restarts the trace, so a request crossing the two ended up split across two trace IDs. Unknown trailing fields on a _higher_ version are still ignored, as the spec intends.

--- a/.changeset/traceparent-w3c-strictness.md
+++ b/.changeset/traceparent-w3c-strictness.md
@@ -1,6 +1,5 @@
 ---
-'posthog-node': patch
 '@posthog/core': patch
 ---
 
-Start a fresh trace on an inbound `traceparent` that W3C requires a vendor to ignore, rather than continuing it. Two headers were being accepted: a version `00` header carrying fields beyond `trace-id`, `parent-id` and `trace-flags`, and one whose ids are uppercase hex. Both were continued here while a conformant peer restarts the trace, so a request crossing the two ended up split across two trace IDs. Unknown trailing fields on a _higher_ version are still ignored, as the spec intends.
+Ignore an inbound `traceparent` that W3C requires a vendor to reject — a version `00` header carrying fields beyond `trace-id`, `parent-id` and `trace-flags`, or one whose ids are uppercase hex — and start a fresh trace instead.

--- a/packages/core/src/traces/traceparent.spec.ts
+++ b/packages/core/src/traces/traceparent.spec.ts
@@ -50,12 +50,17 @@ describe('traceparent', () => {
       expect(parseTraceparent(`00-${TRACE_ID}-${SPAN_ID}-01-`)).toBeUndefined()
     })
 
-    it('normalizes case and surrounding whitespace', () => {
-      expect(parseTraceparent(`  00-${TRACE_ID.toUpperCase()}-${SPAN_ID.toUpperCase()}-01 `)).toEqual({
+    it('trims surrounding whitespace', () => {
+      expect(parseTraceparent(`  00-${TRACE_ID}-${SPAN_ID}-01 `)).toEqual({
         traceId: TRACE_ID,
         spanId: SPAN_ID,
         flags: '01',
       })
+    })
+
+    it('rejects uppercase hex, which W3C requires a vendor to ignore', () => {
+      expect(parseTraceparent(`00-${TRACE_ID.toUpperCase()}-${SPAN_ID}-01`)).toBeUndefined()
+      expect(parseTraceparent(`00-${TRACE_ID}-${SPAN_ID.toUpperCase()}-01`)).toBeUndefined()
     })
 
     it.each([
@@ -138,10 +143,8 @@ describe('normalizeTraceparent', () => {
     expect(normalizeTraceparent(`01-${TRACE_ID}-${SPAN_ID}-01`)).toBe(`01-${TRACE_ID}-${SPAN_ID}-01`)
   })
 
-  it("canonicalises whitespace and case, and drops a higher version's trailing fields", () => {
-    expect(normalizeTraceparent(`  01-${TRACE_ID.toUpperCase()}-${SPAN_ID}-01-extra `)).toBe(
-      `01-${TRACE_ID}-${SPAN_ID}-01`
-    )
+  it("trims surrounding whitespace, and drops a higher version's trailing fields", () => {
+    expect(normalizeTraceparent(`  01-${TRACE_ID}-${SPAN_ID}-01-extra `)).toBe(`01-${TRACE_ID}-${SPAN_ID}-01`)
   })
 
   it.each([
@@ -149,6 +152,7 @@ describe('normalizeTraceparent', () => {
     ['the invalid ff version', `ff-${TRACE_ID}-${SPAN_ID}-01`],
     ['an all-zero trace id', `00-${'0'.repeat(32)}-${SPAN_ID}-01`],
     ['version 00 with trailing fields', `00-${TRACE_ID}-${SPAN_ID}-01-extra`],
+    ['an uppercase trace id', `00-${TRACE_ID.toUpperCase()}-${SPAN_ID}-01`],
     ['a non-string', ['a', 'b']],
   ])('rejects %s', (_name, value) => {
     expect(normalizeTraceparent(value)).toBeUndefined()

--- a/packages/core/src/traces/traceparent.spec.ts
+++ b/packages/core/src/traces/traceparent.spec.ts
@@ -43,9 +43,6 @@ describe('traceparent', () => {
     })
 
     it('rejects version 00 with extra fields, which only a higher version may carry', () => {
-      // W3C defines version 00 as exactly three fields. A peer that follows the
-      // spec restarts the trace here, so continuing it would split the trace in
-      // half across the two services.
       expect(parseTraceparent(`00-${TRACE_ID}-${SPAN_ID}-01-something`)).toBeUndefined()
       expect(parseTraceparent(`00-${TRACE_ID}-${SPAN_ID}-01-`)).toBeUndefined()
     })

--- a/packages/core/src/traces/traceparent.spec.ts
+++ b/packages/core/src/traces/traceparent.spec.ts
@@ -42,6 +42,14 @@ describe('traceparent', () => {
       })
     })
 
+    it('rejects version 00 with extra fields, which only a higher version may carry', () => {
+      // W3C defines version 00 as exactly three fields. A peer that follows the
+      // spec restarts the trace here, so continuing it would split the trace in
+      // half across the two services.
+      expect(parseTraceparent(`00-${TRACE_ID}-${SPAN_ID}-01-something`)).toBeUndefined()
+      expect(parseTraceparent(`00-${TRACE_ID}-${SPAN_ID}-01-`)).toBeUndefined()
+    })
+
     it('normalizes case and surrounding whitespace', () => {
       expect(parseTraceparent(`  00-${TRACE_ID.toUpperCase()}-${SPAN_ID.toUpperCase()}-01 `)).toEqual({
         traceId: TRACE_ID,
@@ -130,9 +138,9 @@ describe('normalizeTraceparent', () => {
     expect(normalizeTraceparent(`01-${TRACE_ID}-${SPAN_ID}-01`)).toBe(`01-${TRACE_ID}-${SPAN_ID}-01`)
   })
 
-  it('canonicalises whitespace and case, and drops unknown trailing fields', () => {
-    expect(normalizeTraceparent(`  00-${TRACE_ID.toUpperCase()}-${SPAN_ID}-01-extra `)).toBe(
-      `00-${TRACE_ID}-${SPAN_ID}-01`
+  it("canonicalises whitespace and case, and drops a higher version's trailing fields", () => {
+    expect(normalizeTraceparent(`  01-${TRACE_ID.toUpperCase()}-${SPAN_ID}-01-extra `)).toBe(
+      `01-${TRACE_ID}-${SPAN_ID}-01`
     )
   })
 
@@ -140,6 +148,7 @@ describe('normalizeTraceparent', () => {
     ['a malformed header', 'not-a-traceparent'],
     ['the invalid ff version', `ff-${TRACE_ID}-${SPAN_ID}-01`],
     ['an all-zero trace id', `00-${'0'.repeat(32)}-${SPAN_ID}-01`],
+    ['version 00 with trailing fields', `00-${TRACE_ID}-${SPAN_ID}-01-extra`],
     ['a non-string', ['a', 'b']],
   ])('rejects %s', (_name, value) => {
     expect(normalizeTraceparent(value)).toBeUndefined()

--- a/packages/core/src/traces/traceparent.ts
+++ b/packages/core/src/traces/traceparent.ts
@@ -7,9 +7,9 @@ export interface RemoteSpanContext {
   flags: string
 }
 
-// `00-<32 hex>-<16 hex>-<2 hex>`. Version `ff` is invalid per the spec; other
-// unknown versions are forwards-compatible, so we parse the first four fields
-// and tolerate whatever a later version appends after them.
+// Version `ff` is invalid per the spec, and a higher version may append fields
+// after the first four, so the trailing group captures them rather than failing
+// the match.
 const TRACEPARENT_RE = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})(-.*)?$/
 
 /**
@@ -46,9 +46,9 @@ function matchTraceparent(value: unknown): TraceparentFields | undefined {
   if (typeof value !== 'string') {
     return undefined
   }
-  // Only surrounding whitespace is forgiven. W3C spells every field lowercase hex
-  // and requires a vendor to ignore a `traceparent` whose ids are not, so folding
-  // the case here would continue a trace that a conformant peer restarts.
+  // W3C spells every field lowercase hex and requires a vendor to ignore a
+  // `traceparent` whose ids are not, so folding the case here would continue a
+  // trace that a conformant peer restarts.
   const match = TRACEPARENT_RE.exec(value.trim())
   if (!match) {
     return undefined
@@ -59,8 +59,7 @@ function matchTraceparent(value: unknown): TraceparentFields | undefined {
   }
   // Version `00` is defined as exactly `trace-id "-" parent-id "-" trace-flags`.
   // W3C scopes the tolerate-what-you-don't-know rule to a *higher* version, so a
-  // version `00` header with anything appended is malformed and starts a fresh
-  // trace, the way a conformant peer handles it.
+  // version `00` header with anything appended is malformed.
   if (version === '00' && trailing) {
     return undefined
   }

--- a/packages/core/src/traces/traceparent.ts
+++ b/packages/core/src/traces/traceparent.ts
@@ -46,7 +46,10 @@ function matchTraceparent(value: unknown): TraceparentFields | undefined {
   if (typeof value !== 'string') {
     return undefined
   }
-  const match = TRACEPARENT_RE.exec(value.trim().toLowerCase())
+  // Only surrounding whitespace is forgiven. W3C spells every field lowercase hex
+  // and requires a vendor to ignore a `traceparent` whose ids are not, so folding
+  // the case here would continue a trace that a conformant peer restarts.
+  const match = TRACEPARENT_RE.exec(value.trim())
   if (!match) {
     return undefined
   }

--- a/packages/core/src/traces/traceparent.ts
+++ b/packages/core/src/traces/traceparent.ts
@@ -8,7 +8,8 @@ export interface RemoteSpanContext {
 }
 
 // `00-<32 hex>-<16 hex>-<2 hex>`. Version `ff` is invalid per the spec; other
-// unknown versions are forwards-compatible, so we parse the first four fields only.
+// unknown versions are forwards-compatible, so we parse the first four fields
+// and tolerate whatever a later version appends after them.
 const TRACEPARENT_RE = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})(-.*)?$/
 
 /**
@@ -49,8 +50,15 @@ function matchTraceparent(value: unknown): TraceparentFields | undefined {
   if (!match) {
     return undefined
   }
-  const [, version, traceId, spanId, flags] = match
+  const [, version, traceId, spanId, flags, trailing] = match
   if (version === 'ff') {
+    return undefined
+  }
+  // Version `00` is defined as exactly `trace-id "-" parent-id "-" trace-flags`.
+  // W3C scopes the tolerate-what-you-don't-know rule to a *higher* version, so a
+  // version `00` header with anything appended is malformed and starts a fresh
+  // trace, the way a conformant peer handles it.
+  if (version === '00' && trailing) {
     return undefined
   }
   if (!isValidTraceId(traceId) || !isValidSpanId(spanId)) {


### PR DESCRIPTION
## Problem

[pointed out on #4579](https://github.com/PostHog/posthog-js/pull/4579#issuecomment-3927707022) that the traceparent parser accepts a version `00` header longer than the 55 characters W3C defines, so the SDK continues a trace that a conformant peer would restart. That's real. Checking the rest of the parser against the spec turned up a second case of the same thing: uppercase hex ids.

W3C defines version `00` as exactly `trace-id "-" parent-id "-" trace-flags`, all lowercase hex. The tolerate-what-you-don't-know rule in "Versioning of `traceparent`" is scoped to *"If a higher version is detected"*, and §3.2.2.4 says a vendor "MUST ignore the `traceparent` when the parent-id is invalid (for example, if it contains non-lowercase hex characters)". OpenTelemetry JS enforces both — its regex is `[\da-f]` with no case folding, plus an explicit `if (match[1] === '00' && match[5]) return null`.

Both accepted headers produce the same failure: the sender is non-conformant, every OTel-instrumented service in the fleet restarts the trace, and this SDK alone continues the old trace ID. The request ends up split across two traces, and neither half is complete.

Measured on `feat/traces-node-mvp` before this change:

```
parseTraceparent('00-4bf9…4736-00f0…02b7-01-extra')
  → { traceId: '4bf9…4736', spanId: '00f0…02b7', flags: '01' }   // continued
parseTraceparent('00-4BF9…4736-00f0…02b7-01')
  → { traceId: '4bf9…4736', spanId: '00f0…02b7', flags: '01' }   // continued
```

Low severity — it takes a broken upstream to reach either — but the fix is a gate and a deletion, and getting it right before the API stabilises is cheaper than after.

## Changes

Two one-line changes in `matchTraceparent`, one per commit so either can be dropped independently.

**`fix(traces): restart the trace on a version 00 traceparent with extra fields`** — the regex keeps its `(-.*)?` group so a *higher* version's unknown trailing fields are still ignored, as the spec intends; version `00` now rejects when that group matched.

**`fix(traces): stop folding an inbound traceparent to lowercase`** — drops the `.toLowerCase()` so uppercase ids are rejected rather than silently repaired. Surrounding whitespace is still trimmed.

A rejected header takes the path a malformed one already took: `_resolveParent` logs `Ignoring malformed traceparent; starting a new trace` and starts a fresh root, and `inertSpan` falls back to the shared no-op instead of passing the header through.

Both are pinned by tests verified to fail when the change is reverted. Three existing tests that asserted the lenient behaviour flip to asserting rejection; `accepts a future version with extra fields` still passes, which is the case the `(-.*)?` group exists for.

### Reviewer notes

- **Stacked on `feat/traces-node-mvp`**, not main — `packages/core/src/traces/` doesn't exist on main yet, and #4579 is already approved.
- **The second commit is a judgment call.** Case folding was deliberate and had a test (`normalizes case and surrounding whitespace`). Postel's law argues for keeping it; the spec's MUST and the split-trace symptom argue against, and being strict about trailing fields while lenient about case is the worst of both. Drop that commit and trim the changeset if you disagree — the first commit stands on its own.
- **No public API change**, so the reference JSON needs no regeneration. The `parent` docstring in `packages/types/src/traces.ts` doesn't currently say what happens to a malformed header; adding that sentence would mean regenerating the references, so it's left out of this diff.
- **Not `Retry-After`-style deferred** — unlike the size-check nit, this needed no number from ingestion.
- **The changeset deliberately carries no rationale.** The split-trace story is above, in Problem; the release note is one line because it lands in `CHANGELOG.md` next to #4579's "Add distributed tracing to `posthog-node`", where an external dev needs the *what*, not the *why*.

### Verification

`packages/core` 1365 pass (63 suites), `packages/node` 1017 pass (36 suites) under both the default and the edge runtime configs, lint and format clean.

Local note for anyone reproducing: `packages/node` resolves `@posthog/core` through `dist`, so a stale core build makes the whole node traces suite fail with `Cannot read properties of undefined (reading 'length')` before any of this. Rebuild core first.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

Only `@posthog/core` is bumped (patch) — it has no checkbox above, and no file under `packages/node` changed. `posthog-node` picks the bump up as a dependent (`updateInternalDependencies: "patch"`), on top of the `minor` it already takes from #4579.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

Backwards compatibility: the traces API is unreleased, so this ships in the same release as #4579 and no shipped behaviour changes.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @turnipdabeets, from arnohillen's review comment on #4579.

The comment was verified before anything was written — the parser was run against both header shapes on the base branch, and the normative text was read out of the spec rather than recalled, because the 55-character rule is easy to misattribute (it appears only in the higher-version parsing steps; what actually condemns the trailing field for version `00` is the version-format ABNF). OTel JS was checked as the reference implementation and agrees on both points.

Decisions worth flagging:

- **Rejecting rather than truncating.** `normalizeTraceparent` already rewrote a trailing-field header to a canonical 55 characters, which silently repaired a peer's broken header instead of restarting. Restarting matches the spec and matches what the rest of a fleet does.
- **Kept `.trim()`.** OTel allows one optional surrounding whitespace character; HTTP OWS stripping isn't the parser's business to be strict about, and it can't cause a trace to split.
- **Split into two commits** because the case-folding half reverses a tested, deliberate decision and the reviewer only reported the first half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AAPCyRnC5HbukEZV9hbai

