### PR TITLE
fix: wait for initial remote config before autocapture

### DIFF
--- a/.changeset/fresh-autocapture-config.md
+++ b/.changeset/fresh-autocapture-config.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Wait for the initial remote config outcome before using cached autocapture enablement, so a newly disabled project does not capture events while its settings load. Disabled remote requests retain local startup behavior, and failed or incomplete responses retain the cached fallback.

--- a/packages/browser/src/__tests__/remote-config.test.ts
+++ b/packages/browser/src/__tests__/remote-config.test.ts
@@ -11,7 +11,11 @@ import { createLogger } from '@posthog/browser-common/utils/logger'
 import { RemoteConfigLoader } from '../remote-config'
 import { RequestRouter } from '../utils/request-router'
 import { PostHog } from '../posthog-core'
-import { PostHogConfig, RemoteConfig } from '../types'
+import { PostHogConfig, RemoteConfig, RemoteConfigResult } from '../types'
+import type { Client } from '@posthog/browser-common'
+import type { RequestResponse } from '@posthog/types'
+import { Autocapture } from '../autocapture'
+import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from '../constants'
 import '../entrypoints/external-scripts-loader'
 import { assignableWindow } from '../utils/globals'
 import { createMockPostHog } from './helpers/posthog-instance'
@@ -51,6 +55,127 @@ describe('RemoteConfigLoader', () => {
 
     afterEach(() => {
         vi.useRealTimers()
+    })
+
+    describe('autocapture with cached remote config', () => {
+        let autocapture: Autocapture
+        let capture: ReturnType<typeof vi.fn>
+        let button: HTMLButtonElement
+        let completeRequest: (response: RequestResponse) => void
+        let cachedOptOut: boolean | undefined
+
+        beforeEach(() => {
+            cachedOptOut = false
+            capture = vi.fn()
+            button = document.createElement('button')
+            document.body.appendChild(button)
+            assignableWindow._POSTHOG_REMOTE_CONFIG = undefined
+            assignableWindow.__PosthogExtensions__.loadExternalDependency = vi.fn((_ph, _name, cb) => cb())
+            posthog.config.autocapture = true
+            posthog._send_request = vi.fn(({ callback }) => {
+                completeRequest = callback!
+            })
+            autocapture = new Autocapture({
+                refresh: (config) => {
+                    config.enabled = !!posthog.config.autocapture
+                    config.remoteRequestsDisabled = posthog._shouldDisableFlags()
+                },
+            })
+            autocapture.setup({
+                capture,
+                kv: {
+                    get: (key: string) => (key === AUTOCAPTURE_DISABLED_SERVER_SIDE ? cachedOptOut : undefined),
+                    set: (_key: string, value: boolean) => {
+                        cachedOptOut = value
+                    },
+                },
+                onRemoteConfig: (handler: (result: RemoteConfigResult) => void) => {
+                    posthog._onRemoteConfig = handler
+                    return { dispose: vi.fn() }
+                },
+            } as unknown as Client)
+        })
+
+        afterEach(() => {
+            autocapture.dispose()
+            assignableWindow._POSTHOG_REMOTE_CONFIG = undefined
+        })
+
+        it.each([
+            ['enabled', { statusCode: 200, json: { autocapture_opt_out: false } }, true],
+            ['disabled', { statusCode: 200, json: { autocapture_opt_out: true } }, false],
+            ['missing opt-out', { statusCode: 200, json: {} }, true],
+            ['unavailable config', { statusCode: 200 }, true],
+            ['network error', { statusCode: 0, error: new TypeError('Failed to fetch') }, true],
+            ['timeout', { statusCode: 0, error: new DOMException('Timed out', 'AbortError') }, true],
+        ])('waits for the initial %s outcome before using cached enablement', (_name, response, enabled) => {
+            new RemoteConfigLoader(posthog).load()
+            button.click()
+            expect(capture).not.toHaveBeenCalled()
+            expect(autocapture.isEnabled).toBe(false)
+
+            completeRequest(response)
+            expect(autocapture.isEnabled).toBe(enabled)
+            expect(capture).not.toHaveBeenCalled() // Do not replay clicks from before the config outcome.
+            button.click()
+            expect(capture).toHaveBeenCalledTimes(enabled ? 1 : 0)
+        })
+
+        it.each([true, false, undefined])('preserves cached opt-out %s when requests are disabled', (optOut) => {
+            cachedOptOut = optOut
+            posthog.config.advanced_disable_flags = true
+            autocapture.startIfEnabled()
+
+            new RemoteConfigLoader(posthog).load()
+            button.click()
+
+            expect(posthog._send_request).not.toHaveBeenCalled()
+            expect(capture).toHaveBeenCalledTimes(optOut === true ? 0 : 1)
+        })
+
+        it.each([true, false])('applies preloaded opt-out %s synchronously', (optOut) => {
+            assignableWindow._POSTHOG_REMOTE_CONFIG = {
+                [posthog.config.token]: { config: { autocapture_opt_out: optOut }, siteApps: [] },
+            }
+
+            new RemoteConfigLoader(posthog).load()
+            button.click()
+
+            expect(posthog._send_request).not.toHaveBeenCalled()
+            expect(assignableWindow.__PosthogExtensions__.loadExternalDependency).not.toHaveBeenCalled()
+            expect(capture).toHaveBeenCalledTimes(optOut ? 0 : 1)
+        })
+
+        it.each([true, false])('preserves local opt-out with remote opt-out %s', (optOut) => {
+            posthog.config.autocapture = false
+            new RemoteConfigLoader(posthog).load()
+            button.click()
+            completeRequest({ statusCode: 200, json: { autocapture_opt_out: optOut } })
+            button.click()
+
+            expect(autocapture.isEnabled).toBe(false)
+            expect(capture).not.toHaveBeenCalled()
+        })
+
+        it('uses subsequent config outcomes without re-gating or duplicating listeners', () => {
+            const loader = new RemoteConfigLoader(posthog)
+            loader.load()
+            completeRequest({ statusCode: 200, json: { autocapture_opt_out: false } })
+            button.click()
+            expect(capture).toHaveBeenCalledTimes(1)
+
+            loader.load()
+            button.click()
+            expect(capture).toHaveBeenCalledTimes(2)
+            completeRequest({ statusCode: 200, json: { autocapture_opt_out: true } })
+            button.click()
+            expect(capture).toHaveBeenCalledTimes(2)
+
+            loader.load()
+            completeRequest({ statusCode: 200, json: { autocapture_opt_out: false } })
+            button.click()
+            expect(capture).toHaveBeenCalledTimes(3)
+        })
     })
 
     describe('remote config', () => {

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -459,9 +459,15 @@ export class Autocapture implements Extension {
         const persistedServerDisabled = this._client?.kv.get<boolean>(AUTOCAPTURE_DISABLED_SERVER_SIDE)
         const memoryDisabled = this._isDisabledServerSide
 
+        const config = this._refreshConfig()
+        // Cached enablement may be stale. Wait for the initial config outcome unless
+        // remote requests are disabled; failures still use the last known server value.
+        if (!config.remoteRequestsDisabled && !this._hasReceivedConfigResponse) {
+            return false
+        }
+
         // The /flags-disabled bypass only applies while no config outcome has arrived;
         // once a response (or failure) has been seen, an unknown opt-out stays off.
-        const config = this._refreshConfig()
         const clientConfigOnly = config.remoteRequestsDisabled && !this._hasReceivedConfigResponse
         if (isNull(memoryDisabled) && !isBoolean(persistedServerDisabled) && !clientConfigOnly) {
             // We only enable if we know that the server has not disabled it


### PR DESCRIPTION
## Problem

Returning visitors can send autocapture events using cached enablement while the SDK loads fresh settings, even after a project remotely disables autocapture.

Addresses https://github.com/PostHog/posthog-js/issues/2097. The broader Next.js SSR integration request is outside this fix.

## Changes

Wait for the initial remote-config outcome before using cached autocapture enablement. Clicks during that wait are dropped, not buffered. Keep explicit local opt-out, synchronous preloaded config, and startup with remote requests disabled unchanged. Failed or incomplete responses still use the cached fallback, so this does not guarantee fresh settings without connectivity.

Add 14 regression cases covering these paths and later remote disable/re-enable. Include the existing posthog-js patch changeset.

### Validation

- Reproduction before the fix: six tests fail because clicks are captured before the config callback.
- Node 24.20.0 and pnpm 11.7.0: 743 tests pass across 12 related suites, with one existing skip. Source typecheck, focused lint, formatting, and commit hooks pass.
- The implementation build passed with all 12 outer tasks executed. Nested rrweb prepublish tasks still used cached results.
- Browser test-project typecheck is blocked by TS2688 for the existing dompurify/dotenv type-definition setup. No dependency or configuration workaround is included.
- No real-browser/Next.js SSR end-to-end or full monorepo run.
- Exact-HEAD branch autoreview passed at `3d1d6e1f10733e3bf06f9802a61dc1eba79dcdf0` against `origin/main`, with no actionable findings.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Included the existing changeset file (not regenerated).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented and reviewed the user-directed fix. Tools included Git, pnpm/Vitest, TypeScript, Oxlint/Oxfmt, GitHub CLI, and isolated Pi autoreview. The existing config lifecycle was reused instead of adding buffering, timers, or an SSR API. Human review is required. No shareable session URL is available.
