### PR TITLE
fix(flags): honor versioned local property matching

### DIFF
--- a/.changeset/versioned-boolean-local-evaluation.md
+++ b/.changeset/versioned-boolean-local-evaluation.md
@@ -1,0 +1,7 @@
+---
+'@posthog/core': patch
+'posthog-node': patch
+'@posthog/convex': patch
+---
+
+Respect the definitions response's `property_matching_version` during local feature flag evaluation. Version 2 uses explicit boolean/string equality and per-member array matching, while missing or other versions retain service legacy matching (including empty-array truthiness). Preserve the version in Node definition caches and Convex persisted definitions, and propagate it through person, group, cohort and dependency evaluation without mixing snapshots during reloads. Existing numeric ambiguity fallback and SemVer parsing policies are unchanged.

--- a/packages/convex/src/client/feature-flags/evaluator.ts
+++ b/packages/convex/src/client/feature-flags/evaluator.ts
@@ -20,6 +20,7 @@ export class LocalFeatureFlagEvaluator {
   readonly flagsByKey: Record<string, PostHogFeatureFlag>
   readonly groupTypeMapping: Record<string, string>
   readonly cohorts: FlagDefinitions['cohorts']
+  readonly propertyMatchingVersion?: number
   debugMode: boolean = false
 
   constructor(definitions: FlagDefinitions) {
@@ -30,6 +31,7 @@ export class LocalFeatureFlagEvaluator {
     }, {})
     this.groupTypeMapping = definitions.groupTypeMapping ?? {}
     this.cohorts = definitions.cohorts ?? {}
+    this.propertyMatchingVersion = definitions.propertyMatchingVersion
   }
 
   debug(enabled: boolean = true): void {
@@ -389,11 +391,11 @@ export class LocalFeatureFlagEvaluator {
       for (const prop of condition.properties) {
         let matches: boolean
         if (prop.type === 'cohort') {
-          matches = matchCohort(prop, properties, this.cohorts, this.debugMode)
+          matches = matchCohort(prop, properties, this.cohorts, this.debugMode, this.propertyMatchingVersion)
         } else if (prop.type === 'flag') {
           matches = await this.evaluateFlagDependency(prop, ctx)
         } else {
-          matches = matchProperty(prop, properties, warn)
+          matches = matchProperty(prop, properties, warn, this.propertyMatchingVersion)
         }
         // `matchPropertyGroup` (cohort path) inverts on `negation`; the top-level flag condition
         // path needs to do the same or any negated property on a flag-level filter quietly passes.

--- a/packages/convex/src/client/feature-flags/match-property.ts
+++ b/packages/convex/src/client/feature-flags/match-property.ts
@@ -16,10 +16,12 @@ export class RequiresServerEvaluation extends Error {
 export function matchProperty(
   property: FlagProperty,
   propertyValues: Record<string, any>,
-  warnFunction?: (msg: string) => void
+  warnFunction?: (msg: string) => void,
+  propertyMatchingVersion?: number
 ): boolean {
   return matchFeatureFlagProperty(property, propertyValues, {
     warnFunction,
+    propertyMatchingVersion,
     semverParsingPolicy: 'legacy-permissive',
   })
 }
@@ -28,7 +30,8 @@ export function matchCohort(
   property: FlagProperty,
   propertyValues: Record<string, any>,
   cohortProperties: Record<string, PropertyGroup>,
-  debugMode: boolean = false
+  debugMode: boolean = false,
+  propertyMatchingVersion?: number
 ): boolean {
   const cohortId = String(property.value)
   if (!(cohortId in cohortProperties)) {
@@ -36,14 +39,21 @@ export function matchCohort(
       `cohort ${cohortId} not found in local cohorts - likely a static cohort that requires server evaluation`
     )
   }
-  return matchPropertyGroup(cohortProperties[cohortId], propertyValues, cohortProperties, debugMode)
+  return matchPropertyGroup(
+    cohortProperties[cohortId],
+    propertyValues,
+    cohortProperties,
+    debugMode,
+    propertyMatchingVersion
+  )
 }
 
 export function matchPropertyGroup(
   propertyGroup: PropertyGroup,
   propertyValues: Record<string, any>,
   cohortProperties: Record<string, PropertyGroup>,
-  debugMode: boolean = false
+  debugMode: boolean = false,
+  propertyMatchingVersion?: number
 ): boolean {
   if (!propertyGroup) return true
 
@@ -57,7 +67,7 @@ export function matchPropertyGroup(
   if ('values' in properties[0]) {
     for (const prop of properties as PropertyGroup[]) {
       try {
-        const matches = matchPropertyGroup(prop, propertyValues, cohortProperties, debugMode)
+        const matches = matchPropertyGroup(prop, propertyValues, cohortProperties, debugMode, propertyMatchingVersion)
         if (propertyGroupType === 'AND') {
           if (!matches) return false
         } else {
@@ -83,7 +93,7 @@ export function matchPropertyGroup(
       try {
         let matches: boolean
         if (prop.type === 'cohort') {
-          matches = matchCohort(prop, propertyValues, cohortProperties, debugMode)
+          matches = matchCohort(prop, propertyValues, cohortProperties, debugMode, propertyMatchingVersion)
         } else if (prop.type === 'flag') {
           if (debugMode) {
             console.warn(
@@ -98,7 +108,7 @@ export function matchPropertyGroup(
           errorMatchingLocally = true
           continue
         } else {
-          matches = matchProperty(prop, propertyValues)
+          matches = matchProperty(prop, propertyValues, undefined, propertyMatchingVersion)
         }
 
         const negation = prop.negation || false

--- a/packages/convex/src/client/feature-flags/types.ts
+++ b/packages/convex/src/client/feature-flags/types.ts
@@ -51,6 +51,8 @@ export type PostHogFeatureFlag = {
 }
 
 export type FlagDefinitions = {
+  /** Top-level definitions matching version; absent in older stored data means legacy matching. */
+  propertyMatchingVersion?: number
   flags: PostHogFeatureFlag[]
   groupTypeMapping: Record<string, string>
   cohorts: Record<string, PropertyGroup>

--- a/packages/convex/src/component/flag-definitions.versioned.test.ts
+++ b/packages/convex/src/component/flag-definitions.versioned.test.ts
@@ -1,0 +1,136 @@
+/// <reference types="vite/client" />
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { convexTest } from 'convex-test'
+import schema from './schema.js'
+import { api, internal } from './_generated/api.js'
+import { PostHog } from '../client/index.js'
+import type { FlagProperty, PostHogFeatureFlag, PropertyGroup } from '../client/feature-flags/types.js'
+
+const modules = import.meta.glob('./**/*.ts')
+const rows: [FlagProperty['value'], unknown, boolean, boolean][] = [
+  [false, 'banana', true, false],
+  [false, 0, true, false],
+  [['true', 'false'], 'true', false, true],
+  [['true', 'false'], 'pro', true, false],
+  [[], true, true, true],
+  [[], [], true, true],
+  [true, [true], true, false],
+  [false, 'FALSE', true, true],
+  [false, null, true, false],
+  [[], [true, ['TRUE', []]], true, true],
+  [[], false, false, false],
+  [[], 0, false, false],
+  [[], 'banana', false, false],
+]
+const makeFlag = (key: string, properties: FlagProperty[], group = false): PostHogFeatureFlag => ({
+  id: 1,
+  name: key,
+  key,
+  active: true,
+  deleted: false,
+  rollout_percentage: null,
+  ensure_experience_continuity: false,
+  experiment_set: [],
+  filters: { groups: [{ properties }], ...(group ? { aggregation_group_type_index: 0 } : {}) },
+})
+const property: FlagProperty = { key: 'value', value: false, operator: 'exact' }
+const flags = [
+  makeFlag('person', [property]),
+  makeFlag('group', [property], true),
+  makeFlag('cohort', [{ key: 'id', type: 'cohort', value: '1' }]),
+  makeFlag('dependent', [{ key: 'person', type: 'flag', value: true, dependency_chain: ['person'] }]),
+  ...rows.flatMap(([value], index) =>
+    ['exact', 'is_not'].map((operator) =>
+      makeFlag(`${index}-${operator}`, [{ key: `value-${index}`, value, operator }])
+    )
+  ),
+]
+const cohorts: Record<string, PropertyGroup> = {
+  '1': { type: 'AND', values: [{ type: 'OR', values: [{ key: 'id', type: 'cohort', value: '2' }] }] },
+  '2': { type: 'AND', values: [property] },
+}
+const personProperties = {
+  value: 'banana',
+  ...Object.fromEntries(rows.map(([, actual], index) => [`value-${index}`, actual])),
+}
+const args = {
+  distinctId: 'user',
+  personProperties,
+  groups: { company: 'acme' },
+  groupProperties: { company: { value: 'banana' } },
+}
+const envelope = (version?: number) => ({
+  flags,
+  cohorts,
+  group_type_mapping: { '0': 'company' },
+  property_matching_version: version,
+})
+
+beforeEach(() => {
+  vi.stubEnv('POSTHOG_PROJECT_TOKEN', 'project')
+  vi.stubEnv('POSTHOG_PERSONAL_API_KEY', 'personal')
+  vi.stubEnv('POSTHOG_HOST', 'https://example.com')
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+describe('versioned definitions through Convex HTTP, storage and client hydration', () => {
+  test('version-only reloads and omitted metadata select the correct semantics on every local API', async () => {
+    const t = convexTest(schema, modules)
+    const client = new PostHog({ lib: { getFlagDefinitions: api.lib.getFlagDefinitions } } as never)
+    const ctx = { runQuery: t.query }
+    for (const version of [undefined, 1, 2, 1, 2, undefined, 3]) {
+      const fetch = vi.fn(
+        async (_url: string) =>
+          new Response(JSON.stringify(envelope(version)), { status: 200, headers: { ETag: 'same-flags' } })
+      )
+      vi.stubGlobal('fetch', fetch)
+      expect(await t.action(api.lib.refreshFlagDefinitions, {})).toEqual({ status: 'updated' })
+      const row = await t.query(api.lib.getFlagDefinitions, {})
+      expect(JSON.parse(row.data!).propertyMatchingVersion).toBe(version)
+      for (const key of ['person', 'group', 'cohort', 'dependent']) {
+        expect(await client.getFeatureFlag(ctx, { ...args, key })).toBe(version !== 2)
+        expect((await client.getFeatureFlagResult(ctx, { ...args, key }))?.enabled).toBe(version !== 2)
+      }
+      for (let index = 0; index < rows.length; index++) {
+        const expected = rows[index][version === 2 ? 3 : 2]
+        expect(await client.getFeatureFlag(ctx, { ...args, key: `${index}-exact` })).toBe(expected)
+        expect(await client.getFeatureFlag(ctx, { ...args, key: `${index}-is_not` })).toBe(!expected)
+      }
+      const all = await client.getAllFlags(ctx, args)
+      expect(all.person).toBe(version !== 2)
+      expect(all.dependent).toBe(version !== 2)
+      expect(fetch).toHaveBeenCalledTimes(1) // Definitions only, never remote /flags fallback.
+      expect(fetch.mock.calls[0][0]).toContain('/flags/definitions')
+    }
+  })
+
+  test('304 and failed refreshes retain the persisted version and definitions', async () => {
+    const t = convexTest(schema, modules)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(envelope(2)), { headers: { ETag: 'v2' } }))
+    )
+    await t.action(api.lib.refreshFlagDefinitions, {})
+    const original = (await t.query(api.lib.getFlagDefinitions, {})).data
+    for (const status of [304, 400]) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status }))
+      )
+      await t.action(api.lib.refreshFlagDefinitions, {})
+      expect((await t.query(api.lib.getFlagDefinitions, {})).data).toBe(original)
+    }
+  })
+
+  test('old persisted JSON without version hydrates as legacy', async () => {
+    const t = convexTest(schema, modules)
+    await t.mutation(internal.lib._setFlagDefinitions, {
+      data: JSON.stringify({ flags, cohorts, groupTypeMapping: { '0': 'company' } }),
+    })
+    const client = new PostHog({ lib: { getFlagDefinitions: api.lib.getFlagDefinitions } } as never)
+    expect(await client.getFeatureFlag({ runQuery: t.query }, { ...args, key: 'cohort' })).toBe(true)
+  })
+})

--- a/packages/convex/src/component/lib.ts
+++ b/packages/convex/src/component/lib.ts
@@ -555,7 +555,7 @@ export const refreshFlagDefinitions = action({
       return { status: 'error' as const, reason: 'unexpected-status' as const }
     }
 
-    let body: { flags?: unknown; group_type_mapping?: unknown; cohorts?: unknown }
+    let body: { flags?: unknown; group_type_mapping?: unknown; cohorts?: unknown; property_matching_version?: number }
     try {
       body = (await response.json()) as typeof body
     } catch (err) {
@@ -571,6 +571,7 @@ export const refreshFlagDefinitions = action({
       flags: body.flags ?? [],
       groupTypeMapping: body.group_type_mapping ?? {},
       cohorts: body.cohorts ?? {},
+      propertyMatchingVersion: body.property_matching_version,
     })
 
     await ctx.runMutation(internal.lib._setFlagDefinitions, {

--- a/packages/core/src/__tests__/featureFlagLocalEvaluation.versioned.spec.ts
+++ b/packages/core/src/__tests__/featureFlagLocalEvaluation.versioned.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+import { InconclusiveMatchError, matchFeatureFlagProperty } from '../featureFlagLocalEvaluation'
+import type { FeatureFlagProperty, MatchFeatureFlagPropertyOptions } from '../featureFlagLocalEvaluation'
+
+const rows: [FeatureFlagProperty['value'], unknown, boolean, boolean][] = [
+  [false, 'banana', true, false],
+  [false, 0, true, false],
+  [['true', 'false'], 'true', false, true],
+  [['true', 'false'], 'pro', true, false],
+  [[], true, true, true],
+  [[], [], true, true],
+  [true, [true], true, false],
+  [false, 'FALSE', true, true],
+  [false, null, true, false],
+  [false, '', true, false],
+  [[], [true, ['TRUE', []]], true, true],
+  [[], [true, false], false, false],
+  [[], false, false, false],
+  [[], 0, false, false],
+  [[], 'banana', false, false],
+  [[true, 'PRO'], 'TRUE', true, true],
+  [[false, 'PRO'], 'banana', false, false],
+  [['FREE', 'PRO'], 'pro', true, true],
+  ['Ä', 'ä', true, true],
+]
+
+describe.each([undefined, 1, 2, 3])('property matching version %s', (propertyMatchingVersion) => {
+  const options: MatchFeatureFlagPropertyOptions = { propertyMatchingVersion }
+  test.each(rows)('filter %j and property %j', (value, actual, legacy, explicit) => {
+    const expected = propertyMatchingVersion === 2 ? explicit : legacy
+    expect(matchFeatureFlagProperty({ key: 'key', value }, { key: actual }, options)).toBe(expected)
+    expect(matchFeatureFlagProperty({ key: 'key', value, operator: 'is_not' }, { key: actual }, options)).toBe(
+      !expected
+    )
+  })
+
+  test('missing properties remain inconclusive', () => {
+    expect(() => matchFeatureFlagProperty({ key: 'key', value: false }, {}, options)).toThrow(InconclusiveMatchError)
+  })
+
+  test('numeric spelling ambiguity remains inconclusive', () => {
+    expect(() => matchFeatureFlagProperty({ key: 'key', value: [1, 'PRO'] }, { key: '1' }, options)).toThrow(
+      InconclusiveMatchError
+    )
+  })
+})

--- a/packages/core/src/featureFlagLocalEvaluation.ts
+++ b/packages/core/src/featureFlagLocalEvaluation.ts
@@ -14,6 +14,8 @@ export type FeatureFlagSemverParsingPolicy = 'strict' | 'legacy-permissive'
 export type MatchFeatureFlagPropertyOptions = {
   warnFunction?: (message: string) => void
   semverParsingPolicy?: FeatureFlagSemverParsingPolicy
+  /** Only version 2 enables explicit equality; absent/other versions use service legacy matching. */
+  propertyMatchingVersion?: number
 }
 
 export type FeatureFlagVariant = {
@@ -381,9 +383,18 @@ export function matchFeatureFlagProperty(
   }
 
   const computeExactMatch = (target: unknown, actual: unknown): boolean => {
-    if (isTruthyOrFalsyPropertyValue(target)) {
+    if (
+      (options.propertyMatchingVersion !== 2 && isTruthyOrFalsyPropertyValue(target)) ||
+      (Array.isArray(target) && target.length === 0)
+    ) {
       assertJsonRepresentable(actual)
       return isTruthyPropertyValue(target) === isTruthyPropertyValue(actual)
+    }
+    // Neither integer nor integral-float spelling can equal a boolean-like filter. This
+    // mismatch is conclusive without weakening the numeric ambiguity fallback below.
+    if (options.propertyMatchingVersion === 2 && typeof actual === 'number' && isTruthyOrFalsyPropertyValue(target)) {
+      assertJsonRepresentable(actual)
+      return false
     }
     if (Array.isArray(target)) {
       const actualString = exactMatchString(actual).toLowerCase()

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -2329,6 +2329,11 @@
           "description": "Server-controlled gate for minimal `$feature_flag_called` events, from the top-level `minimal_flag_called_events` field of the flag-definitions payload. Absent (e.g. cached data written by an older SDK version) means full events.",
           "type": "boolean",
           "name": "minimalFlagCalledEvents"
+        },
+        {
+          "description": "Top-level definitions matching version; absent in older caches means legacy matching.",
+          "type": "number",
+          "name": "propertyMatchingVersion"
         }
       ],
       "path": "src/extensions/feature-flags/cache.ts"

--- a/packages/node/src/__tests__/feature-flags.versioned.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.versioned.spec.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { PostHog } from '../entrypoints/index.node'
+import { FeatureFlagsPoller, FeatureFlagEvaluationContext } from '../extensions/feature-flags/feature-flags'
+import type { FlagDefinitionCacheData } from '../extensions/feature-flags/cache'
+import type { FlagProperty, PostHogFeatureFlag, PropertyGroup } from '../types'
+
+const property: FlagProperty = { key: 'value', value: false, operator: 'exact', type: 'person' }
+const flag = (key: string, properties: FlagProperty[], group = false): PostHogFeatureFlag => ({
+  id: 1,
+  key,
+  name: key,
+  active: true,
+  deleted: false,
+  rollout_percentage: null,
+  ensure_experience_continuity: false,
+  experiment_set: [],
+  filters: { groups: [{ properties }], ...(group ? { aggregation_group_type_index: 0 } : {}) },
+})
+const flags = [
+  flag('person', [property]),
+  flag('group', [property], true),
+  flag('cohort', [{ key: 'id', value: '1', type: 'cohort' }]),
+  flag('dependent', [
+    { key: 'person', type: 'flag', value: true, operator: 'flag_evaluates_to', dependency_chain: ['person'] },
+  ]),
+]
+const cohorts: Record<string, PropertyGroup> = {
+  '1': { type: 'AND', values: [{ type: 'OR', values: [{ key: 'id', value: '2', type: 'cohort' }] }] },
+  '2': { type: 'AND', values: [property] },
+}
+const context = (): FeatureFlagEvaluationContext => ({
+  distinctId: 'user',
+  groups: { company: 'acme' },
+  personProperties: { value: 'banana' },
+  groupProperties: { company: { value: 'banana' } },
+  evaluationCache: {},
+})
+const envelope = (version?: number) => ({
+  flags,
+  cohorts,
+  group_type_mapping: { '0': 'company' },
+  property_matching_version: version,
+})
+const response = (version?: number, status = 200) => ({
+  status,
+  json: async () => envelope(version),
+  text: async () => '',
+  headers: { get: () => 'etag' },
+})
+const pollers: FeatureFlagsPoller[] = []
+function poller(
+  fetch = vi.fn(async () => response()),
+  cacheProvider?: ConstructorParameters<typeof FeatureFlagsPoller>[0]['cacheProvider']
+) {
+  const instance = new FeatureFlagsPoller({
+    pollingInterval: 60000,
+    personalApiKey: 'personal',
+    projectApiKey: 'project',
+    host: 'https://example.com',
+    fetch,
+    cacheProvider,
+  })
+  pollers.push(instance)
+  return instance
+}
+afterEach(async () => {
+  await Promise.all(pollers.splice(0).map((instance) => instance.stopPoller()))
+})
+
+describe('versioned definitions in the Node poller', () => {
+  test('public simple and full-result APIs observe version-only reloads without remote fallback', async () => {
+    let version: number | undefined = 1
+    const fetch = vi.fn(async (_url: string) => response(version))
+    const client = new PostHog('project', { personalApiKey: 'personal', host: 'https://example.com', fetch })
+    const ctx = context()
+    const options = {
+      groups: ctx.groups,
+      personProperties: ctx.personProperties,
+      groupProperties: ctx.groupProperties,
+      onlyEvaluateLocally: true,
+      sendFeatureFlagEvents: false,
+    }
+    try {
+      for (version of [1, 2, 1, 2, undefined]) {
+        await client.reloadFeatureFlags()
+        for (const { key } of flags) {
+          expect(await client.getFeatureFlag(key, 'user', options)).toBe(version !== 2)
+          expect((await client.getFeatureFlagResult(key, 'user', options))?.enabled).toBe(version !== 2)
+        }
+      }
+      expect(fetch.mock.calls.every(([url]) => url.includes('/flags/definitions'))).toBe(true)
+    } finally {
+      await client.shutdown()
+    }
+  })
+
+  test.each([undefined, 1, 2, 3])(
+    'HTTP version %s reaches person, group, recursive cohorts and dependencies',
+    async (version) => {
+      const instance = poller(vi.fn(async () => response(version)))
+      const ctx = context()
+      for (const { key } of flags) {
+        expect(
+          await instance.getFeatureFlag(key, ctx.distinctId, ctx.groups, ctx.personProperties, ctx.groupProperties)
+        ).toBe(version !== 2)
+      }
+      const all = await instance.getAllFlagsAndPayloads(ctx)
+      expect(all.fallbackToFlags).toBe(false)
+      expect(all.response).toEqual(Object.fromEntries(flags.map(({ key }) => [key, version !== 2])))
+    }
+  )
+
+  test.each([undefined, 1, 2, 3])('six rows and negation through Node definitions version %s', async (version) => {
+    const rows: [FlagProperty['value'], unknown, boolean, boolean][] = [
+      [false, 'banana', true, false],
+      [false, 0, true, false],
+      [['true', 'false'], 'true', false, true],
+      [['true', 'false'], 'pro', true, false],
+      [[], true, true, true],
+      [[], [], true, true],
+    ]
+    const rowFlags = rows.flatMap(([value], index) =>
+      ['exact', 'is_not'].map((operator) => flag(`${index}-${operator}`, [{ key: 'value', value, operator }]))
+    )
+    const instance = poller(
+      vi.fn(async () => ({ ...response(version), json: async () => ({ ...envelope(version), flags: rowFlags }) }))
+    )
+    for (let index = 0; index < rows.length; index++) {
+      const [, actual, legacy, explicit] = rows[index]
+      const expected = version === 2 ? explicit : legacy
+      expect(await instance.getFeatureFlag(`${index}-exact`, 'user', {}, { value: actual })).toBe(expected)
+      expect(await instance.getFeatureFlag(`${index}-is_not`, 'user', {}, { value: actual })).toBe(!expected)
+    }
+  })
+
+  test('version-only reloads replace dependency results, and omission resets to legacy', async () => {
+    let version: number | undefined = 1
+    const instance = poller(vi.fn(async () => response(version)))
+    const ctx = context()
+    for (version of [1, 2, 1, 2, undefined]) {
+      await instance.loadFeatureFlags(true)
+      const all = await instance.getAllFlagsAndPayloads(ctx)
+      expect(all.response.dependent).toBe(version !== 2)
+      expect(all.response.person).toBe(version !== 2)
+      expect(all.fallbackToFlags).toBe(false)
+      ctx.evaluationCache = all.response
+    }
+  })
+
+  test('cache provider round trip retains version; old cached data resets to legacy', async () => {
+    let stored: FlagDefinitionCacheData | undefined
+    let shouldFetch = true
+    const cache = {
+      shouldFetchFlagDefinitions: () => shouldFetch,
+      getFlagDefinitions: () => stored,
+      onFlagDefinitionsReceived: vi.fn((data: FlagDefinitionCacheData) => {
+        stored = JSON.parse(JSON.stringify(data))
+      }),
+      shutdown: vi.fn(),
+    }
+    const fetch = vi.fn(async () => response(2))
+    const writer = poller(fetch, cache)
+    await writer.loadFeatureFlags()
+    expect(stored).toHaveProperty('propertyMatchingVersion', 2)
+    shouldFetch = false
+    const reader = poller(fetch, cache)
+    expect(await reader.getFeatureFlag('person', 'user', {}, { value: 'banana' })).toBe(false)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    for (const version of [1, 2, undefined]) {
+      stored = { ...stored!, propertyMatchingVersion: version }
+      if (version === undefined) delete stored.propertyMatchingVersion
+      await reader.loadFeatureFlags(true)
+      expect(await reader.getFeatureFlag('person', 'user', {}, { value: 'banana' })).toBe(version !== 2)
+    }
+  })
+
+  test.each(['empty', 'failed'])('%s cache reads preserve the loaded snapshot/version', async (kind) => {
+    let shouldFetch = true
+    const fetch = vi.fn(async () => response(2))
+    const instance = poller(fetch, {
+      shouldFetchFlagDefinitions: () => shouldFetch,
+      getFlagDefinitions: () => {
+        if (kind === 'failed') throw new Error('cache unavailable')
+        return undefined
+      },
+      onFlagDefinitionsReceived: vi.fn(),
+      shutdown: vi.fn(),
+    })
+    await instance.loadFeatureFlags()
+    shouldFetch = false
+    await instance.loadFeatureFlags(true)
+    expect(await instance.getFeatureFlag('person', 'user', {}, { value: 'banana' })).toBe(false)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('304, HTTP failure and cache-store failure preserve the loaded snapshot/version', async () => {
+    const fetch = vi.fn(async () => response(2))
+    const instance = poller(fetch, {
+      shouldFetchFlagDefinitions: () => true,
+      getFlagDefinitions: () => undefined,
+      onFlagDefinitionsReceived: () => {
+        throw new Error('cache unavailable')
+      },
+      shutdown: vi.fn(),
+    })
+    await instance.loadFeatureFlags()
+    for (const status of [304, 500]) {
+      fetch.mockImplementation(async () => response(undefined, status))
+      await instance.loadFeatureFlags(true)
+      expect(await instance.getFeatureFlag('person', 'user', {}, { value: 'banana' })).toBe(false)
+    }
+  })
+
+  test('an in-flight evaluation keeps its definitions/version across a reload', async () => {
+    const fetch = vi.fn(async () => response(1))
+    const instance = poller(fetch)
+    await instance.loadFeatureFlags()
+    const original = instance.isConditionMatch.bind(instance)
+    let resume!: () => void
+    const paused = new Promise<void>((resolve) => {
+      resume = resolve
+    })
+    let entered!: () => void
+    const started = new Promise<void>((resolve) => {
+      entered = resolve
+    })
+    vi.spyOn(instance, 'isConditionMatch').mockImplementationOnce(async (...args) => {
+      entered()
+      await paused
+      return original(...args)
+    })
+    const pending = instance.getFeatureFlag('cohort', 'user', {}, { value: 'banana' })
+    await started
+    fetch.mockImplementation(async () => response(2))
+    await instance.loadFeatureFlags(true)
+    resume()
+    expect(await pending).toBe(true)
+    expect(await instance.getFeatureFlag('cohort', 'user', {}, { value: 'banana' })).toBe(false)
+  })
+})

--- a/packages/node/src/extensions/feature-flags/cache.ts
+++ b/packages/node/src/extensions/feature-flags/cache.ts
@@ -18,6 +18,8 @@ export interface FlagDefinitionCacheData {
    * data written by an older SDK version) means full events.
    */
   minimalFlagCalledEvents?: boolean
+  /** Top-level definitions matching version; absent in older caches means legacy matching. */
+  propertyMatchingVersion?: number
 }
 
 /**

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -73,12 +73,21 @@ type FeatureFlagsPollerOptions = {
   evaluationContexts?: readonly string[]
 }
 
+type FlagEvaluationSnapshot = {
+  featureFlagsByKey: Record<string, PostHogFeatureFlag>
+  groupTypeMapping: Record<string, string>
+  cohorts: Record<string, PropertyGroup>
+  filteredOutFlagKeys: Set<string>
+  propertyMatchingVersion?: number
+}
+
 export type FeatureFlagEvaluationContext = {
   distinctId: string
   groups: Record<string, string>
   personProperties: Record<string, any>
   groupProperties: Record<string, Record<string, any>>
   evaluationCache: Record<string, FeatureFlagValue>
+  definitions?: FlagEvaluationSnapshot
 }
 
 type ComputeFlagAndPayloadOptions = {
@@ -95,6 +104,7 @@ class FeatureFlagsPoller {
   groupTypeMapping: Record<string, string>
   cohorts: Record<string, PropertyGroup>
   loadedSuccessfullyOnce: boolean
+  propertyMatchingVersion?: number
   timeout?: number
   host: FeatureFlagsPollerOptions['host']
   poller?: NodeJS.Timeout
@@ -157,6 +167,23 @@ class FeatureFlagsPoller {
   private logMsgIfDebug(fn: () => void): void {
     if (this.debugMode) {
       fn()
+    }
+  }
+
+  // Keep definitions and their matching version stable across asynchronous hashes/dependencies.
+  private withEvaluationSnapshot(context: FeatureFlagEvaluationContext): FeatureFlagEvaluationContext {
+    if (context.definitions) return context
+    return {
+      ...context,
+      // Dependency results belong to this evaluation snapshot, never a prior invocation.
+      evaluationCache: {},
+      definitions: {
+        featureFlagsByKey: this.featureFlagsByKey,
+        groupTypeMapping: this.groupTypeMapping,
+        cohorts: this.cohorts,
+        filteredOutFlagKeys: this.filteredOutFlagKeys,
+        propertyMatchingVersion: this.propertyMatchingVersion,
+      },
     }
   }
 
@@ -230,17 +257,18 @@ class FeatureFlagsPoller {
       ? flagKeysToExplicitlyEvaluate.map((key) => this.featureFlagsByKey[key]).filter(Boolean)
       : this.featureFlags
 
-    const sharedEvaluationContext = {
+    const sharedEvaluationContext = this.withEvaluationSnapshot({
       ...evaluationContext,
-      evaluationCache: evaluationContext.evaluationCache ?? {},
-    }
+      definitions: undefined,
+    })
 
     await Promise.all(
       flagsToEvaluate.map(async (flag) => {
         try {
           const { value: matchValue, payload: matchPayload } = await this.computeFlagAndPayloadLocally(
             flag,
-            sharedEvaluationContext
+            sharedEvaluationContext,
+            { skipLoadCheck: true }
           )
           response[flag.key] = matchValue
           if (matchPayload) {
@@ -269,6 +297,9 @@ class FeatureFlagsPoller {
     payload: JsonType | null
   }> {
     const { matchValue, skipLoadCheck = false } = options
+    if (this.loadedSuccessfullyOnce) {
+      evaluationContext = this.withEvaluationSnapshot(evaluationContext)
+    }
 
     // Only load flags if not already loaded and not skipping the check
     if (!skipLoadCheck) {
@@ -279,6 +310,8 @@ class FeatureFlagsPoller {
       return { value: false, payload: null }
     }
 
+    evaluationContext = this.withEvaluationSnapshot(evaluationContext)
+    flag = evaluationContext.definitions!.featureFlagsByKey[flag.key] ?? flag
     let flagValue: FeatureFlagValue
 
     // If matchValue is provided, use it directly; otherwise evaluate the flag
@@ -289,7 +322,7 @@ class FeatureFlagsPoller {
     }
 
     // Always compute payload based on the final flagValue (whether provided or computed)
-    const payload = this.getFeatureFlagPayload(flag.key, flagValue)
+    const payload = resolveFeatureFlagPayload(flag.filters?.payloads, flagValue)
 
     return { value: flagValue, payload }
   }
@@ -315,7 +348,7 @@ class FeatureFlagsPoller {
     const aggregation_group_type_index = flagFilters.aggregation_group_type_index
 
     if (aggregation_group_type_index != undefined) {
-      const groupName = this.groupTypeMapping[String(aggregation_group_type_index)]
+      const groupName = evaluationContext.definitions!.groupTypeMapping[String(aggregation_group_type_index)]
 
       if (!groupName) {
         this.logMsgIfDebug(() =>
@@ -383,10 +416,6 @@ class FeatureFlagsPoller {
     return distinctId
   }
 
-  private getFeatureFlagPayload(key: string, flagValue: FeatureFlagValue): JsonType | null {
-    return resolveFeatureFlagPayload(this.featureFlagsByKey?.[key]?.filters?.payloads, flagValue)
-  }
-
   private async evaluateFlagDependency(
     property: FlagProperty,
     properties: Record<string, any>,
@@ -395,7 +424,7 @@ class FeatureFlagsPoller {
     const { evaluationCache } = evaluationContext
     const targetFlagKey = property.key
 
-    if (!this.featureFlagsByKey) {
+    if (!evaluationContext.definitions!.featureFlagsByKey) {
       throw new InconclusiveMatchError('Feature flags not available for dependency evaluation')
     }
 
@@ -426,9 +455,9 @@ class FeatureFlagsPoller {
     for (const depFlagKey of dependencyChain) {
       if (!(depFlagKey in evaluationCache)) {
         // Need to evaluate this dependency first
-        const depFlag = this.featureFlagsByKey[depFlagKey]
+        const depFlag = evaluationContext.definitions!.featureFlagsByKey[depFlagKey]
         if (!depFlag) {
-          if (this.filteredOutFlagKeys.has(depFlagKey)) {
+          if (evaluationContext.definitions!.filteredOutFlagKeys.has(depFlagKey)) {
             // Dependency was dropped by evaluation-context filtering, not genuinely missing. The
             // remote evaluator pre-seeds context-filtered flags as false so conditions like
             // `flag_evaluates_to=false` still match; do the same here instead of throwing.
@@ -490,6 +519,7 @@ class FeatureFlagsPoller {
     properties: Record<string, any>,
     evaluationContext: FeatureFlagEvaluationContext
   ): Promise<FeatureFlagValue> {
+    evaluationContext = this.withEvaluationSnapshot(evaluationContext)
     const flagFilters = flag.filters || {}
     const flagConditions = flagFilters.groups || []
     const flagAggregation = flagFilters.aggregation_group_type_index
@@ -515,7 +545,7 @@ class FeatureFlagsPoller {
         // This assumes flag-level aggregation is null/undefined for mixed flags.
         if (conditionAggregation !== flagAggregation) {
           if (conditionAggregation !== null && conditionAggregation !== undefined) {
-            const groupName = this.groupTypeMapping[String(conditionAggregation)]
+            const groupName = evaluationContext.definitions!.groupTypeMapping[String(conditionAggregation)]
             if (!groupName || !(groupName in groups)) {
               this.logMsgIfDebug(() =>
                 console.debug(
@@ -590,6 +620,8 @@ class FeatureFlagsPoller {
     properties: Record<string, any>,
     evaluationContext: FeatureFlagEvaluationContext
   ): Promise<ConditionMatchResult> {
+    evaluationContext = this.withEvaluationSnapshot(evaluationContext)
+    const definitions = evaluationContext.definitions!
     const rolloutPercentage = condition.rollout_percentage
     const warnFunction = (msg: string): void => {
       this.logMsgIfDebug(() => console.warn(msg))
@@ -600,8 +632,13 @@ class FeatureFlagsPoller {
         let matches = false
 
         if (propertyType === 'cohort') {
-          const inCohort = await matchCohort(prop, properties, this.cohorts, this.debugMode, (depProp) =>
-            this.evaluateFlagDependency(depProp, properties, evaluationContext)
+          const inCohort = await matchCohort(
+            prop,
+            properties,
+            definitions.cohorts,
+            this.debugMode,
+            (depProp) => this.evaluateFlagDependency(depProp, properties, evaluationContext),
+            definitions.propertyMatchingVersion
           )
           // A flag-level cohort condition carries a membership operator ('in' | 'not_in').
           // `matchCohort` only reports raw membership, so the operator must be applied here.
@@ -611,7 +648,7 @@ class FeatureFlagsPoller {
         } else if (propertyType === 'flag') {
           matches = await this.evaluateFlagDependency(prop, properties, evaluationContext)
         } else {
-          matches = matchProperty(prop, properties, warnFunction)
+          matches = matchProperty(prop, properties, warnFunction, definitions.propertyMatchingVersion)
         }
 
         if (!matches) {
@@ -684,6 +721,7 @@ class FeatureFlagsPoller {
     this.filteredOutFlagKeys = new Set(flagData.flags.filter((flag) => !keptKeys.has(flag.key)).map((flag) => flag.key))
     this.groupTypeMapping = flagData.groupTypeMapping
     this.cohorts = flagData.cohorts
+    this.propertyMatchingVersion = flagData.propertyMatchingVersion
     this.loadedSuccessfullyOnce = true
     // Absence of the field (older cached data, older servers) always means full events.
     this.onMinimalFlagCalledEvents?.(flagData.minimalFlagCalledEvents === true)
@@ -905,6 +943,7 @@ class FeatureFlagsPoller {
           this.filteredOutFlagKeys = new Set()
           this.groupTypeMapping = {}
           this.cohorts = {}
+          this.propertyMatchingVersion = undefined
           this.onMinimalFlagCalledEvents?.(false)
           return
 
@@ -940,6 +979,7 @@ class FeatureFlagsPoller {
             cohorts: (responseJson.cohorts as Record<string, PropertyGroup>) || {},
             // Absence of the field always flips the gate off — fail safe to full events.
             minimalFlagCalledEvents: responseJson.minimal_flag_called_events === true,
+            propertyMatchingVersion: responseJson.property_matching_version,
           }
 
           this.updateFlagState(flagData)
@@ -1081,9 +1121,10 @@ class FeatureFlagsPoller {
 function matchProperty(
   property: FeatureFlagCondition['properties'][number],
   propertyValues: Record<string, any>,
-  warnFunction?: (msg: string) => void
+  warnFunction?: (msg: string) => void,
+  propertyMatchingVersion?: number
 ): boolean {
-  return matchFeatureFlagProperty(property, propertyValues, { warnFunction })
+  return matchFeatureFlagProperty(property, propertyValues, { warnFunction, propertyMatchingVersion })
 }
 
 function parseSemver(value: string): [number, number, number] {
@@ -1105,13 +1146,21 @@ async function matchCohort(
   propertyValues: Record<string, any>,
   cohortProperties: FeatureFlagsPoller['cohorts'],
   debugMode: boolean = false,
-  flagDependencyEvaluator?: FlagDependencyEvaluator
+  flagDependencyEvaluator?: FlagDependencyEvaluator,
+  propertyMatchingVersion?: number
 ): Promise<boolean> {
   const cohortId = String(property.value)
   checkCohortExists(cohortId, cohortProperties)
 
   const propertyGroup = cohortProperties[cohortId]
-  return matchPropertyGroup(propertyGroup, propertyValues, cohortProperties, debugMode, flagDependencyEvaluator)
+  return matchPropertyGroup(
+    propertyGroup,
+    propertyValues,
+    cohortProperties,
+    debugMode,
+    flagDependencyEvaluator,
+    propertyMatchingVersion
+  )
 }
 
 async function matchPropertyGroup(
@@ -1119,7 +1168,8 @@ async function matchPropertyGroup(
   propertyValues: Record<string, any>,
   cohortProperties: FeatureFlagsPoller['cohorts'],
   debugMode: boolean = false,
-  flagDependencyEvaluator?: FlagDependencyEvaluator
+  flagDependencyEvaluator?: FlagDependencyEvaluator,
+  propertyMatchingVersion?: number
 ): Promise<boolean> {
   if (!propertyGroup) {
     return true
@@ -1144,7 +1194,8 @@ async function matchPropertyGroup(
           propertyValues,
           cohortProperties,
           debugMode,
-          flagDependencyEvaluator
+          flagDependencyEvaluator,
+          propertyMatchingVersion
         )
         if (propertyGroupType === 'AND') {
           if (!matches) {
@@ -1181,7 +1232,14 @@ async function matchPropertyGroup(
       try {
         let matches: boolean
         if (prop.type === 'cohort') {
-          matches = await matchCohort(prop, propertyValues, cohortProperties, debugMode, flagDependencyEvaluator)
+          matches = await matchCohort(
+            prop,
+            propertyValues,
+            cohortProperties,
+            debugMode,
+            flagDependencyEvaluator,
+            propertyMatchingVersion
+          )
         } else if (prop.type === 'flag') {
           if (!flagDependencyEvaluator) {
             throw new InconclusiveMatchError(
@@ -1190,7 +1248,7 @@ async function matchPropertyGroup(
           }
           matches = await flagDependencyEvaluator(prop)
         } else {
-          matches = matchProperty(prop, propertyValues)
+          matches = matchProperty(prop, propertyValues, undefined, propertyMatchingVersion)
         }
 
         const negation = prop.negation || false


### PR DESCRIPTION
## Problem

Node and Convex local feature flag evaluation needs to honor the definitions response's `property_matching_version`. Without it, boolean-like filters keep using legacy truthiness even when the server selects explicit matching.

Backend behavior: https://github.com/PostHog/posthog/pull/90694. Shared contract: https://github.com/PostHog/sdk-specs/pull/59.

## Changes

- Shared core uses explicit normalized scalar equality and nonempty filter-array member equality only for numeric version 2. Missing, version 1 and other versions retain released service legacy matching. Empty filters retain recursive truthiness, and `is_not` complements exact matching for known properties.
- Node retains the version in definition caches, accepts older cache entries without it, and snapshots definitions and matching metadata across asynchronous person, group, cohort and dependency evaluation. Version-only reloads take effect without reusing prior dependency results.
- Convex preserves the version in its existing stored definitions JSON and hydrates it into recursive local evaluation. No storage schema migration is needed.
- Add 102 regression tests across core, Node and Convex, a patch changeset for all three packages, and the generated Node API reference for optional `FlagDefinitionCacheData.propertyMatchingVersion`.

Existing numeric ambiguity fallback and SemVer parsing policies are unchanged. There are no browser, mobile or SDK adapter changes. Optional harness coverage is tracked separately in https://github.com/PostHog/posthog-sdk-test-harness/pull/53. This PR does not opt an adapter in.

### Validation

On the final committed branch:

- Core suite: 1,202 passed, one skipped.
- Node feature flag and evaluate-flags suites: 441 passed.
- Convex suite: 198 passed, including persisted definitions and client API coverage.
- Core, Node and Convex production builds passed.
- Changed TypeScript lint and source/test/changeset formatting passed. Node API regeneration was unchanged.
- Isolated committed-branch autoreview against `origin/main` reported no actionable findings.

Prior implementation validation also passed focused new-test typechecks for all three packages. The earlier broad Node run had 944 passing tests and two unrelated failures in `extensions/exception-autocapture.spec.ts`: uncaught errors and unhandled rejections could not resolve extensionless `dist/version` imported by `dist/client.mjs`. That run also reported an unhandled rejection with the same error. Broad test-inclusive TypeScript checks reported existing fixture/mock errors, including readonly JSON arrays in core tests, Node mock signatures, and the Convex `crons.test.ts` mock type. These broad checks were not rerun or repaired for this PR.

Checks used the existing cached Node 26.8.1, pnpm 11.7.0 and Vitest 1.6.1 toolchain. Node differs from the root's 24.x engine requirement. Existing API Extractor TSDoc warnings remain. The API snapshot keeps the generator's formatting rather than reformatting unrelated JSON. This is local validation, not a claim that CI has passed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common
- [x] @posthog/core

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Included the existing patch changeset for core, Node and Convex

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed this work using Pi, Git, GitHub CLI and the isolated autoreview helper. The session is local and has no public session link. The implementation follows the shared matching contract, preserves legacy defaults and leaves browser/mobile behavior and adapter opt-in out of scope. Human review is required before merge.
