### PR TITLE
fix: preserve Error details in event properties

### DIFF
--- a/.changeset/serialize-exception-error-properties.md
+++ b/.changeset/serialize-exception-error-properties.md
@@ -1,0 +1,6 @@
+---
+'@posthog/browser-common': patch
+'posthog-js': patch
+---
+
+Serialize Error names, messages, stacks, and custom enumerable properties in exception additional properties while preserving custom toJSON serialization.

--- a/.changeset/serialize-exception-error-properties.md
+++ b/.changeset/serialize-exception-error-properties.md
@@ -3,4 +3,4 @@
 'posthog-js': patch
 ---
 
-Serialize Error names, messages, stacks, and custom enumerable properties in exception additional properties while preserving custom toJSON serialization.
+Preserve Error details, causes, aggregate errors, and custom enumerable properties in event properties, including cross-realm Errors. Apply string truncation to ordinary capture properties and retain custom toJSON serialization for exception additional properties.

--- a/packages/browser-common/src/utils/general-utils.ts
+++ b/packages/browser-common/src/utils/general-utils.ts
@@ -1,4 +1,4 @@
-import { hasOwnProperty, isArray, isFormData, isNullish, isNumber, isString } from '@posthog/core'
+import { hasOwnProperty, isArray, isError, isFormData, isNullish, isNumber, isString } from '@posthog/core'
 import type { PostHogConfig, Properties } from '@posthog/types'
 
 import { logger } from './logger'
@@ -103,6 +103,20 @@ export const stripEmptyProperties = function (p: Properties): Properties {
     return ret
 }
 
