### PR TITLE
fix(react-native): make Android Expo symbol setup order-independent

### DIFF
--- a/.changeset/fix-react-native-gradle-mod-order.md
+++ b/.changeset/fix-react-native-gradle-mod-order.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix Android native symbol uploads when another Expo plugin registers an app Gradle mod first.

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -2,11 +2,13 @@
 // Copyright (c) 2017 Sentry
 // Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 
+const fs = require('fs')
+
 const {
+  AndroidConfig,
   withAppBuildGradle,
   withBaseMod,
   withGradleProperties,
-  withProjectBuildGradle,
   withXcodeProject,
 } = require('@expo/config-plugins')
 
@@ -182,33 +184,51 @@ export function applyPostHogAndroidGradlePlugin(appBuildGradle: string): string 
   return appBuildGradle
 }
 
-const withAndroidNativeSymbolsPlugin = (config: any) => {
-  // Couple the classpath and `apply plugin`: applying without the classpath breaks the build.
-  // Expo evaluates mods in key-insertion order, so this plugin must register before anything
-  // else touches appBuildGradle — otherwise the flag is read before projectBuildGradle sets it.
-  let classpathPresent = false
+// Expo's standard mods run their action before the previously registered action. This wrapper
+// deliberately runs its action after the rest of the project Gradle mod chain, so it can safely
+// coordinate the project classpath and app plugin edits without relying on mod-key order.
+const withFinalizedProjectBuildGradle = (config: any, action: (config: any) => any) => {
+  return withBaseMod(config, {
+    platform: 'android',
+    mod: 'projectBuildGradle',
+    skipEmptyMod: false,
+    async action(config: any) {
+      const { nextMod, ...modRequest } = config.modRequest
+      const results = await nextMod({ ...config, modRequest })
+      return action(results)
+    },
+  })
+}
 
-  config = withProjectBuildGradle(config, (config: any) => {
+const withAndroidNativeSymbolsPlugin = (config: any) => {
+  return withFinalizedProjectBuildGradle(config, async (config: any) => {
     if (config.modResults.language !== 'groovy') {
       console.warn('Cannot configure the PostHog Android Gradle plugin because the project build.gradle is not groovy')
       return config
     }
-    const result = addPostHogAndroidGradlePluginClasspath(config.modResults.contents)
-    config.modResults.contents = result.contents
-    classpathPresent = result.classpathPresent
-    return config
-  })
 
-  return withAppBuildGradle(config, (config: any) => {
-    if (config.modResults.language !== 'groovy') {
+    const result = addPostHogAndroidGradlePluginClasspath(config.modResults.contents)
+    if (result.contents !== config.modResults.contents) {
+      // Persist the classpath before applying the app plugin so a failed second write cannot
+      // leave an apply line without its matching classpath.
+      await fs.promises.writeFile(config.modResults.path, result.contents)
+      config.modResults.contents = result.contents
+    }
+    if (!result.classpathPresent) {
+      // No classpath (or no buildscript dependencies block) → applying would break the build.
+      return config
+    }
+
+    const appBuildGradle = await AndroidConfig.Paths.getAppBuildGradleAsync(config.modRequest.projectRoot)
+    if (appBuildGradle.language !== 'groovy') {
       console.warn('Cannot configure the PostHog Android Gradle plugin because the app build.gradle is not groovy')
       return config
     }
-    if (!classpathPresent) {
-      // No classpath (kts, or no buildscript dependencies block) → applying would break the build.
-      return config
+
+    const contents = applyPostHogAndroidGradlePlugin(appBuildGradle.contents)
+    if (contents !== appBuildGradle.contents) {
+      await fs.promises.writeFile(appBuildGradle.path, contents)
     }
-    config.modResults.contents = applyPostHogAndroidGradlePlugin(config.modResults.contents)
     return config
   })
 }
@@ -780,10 +800,6 @@ const withPostHogPlugin = (config: any, rawProps: PostHogPluginProps = {}) => {
     dotenvFile: resolveDotenvFileProp(rawProps.dotenvFile),
     releaseMode: resolveReleaseModeProp(rawProps.releaseMode, process.env.POSTHOG_RELEASE_MODE),
   }
-  // Must register first: it inserts the projectBuildGradle mod key ahead of appBuildGradle,
-  // and expo evaluates mods in key-insertion order. Registering withAndroidPlugin first would
-  // make appBuildGradle run before projectBuildGradle, so `classpathPresent` would still be
-  // false and `apply plugin: "com.posthog.android"` would silently never be written.
   // includeSource is iOS-only, so on Android we only care whether upload is enabled.
   if (resolveNativeSymbolUpload(props.uploadNativeSymbols).enabled) {
     config = withAndroidNativeSymbolsPlugin(config)

--- a/packages/react-native/test/expoconfig-android-mods.spec.ts
+++ b/packages/react-native/test/expoconfig-android-mods.spec.ts
@@ -1,0 +1,104 @@
+import { compileModsAsync, withAppBuildGradle, withProjectBuildGradle } from '@expo/config-plugins'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import * as postHogExpoPluginModule from '../src/tooling/expoconfig'
+
+const postHogExpoPlugin = (postHogExpoPluginModule as any).default
+
+const projectGradle =
+  'buildscript {\n    dependencies {\n        classpath("com.android.tools.build:gradle")\n    }\n}\n'
+const appGradle = 'apply plugin: "com.android.application"\n\nandroid {\n    namespace "com.example"\n}\n'
+const applyLine = 'apply plugin: "com.posthog.android"'
+
+// Use Expo's real providers/compiler so both mod-kind ordering and persisted files are exercised.
+describe.each([false, true])('Android native symbols with earlier app mod: %s', (earlierAppMod) => {
+  let projectRoot: string
+
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-expo-android-'))
+    fs.mkdirSync(path.join(projectRoot, 'android/app'), { recursive: true })
+    fs.writeFileSync(path.join(projectRoot, 'android/build.gradle'), projectGradle)
+    fs.writeFileSync(path.join(projectRoot, 'android/app/build.gradle'), appGradle)
+    fs.writeFileSync(path.join(projectRoot, 'android/gradle.properties'), '')
+  })
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true })
+    vi.restoreAllMocks()
+    vi.useFakeTimers()
+  })
+
+  async function prebuild(uploadNativeSymbols = true) {
+    let config: any = { name: 'Test', slug: 'test' }
+    const appMod = vi.fn((config) => config)
+    const projectMod = vi.fn((config) => config)
+    if (earlierAppMod) {
+      config = withAppBuildGradle(config, appMod)
+    }
+    config = postHogExpoPlugin(config, { uploadNativeSymbols })
+    if (!earlierAppMod) {
+      config = withAppBuildGradle(config, appMod)
+    }
+    config = withProjectBuildGradle(config, projectMod)
+    await compileModsAsync(config, { projectRoot, platforms: ['android'] })
+    expect(appMod).toHaveBeenCalledTimes(1)
+    expect(projectMod).toHaveBeenCalledTimes(1)
+  }
+
+  function readGradle(file: string) {
+    return fs.readFileSync(path.join(projectRoot, 'android', file), 'utf8')
+  }
+
+  it('writes both native-symbol Gradle edits and remains idempotent on another prebuild', async () => {
+    await prebuild()
+    const project = readGradle('build.gradle')
+    const app = readGradle('app/build.gradle')
+    expect(project).toContain('classpath("com.posthog:posthog-android-gradle-plugin:')
+    expect(app.split(applyLine)).toHaveLength(2)
+    expect(app).toContain('posthog.gradle')
+    expect(console.warn).not.toHaveBeenCalled()
+
+    await prebuild()
+    expect(readGradle('build.gradle')).toBe(project)
+    expect(readGradle('app/build.gradle')).toBe(app)
+  })
+
+  it('does not apply the plugin when the project has no buildscript dependencies', async () => {
+    fs.writeFileSync(path.join(projectRoot, 'android/build.gradle'), 'buildscript { repositories { google() } }')
+    await prebuild()
+    expect(readGradle('build.gradle')).not.toContain('posthog-android-gradle-plugin')
+    expect(readGradle('app/build.gradle')).not.toContain(applyLine)
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not find a buildscript dependencies block')
+    )
+  })
+
+  it('does not apply the plugin for a Kotlin project Gradle file', async () => {
+    fs.renameSync(path.join(projectRoot, 'android/build.gradle'), path.join(projectRoot, 'android/build.gradle.kts'))
+    await prebuild()
+    expect(readGradle('build.gradle.kts')).toBe(projectGradle)
+    expect(readGradle('app/build.gradle')).not.toContain(applyLine)
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('project build.gradle is not groovy'))
+  })
+
+  it('does not apply the native plugin for a Kotlin app Gradle file', async () => {
+    fs.renameSync(
+      path.join(projectRoot, 'android/app/build.gradle'),
+      path.join(projectRoot, 'android/app/build.gradle.kts')
+    )
+    await prebuild()
+    expect(readGradle('app/build.gradle.kts')).not.toContain(applyLine)
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('app build.gradle is not groovy'))
+  })
+
+  it('leaves native-symbol setup disabled when not requested', async () => {
+    await prebuild(false)
+    expect(readGradle('build.gradle')).toBe(projectGradle)
+    expect(readGradle('app/build.gradle')).not.toContain(applyLine)
+    expect(readGradle('app/build.gradle')).toContain('posthog.gradle')
+  })
+})

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -1,4 +1,4 @@
-import { withXcodeProject } from '@expo/config-plugins'
+import { compileModsAsync, withAppBuildGradle, withXcodeProject } from '@expo/config-plugins'
 import { spawnSync } from 'child_process'
 import * as fs from 'fs'
 import * as os from 'os'
