### PR TITLE
fix(traces): keep inbound context and flag a future span start

### DIFF
--- a/.changeset/traces-context-and-time-fidelity.md
+++ b/.changeset/traces-context-and-time-fidelity.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Forward an inbound `traceparent` whose version is above `00` whole, including the fields that version adds, rather than trimming it to the four this SDK reads. Keep the inbound context when a handle returned with tracing off is passed back as `parent`, so a child no longer starts a fresh trace. Warn when a span's `startTime` is in the future, which costs it its duration.

--- a/packages/core/src/traces/index.spec.ts
+++ b/packages/core/src/traces/index.spec.ts
@@ -1,6 +1,6 @@
 import { PostHogTraces } from './index'
 import { SyncSpanContextManager } from './context'
-import { NOOP_SPAN } from './span'
+import { NOOP_SPAN, inertSpan } from './span'
 import type {
   OtlpSpan,
   OtlpTracesPayload,
@@ -170,6 +170,16 @@ describe('PostHogTraces', () => {
 
       expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('24 hours'))
       expect(sentSpans()).toHaveLength(1)
+    })
+
+    it('warns when a start is in the future, which costs the span its duration', async () => {
+      const traces = createTraces()
+      traces.startSpan('ahead', { startTime: Date.now() + 60 * 60 * 1000 }).end()
+      await traces.flush()
+
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('in the future'))
+      const [span] = sentSpans()
+      expect(span.endTimeUnixNano).toBe(span.startTimeUnixNano)
     })
   })
 
@@ -492,6 +502,49 @@ describe('PostHogTraces', () => {
 
       expect(traces.startSpan('no-parent')).toBe(NOOP_SPAN)
       expect(traces.startSpan('bad-parent', { parent: 'not-a-traceparent' })).toBe(NOOP_SPAN)
+    })
+
+    it('keeps the inbound context when a pass-through handle is used as a parent', () => {
+      // The child is inert either way; what it must not do is drop the context
+      // and leave everything downstream of it on a fresh trace.
+      const traces = createTraces({}, createMockInstance({ optedOut: true }))
+      const parent = traces.startSpan('proxied', { parent: INBOUND_UNSAMPLED, tracestate: 'vendor=abc' })
+
+      const child = traces.startSpan('child', { parent })
+
+      expect(child.traceparent()).toBe(INBOUND_UNSAMPLED)
+      expect(child.tracestate()).toBe('vendor=abc')
+      expect(sentSpans()).toHaveLength(0)
+    })
+
+    it('records nothing for a child of a pass-through once tracing is back on', async () => {
+      // Spec: a child of an inert handle is inert, so this must propagate without
+      // enqueueing a span, even though this instance is recording.
+      const traces = createTraces()
+      const parent = inertSpan({ parent: INBOUND_UNSAMPLED })
+
+      const child = traces.startSpan('child', { parent })
+      child.end()
+      await traces.flush()
+
+      expect(child.traceparent()).toBe(INBOUND_UNSAMPLED)
+      expect(sentSpans()).toHaveLength(0)
+    })
+
+    it('yields a no-op for a child of a no-op', () => {
+      const traces = createTraces()
+      expect(traces.startSpan('child', { parent: NOOP_SPAN })).toBe(NOOP_SPAN)
+    })
+
+    it('survives a parent whose traceparent throws', () => {
+      const traces = createTraces()
+      const hostile = {
+        traceparent: () => {
+          throw new Error('nope')
+        },
+      }
+
+      expect(traces.startSpan('child', { parent: hostile as never })).toBe(NOOP_SPAN)
     })
   })
 
