### PR TITLE
docs(flags): clarify feature flag result semantics

### DIFF
--- a/.changeset/clarify-feature-flag-evaluation-results.md
+++ b/.changeset/clarify-feature-flag-evaluation-results.md
@@ -1,0 +1,13 @@
+---
+'posthog-js': patch
+'posthog-node': patch
+'posthog-react-native': patch
+'@posthog/core': patch
+'@posthog/nuxt': patch
+'@posthog/openfeature-node-provider': patch
+'@posthog/openfeature-web-provider': patch
+'@posthog/react': patch
+'@posthog/types': patch
+---
+
+Clarify feature flag return-value terminology across SDK APIs. A `false` value is a conclusive off evaluation, while `undefined` means no evaluation is available. Remote evaluation omits globally inactive flags, whereas backend local evaluation can resolve cached inactive definitions to `false`.

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -712,7 +712,7 @@
         },
         {
           "category": "",
-          "description": "Returns all currently cached feature flags as `FeatureFlagResult`s. This is a synchronous read of the flags from the last load (no network request); call `reloadFeatureFlags()` first to refresh. Unlike `getFeatureFlag()`, it does not send a `$feature_flag_called` event.",
+          "description": "Returns all currently cached feature flags as `FeatureFlagResult`s. This is a synchronous read of the flags from the last load (no network request); call `reloadFeatureFlags()` first to refresh. Conclusive off evaluations are included with `enabled: false`; keys omitted from the response, including globally inactive flags, are absent. Unlike `getFeatureFlag()`, this method does not send a `$feature_flag_called` event.",
           "details": null,
           "id": "getAllFeatureFlags",
           "showDocs": true,
@@ -776,7 +776,7 @@
         {
           "category": "Feature flags",
           "description": "Gets the value of a feature flag for the current user.",
-          "details": "Returns the feature flag value which can be a boolean, string, or undefined. Supports multivariate flags that can return custom string values.",
+          "details": "Returns the feature flag value which can be a boolean, string, or undefined. Supports multivariate flags that can return custom string values. An evaluated boolean flag returns `true` or `false`; `undefined` means no current evaluation is available for the key. Globally inactive flags are omitted from the remote `/flags` response, so after that response loads they are unavailable rather than represented by a `false` result.",
           "id": "getFeatureFlag",
           "showDocs": true,
           "title": "getFeatureFlag",
@@ -844,7 +844,7 @@
         },
         {
           "category": "Feature flags",
-          "description": "Get a feature flag evaluation result including both the flag value and payload.\nBy default, this method emits the `$feature_flag_called` event.",
+          "description": "Get a feature flag evaluation result including both the flag value and payload.\nA result with `enabled: false` is a conclusive off evaluation. `undefined` means no current evaluation is available for the key. This includes globally inactive flags, which are omitted from the remote `/flags` response.\nBy default, this method emits the `$feature_flag_called` event.",
           "details": null,
           "id": "getFeatureFlagResult",
           "showDocs": true,
@@ -1202,7 +1202,7 @@
         {
           "category": "Feature flags",
           "description": "Checks if a feature flag is enabled for the current user.",
-          "details": "Returns true if the flag is enabled, false if disabled, or undefined if not found (unless `defaultValue` is given, which is returned instead of undefined). This is a convenience method that treats any truthy value as enabled.",
+          "details": "Returns `true` or `false` when the flag has an evaluation value. A `false` result means the value evaluated off; it does not mean the SDK observed the flag's global active setting. Returns `undefined` when no current evaluation is available, unless `defaultValue` is given. Globally inactive flags are omitted from the remote `/flags` response and therefore have no value. This is a convenience method that treats any truthy value as enabled.",
           "id": "isFeatureEnabled",
           "showDocs": true,
           "title": "isFeatureEnabled",

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2385,7 +2385,10 @@ export class PostHog implements PostHogInterface {
      *
      * @remarks
      * Returns the feature flag value which can be a boolean, string, or undefined.
-     * Supports multivariate flags that can return custom string values.
+     * Supports multivariate flags that can return custom string values. An evaluated boolean flag
+     * returns `true` or `false`; `undefined` means no current evaluation is available for the key.
+     * Globally inactive flags are omitted from the remote `/flags` response, so after that response
+     * loads they are unavailable rather than represented by a `false` result.
      *
      * {@label Feature flags}
      *
@@ -2444,6 +2447,10 @@ export class PostHog implements PostHogInterface {
     /**
      * Get a feature flag evaluation result including both the flag value and payload.
      *
+     * A result with `enabled: false` is a conclusive off evaluation. `undefined` means no current
+     * evaluation is available for the key. This includes globally inactive flags, which are omitted
+     * from the remote `/flags` response.
+     *
      * By default, this method emits the `$feature_flag_called` event.
      *
      * {@label Feature flags}
@@ -2480,7 +2487,9 @@ export class PostHog implements PostHogInterface {
     /**
      * Returns all currently cached feature flags as `FeatureFlagResult`s. This is a synchronous read of
      * the flags from the last load (no network request); call `reloadFeatureFlags()` first to refresh.
-     * Unlike `getFeatureFlag()`, it does not send a `$feature_flag_called` event.
+     * Conclusive off evaluations are included with `enabled: false`; keys omitted from the response,
+     * including globally inactive flags, are absent. Unlike `getFeatureFlag()`, this method does not
+     * send a `$feature_flag_called` event.
      *
      * @returns {FeatureFlagResult[]} All loaded flags, or an empty array if none are loaded.
      */
@@ -2492,9 +2501,11 @@ export class PostHog implements PostHogInterface {
      * Checks if a feature flag is enabled for the current user.
      *
      * @remarks
-     * Returns true if the flag is enabled, false if disabled, or undefined if not found
-     * (unless `defaultValue` is given, which is returned instead of undefined).
-     * This is a convenience method that treats any truthy value as enabled.
+     * Returns `true` or `false` when the flag has an evaluation value. A `false` result means the
+     * value evaluated off; it does not mean the SDK observed the flag's global active setting.
+     * Returns `undefined` when no current evaluation is available, unless `defaultValue` is given.
+     * Globally inactive flags are omitted from the remote `/flags` response and therefore have no
+     * value. This is a convenience method that treats any truthy value as enabled.
      *
      * {@label Feature flags}
      *

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -1061,7 +1061,12 @@ export class PostHogFeatureFlags implements Extension {
      *
      * By default, this method may return cached values from localStorage if the `/flags` endpoint
      * hasn't responded yet. This reduces flicker but means you might briefly see stale values
-     * (e.g., a flag that was disabled on the server).
+     * (e.g., a flag that was made globally inactive on the server).
+     *
+     * An evaluated boolean flag returns `true` or `false`; `undefined` means no current evaluation
+     * is available for the key. Globally inactive flags are omitted from the remote `/flags`
+     * response, so after that response loads they are unavailable rather than represented by
+     * a `false` result.
      *
      * ### Usage:
      *
@@ -1075,8 +1080,8 @@ export class PostHogFeatureFlags implements Extension {
      * @param {boolean} [options.send_event=true] If false, won't send a $feature_flag_called event to PostHog.
      * @param {boolean} [options.fresh=false] If true, only returns values loaded from the server, not cached localStorage values.
      *                  Use this when you need to ensure the flag value reflects the current server state,
-     *                  such as after disabling a flag. Returns undefined until the /flags endpoint responds.
-     * @returns {boolean | string | undefined} The flag value, or undefined if not found or not yet loaded.
+     *                  such as after making a flag globally inactive. Returns undefined until the /flags endpoint responds.
+     * @returns {boolean | string | undefined} The flag value, or undefined if no current evaluation is available.
      */
     getFeatureFlag(key: string, options: FeatureFlagOptions = {}): boolean | string | undefined {
         if (options.fresh && !this._flagsLoadedFromRemote) {
@@ -1127,7 +1132,11 @@ export class PostHogFeatureFlags implements Extension {
      *
      * By default, this method may return cached values from localStorage if the `/flags` endpoint
      * hasn't responded yet. This reduces flicker but means you might briefly see stale values
-     * (e.g., a flag that was disabled on the server).
+     * (e.g., a flag that was made globally inactive on the server).
+     *
+     * A result with `enabled: false` is a conclusive off evaluation. `undefined` means no current
+     * evaluation is available for the key. This includes globally inactive flags, which are omitted
+     * from the remote `/flags` response.
      *
      * ### Usage:
      *
@@ -1346,7 +1355,12 @@ export class PostHogFeatureFlags implements Extension {
      *
      * By default, this method may return cached values from localStorage if the `/flags` endpoint
      * hasn't responded yet. This reduces flicker but means you might briefly see stale values
-     * (e.g., a flag that was disabled on the server).
+     * (e.g., a flag that was made globally inactive on the server).
+     *
+     * A `false` result means the flag value evaluated off; it does not mean the SDK observed the
+     * flag's global active setting. When no current evaluation is available, this method returns
+     * `options.defaultValue` if provided, otherwise `undefined`. Globally inactive flags are omitted
+     * from the remote `/flags` response and therefore have no value.
      *
      * ### Usage:
      *

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -1004,6 +1004,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     return getPayloadsFromFlags(details.flags)
   }
 
+  /**
+   * Returns the current evaluation result for a feature flag. `enabled: false` is a conclusive
+   * off result; `undefined` means no evaluation is available for the key.
+   */
   getFeatureFlagResult(key: string, options?: FeatureFlagResultOptions): FeatureFlagResult | undefined {
     return this._getFeatureFlagResult(key, options)
   }
@@ -1116,6 +1120,11 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     }
   }
 
+  /**
+   * Returns the current feature flag value. For backwards compatibility, a missing key can resolve
+   * to `false` once a non-empty flag response has been stored. Use `getFeatureFlagResult()` when
+   * code must distinguish a conclusive off result from an unavailable key.
+   */
   getFeatureFlag(key: string, options?: FeatureFlagResultOptions): FeatureFlagValue | undefined {
     const result = this._getFeatureFlagResult(key, {
       missingFlagBehavior: 'getFeatureFlag',
@@ -1188,6 +1197,11 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     }
   }
 
+  /**
+   * Returns whether the current feature flag value is enabled. When no evaluation is available,
+   * `defaultValue` is returned if provided; without one, the legacy missing-key behavior of
+   * `getFeatureFlag()` applies.
+   */
   isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean }): boolean
   isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
   isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -427,6 +427,7 @@ export type FeatureFlagValue = string | boolean
  */
 export type FeatureFlagResult = {
   readonly key: string
+  /** Whether the returned feature flag evaluation is enabled. `false` is a conclusive off result. */
   readonly enabled: boolean
   readonly variant?: string
   readonly payload?: JsonType

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -484,7 +484,7 @@
         },
         {
           "category": "Feature flags",
-          "description": "Evaluate all feature flags for a user in a single call and return a  snapshot. Branch on `.isEnabled()` / `.getFlag()`, then pass the same snapshot to `capture()` via the `flags` option so the captured event carries the exact flag values the code branched on.\nPrefer this over repeated `isFeatureEnabled()` / `getFeatureFlag()` calls and over `capture({ sendFeatureFlags: true })` — it consolidates flag evaluation into a single `/flags` request per incoming request.\n**Local evaluation is transparent.** When the poller can resolve a flag from cached definitions, no network call is made and the snapshot's `$feature_flag_called` events are tagged `locally_evaluated: true`. A requested key missing from local definitions is included in a `/flags` fallback unless `onlyEvaluateLocally` is true. Locally resolved values remain authoritative when remote results are merged.\n**Trim the request.** Pass `flagKeys` to scope local evaluation, the underlying `/flags` request, and the returned snapshot to a subset of flags. Remote evaluation responses are not cached, so a key missing both locally and remotely costs one `/flags` request per `evaluateFlags()` call.\n**Trim the event payload.** Use `flags.only([...])` or `flags.onlyAccessed()` to filter which flags get attached to a captured event without re-fetching.",
+          "description": "Evaluate all feature flags for a user in a single call and return a  snapshot. Branch on `.isEnabled()` / `.getFlag()`, then pass the same snapshot to `capture()` via the `flags` option so the captured event carries the exact flag values the code branched on.\nPrefer this over repeated `isFeatureEnabled()` / `getFeatureFlag()` calls and over `capture({ sendFeatureFlags: true })` — it consolidates flag evaluation into a single `/flags` request per incoming request.\n**Local evaluation is transparent.** When the poller can resolve a flag from cached definitions, no network call is made and the snapshot's `$feature_flag_called` events are tagged `locally_evaluated: true`. A requested key missing from local definitions is included in a `/flags` fallback unless `onlyEvaluateLocally` is true. Locally resolved values remain authoritative when remote results are merged. In particular, a cached inactive definition is a conclusive `false` result locally, while remote evaluation omits globally inactive flags and therefore leaves those keys absent.\n**Trim the request.** Pass `flagKeys` to scope local evaluation, the underlying `/flags` request, and the returned snapshot to a subset of flags. Remote evaluation responses are not cached, so a key missing both locally and remotely costs one `/flags` request per `evaluateFlags()` call.\n**Trim the event payload.** Use `flags.only([...])` or `flags.onlyAccessed()` to filter which flags get attached to a captured event without re-fetching.",
           "details": null,
           "id": "evaluateFlags",
           "showDocs": true,
@@ -671,7 +671,7 @@
         },
         {
           "category": "Feature flags",
-          "description": "Get the value of a feature flag for a specific user.",
+          "description": "Get the value of a feature flag for a specific user.\nA boolean `false` is a conclusive off evaluation. `undefined` means no result is available, for example because the key was not returned or local-only evaluation was inconclusive. Local evaluation resolves cached inactive definitions to `false`; remote evaluation omits globally inactive flags, so the result depends on which evaluation path is available.",
           "details": null,
           "id": "getFeatureFlag",
           "showDocs": true,
@@ -680,7 +680,7 @@
             {
               "id": "basic_feature_flag_check",
               "name": "Basic feature flag check",
-              "code": "\n\n// Basic feature flag check\nconst flagValue = await client.getFeatureFlag('new-feature', 'user_123')\nif (flagValue === 'variant-a') {\n  // Show variant A\n} else if (flagValue === 'variant-b') {\n  // Show variant B\n} else {\n  // Flag is disabled or not found\n}\n\n\n"
+              "code": "\n\n// Basic feature flag check\nconst flagValue = await client.getFeatureFlag('new-feature', 'user_123')\nif (flagValue === 'variant-a') {\n  // Show variant A\n} else if (flagValue === 'variant-b') {\n  // Show variant B\n} else {\n  // Flag evaluated off, or no value was returned\n}\n\n\n"
             },
             {
               "id": "with_groups_and_properties",
@@ -779,7 +779,7 @@
         },
         {
           "category": "Feature flags",
-          "description": "Get the result of evaluating a feature flag, including its value and payload. This is more efficient than calling getFeatureFlag and getFeatureFlagPayload separately when you need both.",
+          "description": "Get the result of evaluating a feature flag, including its value and payload. This is more efficient than calling getFeatureFlag and getFeatureFlagPayload separately when you need both. A result with `enabled: false` is a conclusive off evaluation; `undefined` means no evaluation is available. Local evaluation resolves cached inactive definitions to `enabled: false`, while remote evaluation omits globally inactive flags.",
           "details": null,
           "id": "getFeatureFlagResult",
           "showDocs": true,
@@ -1063,7 +1063,7 @@
             {
               "id": "basic_feature_flag_check",
               "name": "Basic feature flag check",
-              "code": "\n\n// Basic feature flag check\nconst isEnabled = await client.isFeatureEnabled('new-feature', 'user_123')\nif (isEnabled) {\n  // Feature is enabled\n  console.log('New feature is active')\n} else {\n  // Feature is disabled\n  console.log('New feature is not active')\n}\n\n\n"
+              "code": "\n\n// Basic feature flag check\nconst isEnabled = await client.isFeatureEnabled('new-feature', 'user_123')\nif (isEnabled) {\n  // Feature is enabled\n  console.log('New feature is active')\n} else {\n  // Flag evaluated off, or no value was returned\n  console.log('New feature is not active')\n}\n\n\n"
             },
             {
               "id": "with_groups_and_properties",
@@ -2284,6 +2284,7 @@
           "name": "key"
         },
         {
+          "description": "Whether the returned feature flag evaluation is enabled. `false` is a conclusive off result.",
           "type": "boolean",
           "name": "enabled"
         },

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1188,7 +1188,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * @param distinctId - The user's distinct ID
    * @param options - Evaluation options (includes sendFeatureFlagEvents, defaults to true)
    * @param matchValue - Optional match value for payload lookup (used by getFeatureFlagPayload)
-   * @returns Promise that resolves to the flag result or undefined
+   * @returns Promise that resolves to the flag result, or undefined when no evaluation is available
    */
   private async _getFeatureFlagResult(
     key: string,
@@ -1415,6 +1415,11 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   /**
    * Get the value of a feature flag for a specific user.
    *
+   * A boolean `false` is a conclusive off evaluation. `undefined` means no result is available,
+   * for example because the key was not returned or local-only evaluation was inconclusive.
+   * Local evaluation resolves cached inactive definitions to `false`; remote evaluation omits
+   * globally inactive flags, so the result depends on which evaluation path is available.
+   *
    * @example
    * ```ts
    * // Basic feature flag check
@@ -1424,7 +1429,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * } else if (flagValue === 'variant-b') {
    *   // Show variant B
    * } else {
-   *   // Flag is disabled or not found
+   *   // Flag evaluated off, or no value was returned
    * }
    * ```
    *
@@ -1456,7 +1461,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * @param key - The feature flag key
    * @param distinctId - The user's distinct ID
    * @param options - Optional configuration for flag evaluation
-   * @returns Promise that resolves to the flag value or undefined
+   * @returns Promise that resolves to the flag value, or undefined when no evaluation is available
    */
   async getFeatureFlag(
     key: string,
@@ -1576,6 +1581,9 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   /**
    * Get the result of evaluating a feature flag, including its value and payload.
    * This is more efficient than calling getFeatureFlag and getFeatureFlagPayload separately when you need both.
+   * A result with `enabled: false` is a conclusive off evaluation; `undefined` means no evaluation
+   * is available. Local evaluation resolves cached inactive definitions to `enabled: false`, while
+   * remote evaluation omits globally inactive flags.
    *
    * @example
    * ```ts
@@ -1691,7 +1699,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    *   // Feature is enabled
    *   console.log('New feature is active')
    * } else {
-   *   // Feature is disabled
+   *   // Flag evaluated off, or no value was returned
    *   console.log('New feature is not active')
    * }
    * ```
@@ -1714,7 +1722,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * @param key - The feature flag key
    * @param distinctId - The user's distinct ID
    * @param options - Optional configuration for flag evaluation
-   * @returns Promise that resolves to true if enabled, false if disabled, undefined if not found
+   * @returns Promise that resolves to true if the flag evaluates on, false if it conclusively evaluates off, or undefined when no evaluation is available
    */
   async isFeatureEnabled(
     key: string,
@@ -1944,7 +1952,9 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * cached definitions, no network call is made and the snapshot's `$feature_flag_called`
    * events are tagged `locally_evaluated: true`. A requested key missing from local
    * definitions is included in a `/flags` fallback unless `onlyEvaluateLocally` is true.
-   * Locally resolved values remain authoritative when remote results are merged.
+   * Locally resolved values remain authoritative when remote results are merged. In particular,
+   * a cached inactive definition is a conclusive `false` result locally, while remote evaluation
+   * omits globally inactive flags and therefore leaves those keys absent.
    *
    * **Trim the request.** Pass `flagKeys` to scope local evaluation, the underlying
    * `/flags` request, and the returned snapshot to a subset of flags. Remote evaluation

--- a/packages/node/src/feature-flag-evaluations.ts
+++ b/packages/node/src/feature-flag-evaluations.ts
@@ -121,7 +121,8 @@ export class FeatureFlagEvaluations {
    *
    * Flags that were not returned from the underlying evaluation resolve to
    * `options.defaultValue` (`false` unless overridden). A flag that has a value —
-   * including `false` and variant strings — always wins over `options.defaultValue`.
+   * including a conclusive `false` result and variant strings — always wins over
+   * `options.defaultValue`. Use `getFlag()` to distinguish an absent result from `false`.
    */
   isEnabled(key: string, options: { defaultValue?: boolean } = {}): boolean {
     const flag = this._flags[key]
@@ -133,9 +134,11 @@ export class FeatureFlagEvaluations {
    * Get the evaluated value of a feature flag. Fires a `$feature_flag_called` event
    * on the first access per (distinctId, flag, value) tuple.
    *
-   * Returns the variant string for multivariate flags, `true` for enabled flags
-   * without a variant, `false` for disabled flags, and `undefined` for flags that
-   * were not returned by the evaluation.
+   * Returns the variant string for multivariate flags, `true` for boolean flags that
+   * evaluate on, `false` for boolean flags that conclusively evaluate off, and `undefined`
+   * for flags that were not returned by the evaluation. Cached inactive definitions are
+   * conclusive `false` results during local evaluation, while remote evaluation omits
+   * globally inactive flags.
    */
   getFlag(key: string): FeatureFlagValue | undefined {
     const flag = this._flags[key]

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -422,6 +422,7 @@ export type FeatureFlagErrorType = (typeof FeatureFlagError)[keyof typeof Featur
  */
 export type FeatureFlagResult = {
   key: string
+  /** Whether the returned feature flag evaluation is enabled. `false` is a conclusive off result. */
   enabled: boolean
   variant: string | undefined
   payload: JsonType | undefined
@@ -582,7 +583,7 @@ export interface IPostHog {
    * @param onlyEvaluateLocally optional - whether to only evaluate the flag locally. Defaults to false.
    * @param sendFeatureFlagEvents optional - whether to send feature flag events. Used for Experiments. Defaults to true.
    *
-   * @returns true if the flag is on, false if the flag is off, undefined if there was an error.
+   * @returns true if the flag evaluates on, false if it conclusively evaluates off, or undefined if no result is available. Local evaluation resolves cached inactive definitions to false; remote evaluation omits globally inactive flags, leaving no result.
    *
    * @deprecated Use {@link IPostHog.evaluateFlags} and call `flags.isEnabled(key)` on the
    *   returned snapshot. Will be removed in the next major version.
@@ -613,7 +614,7 @@ export interface IPostHog {
    * @param onlyEvaluateLocally optional - whether to only evaluate the flag locally. Defaults to false.
    * @param sendFeatureFlagEvents optional - whether to send feature flag events. Used for Experiments. Defaults to true.
    *
-   * @returns true or string(for multivariates) if the flag is on, false if the flag is off, undefined if there was an error.
+   * @returns true or a variant string if the flag evaluates on, false if it conclusively evaluates off, or undefined if no result is available. Local evaluation resolves cached inactive definitions to false; remote evaluation omits globally inactive flags, leaving no result.
    *
    * @deprecated Use {@link IPostHog.evaluateFlags} and call `flags.getFlag(key)` on the
    *   returned snapshot. Will be removed in the next major version.
@@ -744,6 +745,9 @@ export interface IPostHog {
    * }
    * posthog.capture({ distinctId: 'user_123', event: 'page_viewed', flags })
    * ```
+   *
+   * Local evaluation resolves cached inactive definitions to `false`. Remote evaluation omits
+   * globally inactive flags, so those keys are absent when no local definition is available.
    *
    * @param options - Optional configuration for flag evaluation. `flagKeys` scopes local evaluation, the `/flags` request, and the returned snapshot. Missing local keys trigger fallback unless `onlyEvaluateLocally` is true.
    */

--- a/packages/nuxt/src/runtime/composables/useFeatureFlagEnabled.ts
+++ b/packages/nuxt/src/runtime/composables/useFeatureFlagEnabled.ts
@@ -6,7 +6,9 @@ import { usePostHog } from './usePostHog'
  *
  * @remarks
  * This composable initializes with the current feature flag value and automatically
- * updates when PostHog feature flags are reloaded.
+ * updates when PostHog feature flags are reloaded. The ref contains `false` for a conclusive off
+ * evaluation and `undefined` when no evaluation is available. Globally inactive flags are omitted
+ * from remote responses and are therefore unavailable after the latest response loads.
  *
  * **Server-Side Rendering (SSR) Behavior:**
  * - During SSR, PostHog is typically not available or feature flags are not yet loaded

--- a/packages/openfeature-node-provider/src/mapping.ts
+++ b/packages/openfeature-node-provider/src/mapping.ts
@@ -81,7 +81,7 @@ export function splitContext(context?: EvaluationContext): SplitContext {
 /**
  * Map PostHog's enabled state to an OpenFeature reason. PostHog's JS
  * `FeatureFlagResult` carries no free-text reason (unlike the Python client), so
- * an enabled flag means a targeting condition matched and a disabled one falls
+ * an enabled flag means a targeting condition matched and an off result falls
  * back to the default rollout.
  */
 function reasonFor(result: PostHogFlagResult): ResolutionReason {
@@ -89,9 +89,9 @@ function reasonFor(result: PostHogFlagResult): ResolutionReason {
 }
 
 /**
- * A `undefined` result means the flag does not exist (or was archived) —
- * `getFeatureFlagResult` returns a populated result with `enabled: false` for a
- * flag that exists but did not match. Surface the former as the OpenFeature
+ * An `undefined` result means no evaluation is available, for example because the
+ * key was not returned or evaluation failed. A populated result with `enabled: false`
+ * is a conclusive off evaluation. Surface unavailable results as the OpenFeature
  * `FLAG_NOT_FOUND` error so callers get their default value.
  */
 function ensureResolved(result: PostHogFlagResult | undefined, flagKey: string): PostHogFlagResult {
@@ -117,10 +117,10 @@ export function resolveStringDetails(
   const resolved = ensureResolved(result, flagKey)
   if (resolved.variant === undefined) {
     if (!resolved.enabled) {
-      // A disabled or unmatched flag has no variant. Resolve to the caller's
+      // A boolean flag that evaluated off has no variant. Resolve to the caller's
       // default (per the OpenFeature spec) rather than throwing — a throw would
       // set reason=ERROR and fire every registered error hook on an ordinary
-      // disabled-flag read.
+      // off-result read.
       return { value: defaultValue, reason: StandardResolutionReasons.DEFAULT }
     }
     // An enabled boolean flag has no string variant: a genuine type mismatch.

--- a/packages/openfeature-node-provider/src/mapping.ts
+++ b/packages/openfeature-node-provider/src/mapping.ts
@@ -117,7 +117,7 @@ export function resolveStringDetails(
   const resolved = ensureResolved(result, flagKey)
   if (resolved.variant === undefined) {
     if (!resolved.enabled) {
-      // A boolean flag that evaluated off has no variant. Resolve to the caller's
+      // An off result has no variant. Resolve to the caller's
       // default (per the OpenFeature spec) rather than throwing — a throw would
       // set reason=ERROR and fire every registered error hook on an ordinary
       // off-result read.

--- a/packages/openfeature-web-provider/src/mapping.ts
+++ b/packages/openfeature-web-provider/src/mapping.ts
@@ -116,7 +116,7 @@ export function resolveStringDetails(
   const resolved = ensureResolved(result, flagKey)
   if (resolved.variant === undefined) {
     if (!resolved.enabled) {
-      // A boolean flag that evaluated off has no variant. Resolve to the caller's
+      // An off result has no variant. Resolve to the caller's
       // default (per the OpenFeature spec) rather than throwing — a throw would
       // set reason=ERROR and fire every registered error hook on an ordinary
       // off-result read.

--- a/packages/openfeature-web-provider/src/mapping.ts
+++ b/packages/openfeature-web-provider/src/mapping.ts
@@ -80,7 +80,7 @@ export function splitContext(context?: EvaluationContext): SplitContext {
 /**
  * Map PostHog's enabled state to an OpenFeature reason. PostHog's JS
  * `FeatureFlagResult` carries no free-text reason (unlike the Python client), so
- * an enabled flag means a targeting condition matched and a disabled one falls
+ * an enabled flag means a targeting condition matched and an off result falls
  * back to the default rollout.
  */
 function reasonFor(result: PostHogFlagResult): ResolutionReason {
@@ -88,9 +88,9 @@ function reasonFor(result: PostHogFlagResult): ResolutionReason {
 }
 
 /**
- * A `undefined` result means the flag does not exist (or was archived) —
- * `getFeatureFlagResult` returns a populated result with `enabled: false` for a
- * flag that exists but did not match. Surface the former as the OpenFeature
+ * An `undefined` result means no evaluation is available, for example because the
+ * key was not returned or flags have not loaded. A populated result with `enabled: false`
+ * is a conclusive off evaluation. Surface unavailable results as the OpenFeature
  * `FLAG_NOT_FOUND` error so callers get their default value.
  */
 function ensureResolved(result: PostHogFlagResult | undefined, flagKey: string): PostHogFlagResult {
@@ -116,10 +116,10 @@ export function resolveStringDetails(
   const resolved = ensureResolved(result, flagKey)
   if (resolved.variant === undefined) {
     if (!resolved.enabled) {
-      // A disabled or unmatched flag has no variant. Resolve to the caller's
+      // A boolean flag that evaluated off has no variant. Resolve to the caller's
       // default (per the OpenFeature spec) rather than throwing — a throw would
       // set reason=ERROR and fire every registered error hook on an ordinary
-      // disabled-flag read.
+      // off-result read.
       return { value: defaultValue, reason: StandardResolutionReasons.DEFAULT }
     }
     // An enabled boolean flag has no string variant: a genuine type mismatch.

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -444,7 +444,7 @@
         },
         {
           "category": "Feature flags",
-          "description": "Gets the value of a feature flag for the current user.\nDefaults to undefined if not loaded yet or if there was a problem loading. Multivariant feature flags are returned as a string.",
+          "description": "Gets the value of a feature flag for the current user.\nReturns `true` or `false` for an evaluated boolean flag and a string for a multivariate flag. Returns `undefined` before flags load or when loading fails. For backwards compatibility, a missing key can resolve to `false` after a non-empty response is stored; use `getFeatureFlagResult()` to distinguish an unavailable key from a conclusive off result.\nGlobally inactive flags are omitted from remote responses, so they follow this missing-key behavior rather than carrying an explicit off evaluation.",
           "details": null,
           "id": "getFeatureFlag",
           "showDocs": true,
@@ -761,7 +761,7 @@
         },
         {
           "category": "Feature flags",
-          "description": "Checks if a feature flag is enabled for the current user.\nDefaults to undefined if not loaded yet or if there was a problem loading, unless `defaultValue` is provided.",
+          "description": "Checks if a feature flag is enabled for the current user.\nA `false` return value means the SDK resolved the current value as off. If no evaluation is available, this method returns `defaultValue` when provided. Without a default, it returns `undefined` before flags load; for backwards compatibility, a missing key can resolve to `false` after a non-empty response is stored.\nGlobally inactive flags are omitted from remote responses, so they follow this missing-key behavior rather than carrying an explicit off evaluation.",
           "details": null,
           "id": "isFeatureEnabled",
           "showDocs": true,
@@ -1730,6 +1730,7 @@
         },
         {
           "category": "",
+          "description": "Returns the current evaluation result for a feature flag. `enabled: false` is a conclusive off result; `undefined` means no evaluation is available for the key.",
           "details": null,
           "id": "getFeatureFlagResult",
           "showDocs": true,

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1055,8 +1055,13 @@ export class PostHog extends PostHogCore {
   /**
    * Checks if a feature flag is enabled for the current user.
    *
-   * Defaults to undefined if not loaded yet or if there was a problem loading,
-   * unless `defaultValue` is provided.
+   * A `false` return value means the SDK resolved the current value as off. If no evaluation is
+   * available, this method returns `defaultValue` when provided. Without a default, it returns
+   * `undefined` before flags load; for backwards compatibility, a missing key can resolve to
+   * `false` after a non-empty response is stored.
+   *
+   * Globally inactive flags are omitted from remote responses, so they follow this missing-key
+   * behavior rather than carrying an explicit off evaluation.
    *
    * {@label Feature flags}
    *
@@ -1076,7 +1081,7 @@ export class PostHog extends PostHogCore {
    *
    * @param key The feature flag key
    * @param options Optional per-call settings
-   * @returns True if enabled, false if disabled; when the flag has no value, defaultValue if given, otherwise undefined
+   * @returns True if the flag evaluates on, false if it evaluates off, or the missing-value fallback described above
    */
   isFeatureEnabled(key: string, options: IsFeatureEnabledOptions & { defaultValue: boolean }): boolean
   isFeatureEnabled(key: string, options?: IsFeatureEnabledOptions): boolean | undefined
@@ -1087,8 +1092,13 @@ export class PostHog extends PostHogCore {
   /**
    * Gets the value of a feature flag for the current user.
    *
-   * Defaults to undefined if not loaded yet or if there was a problem loading.
-   * Multivariant feature flags are returned as a string.
+   * Returns `true` or `false` for an evaluated boolean flag and a string for a multivariate flag.
+   * Returns `undefined` before flags load or when loading fails. For backwards compatibility, a
+   * missing key can resolve to `false` after a non-empty response is stored; use
+   * `getFeatureFlagResult()` to distinguish an unavailable key from a conclusive off result.
+   *
+   * Globally inactive flags are omitted from remote responses, so they follow this missing-key
+   * behavior rather than carrying an explicit off evaluation.
    *
    * {@label Feature flags}
    *
@@ -1102,7 +1112,7 @@ export class PostHog extends PostHogCore {
    *
    * @param key The feature flag key
    * @param options Optional per-call settings
-   * @returns The feature flag value or undefined if not loaded
+   * @returns The current feature flag value, or undefined if flags are unavailable
    */
   getFeatureFlag(key: string, options?: FeatureFlagResultOptions): boolean | string | undefined {
     return super.getFeatureFlag(key, options)

--- a/packages/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/packages/react/src/hooks/useFeatureFlagEnabled.ts
@@ -5,8 +5,10 @@ import { isUndefined } from '../utils/type-utils'
 /**
  * Check whether a feature flag is enabled for the current user.
  *
- * Returns `undefined` while flags are still loading or when the flag is absent, so callers can
- * distinguish "not known yet" from "disabled".
+ * Returns `false` when the current flag value evaluates off. Returns `undefined` while flags are
+ * still loading or when the flag is absent, so callers can distinguish "no evaluation available"
+ * from a conclusive off result. Globally inactive flags are omitted from remote responses and are
+ * therefore absent after the latest response loads.
  *
  * @param flag Key of the feature flag.
  * @returns Whether the flag is enabled, or `undefined` if not yet loaded or not found.

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -64,7 +64,7 @@ export type EarlyAccessFeatureCallback = (earlyAccessFeatures: EarlyAccessFeatur
 export type FeatureFlagResult = {
     /** The key of the feature flag */
     readonly key: string
-    /** Whether the feature flag is enabled (truthy value) */
+    /** Whether the returned feature flag evaluation is enabled. `false` is a conclusive off result. */
     readonly enabled: boolean
     /** The variant key if this is a multivariate flag, undefined for boolean flags */
     readonly variant: string | undefined


### PR DESCRIPTION
## Problem

Feature flag API docs use "disabled" for both an evaluation result and the flag's global status. Those are not the same thing. A boolean flag can evaluate to `false`, while `undefined` means the SDK has no evaluation value for the key.

The difference also depends on the evaluation path. Remote `/flags` responses omit globally inactive flags. Backend local evaluation can receive an inactive definition and conclusively evaluate it to `false`. The existing wording did not explain this and could not be applied consistently across SDKs.

Supersedes #4755 with wording based on the full SDK API audit.

Related frontend copy update: PostHog/posthog#95085.

## Changes

- Describe `false` as a conclusive off evaluation and `undefined` as an unavailable evaluation.
- Document that remote evaluation omits globally inactive flags while Node.js local evaluation resolves cached inactive definitions to `false`.
- Clarify the existing missing-key compatibility behavior in `@posthog/core` and React Native.
- Align browser, React, Nuxt, Node.js, React Native, and OpenFeature wording without changing runtime behavior.
- Regenerate the browser API reference and add a patch changeset.

Validation:

- `pnpm exec oxfmt --check` on all changed source and changeset files
- `pnpm exec oxlint --report-unused-disable-directives-severity error` on all changed TypeScript files
- `pnpm turbo --filter=posthog-js build`
- `pnpm turbo build --filter=posthog-node --filter=posthog-react-native --filter=@posthog/react --filter=@posthog/nuxt --filter=@posthog/openfeature-node-provider --filter=@posthog/openfeature-web-provider`
- Focused browser, core, and Node.js feature flag tests
- `pnpm --dir packages/browser generate-references`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [x] @posthog/nuxt
- [x] @posthog/openfeature-node-provider
- [x] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

`@posthog/core` is also included in the changeset.

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi audited the feature flag lookup APIs and their remote and local evaluation paths. The changes only update documentation, generated references, and release metadata. Pi autoreview found no actionable issues in commit `299da7608bf2bd28ab50acde479f88629e364b40`.

