### PR TITLE
feat(mcp): reduce PII in $mcp_intent (redaction + stronger prompt)

### DIFF
--- a/.changeset/mcp-intent-pii-redaction.md
+++ b/.changeset/mcp-intent-pii-redaction.md
@@ -4,7 +4,7 @@
 
 Reduce personal data in `$mcp_intent`, which is agent-narrated free text and could previously carry personal data a model read aloud.
 
-- Automatically redact structured personal identifiers — email addresses, phone numbers, IPv4/IPv6 addresses, Luhn-valid card numbers, and US SSNs — from `$mcp_intent` before it is captured. Redaction is always on, scoped to the intent only (structured tool `arguments` and results are untouched, since the same shapes are often legitimate data there), and best-effort for those well-defined shapes rather than free-form names or addresses.
+- Automatically redact structured personal identifiers — email addresses, phone numbers, IPv4/IPv6 addresses, Luhn-valid card numbers, and US SSNs — from `$mcp_intent` before it is captured. Redaction is always on, scoped to the intent only (structured tool `arguments` and results are untouched, since the same shapes are often legitimate data there), and best-effort for those well-defined shapes rather than free-form names or addresses. Identifiers grouped with Unicode spaces, dots, or slashes (as produced by copy-paste) and SSNs with space/dot separators are recognized. The email pattern uses bounded quantifiers so a pathological intent cannot cause quadratic-time backtracking.
 - Strengthen the default injected `context` prompt so agents are less likely to write personal data in the first place: the privacy rule is now explicit and lists the identifiers to avoid, and it tells the agent to refer to people and accounts by role ('a user', 'the customer') rather than by identity.
 
 `context: false` and `beforeSend` remain the ways to drop the field entirely.

--- a/.changeset/mcp-intent-pii-redaction.md
+++ b/.changeset/mcp-intent-pii-redaction.md
@@ -2,4 +2,9 @@
 '@posthog/mcp': patch
 ---
 
-Automatically redact structured personal identifiers — email addresses, phone numbers, IPv4/IPv6 addresses, Luhn-valid card numbers, and US SSNs — from `$mcp_intent` before it is captured. The intent is agent-narrated free text, so it could previously carry personal data a model read aloud despite the "no personal data" instruction. Redaction is always on, scoped to the intent only (structured tool `arguments` and results are untouched, since the same shapes are often legitimate data there), and best-effort for those well-defined shapes rather than free-form names or addresses. `context: false` and `beforeSend` remain the ways to drop the field entirely.
+Reduce personal data in `$mcp_intent`, which is agent-narrated free text and could previously carry personal data a model read aloud.
+
+- Automatically redact structured personal identifiers — email addresses, phone numbers, IPv4/IPv6 addresses, Luhn-valid card numbers, and US SSNs — from `$mcp_intent` before it is captured. Redaction is always on, scoped to the intent only (structured tool `arguments` and results are untouched, since the same shapes are often legitimate data there), and best-effort for those well-defined shapes rather than free-form names or addresses.
+- Strengthen the default injected `context` prompt so agents are less likely to write personal data in the first place: the privacy rule is now explicit and lists the identifiers to avoid, and it tells the agent to refer to people and accounts by role ('a user', 'the customer') rather than by identity.
+
+`context: false` and `beforeSend` remain the ways to drop the field entirely.

