### PR TITLE
fix(browser): prevent exception capture errors from reaching customer code

### DIFF
--- a/.changeset/calm-errors-rest.md
+++ b/.changeset/calm-errors-rest.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Prevent failures in automatic and manual exception processing from escaping into customer code.

--- a/packages/browser/playwright/mocked/error-tracking/legacy-autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/legacy-autocapture.spec.ts
@@ -40,6 +40,30 @@ test('captures exceptions with the posthog-js 1.140.1 core', async ({ posthog, p
         })
 })
 
+test('does not throw when exception property building fails with the legacy core', async ({
+    posthog,
+    page,
+    network,
+}) => {
+    await network.mockFlags({ autocaptureExceptions: true })
+    await posthog.init()
+
+    await page.waitForFunction(() => (window as any).onerror?.__POSTHOG_INSTRUMENTED__ === true)
+
+    const result = await page.evaluate(() => {
+        const error = new Error('legacy error')
+        Object.defineProperty(error, 'message', {
+            get() {
+                throw new TypeError('property building failed')
+            },
+        })
+
+        return window.onerror?.('message', 'source', 1, 2, error)
+    })
+
+    expect(result).toBe(false)
+})
+
 test('respects legacy exception exclusion rules', async ({ posthog, page, network }) => {
     await network.mockFlags({
         autocaptureExceptions: {

--- a/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/exception-autocapture.test.ts
@@ -4,6 +4,15 @@ import { assignableWindow, window } from '../../utils/globals'
 describe('exception-autocapture entrypoint', () => {
     const originalOnError = window?.onerror
     const originalOnUnhandledRejection = window?.onunhandledrejection
+    const errorWithThrowingMessage = () => {
+        const error = new Error('legacy error')
+        Object.defineProperty(error, 'message', {
+            get() {
+                throw new TypeError('property building failed')
+            },
+        })
+        return error
+    }
 
     afterEach(() => {
         if (window) {
@@ -47,6 +56,21 @@ describe('exception-autocapture entrypoint', () => {
 
         expect(() => window.onerror?.('message', 'source', 1, 2, new Error('legacy error'))).not.toThrow()
         expect(originalErrorHandler).toHaveBeenCalledTimes(1)
+    })
+
+    it('still calls the original error handler when legacy property building throws', () => {
+        const originalErrorHandler = vi.fn(() => true)
+        const error = errorWithThrowingMessage()
+        if (!window) {
+            throw new Error('window is required for this test')
+        }
+        window.onerror = originalErrorHandler
+
+        assignableWindow.extendPostHogWithExceptionAutocapture({ capture: vi.fn() })
+
+        expect(() => window.onerror?.('message', 'source', 1, 2, error)).not.toThrow()
+        expect(originalErrorHandler).toHaveBeenCalledTimes(1)
+        expect(originalErrorHandler.mock.calls[0][4]).toBe(error)
     })
 
     it('does not capture errors matching legacy exclusion rules', () => {

--- a/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
@@ -35,23 +35,41 @@ describe('ExceptionObserver', () => {
             new RangeError('Invalid array length'),
             Object.assign(new Error('allocation size overflow'), { name: 'InternalError' }),
             new TypeError('something else'),
-        ])('rethrows unrelated errors from exception capture', (error) => {
+        ])('swallows unrelated errors from exception capture', (error) => {
             vi.spyOn(instance.exceptions, 'sendExceptionEvent').mockImplementation(() => {
                 throw error
             })
 
-            expect(() => instance.exceptionObserver.captureException(errorProperties)).toThrow(error)
+            expect(() => instance.exceptionObserver.captureException(errorProperties)).not.toThrow()
         })
 
-        it('swallows a stack overflow raised before sending the exception', () => {
-            const stackOverflowError = new RangeError('Maximum call stack size exceeded')
-            vi.spyOn(instance.exceptionObserver['_rateLimiter'], 'consumeRateLimit').mockImplementation(() => {
-                throw stackOverflowError
-            })
-            const sendExceptionEvent = vi.spyOn(instance.exceptions, 'sendExceptionEvent')
+        it.each([new RangeError('Maximum call stack size exceeded'), new TypeError('rate limiter failed')])(
+            'swallows errors raised before sending the exception',
+            (error) => {
+                vi.spyOn(instance.exceptionObserver['_rateLimiter'], 'consumeRateLimit').mockImplementation(() => {
+                    throw error
+                })
+                const sendExceptionEvent = vi.spyOn(instance.exceptions, 'sendExceptionEvent')
 
-            expect(() => instance.exceptionObserver.captureException(errorProperties)).not.toThrow()
-            expect(sendExceptionEvent).not.toHaveBeenCalled()
+                expect(() => instance.exceptionObserver.captureException(errorProperties)).not.toThrow()
+                expect(sendExceptionEvent).not.toHaveBeenCalled()
+            }
+        )
+
+        it('swallows errors while building a manually captured exception', () => {
+            vi.spyOn(instance.exceptions, 'buildProperties').mockImplementation(() => {
+                throw new TypeError('property building failed')
+            })
+
+            expect(() => instance.captureException(new Error('original exception'))).not.toThrow()
+        })
+
+        it('swallows errors while sending a manually captured exception', () => {
+            vi.spyOn(instance.exceptions, 'sendExceptionEvent').mockImplementation(() => {
+                throw new TypeError('exception sending failed')
+            })
+
+            expect(() => instance.captureException(new Error('original exception'))).not.toThrow()
         })
 
         it.each(['automatic', 'manual'])('does not re-enter autocapture after a %s capture overflows', (mode) => {

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/error-wrapping-functions.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/error-wrapping-functions.test.ts
@@ -6,6 +6,15 @@ const { wrapOnError, wrapUnhandledRejection, wrapConsoleError } = posthogErrorWr
 describe('error wrapping functions', () => {
     const captureFn = vi.fn<[ErrorTracking.ErrorProperties], void>()
     const win = window as any
+    const errorWithThrowingMessage = () => {
+        const error = new Error('boom')
+        Object.defineProperty(error, 'message', {
+            get() {
+                throw new TypeError('property building failed')
+            },
+        })
+        return error
+    }
 
     afterEach(() => {
         captureFn.mockClear()
@@ -38,6 +47,40 @@ describe('error wrapping functions', () => {
             expect(original).toHaveBeenCalledWith('message', 'source', 1, 1, expect.any(Error))
             expect(result).toBe(true)
             expect(captureFn).toHaveBeenCalled()
+        })
+
+        it('still chains to the original handler when building exception properties throws', () => {
+            const original = vi.fn().mockReturnValue(true)
+            const error = errorWithThrowingMessage()
+            win.onerror = original
+            unwrap = wrapOnError(captureFn)
+
+            expect(() => win.onerror('message', 'source', 1, 1, error)).not.toThrow()
+            expect(original).toHaveBeenCalledTimes(1)
+            expect(original.mock.calls[0][4]).toBe(error)
+            expect(captureFn).not.toHaveBeenCalled()
+        })
+
+        it('still chains to the original handler when the capture callback throws', () => {
+            const original = vi.fn().mockReturnValue(true)
+            captureFn.mockImplementationOnce(() => {
+                throw new TypeError('capture failed')
+            })
+            win.onerror = original
+            unwrap = wrapOnError(captureFn)
+
+            expect(() => win.onerror('message', 'source', 1, 1, new Error('boom'))).not.toThrow()
+            expect(original).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not swallow errors from the original handler', () => {
+            const error = new TypeError('original handler failed')
+            win.onerror = vi.fn(() => {
+                throw error
+            })
+            unwrap = wrapOnError(captureFn)
+
+            expect(() => win.onerror('message', 'source', 1, 1, new Error('boom'))).toThrow(error)
         })
 
         it('collects source/lineno/colno from the positional args when there is no Error object', () => {
@@ -87,6 +130,42 @@ describe('error wrapping functions', () => {
             expect(result).toBe(true)
             expect(captureFn).toHaveBeenCalled()
         })
+
+        it('still chains to the original handler when building exception properties throws', () => {
+            const original = vi.fn().mockReturnValue(true)
+            const ev = { reason: errorWithThrowingMessage() } as any
+            win.onunhandledrejection = original
+            unwrap = wrapUnhandledRejection(captureFn)
+
+            expect(() => win.onunhandledrejection(ev)).not.toThrow()
+            expect(original).toHaveBeenCalledTimes(1)
+            expect(original.mock.calls[0][0]).toBe(ev)
+            expect(captureFn).not.toHaveBeenCalled()
+        })
+
+        it('still chains to the original handler when the capture callback throws', () => {
+            const original = vi.fn().mockReturnValue(true)
+            const ev = { reason: new Error('boom') } as any
+            captureFn.mockImplementationOnce(() => {
+                throw new TypeError('capture failed')
+            })
+            win.onunhandledrejection = original
+            unwrap = wrapUnhandledRejection(captureFn)
+
+            expect(() => win.onunhandledrejection(ev)).not.toThrow()
+            expect(original).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not swallow errors from the original handler', () => {
+            const error = new TypeError('original handler failed')
+            const ev = { reason: new Error('boom') } as any
+            win.onunhandledrejection = vi.fn(() => {
+                throw error
+            })
+            unwrap = wrapUnhandledRejection(captureFn)
+
+            expect(() => win.onunhandledrejection(ev)).toThrow(error)
+        })
     })
 
     describe('wrapConsoleError', () => {
@@ -115,6 +194,43 @@ describe('error wrapping functions', () => {
 
             expect(original).toHaveBeenCalledWith('boom')
             expect(captureFn).toHaveBeenCalled()
+        })
+
+        it('still calls the original console when building exception properties throws', () => {
+            const con = console as any
+            const original = vi.fn()
+            const error = errorWithThrowingMessage()
+            con.error = original
+            unwrap = wrapConsoleError(captureFn)
+
+            expect(() => con.error(error)).not.toThrow()
+            expect(original).toHaveBeenCalledTimes(1)
+            expect(original.mock.calls[0][0]).toBe(error)
+            expect(captureFn).not.toHaveBeenCalled()
+        })
+
+        it('still calls the original console when the capture callback throws', () => {
+            const con = console as any
+            const original = vi.fn()
+            captureFn.mockImplementationOnce(() => {
+                throw new TypeError('capture failed')
+            })
+            con.error = original
+            unwrap = wrapConsoleError(captureFn)
+
+            expect(() => con.error('boom')).not.toThrow()
+            expect(original).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not swallow errors from the original console', () => {
+            const con = console as any
+            const error = new TypeError('original console failed')
+            con.error = vi.fn(() => {
+                throw error
+            })
+            unwrap = wrapConsoleError(captureFn)
+
+            expect(() => con.error('boom')).toThrow(error)
         })
     })
 })

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -8,6 +8,18 @@ import { buildErrorPropertiesBuilder } from '../posthog-exceptions'
 const logger = createLogger('[ExceptionAutocapture]')
 const errorPropertiesBuilder = buildErrorPropertiesBuilder()
 
+const safelyBuildAndCapture = (
+    captureFn: (props: ErrorTracking.ErrorProperties) => void,
+    buildProperties: () => ErrorTracking.ErrorProperties
+): void => {
+    try {
+        captureFn(buildProperties())
+    } catch {
+        // Exception autocapture must never throw into customer code. Do not log here because
+        // console.error may be instrumented and would re-enter exception autocapture.
+    }
+}
+
 // `window.onerror` exposes the location positionally, so preserve it when there is no Error object.
 const resolveOnErrorInput = ([event, source, lineno, colno, error]: ErrorEventArgs): unknown => {
     if (error != null) {
@@ -31,10 +43,11 @@ const wrapOnError = (captureFn: (props: ErrorTracking.ErrorProperties) => void) 
     const originalOnError = win.onerror
 
     win.onerror = function (...args: ErrorEventArgs): boolean {
-        const errorProperties = errorPropertiesBuilder.buildFromUnknown(resolveOnErrorInput(args), {
-            mechanism: { handled: false },
-        })
-        captureFn(errorProperties)
+        safelyBuildAndCapture(captureFn, () =>
+            errorPropertiesBuilder.buildFromUnknown(resolveOnErrorInput(args), {
+                mechanism: { handled: false },
+            })
+        )
         return isFunction(originalOnError) ? (originalOnError(...args) ?? false) : false
     }
     win.onerror.__POSTHOG_INSTRUMENTED__ = true
@@ -57,10 +70,11 @@ const wrapUnhandledRejection = (
     const originalOnUnhandledRejection = win.onunhandledrejection
 
     win.onunhandledrejection = function (ev: PromiseRejectionEvent): boolean {
-        const errorProperties = errorPropertiesBuilder.buildFromUnknown(ev, {
-            mechanism: { handled: false },
-        })
-        captureFn(errorProperties)
+        safelyBuildAndCapture(captureFn, () =>
+            errorPropertiesBuilder.buildFromUnknown(ev, {
+                mechanism: { handled: false },
+            })
+        )
         return isFunction(originalOnUnhandledRejection)
             ? (originalOnUnhandledRejection(ev) ?? false)
             : defaultReturnValue
@@ -82,19 +96,20 @@ const wrapConsoleError = (captureFn: (props: ErrorTracking.ErrorProperties) => v
     const originalConsoleError = con.error
 
     con.error = function (...args: any[]): void {
-        let event
-        if (args.length == 1) {
-            event = args[0]
-        } else {
-            event = args.join(' ')
-        }
-        const error = args.find((arg) => arg instanceof Error)
-        const errorProperties = errorPropertiesBuilder.buildFromUnknown(error || event, {
-            mechanism: { handled: false },
-            syntheticException: new Error('PostHog syntheticException'),
-            skipFirstLines: 2,
+        safelyBuildAndCapture(captureFn, () => {
+            let event
+            if (args.length == 1) {
+                event = args[0]
+            } else {
+                event = args.join(' ')
+            }
+            const error = args.find((arg) => arg instanceof Error)
+            return errorPropertiesBuilder.buildFromUnknown(error || event, {
+                mechanism: { handled: false },
+                syntheticException: new Error('PostHog syntheticException'),
+                skipFirstLines: 2,
+            })
         })
-        captureFn(errorProperties)
         if (isFunction(originalConsoleError)) {
             originalConsoleError(...args)
         }

--- a/packages/browser/src/extensions/exception-autocapture/index.ts
+++ b/packages/browser/src/extensions/exception-autocapture/index.ts
@@ -8,7 +8,6 @@ import { EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE } from '../../constants'
 import { isUndefined, BucketedRateLimiter, isObject, resolveExceptionRateLimiterConfig } from '@posthog/core'
 import { ErrorTracking } from '@posthog/core'
 import { ExceptionAutoCaptureConfig } from '../../types'
-import { isStackOverflowError } from '../../utils/stack-overflow'
 
 const logger = createLogger('[ExceptionAutocapture]')
 
@@ -174,12 +173,9 @@ export class ExceptionObserver {
             }
 
             this._instance.exceptions?.sendExceptionEvent(errorProperties)
-        } catch (error) {
-            if (!isStackOverflowError(error)) {
-                throw error
-            }
-            // Do not log here: console.error may be instrumented by exception autocapture and
-            // would re-enter this method while the call stack is still exhausted.
+        } catch {
+            // Exception autocapture must never throw into customer code. Do not log here because
+            // console.error may be instrumented and would re-enter this method.
         }
     }
 }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -4181,17 +4181,23 @@ export class PostHog implements PostHogInterface {
      * @returns The result of the capture, or undefined if exception capture is unavailable.
      */
     captureException(error: unknown, additionalProperties?: Properties): CaptureResult | undefined {
-        if (!this.exceptions) return
+        try {
+            if (!this.exceptions) return
 
-        const syntheticException = new Error('PostHog syntheticException')
-        const errorToProperties = this.exceptions.buildProperties(error, {
-            handled: true,
-            syntheticException,
-        })
-        return this.exceptions.sendExceptionEvent({
-            ...errorToProperties,
-            ...additionalProperties,
-        })
+            const syntheticException = new Error('PostHog syntheticException')
+            const errorToProperties = this.exceptions.buildProperties(error, {
+                handled: true,
+                syntheticException,
+            })
+            return this.exceptions.sendExceptionEvent({
+                ...errorToProperties,
+                ...additionalProperties,
+            })
+        } catch {
+            // Exception capture must never throw into customer code. Do not log here because
+            // console.error may be instrumented and would re-enter exception autocapture.
+            return
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

Automatic exception capture runs inside page-owned `window.onerror`, `window.onunhandledrejection`, and `console.error` handlers. If PostHog fails while building or sending an exception event, that failure can escape into customer code and prevent the original handler from running. Manual `posthog.captureException()` calls can also expose failures while building exception properties.

This follows up on the review discussion in #4786.

## Changes

- Swallow PostHog-owned failures at every automatic exception capture boundary.
- Keep calls to the page's original error, rejection, and console handlers outside the PostHog guard so their behavior is preserved.
- Prevent `posthog.captureException()` from throwing when property building or sending fails.
- Add unit coverage for property building, rate limiting, sending, and callback failures.
- Add a browser compatibility test using the latest exception autocapture bundle with the posthog-js 1.140.1 core.

The lazy bundle keeps the existing callback signatures and does not use new core APIs or persisted state.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and reviewed with Pi after review feedback on #4786. The fix covers automatic and manual exception capture while preserving errors thrown by the customer's own handlers. The lazy-loaded bundle path was checked against the legacy core compatibility suite.
