### PR TITLE
refactor(ai-research): drop JSON-LD type entries that map to empty rules

### DIFF
--- a/packages/browser/src/extensions/replay/external/json-ld.ts
+++ b/packages/browser/src/extensions/replay/external/json-ld.ts
@@ -74,7 +74,6 @@ const ENTITY_RULES: Record<string, JsonLdEntityRules> = {
         aggregateRating: ['AggregateRating'],
         brand: ['Brand'],
     },
-    Person: {},
     Place: {
         aggregateRating: ['AggregateRating'],
     },
@@ -118,9 +117,7 @@ const ENTITY_RULES: Record<string, JsonLdEntityRules> = {
     },
 }
 
-const EMPTY_ENTITY_RULES: JsonLdEntityRules = {}
 const INHERITED_RULE_GROUPS: readonly JsonLdRuleGroup[] = [
-    [ACTION_TYPES, EMPTY_ENTITY_RULES],
     [
         '3DModel AboutPage Answer Article AudioObject Blog BlogPosting Book Clip CollectionPage Comment ContactPage Course CreativeWorkSeason CreativeWorkSeries DataCatalog DataDownload DataFeed Dataset DiscussionForumPosting Episode FAQPage Game HowTo HowToDirection HowToSection HowToStep HowToTip ImageObject LearningResource MediaObject Message MobileApplication Movie MusicPlaylist MusicRecording NewsArticle Photograph PodcastEpisode PodcastSeries ProfilePage QAPage Question Quiz Recipe Review ScholarlyArticle SearchResultsPage SiteNavigationElement SocialMediaPosting SoftwareApplication TVEpisode TVSeries TechArticle VacationRental VideoGame VideoObject WebApplication WebPage WebPageElement WebSite'.split(
             ' '
@@ -134,12 +131,7 @@ const INHERITED_RULE_GROUPS: readonly JsonLdRuleGroup[] = [
     [ORGANIZATION_TYPES, ENTITY_RULES.Organization],
     [PLACE_TYPES, ENTITY_RULES.Place],
     ['Car IndividualProduct ProductGroup ProductModel'.split(' '), ENTITY_RULES.Product],
-    ['AggregateRating EmployerAggregateRating Rating'.split(' '), EMPTY_ENTITY_RULES],
 ]
-const TYPES_WITHOUT_PROPERTIES =
-    'AlignmentObject BedDetails Certification ContactPoint CreditCard DefinedRegion EducationalOccupationalCredential EntryPoint GeoCoordinates GeoShape InteractionCounter JobPosting LocationFeatureSpecification MathSolver MemberProgram MemberProgramTier MerchantReturnPolicy MerchantReturnPolicySeasonalOverride MonetaryAmount NutritionInformation OccupationalExperienceRequirements OfferShippingDetails OpeningHoursSpecification PeopleAudience PostalAddress PriceSpecification PropertyValue QuantitativeValue ServicePeriod ShippingConditions ShippingDeliveryTime ShippingRateSettings ShippingService SpeakableSpecification Thing UnitPriceSpecification'.split(
-        ' '
-    )
 
 export const JSON_LD_EVENT_TAG = '$json_ld'
 
@@ -184,7 +176,7 @@ function getEntityRules(type: string): JsonLdEntityRules | undefined {
             return rules
         }
     }
-    return TYPES_WITHOUT_PROPERTIES.includes(type) ? EMPTY_ENTITY_RULES : undefined
+    return undefined
 }
 
 function getEntityTypes(value: unknown): string[] {


### PR DESCRIPTION
## Problem

Since [#4666](https://github.com/PostHog/posthog-js/pull/4666), the JSON-LD sanitizer keeps any `@type` that has the shape of a Schema.org term. The type lists no longer decide which type names survive. They only decide which properties a type may keep.

That change left 47 type entries that map to an empty rule set: `Person`, the 7 action types, the 3 rating types, and the 36 types in `TYPES_WITHOUT_PROPERTIES`. An entity with one of those types now produces the same output as an entity with an unknown type: the type label plus the universal properties. A reader of the file cannot tell that those entries do nothing, and the entries cost bundle bytes.

## Changes

- Nothing changes in the sanitized output. Every case in the published contract fixture passes unchanged, and the fixture needs no edit.
- The sanitizer drops the entries that map to empty rules: `Person: {}`, the action and rating rule groups, the `TYPES_WITHOUT_PROPERTIES` list, and the `EMPTY_ENTITY_RULES` constant.
- `getEntityRules` returns `undefined` for every type without its own rules. The caller already treats an empty rule set and `undefined` the same way.
- The `ACTION_TYPES`, `ORGANIZATION_TYPES`, and `PLACE_TYPES` lists stay. Nested properties such as `potentialAction`, `seller`, and `areaServed` still use them to limit which type rules apply inside that property.
- The server-side port in [PostHog/posthog#90243](https://github.com/PostHog/posthog/pull/90243) mirrors this file. The same entries come out there in a follow-up.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

No changeset. The change has no behavior. The removed bytes ship with the next posthog-js release.

## Tests

- The existing contract suite in `json-ld.test.ts` covers this change: the type sets prove every listed type still keeps its label, and the cases with `ContactPoint`, `PostalAddress`, and `Person` entities prove those types still keep only the universal properties. No new test is needed.
- Run locally: the JSON-LD unit suite, the lazy recorder unit suite, oxlint, and oxfmt on the changed file.
- `pnpm typecheck` in `packages/browser` passes after the workspace dependencies are built.
- Not run: the Playwright masking test and a bundle size measurement.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code made the change with direction from the assignee, after the assignee asked whether the type lists were still needed once the term shape rule landed.
- The dead entries were first confirmed on the Rust port: removing the matching entries there left the shared contract and the full crate suite green.
- Skills: `/writing-pr-descriptions` and Simplified Technical English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
