### PR TITLE
fix: recheck blocked ancestors before emitting replay mutations

### DIFF
--- a/.changeset/blue-shadow-privacy.md
+++ b/.changeset/blue-shadow-privacy.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Prevent queued session recording mutations from capturing content beneath DOM or shadow ancestors that have become blocked.

--- a/packages/browser/playwright/mocked/session-recording/session-recording-blocked-shadow.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-blocked-shadow.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from '../utils/posthog-playwright-test-base'
+import { start, waitForSessionRecordingToStart } from '../utils/setup'
+
+for (const kind of ['light', 'shadow', 'nested-shadow'] as const) {
+    for (const blocking of ['class', 'selector'] as const) {
+        for (const moves of [0, 1, 2]) {
+            test(`does not emit ${kind} descendants when held moves block their ancestor by ${blocking} (${moves} held moves)`, async ({
+                page,
+                context,
+            }) => {
+                await start(
+                    {
+                        options: { session_recording: { compress_events: false } },
+                        flagsResponseOverrides: {
+                            sessionRecording: {
+                                endpoint: '/ses/',
+                                masking: {
+                                    maskAllInputs: true,
+                                    maskTextSelector: '.ph-mask',
+                                    blockSelector: blocking === 'selector' ? '[data-test-blocked]' : undefined,
+                                },
+                            },
+                            capturePerformance: false,
+                            autocapture_opt_out: true,
+                        },
+                        url: './playground/cypress/index.html',
+                    },
+                    page,
+                    context
+                )
+                await waitForSessionRecordingToStart(page)
+                await page.locator('[data-cy-input]').fill('activate recording')
+                const { rootId, textId } = await page.evaluate((kind) => {
+                    const record = (window as any).__PosthogExtensions__.rrweb.record
+                    const origin = document.createElement('section')
+                    const destination = document.createElement('section')
+                    const root = document.createElement('div')
+                    root.setAttribute('data-held-phase', 'initial')
+                    let content: Element | ShadowRoot = root
+                    for (let level = 0; level < (kind === 'nested-shadow' ? 2 : kind === 'shadow' ? 1 : 0); level++) {
+                        const host = document.createElement('div')
+                        content.append(host)
+                        content = host.attachShadow({ mode: 'open' })
+                    }
+                    const span = document.createElement('span')
+                    const text = document.createTextNode('PUBLIC_BEFORE_HELD_MOVE')
+                    span.append(text)
+                    content.append(span)
+                    origin.append(root)
+                    document.body.append(origin, destination)
+                    record.takeFullSnapshot()
+                    ;(window as any).__heldShadowTest = { record, origin, destination, root, text, span, content }
+                    return { rootId: record.mirror.getId(root), textId: record.mirror.getId(text) }
+                }, kind)
+                expect(rootId).toBeGreaterThan(0)
+                expect(textId).toBeGreaterThan(0)
+
+                const events = async () =>
+                    (await page.capturedEvents())
+                        .filter((event) => event.event === '$snapshot')
+                        .flatMap((event) => event.properties['$snapshot_data'])
+                await expect.poll(async () => JSON.stringify(await events())).toContain('PUBLIC_BEFORE_HELD_MOVE')
+
+                await page.evaluate(
+                    async ({ blocking, moves }) => {
+                        const { record, origin, destination, root, text } = (window as any).__heldShadowTest
+                        const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
+                        const assertHeld = () => {
+                            if (record.mirror.getMeta(root).attributes['data-held-phase'] !== 'initial') {
+                                throw new Error('Recording unexpectedly flushed before the held-move checkpoint')
+                            }
+                        }
+                        record.freezePage()
+                        root.setAttribute('data-held-phase', 'held')
+                        if (moves > 0) destination.append(root)
+                        await settle()
+                        assertHeld()
+                        if (blocking === 'class') root.classList.add('ph-no-capture')
+                        else root.setAttribute('data-test-blocked', '')
+                        text.data = 'PRIVATE_AFTER_HELD_BLOCK'
+                        if (moves === 2) origin.append(root)
+                        await settle()
+                        assertHeld()
+                        // Non-mutation rrweb events release the frozen buffers.
+                        record.addCustomEvent('held-shadow-checkpoint', 'blocked')
+                    },
+                    { blocking, moves }
+                )
+                await expect
+                    .poll(async () =>
+                        (await events()).some(
+                            (e) =>
+                                e.type === 5 && e.data.tag === 'held-shadow-checkpoint' && e.data.payload === 'blocked'
+                        )
+                    )
+                    .toBe(true)
+                const blockedEvents = await events()
+                expect(JSON.stringify(blockedEvents)).not.toContain('PRIVATE_AFTER_HELD_BLOCK')
+                if (moves > 0)
+                    expect(
+                        blockedEvents.some(
+                            (e) =>
+                                e.type === 3 &&
+                                e.data.source === 0 &&
+                                e.data.adds.some(
+                                    (add) =>
+                                        add.node.id === rootId &&
+                                        add.node.attributes?.rr_width !== undefined &&
+                                        add.node.childNodes.length === 0
+                                )
+                        )
+                    ).toBe(true)
+
+                await page.evaluate(() => {
+                    const state = (window as any).__heldShadowTest
+                    state.text.data = 'PRIVATE_WHILE_BLOCKED'
+                    state.span.setAttribute('title', 'PRIVATE_ATTRIBUTE_WHILE_BLOCKED')
+                    const child = document.createElement('b')
+                    child.textContent = 'PRIVATE_NEW_CHILD_WHILE_BLOCKED'
+                    state.content.append(child)
+                    state.privateChild = child
+                    setTimeout(() => state.record.addCustomEvent('held-shadow-checkpoint', 'still-blocked'), 0)
+                })
+                await expect
+                    .poll(async () =>
+                        (await events()).some(
+                            (e) =>
+                                e.type === 5 &&
+                                e.data.tag === 'held-shadow-checkpoint' &&
+                                e.data.payload === 'still-blocked'
+                        )
+                    )
+                    .toBe(true)
+                const stillBlockedBytes = JSON.stringify(await events())
+                for (const marker of [
+                    'PRIVATE_WHILE_BLOCKED',
+                    'PRIVATE_ATTRIBUTE_WHILE_BLOCKED',
+                    'PRIVATE_NEW_CHILD_WHILE_BLOCKED',
+                ])
+                    expect(stillBlockedBytes).not.toContain(marker)
+
+                await page.evaluate(() => {
+                    const { record, origin, destination, root, text, span, privateChild } = (window as any)
+                        .__heldShadowTest
+                    privateChild.remove()
+                    span.removeAttribute('title')
+                    root.classList.remove('ph-no-capture')
+                    root.removeAttribute('data-test-blocked')
+                    text.data = 'PUBLIC_AFTER_UNBLOCK'
+                    // Always change parents; appending an existing last child can be a no-op in WebKit.
+                    ;(root.parentNode === destination ? origin : destination).append(root)
+                    setTimeout(() => record.addCustomEvent('held-shadow-checkpoint', 'restored'), 0)
+                })
+                await expect
+                    .poll(async () =>
+                        (await events()).some(
+                            (e) =>
+                                e.type === 5 && e.data.tag === 'held-shadow-checkpoint' && e.data.payload === 'restored'
+                        )
+                    )
+                    .toBe(true)
+                expect(JSON.stringify(await events())).toContain('PUBLIC_AFTER_UNBLOCK')
+                expect(
+                    await page.evaluate(() => {
+                        const { record, root, text } = (window as any).__heldShadowTest
+                        return {
+                            rootId: record.mirror.getId(root),
+                            textId: record.mirror.getId(text),
+                            textMapped: record.mirror.getNode(record.mirror.getId(text)) === text,
+                        }
+                    })
+                ).toEqual({ rootId, textId, textMapped: true })
+            })
+        }
+    }
+}

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -338,6 +338,33 @@ export default class MutationBuffer {
     }
   };
 
+  // Queued nodes can become blocked before emission. Check the current tree,
+  // including each shadow host: closest()/parentElement do not cross that boundary.
+  private isBlockedAtEmission(node: Node | null): boolean {
+    const blockClass = this.blockClass;
+    const stateful =
+      typeof blockClass !== 'string' && (blockClass.global || blockClass.sticky)
+        ? blockClass
+        : null;
+    const lastIndex = stateful?.lastIndex;
+    try {
+      while (node) {
+        // Additional privacy checks must neither depend on nor advance a
+        // stateful regexp left over from preprocessing/serialization.
+        if (stateful) stateful.lastIndex = 0;
+        if (isBlocked(node, blockClass, this.blockSelector, true)) return true;
+        const root = 'getRootNode' in node ? dom.getRootNode(node) : null;
+        node =
+          root?.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+            ? dom.host(root as ShadowRoot)
+            : null;
+      }
+      return false;
+    } finally {
+      if (stateful) stateful.lastIndex = lastIndex!;
+    }
+  }
+
   private processBufferedMutations = () => {
     // delay any modification of the mirror until this function
     // so that the mirror for takeFullSnapshot doesn't get mutated while it's event is being processed
@@ -364,6 +391,9 @@ export default class MutationBuffer {
       if (!parent || !inDom(n) || (parent as Element).tagName === 'TEXTAREA') {
         return;
       }
+      // A blocked node itself still needs a placeholder, but its descendants
+      // must not be serialized from stale added/moved entries.
+      if (this.isBlockedAtEmission(parent)) return;
       const parentId = isShadowRoot(parent)
         ? this.mirror.getId(getShadowHost(n))
         : this.mirror.getId(parent);
@@ -533,6 +563,7 @@ export default class MutationBuffer {
 
     const payload = {
       texts: this.texts
+        .filter((text) => !this.isBlockedAtEmission(text.node))
         .map((text) => {
           const n = text.node;
           const parent = dom.parentNode(n);
@@ -550,6 +581,7 @@ export default class MutationBuffer {
         // text mutation's id was not in the mirror map means the target node has been removed
         .filter((text) => this.mirror.has(text.id)),
       attributes: this.attributes
+        .filter((attribute) => !this.isBlockedAtEmission(attribute.node))
         .map((attribute) => {
           const { attributes } = attribute;
           if (

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -342,27 +342,23 @@ export default class MutationBuffer {
   // including each shadow host: closest()/parentElement do not cross that boundary.
   private isBlockedAtEmission(node: Node | null): boolean {
     const blockClass = this.blockClass;
+    // Match stateful patterns from zero without writing to the configured
+    // regexp, whose lastIndex may be non-writable. Keep all flags, including y.
     const stateful =
       typeof blockClass !== 'string' && (blockClass.global || blockClass.sticky)
-        ? blockClass
+        ? new RegExp(blockClass)
         : null;
-    const lastIndex = stateful?.lastIndex;
-    try {
-      while (node) {
-        // Additional privacy checks must neither depend on nor advance a
-        // stateful regexp left over from preprocessing/serialization.
-        if (stateful) stateful.lastIndex = 0;
-        if (isBlocked(node, blockClass, this.blockSelector, true)) return true;
-        const root = 'getRootNode' in node ? dom.getRootNode(node) : null;
-        node =
-          root?.nodeType === Node.DOCUMENT_FRAGMENT_NODE
-            ? dom.host(root as ShadowRoot)
-            : null;
-      }
-      return false;
-    } finally {
-      if (stateful) stateful.lastIndex = lastIndex!;
+    while (node) {
+      if (stateful) stateful.lastIndex = 0;
+      if (isBlocked(node, stateful || blockClass, this.blockSelector, true))
+        return true;
+      const root = 'getRootNode' in node ? dom.getRootNode(node) : null;
+      node =
+        root?.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+          ? dom.host(root as ShadowRoot)
+          : null;
     }
+    return false;
   }
 
   private processBufferedMutations = () => {

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -345,7 +345,9 @@ export default class MutationBuffer {
     // Match stateful patterns from zero without writing to the configured
     // regexp, whose lastIndex may be non-writable. Keep all flags, including y.
     const stateful =
-      typeof blockClass !== 'string' && (blockClass.global || blockClass.sticky)
+      blockClass &&
+      typeof blockClass !== 'string' &&
+      (blockClass.global || blockClass.sticky)
         ? new RegExp(blockClass)
         : null;
     while (node) {

--- a/packages/rrweb/rrweb/test/record/mutation-blocking.test.ts
+++ b/packages/rrweb/rrweb/test/record/mutation-blocking.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import MutationBuffer from '../../src/record/mutation';
+
+type BlockingProbe = {
+  blockClass: string | RegExp;
+  blockSelector: string | null;
+  isBlockedAtEmission: (node: Node | null) => boolean;
+};
+
+function createProbe(blockClass: string | RegExp = 'ph-no-capture') {
+  // Exercise the emission predicate without JSDOM's recorder/observer setup.
+  // Built-SDK Playwright tests cover the actual buffered payloads.
+  const buffer = new MutationBuffer() as unknown as BlockingProbe;
+  buffer.blockClass = blockClass;
+  buffer.blockSelector = null;
+  return buffer;
+}
+
+describe('mutation emission blocking', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('reads current light-DOM ancestors instead of caching eligibility', () => {
+    const root = document.createElement('div');
+    const span = document.createElement('span');
+    const text = document.createTextNode('content');
+    span.append(text);
+    root.append(span);
+    document.body.append(root);
+    const buffer = createProbe();
+    expect(buffer.isBlockedAtEmission(text)).toBe(false);
+    root.classList.add('ph-no-capture');
+    expect(buffer.isBlockedAtEmission(text)).toBe(true);
+    root.classList.remove('ph-no-capture');
+    expect(buffer.isBlockedAtEmission(text)).toBe(false);
+    expect(buffer.isBlockedAtEmission(null)).toBe(false);
+  });
+
+  it.each(['open', 'closed'] as const)(
+    'checks every host boundary, including a %s shadow-root target',
+    (mode) => {
+      const root = document.createElement('div');
+      const outerHost = document.createElement('div');
+      const outerShadow = outerHost.attachShadow({ mode: 'open' });
+      const innerHost = document.createElement('div');
+      const innerShadow = innerHost.attachShadow({ mode });
+      const span = document.createElement('span');
+      span.textContent = 'content';
+      innerShadow.append(span);
+      outerShadow.append(innerHost);
+      root.append(outerHost);
+      document.body.append(root);
+      const buffer = createProbe();
+
+      innerHost.classList.add('ph-no-capture');
+      expect(buffer.isBlockedAtEmission(span.firstChild)).toBe(true);
+      expect(buffer.isBlockedAtEmission(innerShadow)).toBe(true);
+      innerHost.classList.remove('ph-no-capture');
+      root.classList.add('ph-no-capture');
+      expect(buffer.isBlockedAtEmission(span.firstChild)).toBe(true);
+      root.classList.remove('ph-no-capture');
+      buffer.blockSelector = '.secret';
+      outerHost.classList.add('secret');
+      expect(buffer.isBlockedAtEmission(span.firstChild)).toBe(true);
+      outerHost.classList.remove('secret');
+      expect(buffer.isBlockedAtEmission(span.firstChild)).toBe(false);
+    },
+  );
+
+  it('does not write to a frozen non-stateful regexp', () => {
+    const root = document.createElement('div');
+    root.className = 'ph-no-capture';
+    document.body.append(root);
+    const blockClass = Object.freeze(/ph-no-capture/);
+    expect(createProbe(blockClass).isBlockedAtEmission(root)).toBe(true);
+  });
+
+  it.each([/ph-no-capture/g, /ph-no-capture/y])(
+    'does not depend on or advance stateful blockClass %s',
+    (blockClass) => {
+      const root = document.createElement('div');
+      const span = document.createElement('span');
+      root.append(span);
+      document.body.append(root);
+      const buffer = createProbe(blockClass);
+      blockClass.lastIndex = 4;
+      root.classList.add('ph-no-capture');
+      for (let i = 0; i < 3; i++) {
+        expect(buffer.isBlockedAtEmission(span)).toBe(true);
+        expect(blockClass.lastIndex).toBe(4);
+      }
+      root.classList.remove('ph-no-capture');
+      expect(buffer.isBlockedAtEmission(span)).toBe(false);
+      expect(blockClass.lastIndex).toBe(4);
+    },
+  );
+});

--- a/packages/rrweb/rrweb/test/record/mutation-blocking.test.ts
+++ b/packages/rrweb/rrweb/test/record/mutation-blocking.test.ts
@@ -76,6 +76,39 @@ describe('mutation emission blocking', () => {
     expect(createProbe(blockClass).isBlockedAtEmission(root)).toBe(true);
   });
 
+  it.each([
+    /ph-no-capture/g,
+    /ph-no-capture/gi,
+    /ph-no-capture/y,
+    /ph-no-capture/iy,
+  ])(
+    'supports frozen stateful blockClass %s without changing its flags',
+    (blockClass) => {
+      blockClass.lastIndex = 4;
+      Object.freeze(blockClass);
+      const root = document.createElement('div');
+      const host = document.createElement('div');
+      const span = document.createElement('span');
+      host.attachShadow({ mode: 'open' }).append(span);
+      root.append(host);
+      document.body.append(root);
+      const buffer = createProbe(blockClass);
+      root.className = 'ph-no-capture';
+      for (let i = 0; i < 3; i++) {
+        expect(buffer.isBlockedAtEmission(span)).toBe(true);
+        expect(blockClass.lastIndex).toBe(4);
+      }
+      root.className = 'PH-NO-CAPTURE';
+      expect(buffer.isBlockedAtEmission(span)).toBe(blockClass.ignoreCase);
+      root.className = 'prefix-ph-no-capture';
+      expect(buffer.isBlockedAtEmission(span)).toBe(!blockClass.sticky);
+      root.className = 'public';
+      expect(buffer.isBlockedAtEmission(span)).toBe(false);
+      expect(blockClass.lastIndex).toBe(4);
+      expect(Object.isFrozen(blockClass)).toBe(true);
+    },
+  );
+
   it.each([/ph-no-capture/g, /ph-no-capture/y])(
     'does not depend on or advance stateful blockClass %s',
     (blockClass) => {

--- a/packages/rrweb/rrweb/test/record/mutation-blocking.test.ts
+++ b/packages/rrweb/rrweb/test/record/mutation-blocking.test.ts
@@ -68,6 +68,48 @@ describe('mutation emission blocking', () => {
     },
   );
 
+  it.each([null, undefined])(
+    'tolerates runtime blockClass %s while retaining selector blocking',
+    (blockClass) => {
+      const root = document.createElement('div');
+      root.className = 'public';
+      const host = document.createElement('div');
+      const span = document.createElement('span');
+      host.attachShadow({ mode: 'open' }).append(span);
+      root.append(host);
+      document.body.append(root);
+      const buffer = createProbe();
+      // Untyped callers can supply nullish values despite the declared type.
+      Object.assign(buffer, { blockClass });
+      expect(buffer.isBlockedAtEmission(span)).toBe(false);
+      buffer.blockSelector = '.secret';
+      root.classList.add('secret');
+      expect(buffer.isBlockedAtEmission(span)).toBe(true);
+      root.classList.remove('secret');
+      expect(buffer.isBlockedAtEmission(span)).toBe(false);
+    },
+  );
+
+  it.each(['g', 'y'])(
+    'retains cross-frame stateful regexps with flag %s',
+    (flag) => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      const blockClass = new (iframe.contentWindow as typeof window).RegExp(
+        'ph-no-capture',
+        flag,
+      );
+      expect(blockClass).not.toBeInstanceOf(RegExp);
+      blockClass.lastIndex = 4;
+      Object.freeze(blockClass);
+      const root = document.createElement('div');
+      root.className = 'ph-no-capture';
+      document.body.append(root);
+      expect(createProbe(blockClass).isBlockedAtEmission(root)).toBe(true);
+      expect(blockClass.lastIndex).toBe(4);
+    },
+  );
+
   it('does not write to a frozen non-stateful regexp', () => {
     const root = document.createElement('div');
     root.className = 'ph-no-capture';


### PR DESCRIPTION
## Problem

Queued session recording mutations can outlive the blocking decision made during preprocessing. If an ancestor becomes blocked before emission, stale additions or updates can still send its descendants. Shadow roots also require checking the hosts outside their local DOM tree.

This reproduces on `main`, independently of the #4217 performance stack. The regressions include blocking with zero, one or two held moves, and inserting shadow content while the ancestor remains blocked.

## Changes

- Check current DOM and shadow-host ancestors before emitting additions, text or attributes.
- Keep blocked-node placeholders by checking an addition's parent rather than excluding the blocked node itself.
- Match global/sticky `blockClass` patterns with a private copy in the emission check. Preserve all flags and leave the configured regexp untouched, including frozen patterns.
- Add wire-privacy and restoration tests, plus a `posthog-js` patch changeset. Queue traversal, mirror cleanup, lifecycle behavior and masking defaults are unchanged.

Validation: 321 recording/accessor tests passed, with 2 existing skips. All 63 Chromium/Firefox/WebKit cases passed, including 54 new blocking cases and 9 existing masking cases. Builds, targeted lint, ES5/ES6 checks and the committed-branch autoreview passed. The retained investigation harness also passed decoded-wire and intermediate replay checks for five shapes with compression on and off. It is not included in this standalone PR.

During the initial validation, two runs failed existing iframe event-count assertions by one extra event. Focused retries, five full baseline runs and five full original-candidate runs passed. The latest full suite also passed. Failure-only diagnostics did not reproduce the extra event. The cause is not established and the assertions were not changed.

This is a privacy correction, not a performance improvement. It adds synchronous ancestry checks. A single sequential 50k-node comparison retained ordering and event counts with no drops or extra snapshots, but does not establish performance neutrality. The recorder grew by 429 raw / 120 gzip bytes. Closed roots have predicate unit coverage, not a built-SDK lifecycle test.

The review follow-up adds four predicate regressions for frozen `g`, `gi`, `y` and `iy` patterns. All four failed on the previous head with a non-writable `lastIndex` error and pass after the change. They also verify case-insensitive and sticky matching and unchanged configured state. String patterns remain allocation-free in the emission check.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file (equivalent patch entry authored directly)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi, bash, Vitest and Playwright under marandaneto's direction. Pi autoreview checked the committed branch. Human review is required.

A cleanup-only change that traversed shadow descendants passed the first reproduction but failed the expanded lifecycle tests. It was rejected in favor of checks at emission. No performance-stack changes or asynchronous recording architecture are included. No session link is published.

