### PR TITLE
feat(react-native): support shuffled survey questions and options

### DIFF
--- a/.changeset/rn-survey-shuffling.md
+++ b/.changeset/rn-survey-shuffling.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+feat(react-native): support shuffled survey questions and answer options

--- a/packages/react-native/src/surveys/components/QuestionTypes.tsx
+++ b/packages/react-native/src/surveys/components/QuestionTypes.tsx
@@ -12,12 +12,8 @@ import {
   VeryDissatisfiedEmoji,
   VerySatisfiedEmoji,
 } from '../icons'
-import {
-  defaultRatingLabelOpacity,
-  getContrastingTextColor,
-  getDisplayOrderChoices,
-  SurveyAppearanceTheme,
-} from '../surveys-utils'
+import { defaultRatingLabelOpacity, getContrastingTextColor, SurveyAppearanceTheme } from '../surveys-utils'
+import { getDisplayOrderChoices } from '../survey-shuffling'
 import {
   SurveyQuestion,
   SurveyRatingDisplay,

--- a/packages/react-native/src/surveys/components/Surveys.tsx
+++ b/packages/react-native/src/surveys/components/Surveys.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useState } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 
-import { getDisplayOrderQuestions, getNextSurveyStep, SurveyAppearanceTheme } from '../surveys-utils'
+import { getNextSurveyStep, SurveyAppearanceTheme } from '../surveys-utils'
+import { getDisplayOrderQuestions, shouldShuffleQuestions } from '../survey-shuffling'
 import {
   Survey,
   SurveyAppearance,
@@ -20,6 +21,16 @@ import {
 import { LinkQuestion, MultipleChoiceQuestion, OpenTextQuestion, RatingQuestion } from './QuestionTypes'
 import { PostHog } from '../../posthog-rn'
 import { usePostHog } from '../../hooks/usePostHog'
+
+// Events receive the configured survey, not its shuffled display copies. Supply
+// positional indices here so legacy response properties do not depend on rendering.
+const buildConfiguredSurveyResponseProperties = (responses: SurveyResponses, survey: Survey) =>
+  buildSurveyResponseProperties(responses, {
+    questions: survey.questions.map((question, originalQuestionIndex) => ({
+      ...question,
+      originalQuestionIndex,
+    })),
+  })
 
 export const sendSurveyShownEvent = (survey: Survey, posthog: PostHog, surveyLanguage?: string | null): void => {
   posthog.capture('survey shown', {
@@ -43,7 +54,7 @@ export const sendSurveyEvent = (
     ...maybeAdd('$survey_iteration', survey.current_iteration),
     ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
     ...(surveyLanguage ? { [SURVEY_LANGUAGE_PROPERTY]: surveyLanguage } : {}),
-    ...buildSurveyResponseProperties(responses, survey),
+    ...buildConfiguredSurveyResponseProperties(responses, survey),
     $set: {
       [getSurveyInteractionProperty(survey, 'responded')]: true,
     },
@@ -63,7 +74,7 @@ export const dismissedSurveyEvent = (
     ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
     ...(surveyLanguage ? { [SURVEY_LANGUAGE_PROPERTY]: surveyLanguage } : {}),
     $survey_partially_completed: surveyHasResponses(responses),
-    ...buildSurveyResponseProperties(responses, survey),
+    ...buildConfiguredSurveyResponseProperties(responses, survey),
     $set: {
       [getSurveyInteractionProperty(survey, 'dismissed')]: true,
     },
@@ -89,18 +100,17 @@ export function Questions({
 }): JSX.Element {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0)
   const surveyQuestions = useMemo(() => getDisplayOrderQuestions(survey), [survey])
+  const questionsAreShuffled = shouldShuffleQuestions(survey)
   const posthog = usePostHog()
 
   const onNextButtonClick = ({
     res,
     originalQuestionIndex,
     questionId,
-  }: // displayQuestionIndex,
-  {
+  }: {
     res: string | string[] | number | null
     originalQuestionIndex: number
     questionId: string
-    // displayQuestionIndex: number
   }): void => {
     const responseKey = getSurveyResponseKey(questionId)
 
@@ -110,15 +120,24 @@ export function Questions({
     }
     onResponsesChange(allResponses)
 
-    // Get the next question index based on conditional logic
+    // Shuffled surveys cannot use branching and must advance through display order.
+    // Non-shuffled surveys retain the configured/original-index branching semantics.
+    if (questionsAreShuffled) {
+      if (currentQuestionIndex === surveyQuestions.length - 1) {
+        sendSurveyEvent(allResponses, survey, posthog, surveyLanguage)
+        onSubmit()
+      } else {
+        setCurrentQuestionIndex((index) => index + 1)
+      }
+      return
+    }
+
     const nextStep = getNextSurveyStep(survey, originalQuestionIndex, res)
 
     if (nextStep === SurveyQuestionBranchingType.End) {
-      // End the survey
       sendSurveyEvent(allResponses, survey, posthog, surveyLanguage)
       onSubmit()
     } else {
-      // Move to the next question
       setCurrentQuestionIndex(nextStep)
     }
   }

--- a/packages/react-native/src/surveys/survey-shuffling.ts
+++ b/packages/react-native/src/surveys/survey-shuffling.ts
@@ -1,0 +1,64 @@
+import { MultipleSurveyQuestion, Survey, SurveyQuestion } from '@posthog/core'
+
+type SurveyWithPartialResponses = Survey & {
+  enable_partial_responses?: boolean | null
+}
+
+const hasBranching = (survey: Survey): boolean => survey.questions.some((question) => !!question.branching?.type)
+
+export const shouldShuffleQuestions = (survey: Survey): boolean => {
+  const partialResponsesEnabled = (survey as SurveyWithPartialResponses).enable_partial_responses
+
+  return !!survey.appearance?.shuffleQuestions && !partialResponsesEnabled && !hasBranching(survey)
+}
+
+/**
+ * Fisher-Yates shuffle without mutating the input array.
+ */
+export const shuffle = <T>(array: readonly T[]): T[] => {
+  const shuffled = [...array]
+
+  for (let index = shuffled.length - 1; index > 0; index--) {
+    const swapIndex = Math.floor(Math.random() * (index + 1))
+    ;[shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]]
+  }
+
+  return shuffled
+}
+
+const reverseIfUnshuffled = <T>(unshuffled: readonly T[], shuffled: T[]): T[] => {
+  if (shuffled.length > 1 && unshuffled.every((value, index) => value === shuffled[index])) {
+    return shuffled.reverse()
+  }
+
+  return shuffled
+}
+
+export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
+  const questions = survey.questions.map((question, originalQuestionIndex) => ({
+    ...question,
+    originalQuestionIndex,
+  }))
+
+  if (!shouldShuffleQuestions(survey)) {
+    return questions
+  }
+
+  return reverseIfUnshuffled(questions, shuffle(questions))
+}
+
+export const getDisplayOrderChoices = (question: MultipleSurveyQuestion): string[] => {
+  if (!question.shuffleOptions) {
+    return question.choices
+  }
+
+  const choices = [...question.choices]
+  const openEndedChoice = question.hasOpenChoice ? choices.pop() : undefined
+  const shuffledChoices = reverseIfUnshuffled(choices, shuffle(choices))
+
+  if (openEndedChoice !== undefined) {
+    shuffledChoices.push(openEndedChoice)
+  }
+
+  return shuffledChoices
+}

--- a/packages/react-native/test/Questions.shuffling.spec.tsx
+++ b/packages/react-native/test/Questions.shuffling.spec.tsx
@@ -1,0 +1,112 @@
+/** @vitest-environment jsdom */
+import React from 'react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Survey, SurveyQuestionBranchingType, SurveyQuestionType, SurveyType } from '@posthog/core'
+
+vi.mock('react-native', async () => {
+  return {
+    StyleSheet: { create: (styles: any) => styles },
+  }
+})
+
+const capture = vi.fn()
+vi.mock('../src/hooks/usePostHog', () => ({
+  usePostHog: () => ({ capture }),
+}))
+
+vi.mock('../src/surveys/components/QuestionTypes', async () => {
+  const RealReact = await vi.importActual<typeof import('react')>('react')
+  const Question = ({ question, onSubmit }: any) =>
+    RealReact.createElement(
+      'button',
+      {
+        'data-testid': `question-${question.id}`,
+        onClick: () => onSubmit(question.id),
+      },
+      question.question
+    )
+
+  return {
+    OpenTextQuestion: Question,
+    LinkQuestion: Question,
+    MultipleChoiceQuestion: Question,
+    RatingQuestion: Question,
+  }
+})
+
+import { Questions } from '../src/surveys/components/Surveys'
+import { defaultSurveyAppearance } from '../src/surveys/surveys-utils'
+
+const makeSurvey = (overrides: Partial<Survey> = {}): Survey =>
+  ({
+    id: 'survey-1',
+    name: 'Shuffle survey',
+    type: SurveyType.Popover,
+    appearance: { shuffleQuestions: true },
+    questions: [
+      { id: 'q1', type: SurveyQuestionType.Open, question: 'Question 1' },
+      { id: 'q2', type: SurveyQuestionType.Open, question: 'Question 2' },
+      { id: 'q3', type: SurveyQuestionType.Open, question: 'Question 3' },
+    ],
+    ...overrides,
+  }) as Survey
+
+afterEach(() => {
+  cleanup()
+  capture.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe('Questions shuffling', () => {
+  it('advances through shuffled display order without skipping questions', () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0)
+    const onSubmit = vi.fn()
+    const onResponsesChange = vi.fn()
+    const { getByTestId, queryByTestId } = render(
+      <Questions
+        survey={makeSurvey()}
+        appearance={defaultSurveyAppearance}
+        onSubmit={onSubmit}
+        onResponsesChange={onResponsesChange}
+      />
+    )
+
+    expect(getByTestId('question-q2')).not.toBeNull()
+
+    act(() => fireEvent.click(getByTestId('question-q2')))
+    expect(getByTestId('question-q3')).not.toBeNull()
+
+    act(() => fireEvent.click(getByTestId('question-q3')))
+    expect(getByTestId('question-q1')).not.toBeNull()
+
+    act(() => fireEvent.click(getByTestId('question-q1')))
+    expect(onSubmit).toHaveBeenCalledOnce()
+    expect(queryByTestId('question-q1')).not.toBeNull()
+    expect(onResponsesChange).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps configured branching semantics even if legacy data also asks to shuffle', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const onSubmit = vi.fn()
+    const survey = makeSurvey({
+      questions: [
+        {
+          id: 'q1',
+          type: SurveyQuestionType.Open,
+          question: 'Question 1',
+          branching: { type: SurveyQuestionBranchingType.SpecificQuestion, index: 2 },
+        },
+        { id: 'q2', type: SurveyQuestionType.Open, question: 'Question 2' },
+        { id: 'q3', type: SurveyQuestionType.Open, question: 'Question 3' },
+      ] as any,
+    })
+    const { getByTestId } = render(
+      <Questions survey={survey} appearance={defaultSurveyAppearance} onSubmit={onSubmit} />
+    )
+
+    expect(getByTestId('question-q1')).not.toBeNull()
+    act(() => fireEvent.click(getByTestId('question-q1')))
+    expect(getByTestId('question-q3')).not.toBeNull()
+  })
+})

--- a/packages/react-native/test/survey-response-attribution.spec.tsx
+++ b/packages/react-native/test/survey-response-attribution.spec.tsx
@@ -1,0 +1,233 @@
+/** @vitest-environment jsdom */
+import React, { useState } from 'react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  Survey,
+  SurveyQuestion,
+  SurveyQuestionBranchingType,
+  SurveyQuestionType,
+  SurveyResponses,
+  SurveyType,
+} from '@posthog/core'
+import type { PostHog } from '../src/posthog-rn'
+
+// Only native views and capture are replaced. Navigation, response state and
+// the shared event serializer run together, as they do in a survey session.
+vi.mock('react-native', () => ({ StyleSheet: { create: (styles: unknown) => styles } }))
+const { capture } = vi.hoisted(() => ({ capture: vi.fn() }))
+vi.mock('../src/hooks/usePostHog', () => ({ usePostHog: () => ({ capture }) }))
+vi.mock('../src/surveys/components/QuestionTypes', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  const Question = ({ question, onSubmit }: { question: SurveyQuestion; onSubmit: (value: string) => void }) =>
+    React.createElement(
+      'button',
+      { 'data-testid': question.id, onClick: () => onSubmit(`answer-${question.id}`) },
+      question.question
+    )
+  return {
+    OpenTextQuestion: Question,
+    LinkQuestion: Question,
+    MultipleChoiceQuestion: Question,
+    RatingQuestion: Question,
+  }
+})
+
+import { dismissedSurveyEvent, Questions, sendSurveyEvent } from '../src/surveys/components/Surveys'
+import { defaultSurveyAppearance } from '../src/surveys/surveys-utils'
+
+const posthog = { capture } as unknown as PostHog
+
+function makeSurvey(shuffleQuestions: boolean, overrides: Partial<Survey> = {}): Survey {
+  const survey = {
+    id: 'attribution',
+    name: 'Response attribution',
+    type: SurveyType.Popover,
+    appearance: { shuffleQuestions },
+    questions: ['q1', 'q2', 'q3'].map((id) => ({ id, type: SurveyQuestionType.Open, question: id })),
+    ...overrides,
+  } as Survey
+  // Definitions from the API need not contain originalQuestionIndex. Freezing
+  // also catches a fix that restores the properties by mutating during render.
+  survey.questions.forEach(Object.freeze)
+  Object.freeze(survey.questions)
+  return Object.freeze(survey)
+}
+
+function SurveySession({ survey, onSubmit }: { survey: Survey; onSubmit: () => void }) {
+  const [responses, setResponses] = useState<SurveyResponses>({})
+  return (
+    <>
+      <Questions
+        survey={survey}
+        appearance={defaultSurveyAppearance}
+        responses={responses}
+        onResponsesChange={setResponses}
+        onSubmit={onSubmit}
+      />
+      <button onClick={() => dismissedSurveyEvent(survey, responses, posthog)}>Dismiss</button>
+    </>
+  )
+}
+
+function expectCaptured(event: string, properties: Record<string, unknown>) {
+  expect(capture).toHaveBeenCalledOnce()
+  expect(capture).toHaveBeenCalledWith(event, properties)
+}
+
+afterEach(() => {
+  cleanup()
+  capture.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe('survey response attribution', () => {
+  it.each([true, false])('preserves configured indices on submission (shuffle=%s)', (shuffle) => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const survey = makeSurvey(shuffle)
+    const before = JSON.stringify(survey)
+    const onSubmit = vi.fn()
+    const { getByTestId } = render(<SurveySession survey={survey} onSubmit={onSubmit} />)
+    const displayOrder = shuffle ? ['q2', 'q3', 'q1'] : ['q1', 'q2', 'q3']
+    for (const id of displayOrder) {
+      fireEvent.click(getByTestId(id))
+    }
+
+    expect(onSubmit).toHaveBeenCalledOnce()
+    expectCaptured('survey sent', {
+      $survey_id: 'attribution',
+      $survey_name: 'Response attribution',
+      $survey_questions: ['q1', 'q2', 'q3'].map((id) => ({ id, question: id, response: `answer-${id}` })),
+      $survey_response_q1: 'answer-q1',
+      $survey_response_q2: 'answer-q2',
+      $survey_response_q3: 'answer-q3',
+      $survey_response: 'answer-q1',
+      $survey_response_1: 'answer-q2',
+      $survey_response_2: 'answer-q3',
+      $set: { '$survey_responded/attribution': true },
+    })
+    expect(JSON.stringify(survey)).toBe(before)
+  })
+
+  it.each([true, false])('preserves configured indices on dismissal (shuffle=%s)', (shuffle) => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const survey = makeSurvey(shuffle)
+    const before = JSON.stringify(survey)
+    const onSubmit = vi.fn()
+    const { getByTestId, getByText } = render(<SurveySession survey={survey} onSubmit={onSubmit} />)
+    const first = shuffle ? 'q2' : 'q1'
+    fireEvent.click(getByTestId(first))
+    fireEvent.click(getByText('Dismiss'))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expectCaptured('survey dismissed', {
+      $survey_id: 'attribution',
+      $survey_name: 'Response attribution',
+      $survey_partially_completed: true,
+      $survey_questions: ['q1', 'q2', 'q3'].map((id) => ({
+        id,
+        question: id,
+        response: id === first ? `answer-${id}` : undefined,
+      })),
+      [`$survey_response_${first}`]: `answer-${first}`,
+      [shuffle ? '$survey_response_1' : '$survey_response']: `answer-${first}`,
+      $set: { '$survey_dismissed/attribution': true },
+    })
+    expect(JSON.stringify(survey)).toBe(before)
+  })
+
+  it('does not renumber answers when branching skips a question', () => {
+    const survey = makeSurvey(true, {
+      questions: [
+        {
+          id: 'q1',
+          type: SurveyQuestionType.Open,
+          question: 'q1',
+          branching: { type: SurveyQuestionBranchingType.SpecificQuestion, index: 2 },
+        },
+        { id: 'q2', type: SurveyQuestionType.Open, question: 'q2' },
+        { id: 'q3', type: SurveyQuestionType.Open, question: 'q3' },
+      ] as SurveyQuestion[],
+    })
+    const onSubmit = vi.fn()
+    const { getByTestId } = render(<SurveySession survey={survey} onSubmit={onSubmit} />)
+    fireEvent.click(getByTestId('q1'))
+    fireEvent.click(getByTestId('q3'))
+
+    expect(onSubmit).toHaveBeenCalledOnce()
+    expect(capture).toHaveBeenCalledOnce()
+    const [event, properties] = capture.mock.calls[0]
+    expect(event).toBe('survey sent')
+    expect(properties).toMatchObject({
+      $survey_response_q1: 'answer-q1',
+      $survey_response_q3: 'answer-q3',
+      $survey_response: 'answer-q1',
+      $survey_response_2: 'answer-q3',
+    })
+    expect(properties).not.toHaveProperty('$survey_response_1')
+    expect(properties).not.toHaveProperty('$survey_response_q2')
+  })
+
+  it.each(['sent', 'dismissed'] as const)('serializes %s responses without a prior render', (event) => {
+    const survey = makeSurvey(false, {
+      current_iteration: 2,
+      current_iteration_start_date: '2026-09-07',
+      questions: ['q1', 'q2', 'q3', 'q4'].map((id) => ({
+        id,
+        type: SurveyQuestionType.Open,
+        question: id,
+      })) as SurveyQuestion[],
+    })
+    const values = [0, null, '', ['A', 'C']]
+    const responses: SurveyResponses = {
+      $survey_response_q1: 0,
+      $survey_response_q2: null,
+      $survey_response_q3: '',
+      $survey_response_q4: ['A', 'C'],
+    }
+    const before = JSON.stringify({ survey, responses })
+    if (event === 'sent') {
+      sendSurveyEvent(responses, survey, posthog, 'pt')
+    } else {
+      dismissedSurveyEvent(survey, responses, posthog, 'pt')
+    }
+
+    expectCaptured(`survey ${event}`, {
+      $survey_id: 'attribution',
+      $survey_name: 'Response attribution',
+      $survey_iteration: 2,
+      $survey_iteration_start_date: '2026-09-07',
+      $survey_language: 'pt',
+      ...(event === 'dismissed' ? { $survey_partially_completed: true } : {}),
+      $survey_questions: survey.questions.map((question, index) => ({
+        id: question.id,
+        question: question.question,
+        response: values[index],
+      })),
+      ...responses,
+      $survey_response: 0,
+      $survey_response_1: null,
+      $survey_response_2: '',
+      $survey_response_3: ['A', 'C'],
+      $set: { [`$survey_${event === 'sent' ? 'responded' : 'dismissed'}/attribution/2`]: true },
+    })
+    expect(JSON.stringify({ survey, responses })).toBe(before)
+    expect(capture.mock.calls[0][1].$survey_response_3).not.toBe(responses.$survey_response_q4)
+  })
+
+  it('does not invent responses for an unanswered dismissal', () => {
+    const survey = makeSurvey(true)
+    dismissedSurveyEvent(survey, {}, posthog)
+    expectCaptured('survey dismissed', {
+      $survey_id: 'attribution',
+      $survey_name: 'Response attribution',
+      $survey_partially_completed: false,
+      $survey_questions: survey.questions.map((question) => ({
+        id: question.id,
+        question: question.question,
+        response: undefined,
+      })),
+      $set: { '$survey_dismissed/attribution': true },
+    })
+  })
+})

--- a/packages/react-native/test/survey-shuffling.spec.ts
+++ b/packages/react-native/test/survey-shuffling.spec.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Survey, SurveyQuestionBranchingType, SurveyQuestionType } from '@posthog/core'
+import {
+  getDisplayOrderChoices,
+  getDisplayOrderQuestions,
+  shouldShuffleQuestions,
+  shuffle,
+} from '../src/surveys/survey-shuffling'
+
+const question = (id: string, extra: Record<string, unknown> = {}) =>
+  ({
+    id,
+    type: SurveyQuestionType.Open,
+    question: id,
+    ...extra,
+  }) as any
+
+const survey = (extra: Record<string, unknown> = {}): Survey =>
+  ({
+    id: 'survey-1',
+    name: 'Survey',
+    questions: [question('q1'), question('q2'), question('q3')],
+    appearance: { shuffleQuestions: true },
+    ...extra,
+  }) as Survey
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('survey shuffling', () => {
+  it('uses Fisher-Yates without mutating the source array', () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0)
+    const input = ['a', 'b', 'c']
+
+    expect(shuffle(input)).toEqual(['b', 'c', 'a'])
+    expect(input).toEqual(['a', 'b', 'c'])
+  })
+
+  it('shuffles questions and preserves their configured indices', () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0)
+    const source = survey()
+
+    const displayed = getDisplayOrderQuestions(source)
+
+    expect(displayed.map((q) => q.id)).toEqual(['q2', 'q3', 'q1'])
+    expect(displayed.map((q) => q.originalQuestionIndex)).toEqual([1, 2, 0])
+    expect(source.questions.map((q) => q.id)).toEqual(['q1', 'q2', 'q3'])
+    expect(source.questions.map((q) => q.originalQuestionIndex)).toEqual([undefined, undefined, undefined])
+  })
+
+  it('forces a different order when randomness produces the identity permutation', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.999999)
+
+    expect(getDisplayOrderQuestions(survey()).map((q) => q.id)).toEqual(['q3', 'q2', 'q1'])
+  })
+
+  it('does not shuffle questions when the feature is off', () => {
+    const source = survey({ appearance: { shuffleQuestions: false } })
+
+    expect(shouldShuffleQuestions(source)).toBe(false)
+    expect(getDisplayOrderQuestions(source).map((q) => q.id)).toEqual(['q1', 'q2', 'q3'])
+  })
+
+  it('does not shuffle partial-response surveys because their progress is positional', () => {
+    const source = survey({ enable_partial_responses: true })
+
+    expect(shouldShuffleQuestions(source)).toBe(false)
+    expect(getDisplayOrderQuestions(source).map((q) => q.id)).toEqual(['q1', 'q2', 'q3'])
+  })
+
+  it('does not shuffle legacy surveys containing branching rules', () => {
+    const source = survey({
+      questions: [
+        question('q1', {
+          branching: {
+            type: SurveyQuestionBranchingType.SpecificQuestion,
+            index: 2,
+          },
+        }),
+        question('q2'),
+        question('q3'),
+      ],
+    })
+
+    expect(shouldShuffleQuestions(source)).toBe(false)
+    expect(getDisplayOrderQuestions(source).map((q) => q.id)).toEqual(['q1', 'q2', 'q3'])
+  })
+
+  it('shuffles choices without mutating the question', () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0)
+    const source = {
+      id: 'q1',
+      type: SurveyQuestionType.MultipleChoice,
+      question: 'Pick one',
+      choices: ['a', 'b', 'c'],
+      shuffleOptions: true,
+    } as any
+
+    expect(getDisplayOrderChoices(source)).toEqual(['b', 'c', 'a'])
+    expect(source.choices).toEqual(['a', 'b', 'c'])
+  })
+
+  it('keeps the open-ended choice last while shuffling the other options', () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0)
+    const source = {
+      id: 'q1',
+      type: SurveyQuestionType.MultipleChoice,
+      question: 'Pick one',
+      choices: ['a', 'b', 'c', 'Other'],
+      shuffleOptions: true,
+      hasOpenChoice: true,
+    } as any
+
+    expect(getDisplayOrderChoices(source)).toEqual(['b', 'c', 'a', 'Other'])
+    expect(source.choices).toEqual(['a', 'b', 'c', 'Other'])
+  })
+
+  it('returns configured choice order when shuffling is disabled', () => {
+    const source = {
+      id: 'q1',
+      type: SurveyQuestionType.SingleChoice,
+      question: 'Pick one',
+      choices: ['a', 'b', 'c'],
+      shuffleOptions: false,
+    } as any
+
+    expect(getDisplayOrderChoices(source)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('handles zero and one shufflable choice safely', () => {
+    expect(
+      getDisplayOrderChoices({
+        id: 'q1',
+        type: SurveyQuestionType.MultipleChoice,
+        question: 'Empty',
+        choices: [],
+        shuffleOptions: true,
+      } as any)
+    ).toEqual([])
+
+    expect(
+      getDisplayOrderChoices({
+        id: 'q2',
+        type: SurveyQuestionType.MultipleChoice,
+        question: 'One',
+        choices: ['only'],
+        shuffleOptions: true,
+      } as any)
+    ).toEqual(['only'])
+  })
+})


### PR DESCRIPTION
## Problem

Addresses https://github.com/PostHog/posthog-js/issues/3162.

The React Native survey renderer ignores `appearance.shuffleQuestions` and `question.shuffleOptions`. Enabling the shuffle helpers alone is insufficient: `Questions` renders a display-order array, while its existing navigation uses configured question indices. Those indices must not be treated as shuffled display positions.

## Changes

- Add non-mutating Fisher–Yates helpers for React Native survey questions and choices, keeping the open-ended choice last.
- Advance shuffled, non-branching surveys through display order. Keep ordinary and branching surveys on the existing `getNextSurveyStep()` path.
- Match the browser's guards: do not shuffle questions when partial responses are enabled or any question has branching configuration.
- Keep original question indices on display copies without mutating the source survey or its choice arrays.
- Preserve both modern question-ID response properties and legacy positional properties when serializing submission and dismissal events.
- Include a **minor** changeset for `posthog-react-native`, as requested in review.

The implementation stays in the React Native surveys package. Shared core serialization and the branching engine are unchanged.

### Review correction: legacy response attribution

The initial implementation annotated only display copies. `sendSurveyEvent` and `dismissedSurveyEvent` still serialized the original survey, so the shared serializer omitted `$survey_response`, `$survey_response_1`, etc. when the input had no `originalQuestionIndex`. The original navigation tests did not check those outgoing properties.

Both event functions now pass configured-order question copies with positional indices to the existing shared serializer. This makes legacy response attribution independent of rendering and preserves the original survey. Skipped questions retain their configured indices rather than being renumbered.

## Verification

**Tested signed commit:** [`df820ebb9cad671ba444bbde4d88661bf7f290c0`](https://github.com/PostHog/posthog-js/commit/df820ebb9cad671ba444bbde4d88661bf7f290c0).

**Final fork verification:** https://github.com/AyobamiH/posthog-js/actions/runs/34123368621

| Check | Result |
| --- | --- |
| New response-attribution tests against the reviewed source `f1c3a289…` | Exactly 7 expected payload failures; 1 unanswered-dismissal control passes |
| Complete React Native suite on the corrected signed source | 717 passed, 0 failed, 0 skipped across 46 test files |
| React Native and required workspace dependency build | Passed |
| React Native lint | 0 warnings, 0 errors |
| Formatting of the review-changed source/test files | Passed |
| Commit signature, authorship, parent and source-tree verification | Passed; GitHub reports `verified: true`, `reason: valid` |

The eight new cases cover shuffled and ordinary submission, shuffled and ordinary dismissal, branching that skips a question, direct event serialization without a prior render, and unanswered dismissal. They also check falsy/array responses, language/iteration metadata and non-mutation using frozen, unannotated survey definitions. Stateful component tests use real navigation and the shared serializer; native views and the capture boundary are test doubles.

The existing 10 shuffling-helper tests and 2 navigation tests remain included. No manual device smoke test or full-monorepo test run is claimed. These are fork verification results, not upstream CI approval.

The seven unsigned commits and review correction were consolidated into one GitHub-signed commit, preserving AyobamiH authorship. Its tree exactly matches the corrected candidate and the final workflow checks out that signed SHA. The old history remains on the fork's `backup/4822-before-review-f1c3a289` branch. Fork-only verification infrastructure is not included in this PR.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-react-native

No other package release is requested.

## Checklist

- [x] Tests for new code, including the response-payload regression identified in review
- [x] Existing branching and non-shuffled behaviour retained
- [x] Backwards-compatible legacy and modern response properties verified
- [x] No new runtime dependencies
- [x] Included a minor changeset for `posthog-react-native`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

@AyobamiH directed the contribution and follow-up corrections. ChatGPT with GitHub tooling assisted with repository investigation, implementation and GitHub Actions verification. The session is private; no public session link is included.

The display-order and configured-index navigation paths remain separate. Following the maintainer's reproduced regression, the correction was placed at the React Native event-serialization boundary rather than restoring render-time mutation or changing shared core behaviour. New stateful payload tests reproduce the reviewed failure and pass on the corrected source. Human review is required.