### PR TITLE
ci: skip credential-dependent checks when secrets are unavailable

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -69,12 +69,12 @@ jobs:
           name: bundle-stats-array.html
           path: packages/browser/bundle-stats-array.html
 
-      - name: Skip PR comments for fork PR
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        run: echo "Skipping bundled-size PR comments for fork PRs because GitHub tokens are read-only."
+      - name: Skip PR comments with a read-only token
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+        run: echo "Skipping bundled-size PR comments for fork or Dependabot PRs because GitHub tokens are read-only."
 
       - name: Find artifact link comment if it exists
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # pin v4.0.0
         id: fc
         with:
@@ -83,7 +83,7 @@ jobs:
           body-includes: Download bundle size visualization
 
       - name: Create or update artifact link comment
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # pin v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -93,7 +93,7 @@ jobs:
           edit-mode: replace
 
       - uses: preactjs/compressed-size-action@f322c295dde06a1cb7ccaef105732dd8a726d1d9 # pin v2.10.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         # v2.10.0 targets Node 24 but still bundles a dependency that calls url.parse().
         env:
           NODE_OPTIONS: --disable-warning=DEP0169

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -7,13 +7,35 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Check changeset credentials
+        id: credentials
+        env:
+          GH_APP_POSTHOG_JS_TESTS_APP_ID: ${{ secrets.GH_APP_POSTHOG_JS_TESTS_APP_ID }}
+          GH_APP_POSTHOG_JS_TESTS_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_JS_TESTS_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          missing=()
+          for name in GH_APP_POSTHOG_JS_TESTS_APP_ID GH_APP_POSTHOG_JS_TESTS_PRIVATE_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} )); then
+            echo "::notice::Skipping automatic changeset generation; missing required environment variables: ${missing[*]}"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Get app token
+        if: steps.credentials.outputs.available == 'true'
         id: app-token
         uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789 # v4.0.0
         with:
           app_id: ${{ secrets.GH_APP_POSTHOG_JS_TESTS_APP_ID }}
           private_key: ${{ secrets.GH_APP_POSTHOG_JS_TESTS_PRIVATE_KEY }}
       - name: Checkout
+        if: steps.credentials.outputs.available == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -25,6 +47,7 @@ jobs:
       # The guard below makes sure this only tolerates the rejected push, not a real
       # failure of the action.
       - name: Generate changeset
+        if: steps.credentials.outputs.available == 'true'
         id: generate
         continue-on-error: true
         uses: the-guild-org/changesets-dependencies-action@f11b16181c79e07d62b112c2f32c9db534a9df09 # v1.2.2
@@ -71,6 +94,7 @@ jobs:
           git reset --mixed HEAD^
 
       - name: Check for a generated changeset
+        if: steps.credentials.outputs.available == 'true'
         id: changes
         env:
           GENERATE_OUTCOME: ${{ steps.generate.outcome }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,20 +57,38 @@ jobs:
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository || needs.affected.outputs.is-affected != 'true' }}
         run: echo "Skipping ${{ matrix.tests.name }} integration tests because the browser package is unaffected or required secrets are unavailable for fork PRs."
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check integration credentials
+        id: credentials
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        shell: bash
+        run: |
+          missing=()
+          for name in POSTHOG_API_HOST POSTHOG_PROJECT_ID POSTHOG_PROJECT_API_KEY POSTHOG_PERSONAL_API_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} )); then
+            echo "::notice::Skipping integration tests; missing required environment variables: ${missing[*]}"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.credentials.outputs.available == 'true'
 
       - uses: ./.github/actions/setup
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
         with:
           build: false
 
       - name: Build packages
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
         run: pnpm build
 
       - name: Run ${{ matrix.tests.name }} test
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
         timeout-minutes: 30
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -198,7 +198,7 @@ jobs:
           report_failures "$FAILED_TESTS"
 
       - name: Find existing compat comment
