### PR TITLE
fix(react-native): keep survey content touches from dismissing keyboard

### DIFF
--- a/.changeset/sixty-loops-smile.md
+++ b/.changeset/sixty-loops-smile.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Keep the keyboard open when touching survey content to select, paste, or scroll text.

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -127,6 +127,7 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
             <View style={[styles.modalRow, { justifyContent: horizontal }]}>
               <View style={styles.modalContent} pointerEvents="box-none">
                 <View
+                  onTouchStart={(event) => event.stopPropagation()}
                   style={[
                     styles.modalContentInner,
                     {

--- a/packages/react-native/test/SurveyModal.spec.tsx
+++ b/packages/react-native/test/SurveyModal.spec.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 import React from 'react'
+import { Keyboard, Platform } from 'react-native'
 import { act, fireEvent, render, cleanup } from '@testing-library/react'
 import { Survey, SurveyQuestionType, SurveyType } from '@posthog/core'
 
@@ -35,7 +36,7 @@ vi.mock('react-native', async () => {
   return {
     View: Box,
     Modal: Box,
-    KeyboardAvoidingView: Box,
+    KeyboardAvoidingView: (props: any) => RealReact.createElement(Box, { ...props, testID: 'keyboard-avoiding-view' }),
     Pressable,
     TouchableOpacity: Pressable,
     Text: Box,
@@ -136,6 +137,28 @@ const clickCancel = (getByTestId: (id: string) => HTMLElement) => {
     fireEvent.click(getByTestId('cancel-stub'))
   })
 }
+
+describe('SurveyModal keyboard touches', () => {
+  afterEach(cleanup)
+
+  it.each(['ios', 'android'] as const)('only dismisses the keyboard for backdrop touches on %s', (platform) => {
+    const originalOS = Platform.OS
+    Platform.OS = platform
+    try {
+      const { getByTestId } = renderSurveyModal()
+
+      fireEvent.mouseDown(getByTestId('questions-stub'))
+      expect(Keyboard.dismiss).not.toHaveBeenCalled()
+
+      // The backdrop is the direct child of the keyboard-avoiding container.
+      const backdrop = getByTestId('keyboard-avoiding-view').firstElementChild!
+      fireEvent.mouseDown(backdrop)
+      expect(Keyboard.dismiss).toHaveBeenCalledTimes(1)
+    } finally {
+      Platform.OS = originalOS
+    }
+  })
+})
 
 describe('SurveyModal close behavior', () => {
   afterEach(() => {


### PR DESCRIPTION
## Problem

Touches inside a React Native survey bubble to the backdrop's `Keyboard.dismiss` handler. Selecting, pasting, or scrolling text can dismiss the keyboard and move the form during the interaction.

## Changes

Stop touch-start propagation at the survey content container. Tapping the backdrop still dismisses the keyboard.

Added coverage using the existing modal test shim for iOS and Android. Both new cases fail before the fix; all 752 React Native SDK tests pass after it. Package lint, repository formatting/correctness checks, playground lint, and the SDK build with its dependencies also pass. The changeset requests a React Native patch release.

These tests verify event propagation, not native keyboard rendering. No fresh simulator/device run was performed against this upstream checkout. The full root lint command stopped at the unrelated Nuxt package because its `eslint-plugin-regexp` dependency was not installed in this filtered workspace setup. Full monorepo build/tests are left to CI to limit local resource use.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

**Human owner:** @Anzormumladze. Please assign me to the PR; GitHub rejected my self-assignment request with HTTP 403.

Codex implemented and tested the change; SDD/Fable reviewed the approach. GitHub CLI was used for publication. [Sanitized session summary](https://gist.github.com/Anzormumladze/113d6d78e82317df471b4744bdffd067) (not the original conversation). The fix stays within the SDK's content/backdrop touch boundary rather than duplicating survey lifecycle logic in the consuming app.
