### PR TITLE
test(core): make retry timing checks deterministic

### DIFF
--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -445,12 +445,12 @@ describe('PostHog Core', () => {
       })
       posthog.capture('test-event-1')
 
-      const time = Date.now()
-      vi.useRealTimers()
-      await expect(posthog.flush()).rejects.toHaveProperty('name', 'PostHogFetchHttpError')
+      const flushExpectation = expect(posthog.flush()).rejects.toHaveProperty('name', 'PostHogFetchHttpError')
+      await vi.advanceTimersByTimeAsync(299)
+      expect(mocks.fetch).toHaveBeenCalledTimes(3)
+      await vi.advanceTimersByTimeAsync(1)
+      await flushExpectation
       expect(mocks.fetch).toHaveBeenCalledTimes(4)
-      expect(Date.now() - time).toBeGreaterThan(300)
-      expect(Date.now() - time).toBeLessThan(1000)
     })
 
     it('responds with an error after retries with network error ', async () => {
@@ -459,12 +459,12 @@ describe('PostHog Core', () => {
       })
       posthog.capture('test-event-1')
 
-      const time = Date.now()
-      vi.useRealTimers()
-      await expect(posthog.flush()).rejects.toHaveProperty('name', 'PostHogFetchNetworkError')
+      const flushExpectation = expect(posthog.flush()).rejects.toHaveProperty('name', 'PostHogFetchNetworkError')
+      await vi.advanceTimersByTimeAsync(299)
+      expect(mocks.fetch).toHaveBeenCalledTimes(3)
+      await vi.advanceTimersByTimeAsync(1)
+      await flushExpectation
       expect(mocks.fetch).toHaveBeenCalledTimes(4)
-      expect(Date.now() - time).toBeGreaterThan(300)
-      expect(Date.now() - time).toBeLessThan(1000)
     })
 
     it('skips when client is disabled', async () => {


### PR DESCRIPTION
## Problem

The core retry tests measure elapsed wall-clock time. Three 100 ms retry delays can complete in exactly 300 ms, but the tests require the duration to be greater than 300 ms. This caused an intermittent CI failure even though all four requests were made correctly.

## Changes

- Keep fake timers enabled for the HTTP and network retry tests.
- Advance time to 299 ms and verify that three requests have occurred.
- Advance the final millisecond and verify the fourth request and expected error.
- Remove the scheduler-dependent wall-clock bounds.

## Release info Sub-libraries affected

### Libraries affected

This is a test-only change and does not require a package release.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the CI failure and replaced wall-clock checks with deterministic Vitest fake-timer assertions. The focused tests were repeated before running the complete core test suite. Pi autoreview found no actionable issues.