-        if: ${{ steps.process-results.outputs.has_failures == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.process-results.outputs.has_failures == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
@@ -207,7 +207,7 @@ jobs:
           body-includes: '<!-- compat-test-results -->'
 
       - name: Create or update compat comment
-        if: ${{ steps.process-results.outputs.has_failures == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.process-results.outputs.has_failures == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -254,7 +254,7 @@ jobs:
             </details>
 
       - name: Delete compat comment if tests pass
-        if: ${{ steps.process-results.outputs.has_failures == 'false' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.process-results.outputs.has_failures == 'false' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-passing-comment
         with:
@@ -263,7 +263,7 @@ jobs:
           body-includes: '<!-- compat-test-results -->'
 
       - name: Remove outdated comment
-        if: ${{ steps.find-passing-comment.outputs.comment-id != '' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.find-passing-comment.outputs.comment-id != '' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_ID: ${{ steps.find-passing-comment.outputs.comment-id }}

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -33,12 +33,12 @@ jobs:
               env:
                   RAW_BODY: ${{ github.event.pull_request.body || '' }}
 
-            - name: Skip shame comment for fork PR
-              if: ${{ steps.is-shame-worthy.outputs.is-shame-worthy == 'true' && github.event.pull_request.head.repo.full_name != github.repository }}
-              run: echo "Skipping no-description PR comment for fork PR because GitHub tokens are read-only."
+            - name: Skip shame comment with a read-only token
+              if: ${{ steps.is-shame-worthy.outputs.is-shame-worthy == 'true' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]') }}
+              run: echo "Skipping no-description PR comment for fork or Dependabot PRs because GitHub tokens are read-only."
 
             - name: Shame if PR has no description
-              if: ${{ steps.is-shame-worthy.outputs.is-shame-worthy == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+              if: ${{ steps.is-shame-worthy.outputs.is-shame-worthy == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |

--- a/.github/workflows/replay-incident-risk.yml
+++ b/.github/workflows/replay-incident-risk.yml
@@ -83,12 +83,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           cat risk.txt
 
-      - name: Skip PR comments for fork PR
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        run: echo "Skipping incident-risk PR comments for fork PRs because GitHub tokens are read-only."
+      - name: Skip PR comments with a read-only token
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+        run: echo "Skipping incident-risk PR comments for fork or Dependabot PRs because GitHub tokens are read-only."
 
       - name: Find existing comment
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # pin v4.0.0
         id: fc
         with:
@@ -97,7 +97,7 @@ jobs:
           body-includes: "<!-- replay-incident-risk -->"
 
       - name: Create or update comment
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (steps.check.outputs.findings != '0' || steps.fc.outputs.comment-id != '') }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && (steps.check.outputs.findings != '0' || steps.fc.outputs.comment-id != '') }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # pin v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -46,28 +46,46 @@ jobs:
             name: IE11
 
     steps:
-      - name: Skip fork PR
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        run: echo "Skipping ${{ matrix.name }} TestCafe tests for fork PRs because required BrowserStack/PostHog secrets are unavailable."
+      - name: Skip TestCafe tests
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository || needs.affected.outputs.is-affected != 'true' }}
+        run: echo "Skipping ${{ matrix.name }} TestCafe tests because the browser package is unaffected or required secrets are unavailable for fork PRs."
+
+      - name: Check TestCafe credentials
+        id: credentials
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        shell: bash
+        run: |
+          missing=()
+          for name in BROWSERSTACK_USERNAME BROWSERSTACK_ACCESS_KEY POSTHOG_PROJECT_API_KEY POSTHOG_PERSONAL_API_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} )); then
+            echo "::notice::Skipping TestCafe tests; missing required environment variables: ${missing[*]}"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
 
       - uses: ./.github/actions/setup
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
         with:
           build: false
 
       - name: Build packages
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
         run: pnpm build
 
       - name: Serve static files
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
         run: python -m http.server 8080 &
 
       - name: Run ${{ matrix.name }} test
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
         timeout-minutes: 10
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -105,7 +123,7 @@ jobs:
         working-directory: packages/browser
 
       - name: Check ${{ matrix.name }} events
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && needs.affected.outputs.is-affected == 'true' }}
+        if: steps.credentials.outputs.available == 'true'
         timeout-minutes: 30
         run: pnpm check-testcafe-results
         working-directory: packages/browser

--- a/.github/workflows/validate-versioning.yml
+++ b/.github/workflows/validate-versioning.yml
@@ -100,7 +100,7 @@ jobs:
           fi
       
       - name: Remove outdated comments
-        if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           NO_CHANGESETS: ${{ steps.check-major.outputs.no_changesets }}
@@ -171,7 +171,7 @@ jobs:
             }
       
       - name: Comment on PR
-        if: ${{ failure() && steps.check-major.outputs.major_bump_found == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ failure() && steps.check-major.outputs.major_bump_found == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MAJOR_FILES: ${{ steps.check-major.outputs.major_files }}
@@ -234,7 +234,7 @@ jobs:
             }
       
       - name: Comment about PR title and changeset mismatch
-        if: ${{ failure() && steps.check-major.outputs.title_mismatch_found == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ failure() && steps.check-major.outputs.title_mismatch_found == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TITLE_MISMATCH_FILES: ${{ steps.check-major.outputs.title_mismatch_files }}
@@ -291,7 +291,7 @@ jobs:
             }
 
       - name: Comment about missing changeset
-        if: ${{ always() && steps.check-major.outputs.no_changesets == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ always() && steps.check-major.outputs.no_changesets == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,6 +238,22 @@ Follow [RELEASING.md](./RELEASING.md) for changeset requirements and writing gui
 | `bundled-size.yaml`       | Monitors bundle size changes                             | PR                                                        |
 | `generate-references.yml` | Generates API documentation                              | Workflow dispatch                                         |
 
+### CI credentials and restricted PRs
+
+Fork and Dependabot PRs may not have repository secrets, and their default `GITHUB_TOKEN` can be read-only. A same-repository PR is not proof that credentials are available.
+
+- `integration.yml` checks `POSTHOG_API_HOST`, `POSTHOG_PROJECT_ID`, `POSTHOG_PROJECT_API_KEY`, and `POSTHOG_PERSONAL_API_KEY` before checkout, dependency installation, builds, or live tests.
+- `testcafe.yml` checks both `BROWSERSTACK_USERNAME`/`BROWSERSTACK_ACCESS_KEY` and both PostHog API keys before setup, browser sessions, or event polling. Its PostHog host and project ID have defaults in the test helper.
+- `dependabot-changeset.yml` checks both GitHub App credentials before token creation or checkout. When unavailable, add any required changeset manually.
+
+These optional credential-dependent jobs succeed with an explicit skip notice when required values are missing. Never print credential values or turn authentication errors, network errors, or test failures into success when credentials are present. Keep fork guards; do not use `pull_request_target` to give PR code access to secrets.
+
+Bundle-size, compatibility, incident-risk, description, and versioning checks skip PR comment operations for forks and Dependabot while retaining their local checks and reports. The shared feature-flags project-board workflow already excludes fork and Dependabot PRs.
+
+The main unit, functional, local Playwright, MCP, SDK compliance, and native plugin checks do not require live API credentials. AI live-provider tests already skip without their respective `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`. Next.js CI smoke builds use dummy configuration and disable real sourcemap uploads.
+
+Publishing, S3 recovery, reference-generation, downstream-upgrade, and watcher worker/sweep workflows run in trusted push, manual, or scheduled contexts rather than untrusted PR test jobs. Their required GitHub App, AWS/OIDC, Slack, and OpenAI configuration must not be bypassed to make a release or automation run appear successful.
+
 ## Configuration Files
 
 - `package.json` - Root workspace scripts and dependencies


### PR DESCRIPTION
## Problem

On #4821, the PostHog project and personal API keys were empty. Playwright spent several minutes building and retrying tests that could not run. TestCafe started an IE11 BrowserStack session, then failed because PostHog had no project token.

The workflows only excluded fork PRs. Dependabot PRs can also lack secrets, even when their branch belongs to this repository. Their default GitHub token can also be read-only.

## Changes

- Playwright integration and TestCafe jobs check their required credentials before checkout, dependency installation, builds, or live tests. Missing values produce a skip notice and a successful job without printing credential values.
- Automatic Dependabot changeset generation skips when either GitHub App credential is missing.
- Optional comment operations for bundle size, compatibility, incident risk, PR descriptions, and versioning skip Dependabot as well as forks. Local checks and reports still run.
- `CONTRIBUTING.md` records the credential requirements and audit findings. Existing AI tests already skip without provider keys. Trusted release and automation workflows retain their authentication requirements.

This does not suppress authentication errors, network errors, or test failures when credentials are present. It does not grant secrets to fork PRs or change workflow triggers.

### Validation

- Ran 72 local shell scenarios covering complete, partial, empty, and unset credentials. Checked that missing values return success, prevent later setup steps, and do not print secret values.
- Verified guards on 10 GitHub API write steps.
- Ran actionlint on all changed workflows with ShellCheck disabled and the existing Depot runner label excluded. The three credential-gated workflows also passed actionlint with ShellCheck enabled.
- Ran `git diff --check`. Live API tests were not run.

## Release info Sub-libraries affected

### Libraries affected

None. This changes CI and contributor documentation only, so no package release or changeset is needed.

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

The validation above used a local workflow test script. No permanent test suite was added.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

Not applicable. No SDK code or package output changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used file-reading, editing, shell, git, and GitHub CLI tools in a dedicated worktree. The requested audit extended the fix to missing App credentials and optional PR comments. Credential presence checks were chosen instead of suppressing test failures or giving PR workflows more permissions.

Autoreview was skipped because the entire diff is limited to GitHub workflows and contributor documentation. Human review is required.
