### PR TITLE
fix(browser): prevent recursive exception capture after stack overflows

### DIFF
--- a/.changeset/stop-exception-stack-overflow-recapture.md
+++ b/.changeset/stop-exception-stack-overflow-recapture.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Prevent automatic and manual exception capture from recursively recapturing stack overflows raised while sending an exception.

--- a/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
@@ -1,6 +1,8 @@
+import Config from '@posthog/browser-common/config'
+import { window } from '@posthog/browser-common/utils/globals'
+import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
 import { PostHog } from '../../posthog-core'
 import { createPosthogInstance } from '../helpers/posthog-instance'
-import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
 import { EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE } from '../../constants'
 import { RemoteConfig } from '../../types'
 
@@ -11,6 +13,75 @@ describe('ExceptionObserver', () => {
         instance = await createPosthogInstance(uuidv7(), {
             api_host: 'https://test.com',
             token: 'testtoken',
+        })
+    })
+
+    describe('captureException', () => {
+        const errorProperties = { $exception_list: [{ type: 'TypeError' }] } as any
+
+        it.each([
+            ['Chromium', new RangeError('Maximum call stack size exceeded')],
+            ['WebKit', new RangeError('Maximum call stack size exceeded.')],
+            ['Firefox', Object.assign(new Error('too much recursion'), { name: 'InternalError' })],
+        ])('swallows %s stack overflow errors', (_browser, stackOverflowError) => {
+            vi.spyOn(instance.exceptions, 'sendExceptionEvent').mockImplementation(() => {
+                throw stackOverflowError
+            })
+
+            expect(() => instance.exceptionObserver.captureException(errorProperties)).not.toThrow()
+        })
+
+        it.each([
+            new RangeError('Invalid array length'),
+            Object.assign(new Error('allocation size overflow'), { name: 'InternalError' }),
+            new TypeError('something else'),
+        ])('rethrows unrelated errors from exception capture', (error) => {
+            vi.spyOn(instance.exceptions, 'sendExceptionEvent').mockImplementation(() => {
+                throw error
+            })
+
+            expect(() => instance.exceptionObserver.captureException(errorProperties)).toThrow(error)
+        })
+
+        it('swallows a stack overflow raised before sending the exception', () => {
+            const stackOverflowError = new RangeError('Maximum call stack size exceeded')
+            vi.spyOn(instance.exceptionObserver['_rateLimiter'], 'consumeRateLimit').mockImplementation(() => {
+                throw stackOverflowError
+            })
+            const sendExceptionEvent = vi.spyOn(instance.exceptions, 'sendExceptionEvent')
+
+            expect(() => instance.exceptionObserver.captureException(errorProperties)).not.toThrow()
+            expect(sendExceptionEvent).not.toHaveBeenCalled()
+        })
+
+        it.each(['automatic', 'manual'])('does not re-enter autocapture after a %s capture overflows', (mode) => {
+            const stackOverflowError = new RangeError('Maximum call stack size exceeded')
+            const capture = vi.spyOn(instance, 'capture').mockImplementation(() => {
+                throw stackOverflowError
+            })
+            const consoleError = vi.fn(() => instance.exceptionObserver.captureException(errorProperties))
+            const originalConsoleError = window!.console.error
+            const originalConsoleLog = window!.console.log
+            const originalDebug = Config.DEBUG
+            window!.console.error = consoleError
+            window!.console.log = vi.fn()
+            Config.DEBUG = true
+
+            try {
+                if (mode === 'automatic') {
+                    instance.exceptionObserver.captureException(errorProperties)
+                } else {
+                    instance.captureException(new Error('original exception'))
+                }
+
+                expect(capture).toHaveBeenCalledTimes(1)
+                expect(consoleError).not.toHaveBeenCalled()
+            } finally {
+                capture.mockRestore()
+                Config.DEBUG = originalDebug
+                window!.console.error = originalConsoleError
+                window!.console.log = originalConsoleLog
+            }
         })
     })
 

--- a/packages/browser/src/extensions/exception-autocapture/index.ts
+++ b/packages/browser/src/extensions/exception-autocapture/index.ts
@@ -8,6 +8,7 @@ import { EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE } from '../../constants'
 import { isUndefined, BucketedRateLimiter, isObject, resolveExceptionRateLimiterConfig } from '@posthog/core'
 import { ErrorTracking } from '@posthog/core'
 import { ExceptionAutoCaptureConfig } from '../../types'