+export function errorToProperties(error: Error & { cause?: unknown; errors?: unknown }): Record<string, unknown> {
+    const copy: Record<string, unknown> = { ...error }
+    for (const detail of ['name', 'message', 'stack', 'cause', 'errors'] as const) {
+        try {
+            if (detail in error) {
+                copy[detail] = error[detail]
+            }
+        } catch {
+            // An unreadable non-enumerable Error detail must not discard the rest of the event.
+        }
+    }
+    return copy
+}
+
 /**
  * Deep copies an object.
  * It handles cycles by replacing all references to them with `undefined`
@@ -132,7 +146,7 @@ function deepCircularCopy<T extends Record<string, any> = Record<string, any>>(
             })
         } else {
             const copy: Record<string, any> = {}
-            each(value, (val, key) => {
+            each(isError(value) ? errorToProperties(value) : value, (val, key) => {
                 if (!COPY_IN_PROGRESS_SET.has(val)) {
                     copy[key] = internalDeepCircularCopy(val, key)
                 }

--- a/packages/browser-common/src/utils/request-utils.ts
+++ b/packages/browser-common/src/utils/request-utils.ts
@@ -8,9 +8,34 @@ const localDomains = ['localhost', '127.0.0.1']
 
 export const jsonStringify = (data: any, space?: string | number): string => {
     try {
-        // Fast path: convert BigInts to strings, since plain JSON.stringify throws on them.
-        // See https://github.com/PostHog/posthog-js/issues/1440.
-        return JSON.stringify(data, (_, value) => (typeof value === 'bigint' ? value.toString() : value), space)
+        let errors: WeakMap<Error, Record<string, unknown>> | undefined
+        return JSON.stringify(
+            data,
+            (_, value) => {
+                // Native JSON.stringify invokes toJSON before this replacer, so custom serializers win.
+                if (value instanceof Error) {
+                    errors ??= new WeakMap()
+                    if (!errors.has(value)) {
+                        const copy: Record<string, unknown> = { ...value }
+                        for (const detail of ['name', 'message', 'stack'] as const) {
+                            try {
+                                copy[detail] = value[detail]
+                            } catch {
+                                // Non-enumerable Error details may be getters. An unreadable
+                                // detail must not discard an otherwise serializable request.
+                            }
+                        }
+                        errors.set(value, copy)
+                    }
+                    // Reuse copies so circular Errors reach the existing fallback instead of
+                    // creating a fresh object on every visit and overflowing the stack.
+                    return errors.get(value)
+                }
+                // Plain JSON.stringify throws on BigInts. See issue #1440.
+                return typeof value === 'bigint' ? value.toString() : value
+            },
+            space
+        )
     } catch {
         // A self-referential value — most commonly a DOM node that retains a React fiber pointing back
         // at the element — makes JSON.stringify throw "Converting circular structure to JSON". With

--- a/packages/browser-common/src/utils/request-utils.ts
+++ b/packages/browser-common/src/utils/request-utils.ts
@@ -1,6 +1,6 @@
-import { isArray, isFile, isUndefined, safeJsonStringify } from '@posthog/core'
+import { isArray, isError, isFile, isUndefined, safeJsonStringify } from '@posthog/core'
 
-import { each } from './general-utils'
+import { each, errorToProperties } from './general-utils'
 import { document, isBrowserOnline, location } from './globals'
 import { logger } from './logger'
 
@@ -13,19 +13,10 @@ export const jsonStringify = (data: any, space?: string | number): string => {
             data,
             (_, value) => {
                 // Native JSON.stringify invokes toJSON before this replacer, so custom serializers win.
-                if (value instanceof Error) {
+                if (isError(value)) {
                     errors ??= new WeakMap()
                     if (!errors.has(value)) {
-                        const copy: Record<string, unknown> = { ...value }
-                        for (const detail of ['name', 'message', 'stack'] as const) {
-                            try {
-                                copy[detail] = value[detail]
-                            } catch {
-                                // Non-enumerable Error details may be getters. An unreadable
-                                // detail must not discard an otherwise serializable request.
-                            }
-                        }
-                        errors.set(value, copy)
+                        errors.set(value, errorToProperties(value))
                     }
                     // Reuse copies so circular Errors reach the existing fallback instead of
                     // creating a fresh object on every visit and overflowing the stack.

--- a/packages/browser-common/tests/utils/general-utils.spec.ts
+++ b/packages/browser-common/tests/utils/general-utils.spec.ts
@@ -1,6 +1,84 @@
-import { extend, migrateConfigField, stripEmptyProperties } from '../../src/utils/general-utils'
+import { runInNewContext } from 'node:vm'
+import {
+    _copyAndTruncateStrings,
+    extend,
+    migrateConfigField,
+    stripEmptyProperties,
+} from '../../src/utils/general-utils'
 
 describe('general utils', () => {
+    describe('_copyAndTruncateStrings', () => {
+        it.each([
+            ['same-realm', () => new TypeError('long error message')],
+            ['cross-realm', () => runInNewContext('new TypeError("long error message")') as Error],
+        ])('preserves and truncates %s Error details without mutating inputs', (_realm, createError) => {
+            const error = Object.assign(createError(), { code: 'long custom code' })
+            const stack = error.stack
+
+            expect(_copyAndTruncateStrings({ nested: [{ error }] }, 10)).toEqual({
+                nested: [
+                    {
+                        error: {
+                            name: 'TypeError',
+                            message: 'long error',
+                            stack: stack?.slice(0, 10),
+                            code: 'long custo',
+                        },
+                    },
+                ],
+            })
+            expect(error.message).toBe('long error message')
+            expect(error.stack).toBe(stack)
+            expect(Object.keys(error)).toEqual(['code'])
+        })
+
+        it('preserves causes and aggregate errors while truncating nested strings', () => {
+            const cause = new Error('root cause')
+            const error = new AggregateError([new Error('nested error'), 'other reason'], 'aggregate', { cause })
+
+            expect(_copyAndTruncateStrings({ error }, 5)).toEqual({
+                error: {
+                    name: 'Aggre',
+                    message: 'aggre',
+                    stack: error.stack?.slice(0, 5),
+                    cause: { name: 'Error', message: 'root ', stack: cause.stack?.slice(0, 5) },
+                    errors: [{ name: 'Error', message: 'neste', stack: error.errors[0].stack.slice(0, 5) }, 'other'],
+                },
+            })
+        })
+
+        it('omits circular causes without dropping other Error details', () => {
+            const error = new Error('circular')
+            Object.defineProperty(error, 'cause', { value: error })
+
+            expect(_copyAndTruncateStrings({ error }, 1000)).toEqual({
+                error: { name: error.name, message: error.message, stack: error.stack?.slice(0, 1000) },
+            })
+        })
+
+        it.each(['name', 'message', 'stack', 'cause', 'errors'] as const)(
+            'omits an unreadable Error %s without discarding sibling properties',
+            (detail) => {
+                const error = Object.assign(new Error('additional'), { code: 'E_TEST' })
+                error.stack = 'safe stack'
+                const expected: Record<string, unknown> = {
+                    name: error.name,
+                    message: error.message,
+                    stack: error.stack,
+                    code: error.code,
+                }
+                delete expected[detail]
+                Object.defineProperty(error, detail, {
+                    get: () => {
+                        throw new Error('unreadable')
+                    },
+                })
+
+                expect(_copyAndTruncateStrings({ error, kept: true }, 100)).toEqual({ error: expected, kept: true })
+            }
+        )
+    })
+
     describe('extend', () => {
         it('overwrites existing values but preserves existing values when source is undefined', () => {
             expect(extend({ a: 1 }, { a: 2 })).toEqual({ a: 2 })

--- a/packages/browser-common/tests/utils/request-utils.spec.ts
+++ b/packages/browser-common/tests/utils/request-utils.spec.ts
@@ -12,6 +12,106 @@ describe('request utils', () => {
             expect(jsonStringify({ count: BigInt(42) })).toBe('{"count":"42"}')
         })
 
+        it('serializes Error details and enumerable custom fields, including shared references', () => {
+            const error = Object.assign(new TypeError('additional error'), { code: 'E_TEST', count: BigInt(42) })
+            const expected = {
+                name: error.name,
+                message: error.message,
+                stack: error.stack,
+                code: 'E_TEST',
+                count: '42',
+            }
+
+            expect(JSON.parse(jsonStringify({ error, nested: [error] }))).toEqual({
+                error: expected,
+                nested: [expected],
+            })
+            expect(Object.keys(error)).toEqual(['code', 'count'])
+        })
+
+        it.each(['name', 'message', 'stack'] as const)(
+            'omits an unreadable non-enumerable Error %s without discarding sibling properties',
+            (detail) => {
+                const error = Object.assign(new Error('additional'), { code: 'E_TEST' })
+                // Avoid lazy stack formatting reading name/message while testing each getter independently.
+                error.stack = 'safe stack'
+                const expected: Record<string, unknown> = {
+                    name: error.name,
+                    message: error.message,
+                    stack: error.stack,
+                    code: error.code,
+                }
+                delete expected[detail]
+                const getter = vi.fn(() => {
+                    throw new Error(`unreadable ${detail}`)
+                })
+                Object.defineProperty(error, detail, { enumerable: false, get: getter })
+
+                expect(JSON.parse(jsonStringify({ error, shared: error, kept: true }))).toEqual({
+                    error: expected,
+                    shared: expected,
+                    kept: true,
+                })
+                expect(getter).toHaveBeenCalledTimes(1)
+                expect(Object.getOwnPropertyDescriptor(error, detail)?.get).toBe(getter)
+            }
+        )
+
+        it('preserves ordinary JSON values and formatting', () => {
+            const value = {
+                date: new Date('2025-01-02T03:04:05.000Z'),
+                invalidDate: new Date(NaN),
+                array: [true, null, undefined, NaN, () => undefined, Symbol('test')],
+                nested: { value: 'kept', missing: undefined },
+            }
+            expect(jsonStringify(value, 2)).toBe(JSON.stringify(value, null, 2))
+        })
+
+        it('preserves native toJSON semantics and formatting', () => {
+            class ErrorWithToJSON extends Error {
+                toJSON(key: string) {
+                    return { key, message: this.message }
+                }
+            }
+            const date = new Date('2025-01-02T03:04:05.000Z')
+            date.toJSON = () => 'custom date'
+            const value = { error: new ErrorWithToJSON('custom error'), date, nested: [true, null, undefined] }
+
+            expect(jsonStringify(value, 2)).toBe(JSON.stringify(value, null, 2))
+        })
+
+        it('retains the existing fallback for circular Errors without repeatedly copying them', () => {
+            const error = new Error('circular error')
+            const getSelf = vi.fn(() => error)
+            Object.defineProperty(error, 'self', { enumerable: true, get: getSelf })
+
+            expect(JSON.parse(jsonStringify({ error }))).toEqual({
+                error: { name: error.name, message: error.message, stack: error.stack },
+            })
+            expect(getSelf.mock.calls.length).toBeLessThanOrEqual(2)
+        })
+
+        it('keeps the existing fallback behavior for throwing getters and toJSON', () => {
+            const error = new Error('additional error')
+            Object.defineProperty(error, 'custom', {
+                enumerable: true,
+                get() {
+                    throw new Error('cannot read custom property')
+                },
+            })
+            // The existing circular-safe fallback can still serialize Error details.
+            expect(JSON.parse(jsonStringify({ error }))).toEqual({
+                error: { name: error.name, message: error.message, stack: error.stack },
+            })
+            expect(() =>
+                jsonStringify({
+                    toJSON() {
+                        throw new Error('cannot serialize')
+                    },
+                })
+            ).toThrow('cannot serialize')
+        })
+
         it('falls back to circular-safe serialization', () => {
             const value: Record<string, any> = { name: 'root' }
             value.self = value

--- a/packages/browser-common/tests/utils/request-utils.spec.ts
+++ b/packages/browser-common/tests/utils/request-utils.spec.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'node:vm'
 import {
     _getHashParam,
     formDataToQuery,
@@ -29,7 +30,42 @@ describe('request utils', () => {
             expect(Object.keys(error)).toEqual(['code', 'count'])
         })
 
-        it.each(['name', 'message', 'stack'] as const)(
+        it('serializes cross-realm Error details', () => {
+            const error = runInNewContext('new TypeError("iframe error")')
+            expect(error).not.toBeInstanceOf(Error)
+
+            expect(JSON.parse(jsonStringify({ error }))).toEqual({
+                error: { name: error.name, message: error.message, stack: error.stack },
+            })
+        })
+
+        it('serializes non-enumerable causes and aggregate errors recursively', () => {
+            const cause = new TypeError('root cause')
+            const error = new Error('outer', { cause })
+            const aggregate = new AggregateError([error, 'non-error reason'], 'aggregate', { cause: 'reason' })
+            expect(Object.getOwnPropertyDescriptor(error, 'cause')?.enumerable).toBe(false)
+            expect(Object.getOwnPropertyDescriptor(aggregate, 'errors')?.enumerable).toBe(false)
+
+            expect(JSON.parse(jsonStringify({ aggregate }))).toEqual({
+                aggregate: {
+                    name: aggregate.name,
+                    message: aggregate.message,
+                    stack: aggregate.stack,
+                    cause: 'reason',
+                    errors: [
+                        {
+                            name: error.name,
+                            message: error.message,
+                            stack: error.stack,
+                            cause: { name: cause.name, message: cause.message, stack: cause.stack },
+                        },
+                        'non-error reason',
+                    ],
+                },
+            })
+        })
+
+        it.each(['name', 'message', 'stack', 'cause', 'errors'] as const)(
             'omits an unreadable non-enumerable Error %s without discarding sibling properties',
             (detail) => {
                 const error = Object.assign(new Error('additional'), { code: 'E_TEST' })

--- a/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture.test.ts
@@ -4,7 +4,8 @@ import { uuidv7 } from '@posthog/browser-common/utils/uuidv7'
 import { PostHog } from '../../posthog-core'
 import { createPosthogInstance } from '../helpers/posthog-instance'
 import { EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE } from '../../constants'
-import { RemoteConfig } from '../../types'
+import { CaptureResult, RemoteConfig } from '../../types'
+import { jsonStringify } from '@posthog/browser-common/utils/request-utils'
 
 describe('ExceptionObserver', () => {
     let instance: PostHog
@@ -55,6 +56,105 @@ describe('ExceptionObserver', () => {
                 expect(sendExceptionEvent).not.toHaveBeenCalled()
             }
         )
+
+        function captureAdditionalProperties(additionalProperties: Record<string, unknown>) {
+            const beforeSend = vi.fn((_event: CaptureResult | null) => null)
+            instance.set_config({ before_send: beforeSend })
+            instance.captureException(new Error('original exception'), additionalProperties)
+            expect(beforeSend).toHaveBeenCalledTimes(1)
+            return JSON.parse(jsonStringify(beforeSend.mock.calls[0][0])).properties
+        }
+
+        it('serializes Date and custom toJSON additional properties on the wire', () => {
+            class ErrorWithToJSON extends Error {
+                toJSON() {
+                    return { name: 'custom error', message: this.message }
+                }
+            }
+            const customDate = new Date('2025-01-02T03:04:05.000Z')
+            customDate.toJSON = () => 'custom date'
+            const toJSON = vi.fn(function (this: { value: string }, key: string) {
+                return `${key}: ${this.value}`
+            })
+            const properties = {
+                date: new Date('2025-01-02T03:04:05.000Z'),
+                invalidDate: new Date(NaN),
+                customDate,
+                error: new ErrorWithToJSON('custom message'),
+                nested: [{ custom: { value: 'kept', toJSON } }],
+                ordinary: { name: 'justin', age: 101, pets: ['dog', 'cat'], enabled: true, missing: null },
+            }
+
+            expect(captureAdditionalProperties(properties)).toMatchObject({
+                date: '2025-01-02T03:04:05.000Z',
+                invalidDate: null,
+                customDate: 'custom date',
+                error: { name: 'custom error', message: 'custom message' },
+                nested: [{ custom: 'custom: kept' }],
+                ordinary: properties.ordinary,
+            })
+            expect(toJSON).toHaveBeenCalledTimes(1)
+        })
+
+        it('serializes Error additional properties without losing custom fields or mutating inputs', () => {
+            const error = Object.assign(new TypeError('additional error'), { code: 'E_TEST' })
+            const properties = { error, nested: [{ error }] }
+            const expected = { name: 'TypeError', message: error.message, stack: error.stack, code: 'E_TEST' }
+
+            expect(captureAdditionalProperties(properties)).toMatchObject({
+                error: expected,
+                nested: [{ error: expected }],
+            })
+            expect(properties.error).toBe(error)
+            expect(Object.keys(error)).toEqual(['code'])
+        })
+
+        it('keeps additional properties available for before_send mutation before calling toJSON', () => {
+            const toJSON = vi.fn(function (this: { message: string }) {
+                return { message: this.message }
+            })
+            const error = Object.assign(new Error('original message'), { toJSON })
+            const beforeSend = vi.fn((event: CaptureResult | null) => {
+                expect(toJSON).not.toHaveBeenCalled()
+                expect(event!.properties.error).toBe(error)
+                event!.properties.error.message = 'updated message'
+                return null
+            })
+            instance.set_config({ before_send: beforeSend })
+            instance.captureException(new Error('original exception'), { error })
+
+            expect(beforeSend).toHaveBeenCalledTimes(1)
+            expect(JSON.parse(jsonStringify(beforeSend.mock.calls[0][0])).properties.error).toEqual({
+                message: 'updated message',
+            })
+            expect(toJSON).toHaveBeenCalledTimes(1)
+        })
+
+        it('contains serialization failures without re-entering exception capture', () => {
+            const toJSON = vi.fn(() => {
+                throw new Error('cannot serialize')
+            })
+            const beforeSend = vi.fn((event: CaptureResult | null) => {
+                jsonStringify(event)
+                return null
+            })
+            instance.set_config({ before_send: beforeSend })
+
+            expect(() =>
+                instance.captureException(new Error('original exception'), { value: { toJSON } })
+            ).not.toThrow()
+            expect(beforeSend).toHaveBeenCalledTimes(1)
+        })
+
+        it('preserves circular-reference handling and shared additional properties', () => {
+            const shared = { name: 'shared' }
+            const circular: Record<string, unknown> = { first: shared, second: shared }
+            circular.self = circular
+
+            expect(captureAdditionalProperties({ circular })).toMatchObject({
+                circular: { first: shared, second: shared, self: '[Circular]' },
+            })
+        })
 
         it('swallows errors while building a manually captured exception', () => {
             vi.spyOn(instance.exceptions, 'buildProperties').mockImplementation(() => {

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -916,6 +916,65 @@ describe('request', () => {
                 )
             })
 
+            it.each(['name', 'message', 'stack'] as const)(
+                'sends the full batch when an additional Error has an unreadable %s',
+                (detail) => {
+                    const error = Object.assign(new Error('additional'), { code: 'E_TEST' })
+                    error.stack = 'safe stack'
+                    const expected: Record<string, unknown> = {
+                        name: error.name,
+                        message: error.message,
+                        stack: error.stack,
+                        code: error.code,
+                    }
+                    delete expected[detail]
+                    Object.defineProperty(error, detail, {
+                        enumerable: false,
+                        get() {
+                            throw new Error(`unreadable ${detail}`)
+                        },
+                    })
+
+                    request(
+                        createRequest({
+                            method: 'POST',
+                            data: [
+                                { event: '$exception', properties: { error, kept: true } },
+                                { event: 'sibling event', properties: { kept: true } },
+                            ],
+                        })
+                    )
+
+                    expect(mockedXHR.send).toHaveBeenCalledTimes(1)
+                    expect(JSON.parse(mockedXHR.send.mock.calls[0][0])).toEqual([
+                        { event: '$exception', properties: { error: expected, kept: true } },
+                        { event: 'sibling event', properties: { kept: true } },
+                    ])
+                    expect(mockCallback).not.toHaveBeenCalled()
+                }
+            )
+
+            it('sends sibling events when a circular Error uses the existing safe fallback', () => {
+                const error = new Error('circular error')
+                Object.assign(error, { self: error })
+
+                request(
+                    createRequest({
+                        method: 'POST',
+                        data: [{ event: '$exception', properties: { error } }, { event: 'sibling event' }],
+                    })
+                )
+
+                expect(mockedXHR.send).toHaveBeenCalledTimes(1)
+                expect(JSON.parse(mockedXHR.send.mock.calls[0][0])).toEqual([
+                    {
+                        event: '$exception',
+                        properties: { error: { name: error.name, message: error.message, stack: error.stack } },
+                    },
+                    { event: 'sibling event' },
+                ])
+            })
+
             it('converts bigint properties to string without throwing', () => {
                 request(
                     createRequest({

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -1,6 +1,8 @@
 /// <reference lib="dom" />
 
 import { TextDecoder } from 'util'
+import { runInNewContext } from 'node:vm'
+import { createPosthogInstance } from './helpers/posthog-instance'
 import * as fflate from 'fflate'
 import { extendURLParams, request } from '../request'
 import { Compression, RequestWithOptions } from '../types'
@@ -104,6 +106,55 @@ describe('request', () => {
         beforeEach(() => {
             transport = 'XHR'
         })
+        it.each(['same-realm', 'cross-realm'])(
+            'preserves %s Error properties in an ordinary capture request',
+            async (realm) => {
+                const instance = await createPosthogInstance(uuidv7(), {
+                    api_transport: 'XHR',
+                    disable_compression: true,
+                    capture_pageview: false,
+                    before_send: (event) => event,
+                    properties_string_max_length: 20,
+                })
+                mockedXHR.send.mockClear()
+                const cause =
+                    realm === 'cross-realm'
+                        ? (runInNewContext('new TypeError("a long root cause message to truncate")') as Error)
+                        : new TypeError('a long root cause message to truncate')
+                const error = Object.assign(
+                    new AggregateError([cause, 'other reason'], 'aggregate', { cause: 'root reason' }),
+                    { code: 'E_TEST' }
+                )
+                const expectedCause = {
+                    name: cause.name,
+                    message: cause.message.slice(0, 20),
+                    stack: cause.stack?.slice(0, 20),
+                }
+
+                instance.capture('ordinary event', { nested: [{ error }] })
+
+                expect(mockedXHR.send).toHaveBeenCalledTimes(1)
+                const {
+                    batch: [body],
+                } = JSON.parse((mockedXHR.send.mock.calls[0] as unknown[])[0] as string)
+                expect(body.event).toBe('ordinary event')
+                expect(body.properties.nested).toEqual([
+                    {
+                        error: {
+                            name: error.name,
+                            message: error.message,
+                            stack: error.stack?.slice(0, 20),
+                            code: 'E_TEST',
+                            cause: 'root reason',
+                            errors: [expectedCause, 'other reason'],
+                        },
+                    },
+                ])
+                expect(cause.message).toBe('a long root cause message to truncate')
+                expect(Object.keys(error)).toEqual(['code'])
+            }
+        )
+
         it('performs the request with default params', () => {
             request(
                 createRequest({


### PR DESCRIPTION
## Problem

Error values in event properties lose their name, message, and stack during JSON serialization. This also affects additional properties passed to `captureException`.

Related to https://github.com/PostHog/posthog-js/issues/1977. Date values and custom `toJSON` methods already work on the current base.

## Changes

Include Error details and enumerable custom fields without mutating the original Error. Skip unreadable non-enumerable details so a throwing getter does not discard the request batch. Reuse Error copies so circular references still reach the existing fallback.

Keep native Date and custom `toJSON` behavior, BigInt conversion, and `before_send` timing unchanged. Add utility, exception-property, and request-batch regression tests.

### Validation

- Reproduction-first tests cover missing Error details and throwing detail getters. Both failed before their fixes and passed afterward.
- 100 browser-common tests and 516 focused browser tests pass.
- Browser-common and browser builds, browser source typecheck, targeted lint/format checks, and ES5 compatibility check pass.
- Exact-HEAD branch autoreview passed at `298852763ebcb4db80490f3cec1c8026447e7ca4` with no findings.
- Browser test-project typechecking remains blocked by TS2688 for `dompurify` and `dotenv`. Clean-base equivalence was not verified. No dependency or configuration workaround was added.
- Existing circular-fallback limitations remain unchanged, including circular payloads combined with inaccessible Error details. No live-browser or full-monorepo test run was performed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

The existing patch changeset is included. No duplicate changeset was created during publication.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the fix and ran tests using shell tools, Git, pnpm, and GitHub CLI. Independent source review identified an unreadable-getter regression, which was reproduced and fixed before publication. Pi autoreview checked the final committed branch. The local session has no shareable URL.

The change stays in browser-common request serialization rather than changing exception capture timing or the shared core fallback. Human review is required.
