### PR TITLE
ci: build the TypeScript consumer package once

### DIFF
--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -10,9 +10,39 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
+  build:
+    name: Build consumer package
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup
+        with:
+          node_version: 24
+          build: false
+
+      - name: Build browser package and React entrypoints
+        run: pnpm exec turbo --filter=posthog-js --filter=@posthog/react build
+
+      - name: Pack browser package
+        run: PACKAGE_DEST="${RUNNER_TEMP}/minimum-version-ts" pnpm --filter=posthog-js package
+
+      - name: Upload consumer package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: minimum-version-ts-package
+          path: ${{ runner.temp }}/minimum-version-ts/posthog-js.tgz
+          if-no-files-found: error
+          retention-days: 1
+
   unit:
     name: Check minimum TS version
+    needs: build
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -32,15 +62,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: ./.github/actions/setup
-        with:
-          node_version: 24
-          build: true
-
       - name: Prepare consumer fixture
-        run: |
-          cp -R .github/fixtures/minimum-version-ts "${RUNNER_TEMP}/minimum-version-ts"
-          PACKAGE_DEST="${RUNNER_TEMP}/minimum-version-ts" pnpm --filter=posthog-js package
+        run: cp -R .github/fixtures/minimum-version-ts "${RUNNER_TEMP}/minimum-version-ts"
+
+      - name: Download consumer package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: minimum-version-ts-package
+          path: ${{ runner.temp }}/minimum-version-ts
 
       - uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
## Problem

The minimum TypeScript version workflow installs and builds the entire workspace on Node 24 in each of its 15 consumer checks. Every check packages the same browser SDK before switching to its consumer Node version.

A recent [successful run](https://github.com/PostHog/posthog-js/actions/runs/34228721050) spent about 74 runner-minutes across those initial setup, install, and build steps. This is total runner time, not elapsed workflow time.

## Changes

- Build the browser SDK, React entrypoints, and their dependencies once on Node 24 instead of building the entire workspace in every matrix job.
- Upload the browser tarball and download that same artifact in all 15 consumer checks. Preserve every Node version, TypeScript version, compiler flag, and runtime import check.
- Skip workspace installation and builds in the consumer jobs. Keep artifact downloads within the current workflow run, with one-day retention and read-only repository permissions.
- Leave caching, other workflows, and publishing unchanged.

Validation passed for `actionlint`, `git diff --check`, the targeted build with an empty Turbo cache, packaging, and all five TypeScript versions on Node 24 using separate consumer fixtures. The matrix was checked against the original workflow and still contains the same 15 combinations. Node 20/22 execution and actual CI savings remain to be verified in CI.

## Release info Sub-libraries affected

### Libraries affected

None. This only changes CI and does not require a package release or changeset.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not applicable)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used shell commands, file editing tools, and the GitHub CLI in a dedicated worktree. The requested scope was to avoid repeated builds without adding caching. This change shares only the test tarball within one workflow run and does not connect PR artifacts to publishing. Autoreview was skipped because the diff only changes a GitHub workflow. Human review is required.