+import { isStackOverflowError } from '../../utils/stack-overflow'
 
 const logger = createLogger('[ExceptionAutocapture]')
 
@@ -161,16 +162,24 @@ export class ExceptionObserver {
     }
 
     captureException(errorProperties: ErrorTracking.ErrorProperties) {
-        const exceptionType = errorProperties?.$exception_list?.[0]?.type ?? 'Exception'
-        const isRateLimited = this._rateLimiter.consumeRateLimit(exceptionType)
+        try {
+            const exceptionType = errorProperties?.$exception_list?.[0]?.type ?? 'Exception'
+            const isRateLimited = this._rateLimiter.consumeRateLimit(exceptionType)
 
-        if (isRateLimited) {
-            logger.info('Skipping exception capture because of client rate limiting.', {
-                exception: exceptionType,
-            })
-            return
+            if (isRateLimited) {
+                logger.info('Skipping exception capture because of client rate limiting.', {
+                    exception: exceptionType,
+                })
+                return
+            }
+
+            this._instance.exceptions?.sendExceptionEvent(errorProperties)
+        } catch (error) {
+            if (!isStackOverflowError(error)) {
+                throw error
+            }
+            // Do not log here: console.error may be instrumented by exception autocapture and
+            // would re-enter this method while the call stack is still exhausted.
         }
-
-        this._instance.exceptions?.sendExceptionEvent(errorProperties)
     }
 }

--- a/packages/browser/src/posthog-exceptions.ts
+++ b/packages/browser/src/posthog-exceptions.ts
@@ -5,6 +5,7 @@ import { CaptureResult, ErrorTrackingSuppressionRule, Properties, RemoteConfigRe
 import { createLogger } from '@posthog/browser-common/utils/logger'
 import { propertyComparisons } from '@posthog/browser-common/utils/property-utils'
 import { isString, isArray, isObject, ErrorTracking, isNullish } from '@posthog/core'
+import { isStackOverflowError } from './utils/stack-overflow'
 
 const logger = createLogger('[Error tracking]')
 
@@ -197,12 +198,16 @@ export class PostHogExceptions implements Extension {
 
                 return result
             } catch (error) {
-                logger.error('Failed to capture exception event. Dropping this exception.', error)
+                if (!isStackOverflowError(error)) {
+                    logger.error('Failed to capture exception event. Dropping this exception.', error)
+                }
                 this._exceptionStepsBuffer.clear()
                 return
             }
         } catch (error) {
-            logger.error('Failed to process exception event. Ignoring this exception.', error)
+            if (!isStackOverflowError(error)) {
+                logger.error('Failed to process exception event. Ignoring this exception.', error)
+            }
             return
         }
     }

--- a/packages/browser/src/utils/stack-overflow.ts
+++ b/packages/browser/src/utils/stack-overflow.ts
@@ -1,0 +1,6 @@
+import { isError } from '@posthog/core'
+
+export const isStackOverflowError = (error: unknown): boolean =>
+    isError(error) &&
+    ((error.name === 'RangeError' && error.message.indexOf('Maximum call stack size exceeded') === 0) ||
+        (error.name === 'InternalError' && error.message === 'too much recursion'))


### PR DESCRIPTION
## Problem

When exception capture itself runs out of stack space, its recovery log can pass through the instrumented `console.error` handler and start exception capture again. This can repeatedly emit the same exception. Manual `posthog.captureException()` calls use the same sending path and can trigger the same behavior.

## Changes

- Detect the stack-overflow signatures used by Chromium, WebKit, and Firefox.
- Avoid capture-aware recovery logging when exception sending fails with a stack overflow.
- Guard automatic exception capture against overflows that happen before the shared sending path.
- Preserve the existing behavior for unrelated errors.
- Add regression coverage for automatic and manual exception capture.

This is a focused replacement for #4777. It excludes the query parser and array polyfill changes from that pull request.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and reviewed with Pi. The fix was placed in the shared exception-sending path so it covers both automatic capture and `posthog.captureException()`. It only suppresses known stack-overflow errors and keeps existing behavior for other failures.
