### PR TITLE
feat(react-native): capture warm-start push opens on Android

### DIFF
--- a/.changeset/rn-warm-start-push-open.md
+++ b/.changeset/rn-warm-start-push-open.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': minor
+---
+
+Capture `$push_notification_opened` on Android when a notification is tapped while the app is already running, not just on a cold start.

--- a/packages/react-native-plugin/android/build.gradle
+++ b/packages/react-native-plugin/android/build.gradle
@@ -91,7 +91,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.posthog:posthog-android:3.61.0"
+  implementation "com.posthog:posthog-android:3.62.0"
 
   testImplementation "junit:junit:4.13.2"
 }

--- a/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
+++ b/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
@@ -1,7 +1,9 @@
 package com.posthogreactnativeplugin
 
+import android.app.Activity
 import android.content.Intent
 import android.util.Log
+import com.facebook.react.bridge.ActivityEventListener
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -23,8 +25,29 @@ import java.util.UUID
 
 class PosthogReactNativePluginModule(
   reactContext: ReactApplicationContext,
-) : ReactContextBaseJavaModule(reactContext) {
+) : ReactContextBaseJavaModule(reactContext),
+  ActivityEventListener {
   override fun getName(): String = NAME
+
+  override fun initialize() {
+    super.initialize()
+    // ReactActivity forwards onNewIntent to its listeners, so unlike a plain Android host the
+    // app needs no code of its own for warm-start taps.
+    reactApplicationContext.addActivityEventListener(this)
+  }
+
+  override fun onActivityResult(
+    activity: Activity?,
+    requestCode: Int,
+    resultCode: Int,
+    data: Intent?,
+  ) = Unit
+
+  // A tap delivered while the process is alive never reaches onActivityCreated, so the native
+  // integration cannot see it. Deduplicated by message id against the cold-start path.
+  override fun onNewIntent(intent: Intent?) {
+    PostHogAndroid.capturePushNotificationOpened(intent)
+  }
 
   @ReactMethod
   fun setup(
@@ -527,6 +550,7 @@ class PosthogReactNativePluginModule(
   fun removeListeners(count: Int) = Unit
 
   override fun invalidate() {
+    reactApplicationContext.removeActivityEventListener(this)
     if (pushModule === this) {
       // Decline mints fast after teardown instead of stalling the native 10s watchdog.
       pushModule = null

--- a/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
+++ b/packages/react-native-plugin/android/src/main/java/com/posthogreactnativeplugin/PosthogReactNativePluginModule.kt
@@ -37,7 +37,7 @@ class PosthogReactNativePluginModule(
   }
 
   override fun onActivityResult(
-    activity: Activity?,
+    activity: Activity,
     requestCode: Int,
     resultCode: Int,
     data: Intent?,
@@ -45,7 +45,7 @@ class PosthogReactNativePluginModule(
 
   // A tap delivered while the process is alive never reaches onActivityCreated, so the native
   // integration cannot see it. Deduplicated by message id against the cold-start path.
-  override fun onNewIntent(intent: Intent?) {
+  override fun onNewIntent(intent: Intent) {
     PostHogAndroid.capturePushNotificationOpened(intent)
   }
 


### PR DESCRIPTION
## Problem

Closes #4857.

On Android, React Native captures `$push_notification_opened` for a cold-start tray tap but never for a tap that arrives while the app is already running. That tap is delivered to `Activity.onNewIntent`, which `ActivityLifecycleCallbacks` does not expose, so posthog-android's integration cannot see it — and the plugin's own launch-intent read (`captureColdStartPushOpenIfNeeded`) only ever looks at the intent the Activity was created with. Those opens are silently missing.

## Changes

- The module now implements `ActivityEventListener` and forwards `onNewIntent` to `PostHogAndroid.capturePushNotificationOpened(intent)`. `ReactActivity` already forwards `onNewIntent` to its listeners, so **hosts need no code of their own** — unlike a plain Android app, which has to add the call to its own activity.
- Raises the `com.posthog:posthog-android` floor from 3.61.0 to **3.62.0**, which is where `PostHogAndroid.capturePushNotificationOpened(intent)` landed (PostHog/posthog-android#753). At 3.61.0 the function does not exist.
- The listener is registered in `initialize()` and removed in `invalidate()`.

Deduplication is posthog-android's, keyed on `google.message_id`, so the new path cannot double-count against the cold-start one.

Worth a reviewer's attention: the RN example app's `MainActivity` uses `android:launchMode="singleTask"` (the React Native template default), which delivers `onNewIntent` just as `singleTop` does. So the `singleTop` requirement documented for plain Android hosts does not apply to a stock RN app.

## Testing

Verified on a Pixel 9 emulator with `examples/example-rn-native-plugin`, pointed at a local stand-in for the ingestion host so each assertion is made against the exact `/batch` body the SDK sent:

| Scenario | Result |
| --- | --- |
| Cold launch carrying `google.message_id` | captured — unchanged, this is the existing path |
| Tap while the app is running (`onNewIntent`) | **captured** — 0 before this change |
| Same message id delivered again | not captured |

Falsified rather than just confirmed: with only the `onNewIntent` body reverted and everything else identical, the warm tap captures nothing; restoring it captures once again. The warm event carries the new intent's payload, not a re-read of the cold one.

**No unit test.** The existing `PosthogReactNativePluginModuleTest` has `junit` only — no Robolectric or mocking framework — so covering this would mean pulling one in to fake `ReactApplicationContext` and `Activity`. That felt like more surface than the change warrants; happy to add it if you'd rather have it.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code ([session](https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd)), driven by @turnipdabeets. Found while correcting the push-notification open-coverage docs across SDKs (PostHog/posthog.com#19905) — the React Native page says "on Android only cold-start taps are captured", and checking whether that was still true turned up the gap rather than a stale sentence.

Two things were measured rather than assumed:

- Whether RN misses cold starts too, the way Flutter did. It does not — `captureColdStartPushOpenIfNeeded` already solves it, with a comment naming the same late-install problem. The docs sentence was accurate; only the warm half was missing.
- Whether hosts would need an `onNewIntent` line, as plain Android apps do. They do not: `ReactActivity` forwards to `ActivityEventListener`, so the plugin can register itself. That is why this closes the gap without a docs-only workaround.

Related, same gap closed elsewhere: PostHog/posthog-android#753 (the entry point), PostHog/posthog-flutter#557 (Flutter's `NewIntentListener`), PostHog/posthog-ios#792 (the iOS cold-start half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd
