### PR TITLE
feat(browser): capture best-effort webview app attribution

### DIFF
--- a/.changeset/tidy-webview-app-attribution.md
+++ b/.changeset/tidy-webview-app-attribution.md
@@ -1,0 +1,8 @@
+---
+'@posthog/core': minor
+'@posthog/browser-common': minor
+'posthog-js': minor
+'posthog-js-lite': minor
+---
+
+Add best-effort in-app browser attribution using `$webview_app` and `$webview_app_version`, without changing existing `$browser` or `$browser_version` values. Detect explicit user-agent markers for Facebook, Facebook Lite, Messenger, Instagram, Threads, LinkedIn, Twitter, TikTok, WhatsApp, Snapchat, WeChat, LINE, Google, Bing, Pinterest, Naver, and KakaoTalk. Unknown apps and versions are omitted; missing markers do not imply a standalone browser.

--- a/packages/browser-common/src/utils/event-utils.ts
+++ b/packages/browser-common/src/utils/event-utils.ts
@@ -6,7 +6,14 @@ import { SDK_DIST_CHANNEL } from '../constants'
 import { each, extend, stripEmptyProperties } from './general-utils'
 import { document, location, userAgent, window } from './globals'
 import type { BrowserDetectionHints, BrowserDetectionOptions } from '@posthog/core'
-import { detectBrowser, detectBrowserVersion, detectDevice, detectDeviceType, detectOS } from '@posthog/core'
+import {
+    detectBrowser,
+    detectBrowserVersion,
+    detectDevice,
+    detectDeviceType,
+    detectOS,
+    detectWebviewApp,
+} from '@posthog/core'
 import { getCookieValue } from './cookie-utils'
 
 const URL_REGEX_PREFIX = 'https?://(.*)'