@@ -989,6 +1042,49 @@ describe('PostHogTraces', () => {
 
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('2 span(s)'))
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('the user has opted out'))
+    })
+  })
+
+  describe('flush backoff', () => {
+    it('resumes the depth trigger after a non-retriable drop clears the backlog', async () => {
+      // A 503 burst raises the consecutive-failure count, which disables the
+      // depth trigger. Dropping the poison batch is progress, so the count has to
+      // clear with it or the queue stays on the slow timer while the endpoint is
+      // healthy.
+      mockInstance._sendTracesBatch
+        .mockResolvedValueOnce({ kind: 'retry-later', error: new Error('503') })
+        .mockResolvedValueOnce({ kind: 'fatal', error: new Error('400') })
+        .mockResolvedValue({ kind: 'ok' })
+
+      const traces = createTraces({ maxExportBatchSize: 1, flushIntervalMs: 10_000 })
+      traces.startSpan('poison').end()
+      await flushMicrotasks()
+      await traces.flush()
+      mockInstance._sendTracesBatch.mockClear()
+
+      // Depth trigger only fires again if the failure count was cleared.
+      traces.startSpan('after').end()
+      await flushMicrotasks()
+
+      expect(mockInstance._sendTracesBatch).toHaveBeenCalled()
+    })
+
+    it('resumes the depth trigger after a too-large single-span drop', async () => {
+      mockInstance._sendTracesBatch
+        .mockResolvedValueOnce({ kind: 'retry-later', error: new Error('503') })
+        .mockResolvedValueOnce({ kind: 'too-large' })
+        .mockResolvedValue({ kind: 'ok' })
+
+      const traces = createTraces({ maxExportBatchSize: 1, flushIntervalMs: 10_000 })
+      traces.startSpan('huge').end()
+      await flushMicrotasks()
+      await traces.flush()
+      mockInstance._sendTracesBatch.mockClear()
+
+      traces.startSpan('after').end()
+      await flushMicrotasks()
+
+      expect(mockInstance._sendTracesBatch).toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/traces/index.ts
+++ b/packages/core/src/traces/index.ts
@@ -8,7 +8,7 @@ import type {
   TraceSdkContext,
   TracesHost,
 } from './types'
-import { NOOP_SPAN, PostHogSpan, describeError, inertSpan, monotonicNow, runWithActiveSpan } from './span'
+import { PostHogSpan, describeError, inertSpan, monotonicNow, runWithActiveSpan } from './span'
 import { newSpanId, newTraceId } from './ids'
 import { parseTraceparent, sanitizeTracestate } from './traceparent'
 import { resolveStartTime, sanitizeName } from './sanitize'
@@ -115,9 +115,11 @@ export class PostHogTraces {
     const explicitParent = options?.parent
     if (explicitParent && typeof explicitParent !== 'string' && !isOwnSpan(explicitParent)) {
       if (looksLikeSpan(explicitParent)) {
-        // A child of a no-op is itself a no-op, never an orphan with invented ids.
+        // Inert like its parent, never an orphan with invented ids — but a
+        // pass-through parent's inbound context carries to the child rather than
+        // the trace ending here.
         this._logger.debug('Span parent is not a span from this SDK; returning an inert span')
-        return NOOP_SPAN
+        return inertSpan(options)
       }
       // No `traceparent()` to read: `req.headers.traceparent` is `string[]` when the
       // header arrives twice, and a span from another tracer exposes `spanContext()`
@@ -523,6 +525,7 @@ export class PostHogTraces {
             remaining -= 1
             removed += 1
             this._recordDrop(1, 'the ingestion endpoint rejected it as too large')
+            this._consecutiveFlushFailures = 0
             this._headBatchFailures = 0
             continue
           }
@@ -560,6 +563,7 @@ export class PostHogTraces {
         this._queue.splice(0, size)
         remaining -= size
         removed += size
+        this._consecutiveFlushFailures = 0
         this._headBatchFailures = 0
         this._recordDrop(size, 'the ingestion endpoint rejected the batch')
       }

--- a/packages/core/src/traces/sanitize.ts
+++ b/packages/core/src/traces/sanitize.ts
@@ -78,7 +78,7 @@ export function resolveStartTime(value: SpanTimeInput | undefined, now: number, 
   } else if (supplied > now) {
     // Warned rather than clamped, matching the deep-backdate rule: the value is
     // the caller's. The duration is what suffers, since the end clamps to it.
-    logger?.debug('Span startTime is in the future; the span will export with a zero duration')
+    logger?.debug('Span startTime is in the future; the span may export with a zero duration')
   }
   return supplied
 }

--- a/packages/core/src/traces/sanitize.ts
+++ b/packages/core/src/traces/sanitize.ts
@@ -75,6 +75,10 @@ export function resolveStartTime(value: SpanTimeInput | undefined, now: number, 
     logger?.debug(
       'Span startTime is more than 24 hours in the past; the server will clamp it to receive time and keep the original in $originalTimestamp'
     )
+  } else if (supplied > now) {
+    // Warned rather than clamped, matching the deep-backdate rule: the value is
+    // the caller's. The duration is what suffers, since the end clamps to it.
+    logger?.debug('Span startTime is in the future; the span will export with a zero duration')
   }
   return supplied
 }

--- a/packages/core/src/traces/span.ts
+++ b/packages/core/src/traces/span.ts
@@ -269,11 +269,26 @@ export class PassThroughSpan extends NoopSpan {
  * caller supplied a usable `parent` header, the shared no-op otherwise.
  */
 export function inertSpan(options?: { parent?: unknown; tracestate?: unknown }): Span {
-  const traceparent = normalizeTraceparent(options?.parent)
+  const parent = options?.parent
+  // A handle parent reports its own context, read behind a guard because a
+  // foreign handle's accessor may throw. A no-op reports none and stays a no-op.
+  const inbound = typeof parent === 'string' || parent == null ? parent : readHandle(parent, 'traceparent')
+  const traceparent = normalizeTraceparent(inbound)
   if (!traceparent) {
     return NOOP_SPAN
   }
-  return new PassThroughSpan(traceparent, sanitizeTracestate(options?.tracestate))
+  const tracestate =
+    typeof parent === 'string' || parent == null ? options?.tracestate : readHandle(parent, 'tracestate')
+  return new PassThroughSpan(traceparent, sanitizeTracestate(tracestate))
+}
+
+function readHandle(parent: unknown, method: 'traceparent' | 'tracestate'): unknown {
+  try {
+    const fn = (parent as Span)[method]
+    return typeof fn === 'function' ? fn.call(parent) : undefined
+  } catch {
+    return undefined
+  }
 }
 
 /**

--- a/packages/core/src/traces/traceparent.spec.ts
+++ b/packages/core/src/traces/traceparent.spec.ts
@@ -140,8 +140,12 @@ describe('normalizeTraceparent', () => {
     expect(normalizeTraceparent(`01-${TRACE_ID}-${SPAN_ID}-01`)).toBe(`01-${TRACE_ID}-${SPAN_ID}-01`)
   })
 
-  it("trims surrounding whitespace, and drops a higher version's trailing fields", () => {
-    expect(normalizeTraceparent(`  01-${TRACE_ID}-${SPAN_ID}-01-extra `)).toBe(`01-${TRACE_ID}-${SPAN_ID}-01`)
+  it("keeps a higher version's trailing fields, so a peer that reads them still can", () => {
+    expect(normalizeTraceparent(`01-${TRACE_ID}-${SPAN_ID}-01-extra`)).toBe(`01-${TRACE_ID}-${SPAN_ID}-01-extra`)
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeTraceparent(`  00-${TRACE_ID}-${SPAN_ID}-01 `)).toBe(`00-${TRACE_ID}-${SPAN_ID}-01`)
   })
 
   it.each([

--- a/packages/core/src/traces/traceparent.ts
+++ b/packages/core/src/traces/traceparent.ts
@@ -70,13 +70,14 @@ function matchTraceparent(value: unknown): TraceparentFields | undefined {
 }
 
 /**
- * The canonical form of an inbound `traceparent`, or `undefined` when it is
- * malformed. Version and flags are carried through as received, so a service
- * that forwards this value continues the caller's trace exactly as sent.
+ * The inbound `traceparent` as received, or `undefined` when it is malformed.
+ *
+ * Returned whole rather than rebuilt: a version above `00` may append fields
+ * this SDK does not read, and rebuilding would forward a header still labelled
+ * with that version but missing what the version defines.
  */
 export function normalizeTraceparent(value: unknown): string | undefined {
-  const fields = matchTraceparent(value)
-  return fields && `${fields.version}-${fields.traceId}-${fields.spanId}-${fields.flags}`
+  return matchTraceparent(value) && (value as string).trim()
 }
 
 /** The W3C sampled bit, set on a trace this SDK started. */


### PR DESCRIPTION
## Problem

An independent review of the traces stack found four conformance gaps. All four are in #4579's surface, all four reproduce, and none are regressions from #4584 — they were simply never exercised. Each is small on its own; together they are the difference between a distributed trace surviving a hop and quietly splitting in two.

**A `traceparent` above version `00` lost the fields that version defines.** `normalizeTraceparent` rebuilt the header from the four fields this SDK reads, so `02-<id>-<id>-01-extra` was forwarded as `02-<id>-<id>-01`. That is the one clearly wrong shape: forwarding it verbatim is correct pass-through, and relabelling it `00-` is correct mutation, but a header still labelled `02` with its `02`-defined fields removed is one a v02-aware peer must treat as malformed. #4776 tightened the neighbouring cases — trailing fields on `00`, uppercase ids — and sharpened this one: the regex now captures the trailing group, uses it to reject `00`, then discards it.

**A pass-through handle used as a `parent` severed the trace.** With tracing off, `startSpan('x', { parent: req.headers.traceparent })` returns a handle that carries the inbound context. Passing that handle back as `parent` produced a bare `NOOP_SPAN`, whose `traceparent()` is `null` — so everything below it started a fresh trace, on the exact path the pass-through handle exists to keep whole.

**A `startTime` in the future was accepted silently.** The option is documented as *"Backdate the span's start"*, and the SDK already warns when a backdate is deep enough for the server to clamp it. The future direction had no guard at all, and it costs the span its duration: a backdated span reads the wall clock at `end()`, so an end before the start clamps to zero. Verified against production ingestion — the server stores the future timestamp **un-clamped**, so the span lands an hour ahead of its trace with `duration_nano: 0`.

**A dropped batch left the export loop backed off.** `_consecutiveFlushFailures` gates the queue-depth flush trigger and drives the backoff, and only the success path cleared it. After a 503 burst, a non-retriable `400` or a `too-large` drop cleared `_headBatchFailures` but not this one, so a healthy endpoint kept the depth trigger disabled and the interval pinned at its 30s ceiling until an unrelated send happened to succeed.

## Changes

- **`normalizeTraceparent` returns the header as received** rather than rebuilding it. Its only caller is the pass-through handle, whose job is to echo.
- **`inertSpan` resolves a handle parent**, reading `traceparent()`/`tracestate()` behind a guard. Centralised there rather than in `startSpan`, so it covers all three inert paths — opted out, disabled, and the live-span bound — not just the one the finding named.
- **`resolveStartTime` warns on a future start**, matching the deep-backdate rule.
- **The `fatal` and `too-large` drop paths clear `_consecutiveFlushFailures`**, as the retry-exhaustion path already did.

### Two places the review's suggested remedy was wrong

Worth flagging, because both would have been changes for the worse:

- The review proposed accepting a pass-through parent **by re-parsing its `traceparent()` and recording a real child**. The spec says the opposite: *"A child started with a pass-through handle as `parent` SHALL itself be inert."* The child here stays inert and records nothing — it just stops throwing the context away. There is a test pinning that it enqueues nothing even when the instance is recording.
- The review proposed **falling back to `now`** for a future `startTime`. The spec requires only range validity, and explicitly contemplates *"a future-dated leaked span"* when it specifies the live-span age bound against the monotonic clock. Silently rewriting a caller's value would also diverge from every other port. Deep backdating is a `SHOULD` **warn**, not a clamp, so this warns.

### Verification

Each fix is pinned by a test that fails when it is reverted — checked one at a time (1 test, 2, 1, 2 respectively).

`packages/core` 1402 pass, `packages/node` 988 pass, oxlint and oxfmt clean.

**Run as a real Express service against production ingestion** (project 381971), spans read back out of the product rather than off the wire — 11/11:

- a `02-…-01-extra` parent forwarded whole, `tracestate` intact
- a recorded span continuing that v02 trace lands in the product on trace id `4BF92F3577B34DA6A3CE929D0E0E4736`, parented to the inbound span id
- a child of the pass-through keeps the context and enqueues nothing
- the future-dated span warns, exports, is accepted, and reads back at `17:11` against its sibling's `16:11` with `duration_nano: 0`

The failure-counter fix is covered by unit tests rather than the live run: reproducing it needs an injected `503` followed by a `400`, which is not something to provoke against production ingestion.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

`@posthog/core` only; it has no checkbox above. All four sites are inside the traces feature #4579 introduces, which has not shipped, so nothing released changes behaviour.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @turnipdabeets. The four findings came from a review pass over the #4584 stack; each was reproduced before being changed, and the spec was consulted before fixing, which is what caught the two suggested remedies that would have contradicted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTHb6UUMhVJSWC2cWBzSxc
