### PR TITLE
ci(nuxt): wait for npm packages before consumer test

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -30,7 +30,7 @@
     "build": "nuxt-module-build build",
     "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
     "lint": "oxlint --report-unused-disable-directives-severity error .",
-    "test:unit": "node tests/vue-plugin.test.mjs && node tests/nitro-plugin.test.mjs && node tests/sourcemaps-ssr.test.mjs && node tests/nuxt5-consumer.test.mjs"
+    "test:unit": "node tests/vue-plugin.test.mjs && node tests/nitro-plugin.test.mjs && node tests/sourcemaps-ssr.test.mjs && node tests/wait-for-packages.test.mjs && node tests/nuxt5-consumer.test.mjs"
   },
   "dependencies": {
     "@posthog/cli": "catalog:",

--- a/packages/nuxt/tests/nuxt5-consumer.test.mjs
+++ b/packages/nuxt/tests/nuxt5-consumer.test.mjs
@@ -37,6 +37,43 @@ async function waitForServer(url) {
   throw new Error('Nuxt server did not start')
 }
 
+async function waitForPackages(packages) {
+  const pending = new Map(packages)
+
+  for (let attempt = 1; attempt <= 30; attempt++) {
+    for (const [name, version] of pending) {
+      let publishedVersion
+      try {
+        publishedVersion = execFileSync('pnpm', ['view', `${name}@${version}`, 'version'], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim()
+      } catch {
+        // Keep polling while npm propagates the package.
+      }
+
+      if (publishedVersion === version) {
+        console.log(`${name}@${version} is available on npm.`)
+        pending.delete(name)
+      }
+    }
+
+    if (pending.size === 0) {
+      return
+    }
+    if (attempt === 30) {
+      throw new Error(
+        `${[...pending].map(([name, version]) => `${name}@${version}`).join(', ')} did not become available on npm within 15 minutes`
+      )
+    }
+
+    console.log(
+      `${[...pending].map(([name, version]) => `${name}@${version}`).join(', ')} not available on npm yet (attempt ${attempt}/30). Retrying in 30 seconds...`
+    )
+    await new Promise((resolve) => setTimeout(resolve, 30_000))
+  }
+}
+
 function withTimeout(promise, milliseconds, message) {
   let timer
   return Promise.race([
@@ -49,6 +86,7 @@ function withTimeout(promise, milliseconds, message) {
 
 try {
   const packageManifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))
+  const packagesToWaitFor = new Map()
   packageManifest.dependencies = Object.fromEntries(
     Object.entries(packageManifest.dependencies).map(([name, version]) => {
       if (version !== 'catalog:' && !version.startsWith('workspace:')) {
@@ -59,6 +97,7 @@ try {
         readFileSync(join(packageRoot, 'node_modules', ...name.split('/'), 'package.json'), 'utf8')
       )
       const range = version === 'workspace:^' ? '^' : version === 'workspace:~' ? '~' : ''
+      packagesToWaitFor.set(name, dependencyManifest.version)
       return [name, `${range}${dependencyManifest.version}`]
     })
   )
@@ -121,6 +160,7 @@ try {
     `setInterval(() => {}, 60_000)\nexport default () => { process.once('SIGUSR2', () => { Promise.reject(new Error('background shutdown test')) }) }\n`
   )
 
+  await waitForPackages(packagesToWaitFor)
   execFileSync('pnpm', ['install', '--ignore-scripts', '--no-frozen-lockfile'], { cwd: fixtureDir, stdio: 'inherit' })
   execFileSync('pnpm', ['exec', 'nuxt', 'build'], { cwd: fixtureDir, stdio: 'inherit' })
 

--- a/packages/nuxt/tests/nuxt5-consumer.test.mjs
+++ b/packages/nuxt/tests/nuxt5-consumer.test.mjs
@@ -7,6 +7,8 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { waitForPackages } from './wait-for-packages.mjs'
+
 const packageDir = dirname(fileURLToPath(import.meta.url))
 const fixtureDir = mkdtempSync(join(tmpdir(), 'posthog-nuxt5-consumer-'))
 const packageRoot = join(packageDir, '..')
@@ -35,43 +37,6 @@ async function waitForServer(url) {
     }
   }
   throw new Error('Nuxt server did not start')
-}
-
-async function waitForPackages(packages) {
-  const pending = new Map(packages)
-
-  for (let attempt = 1; attempt <= 30; attempt++) {
-    for (const [name, version] of pending) {
-      let publishedVersion
-      try {
-        publishedVersion = execFileSync('pnpm', ['view', `${name}@${version}`, 'version'], {
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'ignore'],
-        }).trim()
-      } catch {
-        // Keep polling while npm propagates the package.
-      }
-
-      if (publishedVersion === version) {
-        console.log(`${name}@${version} is available on npm.`)
-        pending.delete(name)
-      }
-    }
-
-    if (pending.size === 0) {
-      return
-    }
-    if (attempt === 30) {
-      throw new Error(
-        `${[...pending].map(([name, version]) => `${name}@${version}`).join(', ')} did not become available on npm within 15 minutes`
-      )
-    }
-
-    console.log(
-      `${[...pending].map(([name, version]) => `${name}@${version}`).join(', ')} not available on npm yet (attempt ${attempt}/30). Retrying in 30 seconds...`
-    )
-    await new Promise((resolve) => setTimeout(resolve, 30_000))
-  }
 }
 
 function withTimeout(promise, milliseconds, message) {

--- a/packages/nuxt/tests/wait-for-packages.mjs
+++ b/packages/nuxt/tests/wait-for-packages.mjs
@@ -1,0 +1,50 @@
+import { execFileSync } from 'node:child_process'
+
+const NPM_LOOKUP_TIMEOUT_MS = 30_000
+
+export async function waitForPackages(
+  packages,
+  { attempts = 30, execute = execFileSync, log = console.log, retryDelayMs = 30_000, sleep = defaultSleep } = {}
+) {
+  const pending = new Map(packages)
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    for (const [name, version] of pending) {
+      let publishedVersion
+      try {
+        publishedVersion = execute('pnpm', ['view', `${name}@${version}`, 'version'], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: NPM_LOOKUP_TIMEOUT_MS,
+        }).trim()
+      } catch {
+        // Keep polling while npm propagates the package.
+      }
+
+      if (publishedVersion === version) {
+        log(`${name}@${version} is available on npm.`)
+        pending.delete(name)
+      }
+    }
+
+    if (pending.size === 0) {
+      return
+    }
+    if (attempt === attempts) {
+      throw new Error(`${formatPackages(pending)} did not become available on npm after ${attempts} attempts`)
+    }
+
+    log(
+      `${formatPackages(pending)} not available on npm yet (attempt ${attempt}/${attempts}). Retrying in ${retryDelayMs / 1000} seconds...`
+    )
+    await sleep(retryDelayMs)
+  }
+}
+
+function defaultSleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+function formatPackages(packages) {
+  return [...packages].map(([name, version]) => `${name}@${version}`).join(', ')
+}

--- a/packages/nuxt/tests/wait-for-packages.test.mjs
+++ b/packages/nuxt/tests/wait-for-packages.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+
+import { waitForPackages } from './wait-for-packages.mjs'
+
+const packages = new Map([['posthog-node', '5.0.0']])
+
+{
+  const lookups = []
+  const delays = []
+  const logs = []
+  await waitForPackages(packages, {
+    attempts: 5,
+    execute(command, args, options) {
+      lookups.push({ command, args, options })
+      if (lookups.length < 3) {
+        throw new Error('not published yet')
+      }
+      return '5.0.0\n'
+    },
+    log(message) {
+      logs.push(message)
+    },
+    retryDelayMs: 1,
+    async sleep(milliseconds) {
+      delays.push(milliseconds)
+    },
+  })
+
+  assert.equal(lookups.length, 3)
+  assert.deepEqual(lookups[0].args, ['view', 'posthog-node@5.0.0', 'version'])
+  assert.equal(lookups[0].options.timeout, 30_000)
+  assert.deepEqual(delays, [1, 1])
+  assert.match(logs.at(-1), /posthog-node@5\.0\.0 is available on npm/)
+}
+
+{
+  let lookupCount = 0
+  const delays = []
+  await assert.rejects(
+    waitForPackages(packages, {
+      attempts: 3,
+      execute() {
+        lookupCount++
+        throw new Error('not published yet')
+      },
+      log() {},
+      retryDelayMs: 1,
+      async sleep(milliseconds) {
+        delays.push(milliseconds)
+      },
+    }),
+    /posthog-node@5\.0\.0 did not become available on npm after 3 attempts/
+  )
+  assert.equal(lookupCount, 3)
+  assert.deepEqual(delays, [1, 1])
+}


### PR DESCRIPTION
## Problem

The Nuxt 5 consumer test installs a packed `@posthog/nuxt` package from a temporary project. After a version bump lands, the packed package can reference workspace dependency versions that npm has not made available yet. The install then fails with `ERR_PNPM_NO_MATCHING_VERSION`, as seen in [this CI job](https://github.com/PostHog/posthog-js/actions/runs/33848535926/job/100945834705?pr=4764).

## Changes

The consumer test now checks npm for each workspace or catalog dependency version that it writes into the packed package manifest. It checks every 30 seconds for up to 15 minutes, matching the polling window used by the PostHog upgrade workflow. The test continues as soon as every package is available and still fails if the versions are unavailable after the timeout.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and GitHub CLI. The change was kept in the Nuxt consumer test because that is the only job path that installs the newly published workspace versions. The existing 15-minute npm polling policy from `.github/workflows/posthog-upgrade.yml` was reused. Pi autoreview found no actionable issues.