@@ -297,6 +304,7 @@ export function getEventProperties(
         ? [...PERSONAL_DATA_CAMPAIGN_PARAMS, ...(customPersonalDataProperties || [])]
         : []
     const [os_name, os_version] = detectOS(userAgent)
+    const [webviewApp, webviewAppVersion] = detectWebviewApp(userAgent)
     const browserHints = getBrowserDetectionHints()
     const browserOptions: BrowserDetectionOptions = {}
     if (!isUndefined(detectGoogleSearchApp)) {
@@ -332,6 +340,8 @@ export function getEventProperties(
             $os: os_name,
             $os_version: os_version,
             $browser: detectBrowser(userAgent, navigator.vendor, browserHints, browserOptions),
+            $webview_app: webviewApp,
+            $webview_app_version: webviewAppVersion,
             $device: detectDevice(userAgent),
             $device_type: detectDeviceType(userAgent, deviceOptions),
             $timezone: getTimezone(),

--- a/packages/browser/src/__tests__/utils/event-utils.test.ts
+++ b/packages/browser/src/__tests__/utils/event-utils.test.ts
@@ -68,6 +68,48 @@ describe(`event-utils`, () => {
         })
     })
 
+    describe('webview app properties', () => {
+        const androidUA =
+            'Mozilla/5.0 (Linux; Android 13; Pixel 7; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.6099.230 Mobile Safari/537.36'
+
+        const iosUA =
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+
+        it.each([
+            [androidUA + ' LinkedInApp/2.295.106', 'LinkedIn', '2.295.106', undefined, 'Chrome', 120],
+            [androidUA + ' [LinkedInApp]', 'LinkedIn', undefined, undefined, 'Chrome', 120],
+            [androidUA + ' [FBAN/FB4A;FBAV/440.0.0;]', 'Facebook', '440.0.0', undefined, 'Chrome', 120],
+            [iosUA + ' [FBIOS;FBAV/440.0.0;]', 'Facebook', '440.0.0', undefined, 'Facebook Mobile', null],
+            [androidUA + ' GSA/315.0.1', 'Google', '315.0.1', false, 'Chrome', 120],
+            [androidUA + ' GSA/315.0.1', 'Google', '315.0.1', true, 'Google Search App', 315],
+            [androidUA + ' musical_ly_2022803040 app_version/28.3.4', 'TikTok', '28.3.4', undefined, 'Chrome', 120],
+            [androidUA + ' musical_ly_2022803040', 'TikTok', undefined, undefined, 'Chrome', 120],
+            [androidUA + ' WA4A/2.26.30.97', 'WhatsApp', '2.26.30.97', undefined, 'Chrome', 120],
+            [androidUA + ' [FBAN/Orca-Android;FBAV/440.0.0;]', 'Messenger', '440.0.0', undefined, 'Chrome', 120],
+        ])(
+            'adds app properties for %s without changing browser attribution',
+            (ua, app, version, gsa, browser, browserVersion) => {
+                vi.spyOn(globals, 'userAgent', 'get').mockReturnValue(ua)
+                const properties = getEventProperties(false, undefined, gsa)
+                expect(properties['$webview_app']).toBe(app)
+                if (version) {
+                    expect(properties['$webview_app_version']).toBe(version)
+                } else {
+                    expect(properties).not.toHaveProperty('$webview_app_version')
+                }
+                expect(properties['$browser']).toBe(browser)
+                expect(properties['$browser_version']).toBe(browserVersion)
+            }
+        )
+
+        it.each([androidUA, androidUA.replace('; wv', ''), ''])('omits unknown app properties for %s', (ua) => {
+            vi.spyOn(globals, 'userAgent', 'get').mockReturnValue(ua)
+            const properties = getEventProperties()
+            expect(properties).not.toHaveProperty('$webview_app')
+            expect(properties).not.toHaveProperty('$webview_app_version')
+        })
+    })
+
     describe('tablet detection via supplementary signals', () => {
         const androidTabletDesktopUA =
             'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36'

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -12,6 +12,7 @@ export * from './type-utils'
 export * from './promise-queue'
 export * from './logger'
 export * from './user-agent-utils'
+export * from './webview-app-utils'
 
 export const STRING_FORMAT = 'utf8'
 

--- a/packages/core/src/utils/webview-app-utils.spec.ts
+++ b/packages/core/src/utils/webview-app-utils.spec.ts
@@ -1,0 +1,118 @@
+import { detectWebviewApp } from './webview-app-utils'
+
+const androidUA =
+  'Mozilla/5.0 (Linux; Android 13; Pixel 7 Build/TQ3A.230805.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.6099.230 Mobile Safari/537.36'
+const iosUA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+
+describe('detectWebviewApp', () => {
+  test.each([
+    ['Facebook iOS', iosUA + ' [FBIOS;FBAV/440.0.0.35.117;]', 'Facebook', '440.0.0.35.117'],
+    ['Facebook Android', androidUA + ' [FBAN/FB4A;FBAV/440.0.0.35.117;]', 'Facebook', '440.0.0.35.117'],
+    ['Facebook IAB', androidUA + ' [FB_IAB/FB4A;FBAV/440.0.0.35.117;]', 'Facebook', '440.0.0.35.117'],
+    ['Instagram iOS', iosUA + ' Instagram 300.0.0.17.109 (iPhone14,5; iOS 17_1; en_US)', 'Instagram', '300.0.0.17.109'],
+    [
+      'Instagram Android',
+      androidUA + ' Instagram 300.0.0.17.109 Android (33/13; 420dpi)',
+      'Instagram',
+      '300.0.0.17.109',
+    ],
+    ['LinkedIn iOS', iosUA + ' [LinkedInApp]', 'LinkedIn', ''],
+    ['LinkedIn Android', androidUA + ' LinkedInApp/2.295.106', 'LinkedIn', '2.295.106'],
+    ['LinkedIn bracketed version', iosUA + ' [LinkedInApp]/2.295.106', 'LinkedIn', '2.295.106'],
+    ['Twitter', iosUA + ' Twitter for iPhone/10.1', 'Twitter', '10.1'],
+    ['TikTok', iosUA + ' musical_ly_35.1.0', 'TikTok', '35.1.0'],
+    ['WeChat', androidUA + ' MicroMessenger/8.0.40.2420', 'WeChat', '8.0.40.2420'],
+    ['LINE', iosUA + ' Line/14.1.0', 'Line', '14.1.0'],
+    ['Google iOS', iosUA + ' GSA/315.0.630435', 'Google', '315.0.630435'],
+    ['Google Android', androidUA + ' GSA/15.1.2.28.arm64', 'Google', '15.1.2.28'],
+    ['Pinterest iOS', iosUA + ' [Pinterest/iOS]', 'Pinterest', ''],
+    ['Pinterest Android', androidUA + ' [Pinterest/Android]', 'Pinterest', ''],
+    ['Facebook without version', iosUA + ' [FBIOS]', 'Facebook', ''],
+    ['Instagram without version', iosUA + ' Instagram', 'Instagram', ''],
+    [
+      'Instagram with Facebook markers',
+      iosUA + ' Instagram 300.0.0 [FBAN/Instagram;FBAV/1.0;]',
+      'Instagram',
+      '300.0.0',
+    ],
+    ['Facebook malformed version', iosUA + ' [FBIOS;FBAV/unknown;]', 'Facebook', ''],
+  ])('detects %s', (_name, userAgent, app, version) => {
+    expect(detectWebviewApp(userAgent)).toEqual([app, version])
+  })
+
+  // Marker/version combinations from upstream fixtures, using the common browser
+  // prefixes above. These are UA facts, not imported parser rules or dependencies:
+  // https://github.com/faisalman/ua-parser-js/blob/61515039822d0a451837e7871537562b8f9804cb/test/data/ua/browser/browser-all.json
+  // https://github.com/matomo-org/device-detector/blob/5a6f5d0184b5a867c1db9c0733f6b89686c5c47b/regexes/client/mobile_apps.yml
+  test.each([
+    ['TikTok trill iOS', iosUA + ' trill_43.0.0 BytedanceWebview/d8a21c6', 'TikTok', '43.0.0'],
+    [
+      'TikTok build number',
+      androidUA + ' musical_ly_2022803040 AppName/musical_ly app_version/28.3.4',
+      'TikTok',
+      '28.3.4',
+    ],
+    [
+      'TikTok trill build number',
+      androidUA + ' trill_2022109040 AppName/musical_ly app_version/21.9.4',
+      'TikTok',
+      '21.9.4',
+    ],
+    ['TikTok trill app name', androidUA + ' AppName/trill app_version/21.9.4', 'TikTok', '21.9.4'],
+    ['TikTok explicit version wins', androidUA + ' musical_ly_28.0.0 app_version/28.3.4', 'TikTok', '28.3.4'],
+    ['TikTok build only', androidUA + ' musical_ly_2022803040', 'TikTok', ''],
+    ['TikTok malformed explicit version', iosUA + ' trill_43.0.0 app_version/unknown', 'TikTok', '43.0.0'],
+    ['Twitter Android', androidUA + ' TwitterAndroid', 'Twitter', ''],
+    ['Twitter Android version', androidUA + ' TwitterAndroid/10.34', 'Twitter', '10.34'],
+    ['WhatsApp Android', androidUA + ' WA4A/2.26.30.97', 'WhatsApp', '2.26.30.97'],
+    ['WhatsApp iOS', iosUA + ' [WAiOS/2.26.31]', 'WhatsApp', '2.26.31'],
+    ['Snapchat', iosUA + ' Snapchat/12.33.0.36 (like Safari/8614.1.25.0.31, panda)', 'Snapchat', '12.33.0.36'],
+    ['Bing iOS', iosUA + ' BingSapphire/31.8.430522001', 'Bing', '31.8.430522001'],
+    ['Bing Android', androidUA + ' BingWeb/6.9.12', 'Bing', '6.9.12'],
+    ['Messenger iOS', iosUA + ' [FBAN/MessengerForiOS;FBAV/132.0.0.41.90;]', 'Messenger', '132.0.0.41.90'],
+    ['Messenger Android', androidUA + ' [FBAN/Orca-Android;FBAV/440.0.0;]', 'Messenger', '440.0.0'],
+    ['Messenger Android IAB', androidUA + ' [FB_IAB/Orca-Android;FBAV/440.0.0;]', 'Messenger', '440.0.0'],
+    ['Messenger before Facebook', iosUA + ' [FBIOS;FBAN/MessengerForiOS;FBAV/132.0.0;]', 'Messenger', '132.0.0'],
+    ['Messenger without version', iosUA + ' [FBAN/MessengerForiOS;]', 'Messenger', ''],
+    ['Facebook Lite', androidUA + ' [FBAN/EMA;FBAV/440.0.0;]', 'Facebook Lite', '440.0.0'],
+    ['Threads', iosUA + ' Barcelona/300.0.0.17.109', 'Threads', '300.0.0.17.109'],
+    ['WeChat alternative', iosUA + ' WeChat/8.0.40', 'WeChat', '8.0.40'],
+    ['Pinterest iOS version', iosUA + ' Pinterest for iOS/7.11 (iPhone7,2; 12.1.4)', 'Pinterest', '7.11'],
+    ['Pinterest Android version', androidUA + ' Pinterest for Android/9.0.4 (K83CA; 9)', 'Pinterest', '9.0.4'],
+    ['Pinterest tablet version', androidUA + ' Pinterest for Android Tablet/9.0.4', 'Pinterest', '9.0.4'],
+    ['Pinterest version', iosUA + ' Pinterest/9.0.4', 'Pinterest', '9.0.4'],
+    ['Naver Android', androidUA + ' NAVER(inapp; search; 1010; 11.11.2)', 'Naver', '11.11.2'],
+    ['Naver iOS', iosUA + ' NAVER(inapp; search; 720; 10.25.0; 11PRO)', 'Naver', '10.25.0'],
+    ['KakaoTalk iOS', iosUA + ' BizWebView KAKAOTALK 9.7.6', 'KakaoTalk', '9.7.6'],
+    ['KakaoTalk Android build only', androidUA + ';KAKAOTALK 2409760', 'KakaoTalk', ''],
+    ['KakaoTalk slash version', iosUA + ' KakaoTalk/9.7.6', 'KakaoTalk', '9.7.6'],
+  ])('detects additional marker: %s', (_name, userAgent, app, version) => {
+    expect(detectWebviewApp(userAgent)).toEqual([app, version])
+  })
+
+  test.each([
+    '',
+    androidUA, // A generic WebView does not identify its host app.
+    iosUA,
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    iosUA + ' Version/17.1 Safari/604.1',
+    'Mozilla/5.0 (compatible; Pinterestbot/1.0; +http://www.pinterest.com/bot.html)',
+    'LinkedInBot/1.0',
+    'Twitterbot/1.0',
+    'facebookexternalhit/1.1',
+    'WhatsApp/2.26.31', // Generic WhatsApp UAs can be link-preview requests.
+    'bingbot/2.0',
+    androidUA + ' BytedanceWebview/d8a21c6', // Shared engine, not a TikTok app marker.
+    androidUA + ' app_version/28.3.4',
+    androidUA + ' NotSnapchat/1.0',
+    androidUA + ' NotWA4A/1.0',
+    androidUA + ' NotBingWeb/1.0',
+    androidUA + ' NAVER(inapp; naverdicapp; 1; 2.0)', // A different Naver app.
+    androidUA + ' WeChatShareExtensionNew/8.0.40',
+    androidUA + ' NotInstagram/1.0',
+    androidUA + ' NotLine/1.0',
+  ])('does not infer a host app from %s', (userAgent) => {
+    expect(detectWebviewApp(userAgent)).toEqual(['', ''])
+  })
+})

--- a/packages/core/src/utils/webview-app-utils.ts
+++ b/packages/core/src/utils/webview-app-utils.ts
@@ -1,0 +1,49 @@
+// App markers must be checked independently of browser detection: the host app
+// and the browser rendering its webview are separate dimensions.
+const facebookAppVersion = /\bFBAV\/(\d+(?:\.\d+)*)/i
+const webviewAppMatchers: [RegExp, string, RegExp?][] = [
+  [/\bInstagram(?:[ /](\d+(?:\.\d+)*))?\b/i, 'Instagram'],
+  [/\bBarcelona[ /](\d+(?:\.\d+)*)?/i, 'Threads'],
+  // Specific Meta apps must precede Facebook, which can share their markers.
+  [/\b(?:MessengerForiOS|(?:FBAN|FB_IAB)\/Orca-Android)\b/i, 'Messenger', facebookAppVersion],
+  [/\bFBAN\/EMA\b/i, 'Facebook Lite', facebookAppVersion],
+  [/\b(?:FBIOS|(?:FBAN|FB_IAB)\/(?:FB4A|FBIOS))\b/i, 'Facebook', facebookAppVersion],
+  [/\bLinkedInApp(?:\]?\/(\d+(?:\.\d+)*))?\b/i, 'LinkedIn'],
+  [/\bTwitter(?:Android| for (?:iPhone|iPad|Android))(?:\/(\d+(?:\.\d+)*))?\b/i, 'Twitter'],
+  // Android's musical_ly_/trill_ suffix can be a build number. Prefer the
+  // explicit app_version token, and only use a dotted suffix as a fallback.
+  [/\b(?:musical_ly|trill)(?:[_/](\d+\.\d+(?:\.\d+)*))?(?=\b|_)/i, 'TikTok', /\bapp_version\/(\d+(?:\.\d+)*)/i],
+  [/\b(?:MicroMessenger|WeChat)\/(\d+(?:\.\d+)*)?/i, 'WeChat'],
+  [/\bLine\/(\d+(?:\.\d+)*)?/i, 'Line'],
+  [/\bGSA\/(\d+(?:\.\d+)*)?/i, 'Google'],
+  [/\[Pinterest\/(?:iOS|Android)\b|\bPinterest(?: for (?:Android(?: Tablet)?|iOS))?\/(\d+(?:\.\d+)*)/i, 'Pinterest'],
+  // Generic WhatsApp/ UAs can be link previews, not an embedded browser.
+  [/\b(?:WA4A|WAiOS)\/(\d+(?:\.\d+)*)?/i, 'WhatsApp'],
+  [/\bSnapchat[ /](\d+(?:\.\d+)*)?/i, 'Snapchat'],
+  [/\bBing(?:Web|Sapphire)\/(\d+(?:\.\d+)*)?/i, 'Bing'],
+  [/\bNAVER\(inapp; search;/i, 'Naver', /\bNAVER\(inapp; search;[^;)]*; (\d+(?:\.\d+)*)/i],
+  // KakaoTalk also emits integer build identifiers, not dotted app versions.
+  [/\bKAKAOTALK[ /](\d+\.\d+(?:\.\d+)*)?/i, 'KakaoTalk'],
+]
+
+/**
+ * Best-effort detection of the app hosting a webview from explicit User-Agent
+ * markers. Some apps use the same UA as a standalone browser, so no match means
+ * unknown, not that this is definitely NOT an in-app browser. A generic Android
+ * `wv` marker alone cannot identify the host app. Never infer it from a referrer.
+ *
+ * Returns [app name, app version], using empty strings for unknown values. Only
+ * explicit app versions are returned, as strings to preserve all components;
+ * browser/OS versions are not substitutes for a missing app version.
+ */
+export function detectWebviewApp(userAgent: string): [string, string] {
+  for (let i = 0; i < webviewAppMatchers.length; i++) {
+    const [regex, name, versionRegex] = webviewAppMatchers[i]
+    const match = userAgent.match(regex)
+    if (match) {
+      const versionMatch = (versionRegex && userAgent.match(versionRegex)) || match
+      return [name, versionMatch?.[1] || '']
+    }
+  }
+  return ['', '']
+}

--- a/packages/web/src/context.ts
+++ b/packages/web/src/context.ts
@@ -1,4 +1,4 @@
-import { currentTimestamp, detectBrowser, detectBrowserVersion, stripUrlHash } from '@posthog/core'
+import { currentTimestamp, detectBrowser, detectBrowserVersion, detectWebviewApp, stripUrlHash } from '@posthog/core'
 import { version } from './version'
 
 export function getContext(window: Window | undefined, disableCaptureUrlHashes: boolean = false): any {
@@ -6,10 +6,13 @@ export function getContext(window: Window | undefined, disableCaptureUrlHashes: 
   if (window?.navigator) {
     const userAgent = window.navigator.userAgent
     const osValue = os(window)
+    const [webviewApp, webviewAppVersion] = detectWebviewApp(userAgent)
     context = {
       ...context,
       ...(osValue !== undefined && { $os: osValue }),
       $browser: detectBrowser(userAgent, window.navigator.vendor),
+      ...(webviewApp && { $webview_app: webviewApp }),
+      ...(webviewAppVersion && { $webview_app_version: webviewAppVersion }),
       $referrer: window.document.referrer,
       $referring_domain: referringDomain(window.document.referrer),
       $device: device(userAgent),

--- a/packages/web/test/context.spec.ts
+++ b/packages/web/test/context.spec.ts
@@ -10,6 +10,43 @@ const windowWithUserAgent = (userAgent: string): Window =>
   }) as Window
 
 describe('getContext', () => {
+  const chromeUA =
+    'Mozilla/5.0 (Linux; Android 13; Pixel 7; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.6099.230 Mobile Safari/537.36'
+
+  test.each([
+    ['LinkedInApp/2.295.106', 'LinkedIn', '2.295.106'],
+    ['musical_ly_2022803040 app_version/28.3.4', 'TikTok', '28.3.4'],
+    ['WA4A/2.26.30.97', 'WhatsApp', '2.26.30.97'],
+    ['[FBAN/Orca-Android;FBAV/440.0.0;]', 'Messenger', '440.0.0'],
+  ])('adds host app and full app version without replacing the browser: %s', (marker, app, version) => {
+    expect(getContext(windowWithUserAgent(chromeUA + ' ' + marker))).toEqual(
+      expect.objectContaining({
+        $browser: 'Chrome',
+        $browser_version: 120,
+        $webview_app: app,
+        $webview_app_version: version,
+      })
+    )
+  })
+
+  test('omits an unknown app version rather than using the browser version', () => {
+    const context = getContext(windowWithUserAgent(chromeUA + ' [LinkedInApp]'))
+    expect(context.$webview_app).toBe('LinkedIn')
+    expect(context).not.toHaveProperty('$webview_app_version')
+  })
+
+  test.each([chromeUA, chromeUA.replace('; wv', ''), ''])('omits unknown app properties for %s', (ua) => {
+    const context = getContext(windowWithUserAgent(ua))
+    expect(context).not.toHaveProperty('$webview_app')
+    expect(context).not.toHaveProperty('$webview_app_version')
+  })
+
+  test('does not require a browser environment', () => {
+    const context = getContext(undefined)
+    expect(context).not.toHaveProperty('$webview_app')
+    expect(context).not.toHaveProperty('$webview_app_version')
+  })
+
   test.each([
     {
       name: 'Claude desktop browser',


### PR DESCRIPTION
## Problem

Sites cannot reliably segment traffic opened inside apps such as LinkedIn, TikTok, or WhatsApp. Their embedded browsers often look like Chrome or Mobile Safari in `$browser`.

Related to https://github.com/PostHog/posthog/issues/83413. This follows the proposal to capture the host app as a separate dimension rather than replacing the browser name.

## Changes

- Add shared, best-effort detection of explicit user-agent markers and emit `$webview_app` and `$webview_app_version` from the browser and lite SDKs.
- Recognize Facebook, Facebook Lite, Messenger, Instagram, Threads, LinkedIn, Twitter, TikTok, WhatsApp, Snapchat, WeChat, LINE, Google, Bing, Pinterest, Naver, and KakaoTalk.
- Preserve existing `$browser` and `$browser_version` values, including the existing Facebook and Google special cases. Migrating those defaults and updating the CDP transformation or Web Analytics UI are outside this PR.
- Keep app versions as strings. Prefer TikTok's explicit `app_version` over its numeric build identifier. Keep Messenger separate from Facebook and avoid generic WhatsApp link-preview UAs.
- Omit unknown apps and versions. The code comment explains that missing markers do not prove a standalone browser, and a generic WebView marker does not identify its host app.

Marker coverage was checked against [UAParser.js fixtures](https://github.com/faisalman/ua-parser-js/blob/61515039822d0a451837e7871537562b8f9804cb/test/data/ua/browser/browser-all.json) and [Matomo's app rules](https://github.com/matomo-org/device-detector/blob/5a6f5d0184b5a867c1db9c0733f6b89686c5c47b/regexes/client/mobile_apps.yml). No parser dependency was added.

### Validation

- 801 tests passed across the detector, browser event properties, existing browser detection, and the full lite SDK suite.
- Checked 13 full upstream UA fixtures against the built detector.
- Core, browser-common, and lite builds passed. Changed-file lint, formatting, and `git diff --check` passed.
- Fast esbuild comparison against `origin/main` (`f8013ed4`): minified +1.29 KiB (+0.40%), gzip +0.52 KiB (+0.53%), Brotli +0.45 KiB (+0.55%). These are directional estimates, not production Rollup measurements.
- Autoreview passed on `f4e298805102078fdfa7e5256ac0d3d4ea650a82` with no actionable findings. No live mobile-app testing was performed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [x] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common
- [x] @posthog/core

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using file and shell tools, GitHub CLI, and the isolated autoreview helper. The human-directed scope was additive host-app attribution with documented best-effort limits. We kept browser reporting unchanged and used narrow app markers rather than introducing a general-purpose UA parser. Human review is required.
