### PR TITLE
fix(react-native): preserve wrapped Expo static exports

### DIFF
--- a/.changeset/quiet-moles-export.md
+++ b/.changeset/quiet-moles-export.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Preserve Expo static exports and their per-asset Chunk IDs when wrapping Expo's Metro serializer.

--- a/packages/react-native/src/tooling/posthogMetroSerializer.ts
+++ b/packages/react-native/src/tooling/posthogMetroSerializer.ts
@@ -19,6 +19,7 @@ import { createDefaultMetroSerializer } from './vendor/metro/utils'
 type SourceMap = Record<string, unknown>
 type PostHogSerializerOptions = Parameters<MetroSerializer>[3] & {
   posthogBundleCallback?: (bundle: Bundle) => Bundle
+  serializerOptions?: { output?: string }
 }
 
 const DEBUG_ID_PLACE_HOLDER = '__POSTHOG_CHUNK_ID__'
@@ -62,6 +63,8 @@ export function unstableBeforeAssetSerializationDebugIdPlugin({
 /**
  * Creates a Metro serializer that adds Chunk ID module to the plain bundle.
  * The Chunk ID module is a virtual module that provides a Chunk ID in runtime.
+ * Expo static exports are delegated unchanged. Use getPostHogExpoConfig to
+ * enable PostHog Chunk IDs through Expo's per-asset serialization hook.
  *
  * RAM Bundles do not support custom serializers.
  */
@@ -69,6 +72,13 @@ export const createPostHogMetroSerializer = (customSerializer?: MetroSerializer)
   const serializer = customSerializer || createDefaultMetroSerializer()
   return async function (entryPoint, premodules, graph, options) {
     if (isDevServerBuild(graph, options)) {
+      return serializer(entryPoint, premodules, graph, options)
+    }
+
+    // Expo static exports can contain multiple assets (or JSON), not one plain
+    // bundle. Its per-asset PostHog plugin injects real IDs before source maps
+    // are generated. A placeholder here would prevent that plugin from running.
+    if (customSerializer && isExpoStaticExport(options)) {
       return serializer(entryPoint, premodules, graph, options)
     }
 
@@ -124,6 +134,31 @@ export const createPostHogMetroSerializer = (customSerializer?: MetroSerializer)
       code: bundleCodeWithDebugId,
       map: JSON.stringify(bundleMap),
     }
+  }
+}
+
+function isExpoStaticExport(options: PostHogSerializerOptions): boolean {
+  // Match Expo's precedence: explicit serializer options override the URL,
+  // even when they do not specify an output mode.
+  if (options.serializerOptions) {
+    return options.serializerOptions.output === 'static'
+  }
+  if (!options.sourceUrl) {
+    return false
+  }
+
+  try {
+    const url = new URL(options.sourceUrl, 'https://expo.dev')
+    // JSC-safe URLs move the query into the path after //&. Only decode that
+    // form when there is no actual query, as Expo's serializer does.
+    const jscQueryStart = url.pathname.indexOf('//&')
+    const query =
+      !options.sourceUrl.split('#')[0].includes('?') && jscQueryStart !== -1
+        ? new URLSearchParams(url.pathname.slice(jscQueryStart + 3))
+        : url.searchParams
+    return query.get('serializer.output') === 'static'
+  } catch {
+    return false
   }
 }
 

--- a/packages/react-native/test/posthogMetroSerializer.spec.ts
+++ b/packages/react-native/test/posthogMetroSerializer.spec.ts
@@ -1,5 +1,8 @@
 import type { MixedOutput, Module } from 'metro'