--- a/.changeset/mcp-intent-pii-redaction.md
+++ b/.changeset/mcp-intent-pii-redaction.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': patch
+---
+
+Automatically redact structured personal identifiers — email addresses, phone numbers, IPv4/IPv6 addresses, Luhn-valid card numbers, and US SSNs — from `$mcp_intent` before it is captured. The intent is agent-narrated free text, so it could previously carry personal data a model read aloud despite the "no personal data" instruction. Redaction is always on, scoped to the intent only (structured tool `arguments` and results are untouched, since the same shapes are often legitimate data there), and best-effort for those well-defined shapes rather than free-form names or addresses. `context: false` and `beforeSend` remain the ways to drop the field entirely.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -150,6 +150,14 @@ instrument(server, posthog, {
 
 `intentFallback` is the third option: supply the intent yourself when the agent did not send one.
 
+Whatever the agent narrates, the SDK redacts structured personal identifiers — email addresses, phone
+numbers, IPv4/IPv6 addresses, Luhn-valid card numbers, and US SSNs — from `$mcp_intent` before it is
+sent. This is always on and needs no configuration. It is best-effort for those well-defined shapes,
+not for free-form personal data such as names or postal addresses, which a regex cannot catch without
+over-redacting ordinary prose. It also applies only to `$mcp_intent`: structured tool `arguments` and
+results are left as-is, because the same shapes are often legitimate data there. If you need a stronger
+guarantee, `context: false` and the `beforeSend` hook above remain the ways to drop the field entirely.
+
 ### What `$mcp_llm_model` records, and when it stays empty
 
 `captureModel` is **off** by default. Turn it on and the SDK adds a required `llm_model` parameter to

--- a/packages/mcp/src/__tests__/mcp-payloads.test.ts
+++ b/packages/mcp/src/__tests__/mcp-payloads.test.ts
@@ -112,9 +112,30 @@ describe('redactPii', () => {
     )
   })
 
-  it('redacts US social security numbers', () => {
-    expect(redactPii('Verifying identity with SSN 123-45-6789 for the claim.')).toBe(
-      'Verifying identity with SSN [redacted] for the claim.'
+  it('redacts US social security numbers with dash, space, or dot separators', () => {
+    for (const ssn of ['123-45-6789', '123 45 6789', '123.45.6789']) {
+      expect(redactPii(`Verifying identity with SSN ${ssn} for the claim.`)).toBe(
+        'Verifying identity with SSN [redacted] for the claim.'
+      )
+    }
+  })
+
+  it('does not treat a bare 9-digit number as an SSN', () => {
+    expect(redactPii('Looking up record 123456789 in the ledger.')).toBe('Looking up record 123456789 in the ledger.')
+  })
+
+  it('redacts cards grouped with dots or slashes without leaking a trailing digit', () => {
+    for (const card of ['4111.1111.1111.1111', '4111/1111/1111/1111']) {
+      expect(redactPii(`Charging the saved card ${card} today.`)).toBe('Charging the saved card [redacted] today.')
+    }
+  })
+
+  it('redacts identifiers grouped with Unicode (NBSP) spaces copied from web pages', () => {
+    const NBSP = String.fromCharCode(0x00a0)
+    const NNBSP = String.fromCharCode(0x202f)
+    expect(redactPii(`Charging card 4111${NBSP}1111${NBSP}1111${NBSP}1111 now.`)).toBe('Charging card [redacted] now.')
+    expect(redactPii(`Calling the customer on 415${NNBSP}555${NNBSP}0132 today.`)).toBe(
+      'Calling the customer on [redacted] today.'
     )
   })
 
@@ -132,5 +153,20 @@ describe('redactPii', () => {
   it('returns the input unchanged when there is no PII', () => {
     const intent = 'Searching the organization repositories to prioritize open performance issues.'
     expect(redactPii(intent)).toBe(intent)
+  })
+
+  it('handles a long pathological string quickly (email pattern is not quadratic)', () => {
+    // A 100k-char run with an `@` but no valid TLD is the worst case for an
+    // unbounded email pattern. With bounded quantifiers this stays linear; a
+    // regression to `+` would blow the default test timeout instead.
+    const pathological = `${'a'.repeat(50_000)}@${'a'.repeat(50_000)}`
+    const start = Date.now()
+    expect(redactPii(pathological)).toBe(pathological)
+    expect(Date.now() - start).toBeLessThan(1000)
+  })
+
+  it('still redacts an email with a maximal 64-char local part', () => {
+    const local = 'a'.repeat(64)
+    expect(redactPii(`from ${local}@example.com now`)).toBe('from [redacted] now')
   })
 })

--- a/packages/mcp/src/__tests__/mcp-payloads.test.ts
+++ b/packages/mcp/src/__tests__/mcp-payloads.test.ts
@@ -1,4 +1,4 @@
-import { buildCapturedMcpParameters } from '../extensions/mcp-payloads'
+import { buildCapturedMcpParameters, redactPii } from '../extensions/mcp-payloads'
 
 describe('buildCapturedMcpParameters', () => {
   it('captures useful tool-call inputs without transport internals or duplicated intent', () => {
@@ -63,5 +63,74 @@ describe('buildCapturedMcpParameters', () => {
         },
       },
     })
+  })
+})
+
+describe('redactPii', () => {
+  it('redacts email addresses', () => {
+    expect(redactPii('Looking up orders for jane.doe@acme.co.uk before refunding.')).toBe(
+      'Looking up orders for [redacted] before refunding.'
+    )
+  })
+
+  it('redacts phone numbers with grouping characters', () => {
+    expect(redactPii('Calling the customer back on +1 (415) 555-0142 about the outage.')).toBe(
+      'Calling the customer back on [redacted] about the outage.'
+    )
+    expect(redactPii('Reference ticket for number 415-555-0142 escalation.')).toBe(
+      'Reference ticket for number [redacted] escalation.'
+    )
+  })
+
+  it('leaves bare numeric identifiers without grouping untouched', () => {
+    expect(redactPii('Fetching record 4155550142 from the ledger service.')).toBe(
+      'Fetching record 4155550142 from the ledger service.'
+    )
+  })
+
+  it('redacts IPv4 addresses', () => {
+    expect(redactPii('Blocking traffic from 203.0.113.42 after abuse reports.')).toBe(
+      'Blocking traffic from [redacted] after abuse reports.'
+    )
+  })
+
+  it('redacts IPv6 addresses', () => {
+    expect(redactPii('Tracing request from 2001:db8::ff00:42:8329 across the mesh.')).toBe(
+      'Tracing request from [redacted] across the mesh.'
+    )
+  })
+
+  it('redacts Luhn-valid credit-card numbers', () => {
+    expect(redactPii('Charging the saved card 4111 1111 1111 1111 for the renewal.')).toBe(
+      'Charging the saved card [redacted] for the renewal.'
+    )
+  })
+
+  it('leaves Luhn-invalid long digit runs untouched', () => {
+    expect(redactPii('Correlating with order 1234567890123456 in the warehouse.')).toBe(
+      'Correlating with order 1234567890123456 in the warehouse.'
+    )
+  })
+
+  it('redacts US social security numbers', () => {
+    expect(redactPii('Verifying identity with SSN 123-45-6789 for the claim.')).toBe(
+      'Verifying identity with SSN [redacted] for the claim.'
+    )
+  })
+
+  it('redacts multiple identifiers in one string', () => {
+    expect(redactPii('Emailing bob@example.com and calling +1-202-555-0170 about the issue.')).toBe(
+      'Emailing [redacted] and calling [redacted] about the issue.'
+    )
+  })
+
+  it('does not touch ordinary prose, versions, dates, or code separators', () => {
+    const clean = 'Upgrading to v1.2.3 on 2024-01-15 by refactoring std::vector usage for the team.'
+    expect(redactPii(clean)).toBe(clean)
+  })
+
+  it('returns the input unchanged when there is no PII', () => {
+    const intent = 'Searching the organization repositories to prioritize open performance issues.'
+    expect(redactPii(intent)).toBe(intent)
   })
 })

--- a/packages/mcp/src/__tests__/mcp-payloads.test.ts
+++ b/packages/mcp/src/__tests__/mcp-payloads.test.ts
@@ -67,92 +67,84 @@ describe('buildCapturedMcpParameters', () => {
 })
 
 describe('redactPii', () => {
-  it('redacts email addresses', () => {
-    expect(redactPii('Looking up orders for jane.doe@acme.co.uk before refunding.')).toBe(
-      'Looking up orders for [redacted] before refunding.'
-    )
+  const NBSP = String.fromCharCode(0x00a0)
+  const NNBSP = String.fromCharCode(0x202f)
+
+  it.each([
+    [
+      'an email address',
+      'Looking up orders for jane.doe@acme.co.uk before refunding.',
+      'Looking up orders for [redacted] before refunding.',
+    ],
+    ['an email with a maximal 64-char local part', `from ${'a'.repeat(64)}@example.com now`, 'from [redacted] now'],
+    [
+      'an IPv4 address',
+      'Blocking traffic from 203.0.113.42 after abuse.',
+      'Blocking traffic from [redacted] after abuse.',
+    ],
+    [
+      'an IPv6 address with a middle ::',
+      'Tracing request from 2001:db8::ff00:42:8329 across the mesh.',
+      'Tracing request from [redacted] across the mesh.',
+    ],
+    ['an IPv6 address ending in ::', 'Routing host 2001:db8:: for now.', 'Routing host [redacted] for now.'],
+    ['an IPv6 loopback ::1', 'Health check from ::1 passed.', 'Health check from [redacted] passed.'],
+    [
+      'a NANP phone with dashes',
+      'Reference ticket for number 415-555-0142 escalation.',
+      'Reference ticket for number [redacted] escalation.',
+    ],
+    ['a NANP phone with slashes', 'Call the customer on 415/555/0142 today.', 'Call the customer on [redacted] today.'],
+    [
+      'a NANP phone with parens and +1',
+      'Calling back on +1 (415) 555-0142 about the outage.',
+      'Calling back on [redacted] about the outage.',
+    ],
+    ['an international phone with a + country code', 'Ring +44 (0) 20 7946 0958 please.', 'Ring [redacted] please.'],
+    [
+      'a phone grouped with NBSP spaces',
+      `Calling the customer on 415${NNBSP}555${NNBSP}0132 today.`,
+      'Calling the customer on [redacted] today.',
+    ],
+    [
+      'a Luhn-valid card with spaces',
+      'Charging the saved card 4111 1111 1111 1111 for the renewal.',
+      'Charging the saved card [redacted] for the renewal.',
+    ],
+    ['a card grouped with dots', 'Charging card 4111.1111.1111.1111 today.', 'Charging card [redacted] today.'],
+    ['a card grouped with slashes', 'Charging card 4111/1111/1111/1111 today.', 'Charging card [redacted] today.'],
+    [
+      'a card grouped with NBSP spaces',
+      `Charging card 4111${NBSP}1111${NBSP}1111${NBSP}1111 now.`,
+      'Charging card [redacted] now.',
+    ],
+    ['an SSN with dashes', 'Verifying SSN 123-45-6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],
+    ['an SSN with spaces', 'Verifying SSN 123 45 6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],
+    ['an SSN with dots', 'Verifying SSN 123.45.6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],
+  ])('redacts %s', (_label, input, expected) => {
+    expect(redactPii(input)).toBe(expected)
   })
 
-  it('redacts phone numbers with grouping characters', () => {
-    expect(redactPii('Calling the customer back on +1 (415) 555-0142 about the outage.')).toBe(
-      'Calling the customer back on [redacted] about the outage.'
-    )
-    expect(redactPii('Reference ticket for number 415-555-0142 escalation.')).toBe(
-      'Reference ticket for number [redacted] escalation.'
-    )
-  })
-
-  it('leaves bare numeric identifiers without grouping untouched', () => {
-    expect(redactPii('Fetching record 4155550142 from the ledger service.')).toBe(
-      'Fetching record 4155550142 from the ledger service.'
-    )
-  })
-
-  it('redacts IPv4 addresses', () => {
-    expect(redactPii('Blocking traffic from 203.0.113.42 after abuse reports.')).toBe(
-      'Blocking traffic from [redacted] after abuse reports.'
-    )
-  })
-
-  it('redacts IPv6 addresses', () => {
-    expect(redactPii('Tracing request from 2001:db8::ff00:42:8329 across the mesh.')).toBe(
-      'Tracing request from [redacted] across the mesh.'
-    )
-  })
-
-  it('redacts Luhn-valid credit-card numbers', () => {
-    expect(redactPii('Charging the saved card 4111 1111 1111 1111 for the renewal.')).toBe(
-      'Charging the saved card [redacted] for the renewal.'
-    )
-  })
-
-  it('leaves Luhn-invalid long digit runs untouched', () => {
-    expect(redactPii('Correlating with order 1234567890123456 in the warehouse.')).toBe(
-      'Correlating with order 1234567890123456 in the warehouse.'
-    )
-  })
-
-  it('redacts US social security numbers with dash, space, or dot separators', () => {
-    for (const ssn of ['123-45-6789', '123 45 6789', '123.45.6789']) {
-      expect(redactPii(`Verifying identity with SSN ${ssn} for the claim.`)).toBe(
-        'Verifying identity with SSN [redacted] for the claim.'
-      )
-    }
-  })
-
-  it('does not treat a bare 9-digit number as an SSN', () => {
-    expect(redactPii('Looking up record 123456789 in the ledger.')).toBe('Looking up record 123456789 in the ledger.')
-  })
-
-  it('redacts cards grouped with dots or slashes without leaking a trailing digit', () => {
-    for (const card of ['4111.1111.1111.1111', '4111/1111/1111/1111']) {
-      expect(redactPii(`Charging the saved card ${card} today.`)).toBe('Charging the saved card [redacted] today.')
-    }
-  })
-
-  it('redacts identifiers grouped with Unicode (NBSP) spaces copied from web pages', () => {
-    const NBSP = String.fromCharCode(0x00a0)
-    const NNBSP = String.fromCharCode(0x202f)
-    expect(redactPii(`Charging card 4111${NBSP}1111${NBSP}1111${NBSP}1111 now.`)).toBe('Charging card [redacted] now.')
-    expect(redactPii(`Calling the customer on 415${NNBSP}555${NNBSP}0132 today.`)).toBe(
-      'Calling the customer on [redacted] today.'
-    )
+  it.each([
+    ['a bare numeric identifier without grouping', 'Fetching record 4155550142 from the ledger service.'],
+    ['a bare 9-digit number that is not an SSN', 'Looking up record 123456789 in the ledger.'],
+    ['a Luhn-invalid long digit run', 'Correlating with order 1234567890123456 in the warehouse.'],
+    ['a date and time that resembles a phone number', 'Deploying at 2024-01-15 12:30 UTC after review.'],
+    ['a dotted version/build number', 'Upgrading to build 2024.11.05.1830 for the team.'],
+    ['a C++ scope expression that resembles IPv6', 'Calling std::bad and std::vector helpers for the team.'],
+    [
+      'ordinary prose with versions, dates, and code separators',
+      'Upgrading to v1.2.3 on 2024-01-15 by refactoring std::vector usage.',
+    ],
+    ['prose with no personal data', 'Searching the organization repositories to prioritize open performance issues.'],
+  ])('leaves %s untouched', (_label, input) => {
+    expect(redactPii(input)).toBe(input)
   })
 
   it('redacts multiple identifiers in one string', () => {
     expect(redactPii('Emailing bob@example.com and calling +1-202-555-0170 about the issue.')).toBe(
       'Emailing [redacted] and calling [redacted] about the issue.'
     )
-  })
-
-  it('does not touch ordinary prose, versions, dates, or code separators', () => {
-    const clean = 'Upgrading to v1.2.3 on 2024-01-15 by refactoring std::vector usage for the team.'
-    expect(redactPii(clean)).toBe(clean)
-  })
-
-  it('returns the input unchanged when there is no PII', () => {
-    const intent = 'Searching the organization repositories to prioritize open performance issues.'
-    expect(redactPii(intent)).toBe(intent)
   })
 
   it('handles a long pathological string quickly (email pattern is not quadratic)', () => {
@@ -163,10 +155,5 @@ describe('redactPii', () => {
     const start = Date.now()
     expect(redactPii(pathological)).toBe(pathological)
     expect(Date.now() - start).toBeLessThan(1000)
-  })
-
-  it('still redacts an email with a maximal 64-char local part', () => {
-    const local = 'a'.repeat(64)
-    expect(redactPii(`from ${local}@example.com now`)).toBe('from [redacted] now')
   })
 })

--- a/packages/mcp/src/__tests__/mcp-payloads.test.ts
+++ b/packages/mcp/src/__tests__/mcp-payloads.test.ts
@@ -100,6 +100,11 @@ describe('redactPii', () => {
       'Calling back on +1 (415) 555-0142 about the outage.',
       'Calling back on [redacted] about the outage.',
     ],
+    [
+      'a NANP phone with a parenthesized area code and no following separator',
+      'Reaching them at (415)555-0142 today.',
+      'Reaching them at [redacted] today.',
+    ],
     ['an international phone with a + country code', 'Ring +44 (0) 20 7946 0958 please.', 'Ring [redacted] please.'],
     [
       'a phone grouped with NBSP spaces',

--- a/packages/mcp/src/__tests__/mcp-payloads.test.ts
+++ b/packages/mcp/src/__tests__/mcp-payloads.test.ts
@@ -123,6 +123,11 @@ describe('redactPii', () => {
       `Charging card 4111${NBSP}1111${NBSP}1111${NBSP}1111 now.`,
       'Charging card [redacted] now.',
     ],
+    [
+      'a card without absorbing an adjacent expiry field',
+      'Charging card 4111 1111 1111 1111 12/30 for renewal.',
+      'Charging card [redacted] 12/30 for renewal.',
+    ],
     ['an SSN with dashes', 'Verifying SSN 123-45-6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],
     ['an SSN with spaces', 'Verifying SSN 123 45 6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],
     ['an SSN with dots', 'Verifying SSN 123.45.6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],

--- a/packages/mcp/src/__tests__/mcp-payloads.test.ts
+++ b/packages/mcp/src/__tests__/mcp-payloads.test.ts
@@ -128,6 +128,11 @@ describe('redactPii', () => {
       'Charging card 4111 1111 1111 1111 12/30 for renewal.',
       'Charging card [redacted] 12/30 for renewal.',
     ],
+    [
+      'every card when two appear in one span',
+      'Moving funds 4111 1111 1111 1111 5555 5555 5555 4444 now.',
+      'Moving funds [redacted] [redacted] now.',
+    ],
     ['an SSN with dashes', 'Verifying SSN 123-45-6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],
     ['an SSN with spaces', 'Verifying SSN 123 45 6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],
     ['an SSN with dots', 'Verifying SSN 123.45.6789 for the claim.', 'Verifying SSN [redacted] for the claim.'],

--- a/packages/mcp/src/__tests__/sanitization.test.ts
+++ b/packages/mcp/src/__tests__/sanitization.test.ts
@@ -446,6 +446,54 @@ describe('sanitizeEvent - exception values', () => {
   })
 })
 
+describe('sanitizeEvent - intent PII redaction', () => {
+  it('redacts structured PII from the agent-narrated intent', () => {
+    const event = makeEvent({
+      userIntent: 'Looking up orders for jane.doe@acme.com and calling +1 (415) 555-0142 about a refund.',
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.userIntent).toBe('Looking up orders for [redacted] and calling [redacted] about a refund.')
+  })
+
+  it('composes PII redaction with PostHog token redaction on the intent', () => {
+    const event = makeEvent({
+      userIntent: 'Rotating token phc_123456789012345678901234567890 for user carol@example.org.',
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.userIntent).toBe('Rotating token [redacted] for user [redacted].')
+  })
+
+  it('does not redact the same PII shapes from structured parameters or responses', () => {
+    const event = makeEvent({
+      userIntent: 'Enriching the profile for dave@example.com from the CRM.',
+      parameters: { email: 'dave@example.com', ip: '203.0.113.42' },
+      response: { content: [{ type: 'text', text: 'Matched dave@example.com at 203.0.113.42.' }] },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.userIntent).toBe('Enriching the profile for [redacted] from the CRM.')
+    // Structured tool data keeps the same shapes: they are often legitimate here.
+    expect(result.parameters).toEqual({ email: 'dave@example.com', ip: '203.0.113.42' })
+    expect((result.response as { content: { text: string }[] }).content[0].text).toBe(
+      'Matched dave@example.com at 203.0.113.42.'
+    )
+  })
+
+  it('does not mutate the original intent string', () => {
+    const original = 'Paging on-call about ticket from user@example.com right now.'
+    const event = makeEvent({ userIntent: original })
+
+    sanitizeEvent(event)
+
+    expect(event.userIntent).toBe(original)
+  })
+})
+
 describe('sanitizeEvent - integration', () => {
   it('should sanitize both parameters and response in a full event', () => {
     const largeBase64 = makeLargeBase64()

--- a/packages/mcp/src/extensions/constants.ts
+++ b/packages/mcp/src/extensions/constants.ts
@@ -5,7 +5,7 @@
 
 export const INACTIVITY_TIMEOUT_IN_MINUTES = 30
 
-export const DEFAULT_CONTEXT_PARAMETER_DESCRIPTION = `Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): "Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization."`
+export const DEFAULT_CONTEXT_PARAMETER_DESCRIPTION = `Explain in 15-25 words, in third person, why this tool is called and how it supports the user's goal. For analytics only. You MUST describe only the abstract purpose of the tool call. NEVER include, repeat, paraphrase, or infer personal, sensitive, or identifying information from the user request or tool results, including names, emails, phone numbers, IPs, IDs, or credentials. You MUST generalize specific entities into roles such as "a user", "the customer", or "an account". Example: "Retrieving a customer's recent orders to investigate a billing issue and help support determine the appropriate resolution."`
 
 export const DEFAULT_MODEL_PARAMETER_DESCRIPTION = `The exact model identifier you (the assistant) are running as, taken from your system prompt or environment (e.g. "claude-opus-4-8", "gpt-5.2"). Used for analytics only. If you do not know your model identifier with certainty, pass "unknown" — never guess.`
 

--- a/packages/mcp/src/extensions/mcp-payloads.ts
+++ b/packages/mcp/src/extensions/mcp-payloads.ts
@@ -16,6 +16,31 @@ const POSTHOG_TOKEN_PATTERN = /\bph[a-z]_[A-Za-z0-9_-]{20,}\b/g
 const SENSITIVE_KEY_PATTERN =
   /^(authorization|cookie|set-cookie|x-api-key|api[-_]?key|api[-_]?token|access[-_]?token|refresh[-_]?token|token|password|secret|client[-_]?secret|private[-_]?key)$/i
 
+// PII redaction for the agent-narrated intent string only. `$mcp_intent` is free
+// text the calling LLM writes into the injected `context` argument, so it can
+// carry personal data the model read aloud despite being told not to. We redact
+// well-defined *structured identifiers* — the kind regex can match with high
+// precision. Person names and postal addresses are deliberately out of scope:
+// they need an NER model that a client SDK cannot ship, and naive patterns would
+// over-redact ordinary prose. Patterns are ordered so an earlier pass never eats
+// digits a later pass needs (email before phone, IPs before phone, cards before
+// the generic phone pass). See `redactPii`.
+const EMAIL_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g
+const IPV4_PATTERN = /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g
+// Full 8-group form, or any compressed form containing "::". Requiring "::" for
+// the compressed branch keeps clock/time strings like "12:30:45" from matching.
+const IPV6_PATTERN =
+  /\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b|\b[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6}::(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6})?\b|::(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6})/g
+const US_SSN_PATTERN = /\b\d{3}-\d{2}-\d{4}\b/g
+// 13–19 digits, optionally grouped by single spaces or dashes. This only marks a
+// candidate; the Luhn check in `redactPii` is what confirms it is a real card and
+// keeps arbitrary long digit runs from being redacted.
+const CREDIT_CARD_CANDIDATE_PATTERN = /\b\d(?:[ -]?\d){12,18}\b/g
+// A permissive phone candidate; `redactPii` confirms it has 10–15 digits and at
+// least one grouping character (`+`, parentheses, space, dash, or dot) so bare
+// numeric IDs are left intact.
+const PHONE_CANDIDATE_PATTERN = /\+?\d[\d ().-]{7,16}\d/g
+
 type JsonRecord = Record<string, unknown>
 
 function isRecord(value: unknown): value is JsonRecord {
@@ -52,6 +77,50 @@ function sanitizeString(value: string): string {
     return BINARY_REDACTED_VALUE
   }
   return value.replace(POSTHOG_TOKEN_PATTERN, REDACTED_VALUE)
+}
+
+function passesLuhn(digits: string): boolean {
+  let sum = 0
+  let double = false
+  for (let index = digits.length - 1; index >= 0; index--) {
+    let digit = digits.charCodeAt(index) - 48
+    if (digit < 0 || digit > 9) {
+      return false
+    }
+    if (double) {
+      digit *= 2
+      if (digit > 9) {
+        digit -= 9
+      }
+    }
+    sum += digit
+    double = !double
+  }
+  return sum % 10 === 0
+}
+
+/**
+ * Redacts structured personal identifiers (emails, IP addresses, credit-card
+ * numbers, US SSNs, and phone numbers) from a free-text string. Intended for the
+ * agent-narrated `$mcp_intent` value only — not for structured tool parameters or
+ * responses, where the same shapes are often legitimate data. Returns a new
+ * string; leaves the input untouched when nothing matches.
+ */
+export function redactPii(value: string): string {
+  let result = value.replace(EMAIL_PATTERN, REDACTED_VALUE)
+  result = result.replace(IPV4_PATTERN, REDACTED_VALUE)
+  result = result.replace(IPV6_PATTERN, REDACTED_VALUE)
+  result = result.replace(CREDIT_CARD_CANDIDATE_PATTERN, (match) => {
+    const digits = match.replace(/[ -]/g, '')
+    return digits.length >= 13 && digits.length <= 19 && passesLuhn(digits) ? REDACTED_VALUE : match
+  })
+  result = result.replace(US_SSN_PATTERN, REDACTED_VALUE)
+  result = result.replace(PHONE_CANDIDATE_PATTERN, (match) => {
+    const digits = match.replace(/\D/g, '')
+    const hasGrouping = /[+() .-]/.test(match)
+    return digits.length >= 10 && digits.length <= 15 && hasGrouping ? REDACTED_VALUE : match
+  })
+  return result
 }
 
 export function sanitizeCapturedValue(value: unknown): unknown {

--- a/packages/mcp/src/extensions/mcp-payloads.ts
+++ b/packages/mcp/src/extensions/mcp-payloads.ts
@@ -25,17 +25,30 @@ const SENSITIVE_KEY_PATTERN =
 // over-redact ordinary prose. Patterns are ordered so an earlier pass never eats
 // digits a later pass needs (email before phone, IPs before phone, cards before
 // the generic phone pass). See `redactPii`.
-const EMAIL_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g
+// Horizontal Unicode spaces (NBSP, narrow NBSP, ideographic space, ...) are what
+// appear when text is copied from web pages or PDFs. `redactPii` normalizes them
+// to an ASCII space first so the separator-based card/phone/SSN candidates match
+// them instead of leaking the identifier they group.
+const UNICODE_SPACE_PATTERN = /[\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]/g
+// Quantifiers are bounded to RFC-ish limits (local-part <=64, domain <=255,
+// TLD <=24) rather than open-ended `+`. Unbounded `+` here is quadratic: on a
+// long run of local-part chars with no valid `.tld`, `replace` rescans from
+// every start position. `$mcp_intent` is attacker-influenceable free text seen
+// before truncation, so an open-ended pattern is a reachable event-loop stall.
+const EMAIL_PATTERN = /[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Za-z]{2,24}/g
 const IPV4_PATTERN = /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g
 // Full 8-group form, or any compressed form containing "::". Requiring "::" for
 // the compressed branch keeps clock/time strings like "12:30:45" from matching.
 const IPV6_PATTERN =
   /\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b|\b[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6}::(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6})?\b|::(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6})/g
-const US_SSN_PATTERN = /\b\d{3}-\d{2}-\d{4}\b/g
-// 13–19 digits, optionally grouped by single spaces or dashes. This only marks a
-// candidate; the Luhn check in `redactPii` is what confirms it is a real card and
-// keeps arbitrary long digit runs from being redacted.
-const CREDIT_CARD_CANDIDATE_PATTERN = /\b\d(?:[ -]?\d){12,18}\b/g
+// A separator (space, dot, or dash) is required between the 3-2-4 groups so bare
+// 9-digit IDs are never mistaken for an SSN.
+const US_SSN_PATTERN = /\b\d{3}[ .-]\d{2}[ .-]\d{4}\b/g
+// 13–19 digits, optionally grouped by a single space, dot, dash, or slash. This
+// only marks a candidate; the Luhn check in `redactPii` is what confirms it is a
+// real card, so widening the separators cannot add false positives — it only
+// lets dot/slash-grouped cards reach the check instead of leaking past it.
+const CREDIT_CARD_CANDIDATE_PATTERN = /\b\d(?:[ ./-]?\d){12,18}\b/g
 // A permissive phone candidate; `redactPii` confirms it has 10–15 digits and at
 // least one grouping character (`+`, parentheses, space, dash, or dot) so bare
 // numeric IDs are left intact.
@@ -103,15 +116,18 @@ function passesLuhn(digits: string): boolean {
  * Redacts structured personal identifiers (emails, IP addresses, credit-card
  * numbers, US SSNs, and phone numbers) from a free-text string. Intended for the
  * agent-narrated `$mcp_intent` value only — not for structured tool parameters or
- * responses, where the same shapes are often legitimate data. Returns a new
- * string; leaves the input untouched when nothing matches.
+ * responses, where the same shapes are often legitimate data. Horizontal Unicode
+ * spaces are first normalized to an ASCII space so copy-pasted identifiers still
+ * match. Returns a new string; leaves the input's identifiers untouched when
+ * nothing matches.
  */
 export function redactPii(value: string): string {
-  let result = value.replace(EMAIL_PATTERN, REDACTED_VALUE)
+  let result = value.replace(UNICODE_SPACE_PATTERN, ' ')
+  result = result.replace(EMAIL_PATTERN, REDACTED_VALUE)
   result = result.replace(IPV4_PATTERN, REDACTED_VALUE)
   result = result.replace(IPV6_PATTERN, REDACTED_VALUE)
   result = result.replace(CREDIT_CARD_CANDIDATE_PATTERN, (match) => {
-    const digits = match.replace(/[ -]/g, '')
+    const digits = match.replace(/[ ./-]/g, '')
     return digits.length >= 13 && digits.length <= 19 && passesLuhn(digits) ? REDACTED_VALUE : match
   })
   result = result.replace(US_SSN_PATTERN, REDACTED_VALUE)

--- a/packages/mcp/src/extensions/mcp-payloads.ts
+++ b/packages/mcp/src/extensions/mcp-payloads.ts
@@ -37,10 +37,13 @@ const UNICODE_SPACE_PATTERN = /[\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]/g
 // before truncation, so an open-ended pattern is a reachable event-loop stall.
 const EMAIL_PATTERN = /[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Za-z]{2,24}/g
 const IPV4_PATTERN = /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g
-// Full 8-group form, or any compressed form containing "::". Requiring "::" for
-// the compressed branch keeps clock/time strings like "12:30:45" from matching.
+// Four forms: full 8-group, `::`-terminated (`2001:db8::`), a middle `::`
+// (`2001:db8::8a2e:1`), and a leading `::` (`::1`). The compressed branches use a
+// `(?<![\w:])` boundary so a hex-looking C++ scope like `std::bad` — whose left
+// side is not a valid hex group — is not mistaken for an address, while a
+// genuinely address-shaped `dead::beef` still matches.
 const IPV6_PATTERN =
-  /\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b|\b[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6}::(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6})?\b|::(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){0,6})/g
+  /\b(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}\b|(?<![\w:])(?:[0-9A-Fa-f]{1,4}:){1,7}:(?![\w:])|(?<![\w:])(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4}){0,5}(?![\w])|(?<![\w:])::(?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4}){0,6})(?![\w])/g
 // A separator (space, dot, or dash) is required between the 3-2-4 groups so bare
 // 9-digit IDs are never mistaken for an SSN.
 const US_SSN_PATTERN = /\b\d{3}[ .-]\d{2}[ .-]\d{4}\b/g
@@ -49,12 +52,13 @@ const US_SSN_PATTERN = /\b\d{3}[ .-]\d{2}[ .-]\d{4}\b/g
 // real card, so widening the separators cannot add false positives — it only
 // lets dot/slash-grouped cards reach the check instead of leaking past it.
 const CREDIT_CARD_CANDIDATE_PATTERN = /\b\d(?:[ ./-]?\d){12,18}\b/g
-// A permissive phone candidate; `redactPii` confirms it has 10–15 digits and at
-// least one grouping character (`+`, parentheses, space, dash, or dot) so bare
-// numeric IDs are left intact.
-const PHONE_CANDIDATE_PATTERN = /\+?\d[\d ().-]{7,16}\d/g
-// Strips every non-digit from a card/phone candidate to count its digits.
-const NON_DIGIT_PATTERN = /\D/g
+// Phone matching is structural rather than "any 10–15 digits", so dates
+// (`2024-01-15 12:30`) and dotted versions are not mistaken for numbers. Two
+// forms: a North-American 3-3-4 grouping that requires a real separator (space,
+// dot, dash, or slash, optional parens and `+1`), and an international number
+// that must start with `+` and a country code.
+const PHONE_NANP_PATTERN = /(?<![\w+])(?:\+?1[ ./-]?)?\(?\d{3}\)?[ ./-]\d{3}[ ./-]\d{4}(?![\w])/g
+const PHONE_INTL_PATTERN = /(?<!\w)\+\d{1,3}(?:[ ./()-]{0,2}\d){7,13}(?![\w])/g
 
 type JsonRecord = Record<string, unknown>
 
@@ -123,35 +127,20 @@ function passesLuhn(digits: string): boolean {
  * match. Returns a new string; leaves the input's identifiers untouched when
  * nothing matches.
  */
-// A candidate substring (already matched by a card/phone pattern, so it holds
-// only digits and its own separators) becomes `[redacted]` only when its digit
-// count is in range and `confirm` accepts it — Luhn for cards, a grouping char
-// for phones. This keeps bare numeric IDs and non-card digit runs intact.
-function redactConfirmedCandidate(
-  match: string,
-  minDigits: number,
-  maxDigits: number,
-  confirm: (match: string, digits: string) => boolean
-): string {
-  const digits = match.replace(NON_DIGIT_PATTERN, '')
-  return digits.length >= minDigits && digits.length <= maxDigits && confirm(match, digits) ? REDACTED_VALUE : match
-}
-
 export function redactPii(value: string): string {
   let result = value.replace(UNICODE_SPACE_PATTERN, ' ')
   result = result.replace(EMAIL_PATTERN, REDACTED_VALUE)
   result = result.replace(IPV4_PATTERN, REDACTED_VALUE)
   result = result.replace(IPV6_PATTERN, REDACTED_VALUE)
-  result = result.replace(CREDIT_CARD_CANDIDATE_PATTERN, (match) =>
-    redactConfirmedCandidate(match, 13, 19, (_, digits) => passesLuhn(digits))
-  )
+  // Card grouping (space/dot/dash/slash) is stripped so only the Luhn check on
+  // the digits decides — a non-card digit run of the same length is left intact.
+  result = result.replace(CREDIT_CARD_CANDIDATE_PATTERN, (match) => {
+    const digits = match.replace(/[ ./-]/g, '')
+    return digits.length >= 13 && digits.length <= 19 && passesLuhn(digits) ? REDACTED_VALUE : match
+  })
   result = result.replace(US_SSN_PATTERN, REDACTED_VALUE)
-  // The phone candidate only admits digits plus grouping chars, so a length
-  // gap means a grouping char is present — this keeps a bare digit run (an ID)
-  // from being redacted, without a second scan of the match.
-  result = result.replace(PHONE_CANDIDATE_PATTERN, (match) =>
-    redactConfirmedCandidate(match, 10, 15, (phone, digits) => digits.length !== phone.length)
-  )
+  result = result.replace(PHONE_NANP_PATTERN, REDACTED_VALUE)
+  result = result.replace(PHONE_INTL_PATTERN, REDACTED_VALUE)
   return result
 }
 

--- a/packages/mcp/src/extensions/mcp-payloads.ts
+++ b/packages/mcp/src/extensions/mcp-payloads.ts
@@ -54,10 +54,12 @@ const US_SSN_PATTERN = /\b\d{3}[ .-]\d{2}[ .-]\d{4}\b/g
 const CREDIT_CARD_CANDIDATE_PATTERN = /\b\d(?:[ ./-]?\d){12,18}\b/g
 // Phone matching is structural rather than "any 10–15 digits", so dates
 // (`2024-01-15 12:30`) and dotted versions are not mistaken for numbers. Two
-// forms: a North-American 3-3-4 grouping that requires a real separator (space,
-// dot, dash, or slash, optional parens and `+1`), and an international number
-// that must start with `+` and a country code.
-const PHONE_NANP_PATTERN = /(?<![\w+])(?:\+?1[ ./-]?)?\(?\d{3}\)?[ ./-]\d{3}[ ./-]\d{4}(?![\w])/g
+// forms: a North-American 3-3-4 grouping, and an international number that must
+// start with `+` and a country code. The area code is either `(415)` (the
+// separator after it is optional, so `(415)555-0142` matches) or a bare `415`
+// that must be followed by a separator (space, dot, dash, or slash) — so a bare
+// digit run is never taken for a phone number.
+const PHONE_NANP_PATTERN = /(?<![\w+])(?:\+?1[ ./-]?)?(?:\(\d{3}\)[ ./-]?|\d{3}[ ./-])\d{3}[ ./-]\d{4}(?![\w])/g
 const PHONE_INTL_PATTERN = /(?<!\w)\+\d{1,3}(?:[ ./()-]{0,2}\d){7,13}(?![\w])/g
 
 type JsonRecord = Record<string, unknown>

--- a/packages/mcp/src/extensions/mcp-payloads.ts
+++ b/packages/mcp/src/extensions/mcp-payloads.ts
@@ -53,6 +53,8 @@ const CREDIT_CARD_CANDIDATE_PATTERN = /\b\d(?:[ ./-]?\d){12,18}\b/g
 // least one grouping character (`+`, parentheses, space, dash, or dot) so bare
 // numeric IDs are left intact.
 const PHONE_CANDIDATE_PATTERN = /\+?\d[\d ().-]{7,16}\d/g
+// Strips every non-digit from a card/phone candidate to count its digits.
+const NON_DIGIT_PATTERN = /\D/g
 
 type JsonRecord = Record<string, unknown>
 
@@ -121,21 +123,35 @@ function passesLuhn(digits: string): boolean {
  * match. Returns a new string; leaves the input's identifiers untouched when
  * nothing matches.
  */
+// A candidate substring (already matched by a card/phone pattern, so it holds
+// only digits and its own separators) becomes `[redacted]` only when its digit
+// count is in range and `confirm` accepts it — Luhn for cards, a grouping char
+// for phones. This keeps bare numeric IDs and non-card digit runs intact.
+function redactConfirmedCandidate(
+  match: string,
+  minDigits: number,
+  maxDigits: number,
+  confirm: (match: string, digits: string) => boolean
+): string {
+  const digits = match.replace(NON_DIGIT_PATTERN, '')
+  return digits.length >= minDigits && digits.length <= maxDigits && confirm(match, digits) ? REDACTED_VALUE : match
+}
+
 export function redactPii(value: string): string {
   let result = value.replace(UNICODE_SPACE_PATTERN, ' ')
   result = result.replace(EMAIL_PATTERN, REDACTED_VALUE)
   result = result.replace(IPV4_PATTERN, REDACTED_VALUE)
   result = result.replace(IPV6_PATTERN, REDACTED_VALUE)
-  result = result.replace(CREDIT_CARD_CANDIDATE_PATTERN, (match) => {
-    const digits = match.replace(/[ ./-]/g, '')
-    return digits.length >= 13 && digits.length <= 19 && passesLuhn(digits) ? REDACTED_VALUE : match
-  })
+  result = result.replace(CREDIT_CARD_CANDIDATE_PATTERN, (match) =>
+    redactConfirmedCandidate(match, 13, 19, (_, digits) => passesLuhn(digits))
+  )
   result = result.replace(US_SSN_PATTERN, REDACTED_VALUE)
-  result = result.replace(PHONE_CANDIDATE_PATTERN, (match) => {
-    const digits = match.replace(/\D/g, '')
-    const hasGrouping = /[+() .-]/.test(match)
-    return digits.length >= 10 && digits.length <= 15 && hasGrouping ? REDACTED_VALUE : match
-  })
+  // The phone candidate only admits digits plus grouping chars, so a length
+  // gap means a grouping char is present — this keeps a bare digit run (an ID)
+  // from being redacted, without a second scan of the match.
+  result = result.replace(PHONE_CANDIDATE_PATTERN, (match) =>
+    redactConfirmedCandidate(match, 10, 15, (phone, digits) => digits.length !== phone.length)
+  )
   return result
 }
 

--- a/packages/mcp/src/extensions/mcp-payloads.ts
+++ b/packages/mcp/src/extensions/mcp-payloads.ts
@@ -123,30 +123,43 @@ function passesLuhn(digits: string): boolean {
   return sum % 10 === 0
 }
 
-// Within a card candidate, finds the actual card — the longest, earliest run of
-// whole separator-delimited digit groups whose joined digits are 13–19 long and
-// pass Luhn — and redacts only that span, leaving any adjacent field (an expiry,
-// a following ID) in place. Checking group-aligned runs rather than arbitrary
-// digit windows keeps the false-positive rate at Luhn's own ~1-in-10, instead of
-// letting a chance-valid sub-window of an ordinary long ID trigger redaction.
+// A card candidate can span more than one card plus adjacent fields (e.g. an
+// expiry, or a second card). This redacts every card in it: scanning
+// left-to-right over the whole separator-delimited digit groups, at each start it
+// takes the longest run whose joined digits are 13–19 long and pass Luhn, redacts
+// just that span, and resumes after it; a group that begins no valid run is kept
+// and skipped. Checking group-aligned runs rather than arbitrary digit windows
+// keeps the false-positive rate at Luhn's own ~1-in-10, instead of letting a
+// chance-valid sub-window of an ordinary long ID trigger redaction.
 function redactCardInMatch(match: string): string {
   const groups: { digits: string; start: number; end: number }[] = []
   for (let m = DIGIT_GROUP_PATTERN.exec(match); m !== null; m = DIGIT_GROUP_PATTERN.exec(match)) {
     groups.push({ digits: m[0], start: m.index, end: m.index + m[0].length })
   }
-  for (let first = 0; first < groups.length; first++) {
+  let output = ''
+  let cursor = 0
+  let first = 0
+  while (first < groups.length) {
     let digits = ''
+    let matchedLast = -1
     for (let last = first; last < groups.length; last++) {
       digits += groups[last].digits
       if (digits.length > 19) {
         break
       }
       if (digits.length >= 13 && passesLuhn(digits)) {
-        return match.slice(0, groups[first].start) + REDACTED_VALUE + match.slice(groups[last].end)
+        matchedLast = last
       }
     }
+    if (matchedLast >= 0) {
+      output += match.slice(cursor, groups[first].start) + REDACTED_VALUE
+      cursor = groups[matchedLast].end
+      first = matchedLast + 1
+    } else {
+      first++
+    }
   }
-  return match
+  return output + match.slice(cursor)
 }
 
 /**

--- a/packages/mcp/src/extensions/mcp-payloads.ts
+++ b/packages/mcp/src/extensions/mcp-payloads.ts
@@ -47,11 +47,14 @@ const IPV6_PATTERN =
 // A separator (space, dot, or dash) is required between the 3-2-4 groups so bare
 // 9-digit IDs are never mistaken for an SSN.
 const US_SSN_PATTERN = /\b\d{3}[ .-]\d{2}[ .-]\d{4}\b/g
-// 13–19 digits, optionally grouped by a single space, dot, dash, or slash. This
-// only marks a candidate; the Luhn check in `redactPii` is what confirms it is a
-// real card, so widening the separators cannot add false positives — it only
-// lets dot/slash-grouped cards reach the check instead of leaking past it.
-const CREDIT_CARD_CANDIDATE_PATTERN = /\b\d(?:[ ./-]?\d){12,18}\b/g
+// A run of >=13 digits optionally grouped by a single space, dot, dash, or
+// slash. This only marks the numeric region; `redactCardInMatch` then looks for
+// the actual card as a run of whole separator-delimited groups that passes Luhn,
+// so an adjacent field such as an expiry (`4111 1111 1111 1111 12/30`) is not
+// absorbed into a failing check that would leak the card.
+const CREDIT_CARD_CANDIDATE_PATTERN = /\b\d(?:[ ./-]?\d){12,}\b/g
+// Matches each separator-delimited digit group inside a card candidate.
+const DIGIT_GROUP_PATTERN = /\d+/g
 // Phone matching is structural rather than "any 10–15 digits", so dates
 // (`2024-01-15 12:30`) and dotted versions are not mistaken for numbers. Two
 // forms: a North-American 3-3-4 grouping, and an international number that must
@@ -120,6 +123,32 @@ function passesLuhn(digits: string): boolean {
   return sum % 10 === 0
 }
 
+// Within a card candidate, finds the actual card — the longest, earliest run of
+// whole separator-delimited digit groups whose joined digits are 13–19 long and
+// pass Luhn — and redacts only that span, leaving any adjacent field (an expiry,
+// a following ID) in place. Checking group-aligned runs rather than arbitrary
+// digit windows keeps the false-positive rate at Luhn's own ~1-in-10, instead of
+// letting a chance-valid sub-window of an ordinary long ID trigger redaction.
+function redactCardInMatch(match: string): string {
+  const groups: { digits: string; start: number; end: number }[] = []
+  for (let m = DIGIT_GROUP_PATTERN.exec(match); m !== null; m = DIGIT_GROUP_PATTERN.exec(match)) {
+    groups.push({ digits: m[0], start: m.index, end: m.index + m[0].length })
+  }
+  for (let first = 0; first < groups.length; first++) {
+    let digits = ''
+    for (let last = first; last < groups.length; last++) {
+      digits += groups[last].digits
+      if (digits.length > 19) {
+        break
+      }
+      if (digits.length >= 13 && passesLuhn(digits)) {
+        return match.slice(0, groups[first].start) + REDACTED_VALUE + match.slice(groups[last].end)
+      }
+    }
+  }
+  return match
+}
+
 /**
  * Redacts structured personal identifiers (emails, IP addresses, credit-card
  * numbers, US SSNs, and phone numbers) from a free-text string. Intended for the
@@ -134,12 +163,7 @@ export function redactPii(value: string): string {
   result = result.replace(EMAIL_PATTERN, REDACTED_VALUE)
   result = result.replace(IPV4_PATTERN, REDACTED_VALUE)
   result = result.replace(IPV6_PATTERN, REDACTED_VALUE)
-  // Card grouping (space/dot/dash/slash) is stripped so only the Luhn check on
-  // the digits decides — a non-card digit run of the same length is left intact.
-  result = result.replace(CREDIT_CARD_CANDIDATE_PATTERN, (match) => {
-    const digits = match.replace(/[ ./-]/g, '')
-    return digits.length >= 13 && digits.length <= 19 && passesLuhn(digits) ? REDACTED_VALUE : match
-  })
+  result = result.replace(CREDIT_CARD_CANDIDATE_PATTERN, redactCardInMatch)
   result = result.replace(US_SSN_PATTERN, REDACTED_VALUE)
   result = result.replace(PHONE_NANP_PATTERN, REDACTED_VALUE)
   result = result.replace(PHONE_INTL_PATTERN, REDACTED_VALUE)

--- a/packages/mcp/src/extensions/sanitization.ts
+++ b/packages/mcp/src/extensions/sanitization.ts
@@ -4,7 +4,7 @@
 // Licensed under the MIT License: https://github.com/agentcathq/agentcat-typescript-sdk/blob/main/LICENSE
 
 import type { ErrorProperties, Event, McpEvent } from '../types'
-import { sanitizeCapturedValue } from './mcp-payloads'
+import { redactPii, sanitizeCapturedValue } from './mcp-payloads'
 
 type SanitizedRecord = Record<string, unknown>
 
@@ -32,11 +32,14 @@ export function sanitizeEvent<T extends Event | McpEvent>(event: T): T {
     result.parameters = sanitizeParameters(result.parameters)
   }
 
-  // The intent comes straight from an agent-narrated `context` string, so it
-  // can contain a secret the LLM read aloud. Redact it like any other captured
-  // value rather than shipping it raw as `$mcp_intent`.
+  // The intent comes straight from an agent-narrated `context` string, so it can
+  // contain a secret the LLM read aloud or personal data it narrated about the
+  // user. Redact it like any other captured value, then strip structured PII
+  // (emails, phone numbers, IPs, cards, SSNs) rather than shipping it raw as
+  // `$mcp_intent`. PII redaction is scoped to the intent only — structured tool
+  // parameters and responses often hold the same shapes as legitimate data.
   if (result.userIntent != null) {
-    result.userIntent = sanitizeCapturedValue(result.userIntent) as string
+    result.userIntent = redactPii(sanitizeCapturedValue(result.userIntent) as string)
   }
 
   if (result.llmModel != null) {


### PR DESCRIPTION
## Problem

`$mcp_intent` is free text the calling agent writes into the injected `context` argument. Agents sometimes narrate personal data (emails, phone numbers, names) into it, and the SDK previously stored it almost verbatim — the only cleanup removed PostHog tokens and large binary blobs, and the "no personal data" instruction was prompt-only, not enforced.

## Changes

Two layers, both scoped to `@posthog/mcp`:

- **Always-on redaction** (`redactPii` in `mcp-payloads.ts`, applied to `userIntent` in `sanitization.ts`): strips structured identifiers — emails, phone numbers, IPv4/IPv6, Luhn-valid card numbers, US SSNs — from `$mcp_intent` before capture. Covers both the `instrument()` and `PostHogMCP` paths via the shared `sanitizeEvent`. Scoped to the intent only; structured tool `arguments`/results are untouched, since the same shapes are often legitimate there.
- **Stronger default `context` prompt** (`DEFAULT_CONTEXT_PARAMETER_DESCRIPTION`): now forbids repeating/paraphrasing/inferring personal data and tells the agent to generalize entities to roles ("a user", "the customer") — covering names, which regex cannot. Tests reference the constant symbolically, so no assertions changed.

Unit tests added for both. All 694 `@posthog/mcp` unit tests pass; `oxlint` clean.

### Libraries affected

- [x] @posthog/mcp _(not in the list below)_

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility (no API break; redaction changes only the captured `$mcp_intent` content)
- [x] Took care not to unnecessarily increase the bundle size (a few regexes + one function)
- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Desktop (Claude Opus). The human driver chose the scope (redaction limited to the intent, always-on, no config flag), the structured-identifier pattern set, and the final wording of the default prompt. Names/addresses were deliberately left to the prompt layer rather than regex, to avoid over-redacting ordinary prose. `tsc`/`rslib build` OOM locally in this environment (pre-existing, unrelated to the diff); verified via the vitest suite and oxlint instead.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*