@@ -911,6 +911,86 @@ describe('resolveReleaseModeProp', () => {
   it('stops the prebuild on a typo rather than falling back to the default', () => {
     expect(resolveReleaseModeProp(' event ')).toBe('event')
     expect(() => resolveReleaseModeProp('evnet')).toThrow("was 'evnet'")
+  })
+})
+
+describe('postHogExpoPlugin Android native symbols', () => {
+  const projectRoots: string[] = []
+  const projectBuildGradle = [
+    'buildscript {',
+    '    repositories {',
+    '        google()',
+    '        mavenCentral()',
+    '    }',
+    '    dependencies {',
+    '        classpath("com.android.tools.build:gradle")',
+    '    }',
+    '}',
+  ].join('\n')
+  const appBuildGradle = [
+    'apply plugin: "com.android.application"',
+    'apply plugin: "com.facebook.react"',
+    '',
+    'android {',
+    '    namespace "com.example"',
+    '}',
+  ].join('\n')
+
+  const compilePlugin = async (projectContents = projectBuildGradle) => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'posthog-expo-gradle-'))
+    const androidRoot = path.join(projectRoot, 'android')
+    const appRoot = path.join(androidRoot, 'app')
+    projectRoots.push(projectRoot)
+    fs.mkdirSync(appRoot, { recursive: true })
+    fs.writeFileSync(path.join(androidRoot, 'build.gradle'), projectContents)
+    fs.writeFileSync(path.join(appRoot, 'build.gradle'), appBuildGradle)
+    fs.writeFileSync(path.join(androidRoot, 'gradle.properties'), '')
+
+    const withEarlierAppGradlePlugin = withAppBuildGradle(
+      { name: 'PostHog config plugin test', slug: 'posthog-config-plugin-test' } as any,
+      (config) => {
+        config.modResults.contents += '\n// Added by earlier config plugin'
+        return config
+      }
+    )
+    const config = postHogExpoPlugin(withEarlierAppGradlePlugin, {
+      uploadNativeSymbols: true,
+      disableSandboxing: false,
+    })
+    await compileModsAsync(config, { projectRoot, platforms: ['android'] })
+
+    return {
+      project: fs.readFileSync(path.join(androidRoot, 'build.gradle'), 'utf8'),
+      app: fs.readFileSync(path.join(appRoot, 'build.gradle'), 'utf8'),
+    }
+  }
+
+  afterEach(() => {
+    for (const projectRoot of projectRoots.splice(0)) {
+      fs.rmSync(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('applies the Android plugin when an earlier config plugin registers appBuildGradle first', async () => {
+    const result = await compilePlugin()
+
+    expect(result.project).toContain('classpath("com.posthog:posthog-android-gradle-plugin:')
+    expect(result.app).toContain('// Added by earlier config plugin')
+    expect(result.app).toContain('apply plugin: "com.posthog.android"')
+  })
+
+  it('does not apply the Android plugin when its classpath cannot be configured', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const projectContents = 'plugins {\n    id "com.android.application"\n}'
+      const result = await compilePlugin(projectContents)
+
+      expect(result.project).toBe(projectContents)
+      expect(result.app).not.toContain('apply plugin: "com.posthog.android"')
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Could not find a buildscript dependencies block'))
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
## Problem

When an Expo config plugin listed before PostHog registers an `appBuildGradle` mod, Expo can evaluate `appBuildGradle` before `projectBuildGradle`. The previous implementation read a `classpathPresent` flag before it was set and silently omitted `apply plugin: "com.posthog.android"`, so Android R8 mappings were not uploaded.

Fixes #4852

## Changes

- Coordinate the Android classpath and app-plugin edits through the existing `withBaseMod` API, running the project Gradle chain before the PostHog action instead of relying on mod-key insertion order.
- Persist the classpath before writing the app plugin so a failed second write cannot leave an app plugin without its matching classpath.
- Keep the existing fail-safe behavior for unsupported project/app Gradle languages or projects without a `buildscript.dependencies` block.
- Add an integration regression test with an earlier `withAppBuildGradle` mod, including a check that the earlier mod's content is preserved.

## Validation

- `oxlint --report-unused-disable-directives-severity error src test` (pass)
- `oxfmt --check` on the changed source, test, and changeset (pass)
- Targeted TypeScript check for `src/tooling/expoconfig.ts` (pass)
- Android Expo mod-order regression tests: 2 passed
- Remaining non-shell `expoconfig.spec.ts` tests: 75 passed
- Compatibility harness using `@expo/config-plugins@4.1.5` (pass)

The full `expoconfig.spec.ts` file also ran locally on Windows; its seven shell-syntax assertions could not execute because Node could not resolve `/bin/sh`. The changed Android tests and all other tests passed; this is an existing platform limitation in those assertions.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact across Android and iOS (iOS behavior is unchanged)
- [x] Accounted for backwards compatibility with older Expo config-plugin runtimes
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a changeset for `posthog-react-native`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using repository inspection, GitHub CLI, targeted Vitest/Oxlint/Oxfmt checks, and an older Expo config-plugin compatibility harness. The fix deliberately uses the repository's existing `withBaseMod` pattern rather than `withFinalizedMod`, because the package can run with older Expo config-plugin versions. The PR is attributable to `dvd233` as the directing contributor; no manual Android device build was claimed.

GitHub did not grant this fork contributor permission to set the base-repository assignee, so the PR remains unassigned; authorship and human direction are recorded here instead.