-import { createPostHogMetroSerializer } from '../src/tooling/posthogMetroSerializer'
+import {
+  createPostHogMetroSerializer,
+  unstableBeforeAssetSerializationDebugIdPlugin,
+} from '../src/tooling/posthogMetroSerializer'
 import {
   createDebugIdSnippet,
   createVirtualJSModule,
@@ -125,6 +128,101 @@ describe('PostHog Metro serializer', () => {
     expect(determineDebugIdFromBundleSource(result.code)).toMatch(UUID_PATTERN)
     expect(consoleLogSpy).toHaveBeenCalledTimes(1)
     consoleLogSpy.mockRestore()
+  })
+
+  describe('Expo static exports', () => {
+    test.each([
+      { name: 'explicit options', options: { serializerOptions: { output: 'static' } } },
+      {
+        name: 'explicit static options overriding a plain URL',
+        options: {
+          serializerOptions: { output: 'static' },
+          sourceUrl: 'https://expo.dev/index.bundle?serializer.output=default',
+        },
+      },
+      { name: 'source URL', options: { sourceUrl: 'https://expo.dev/index.bundle?serializer.output=static' } },
+      { name: 'relative URL', options: { sourceUrl: '/index.bundle?serializer.output=static' } },
+      { name: 'JSC-safe URL', options: { sourceUrl: 'https://expo.dev/index.bundle//&serializer.output=static' } },
+    ])('delegates before injection with $name', async ({ options }) => {
+      const input = mockSerializerArgs(options, { transformOptions: { platform: 'ios' } })
+      const chunkId = '12345678-1234-4abc-8def-123456789abc'
+      const inner = vi.fn((...[_entryPoint, premodules, graph]: Parameters<MetroSerializer>) => {
+        const modules = unstableBeforeAssetSerializationDebugIdPlugin({
+          graph,
+          premodules: [...premodules],
+          debugId: chunkId,
+        })
+        const code = modules.map((module) => module.getSource().toString()).join('\n')
+        return {
+          artifacts: [
+            { type: 'js', filename: 'index.js', source: code },
+            { type: 'map', filename: 'index.js.map', source: JSON.stringify({ debugId: chunkId }) },
+          ],
+          assets: [],
+        }
+      })
+      // Expo's static export result is outside Metro's plain-bundle return type.
+      const result = await createPostHogMetroSerializer(inner as unknown as MetroSerializer)(...input)
+      const exported = inner.mock.results[0].value
+
+      expect(result).toBe(exported)
+      expect(inner).toHaveBeenCalledTimes(1)
+      expect(inner.mock.calls[0][1]).toBe(input[1])
+      expect(inner).toHaveBeenCalledWith(...input)
+      expect(input[3]).not.toHaveProperty('posthogBundleCallback')
+      expect(determineDebugIdFromBundleSource(exported.artifacts[0].source)).toBe(chunkId)
+      expect(JSON.parse(exported.artifacts[1].source).debugId).toBe(chunkId)
+      expect(JSON.stringify(exported)).not.toContain('__POSTHOG_CHUNK_ID__')
+    })
+
+    test.each(['array', 'promised array', 'JSON', 'binary artifact'])('preserves %s output', async (shape) => {
+      const assets = [{ filename: 'index.js', source: 'console.log("app");' }]
+      const output =
+        shape === 'JSON'
+          ? JSON.stringify({ artifacts: assets, assets: [] })
+          : shape === 'binary artifact'
+            ? { artifacts: [{ filename: 'index.hbc', source: Buffer.from([0, 255, 1]) }], assets: [] }
+            : assets
+      const inner = vi.fn(() => (shape === 'promised array' ? Promise.resolve(output) : output))
+      const input = mockSerializerArgs({ serializerOptions: { output: 'static' } })
+      const result = await createPostHogMetroSerializer(inner as unknown as MetroSerializer)(...input)
+
+      expect(result).toBe(output)
+      expect(inner).toHaveBeenCalledTimes(1)
+      expect(inner).toHaveBeenCalledWith(...input)
+      expect(input[3]).not.toHaveProperty('posthogBundleCallback')
+    })
+
+    test.each([
+      { serializerOptions: { output: 'default' }, sourceUrl: 'https://expo.dev/index.bundle?serializer.output=static' },
+      { serializerOptions: {}, sourceUrl: 'https://expo.dev/index.bundle?serializer.output=static' },
+      { sourceUrl: 'https://expo.dev/index.bundle?serializer.output=default' },
+      { sourceUrl: 'https://expo.dev/index.bundle?other=serializer.output%3Dstatic' },
+      { sourceUrl: 'https://expo.dev/index.bundle#serializer.output=static' },
+      { sourceUrl: 'https://expo.dev/index.bundle//&serializer.output=static?serializer.output=default' },
+      { sourceUrl: 'http://[' },
+    ])('keeps the plain-bundle path for %j', async (options) => {
+      const inner = vi.fn<MetroSerializer>(() => ({ code: 'console.log("app");', map: '{}' }))
+      await expect(createPostHogMetroSerializer(inner)(...mockSerializerArgs(options))).rejects.toThrow(
+        'Chunk ID was not found in the bundle.'
+      )
+      expect(inner).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not skip the default Metro serializer based on Expo options alone', async () => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+      try {
+        const result = await createPostHogMetroSerializer()(
+          ...mockSerializerArgs({ serializerOptions: { output: 'static' } })
+        )
+        expect(typeof result).not.toBe('string')
+        if (typeof result !== 'string') {
+          expect(determineDebugIdFromBundleSource(result.code)).toMatch(UUID_PATTERN)
+        }
+      } finally {
+        log.mockRestore()
+      }
+    })
   })
 
   test('extracts the generated id when the runtime map uses a variable stack key', () => {


### PR DESCRIPTION
## Problem

Follow-up to the Expo compatibility issue deferred in [#4778](https://github.com/PostHog/posthog-js/pull/4778#issuecomment-5543753821).

Wrapping Expo's serializer with `createPostHogMetroSerializer()` breaks static exports. Those exports can return assets or JSON rather than a single `{ code, map }` bundle. The wrapper tries to read them as JavaScript and throws.

An output-only guard is not enough. The wrapper first injects a placeholder module, which causes Expo's PostHog per-asset hook to skip the real Chunk ID. Returning the output afterward would preserve that placeholder.

The standard `getPostHogExpoConfig()` setup does not install this wrapper and is not affected by this particular composition bug.

## Changes

- Delegate static exports to the custom serializer before injecting a placeholder or callback. Keep its arguments and output unchanged, and invoke it once.
- Recognize explicit serializer options, ordinary source URLs, and JSC-safe URLs. Preserve Expo's option precedence.
- Leave the default Metro serializer and non-static bundle behavior unchanged.
- Document that Expo Chunk IDs require the per-asset hook configured by `getPostHogExpoConfig()`.
- Add regression coverage and a `posthog-react-native` patch changeset.

This is a focused Expo static-export fix. It does not add generic support for arbitrary custom serializers that return assets without identifying a static export.

### Validation

- New regressions reproduced the crash and placeholder interference before the fix.
- Full React Native suite: 43 files, 714 tests passed.
- React Native oxlint, formatting, and `pnpm turbo --filter=posthog-react-native build` passed.
- Six additional local checks used the real Expo serializer on iOS and Android, covering explicit options, ordinary URLs, and JSC-safe URLs. Exported code and source maps retained matching IDs with no placeholder.
- Autoreview of `942a0d2b7` against `origin/main` found no actionable issues.

The real-serializer checks used an isolated fixture with `@expo/metro-config@0.20.17` and Metro 0.82.5 because the workspace's Expo/Metro development dependency combination cannot load that serializer. The fixture is not part of this PR. Validation ran on Node 24.18.1. No real app export, Hermes compilation, or EAS Update upload was performed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added the equivalent patch changeset file manually

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using GitHub CLI, Vitest, and isolated autoreview. The investigation confirmed that an output-only pass-through could ship a placeholder ID, so this change delegates before injection instead. Local investigation artifacts are excluded from the PR. Human review is required.
