### PR TITLE
fix(replay): disable autofill on inputs rebuilt for replay

### DIFF
--- a/.changeset/replay-disable-input-autocomplete.md
+++ b/.changeset/replay-disable-input-autocomplete.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Set `autocomplete="off"` on `<input>` and `<textarea>` elements rebuilt during session replay. The replay iframe is a live document, so the viewer's own browser offered autofill on those fields and an accepted suggestion wrote the viewer's saved data into the replay, where it read as the recorded user's input.

--- a/.changeset/replay-disable-input-autocomplete.md
+++ b/.changeset/replay-disable-input-autocomplete.md
@@ -2,4 +2,4 @@
 'posthog-js': patch
 ---
 
-Set `autocomplete="off"` on `<input>` and `<textarea>` elements rebuilt during session replay. The replay iframe is a live document, so the viewer's own browser offered autofill on those fields and an accepted suggestion wrote the viewer's saved data into the replay, where it read as the recorded user's input.
+Disable browser autofill on input and textarea fields during session replay.

--- a/packages/rrweb/rrdom/test/diff.test.ts
+++ b/packages/rrweb/rrdom/test/diff.test.ts
@@ -5,7 +5,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as puppeteer from 'puppeteer';
 import { vi, MockInstance } from 'vitest';
-import { createMirror, Mirror as NodeMirror } from '@posthog/rrweb-snapshot';
+import {
+  buildNodeWithSN,
+  createCache,
+  createMirror,
+  Mirror as NodeMirror,
+} from '@posthog/rrweb-snapshot';
 import {
   buildFromDom,
   getDefaultSN,
@@ -524,6 +529,41 @@ describe('diff algorithm for rrdom', () => {
       expect(setAttributeSpy).toHaveBeenCalledWith('type', 'application/css');
 
       setAttributeSpy.mockRestore();
+    });
+  });
+
+  describe('a form field added while fast-forwarding', () => {
+    // Fast-forward builds the node against the RRDocument, so rebuild's
+    // autofill guard lands on an RRElement. createOrGetNode then makes a bare
+    // real element, leaving diffProps as the only thing that carries it over.
+    it('keeps autocomplete="off" on the real input', () => {
+      const rrDocument = new RRDocument();
+      const rrContainer = rrDocument.createElement('div');
+      const rrInput = buildNodeWithSN(
+        {
+          type: RRNodeType.Element,
+          tagName: 'input',
+          attributes: { type: 'text' },
+          childNodes: [],
+          id: 2,
+        } as serializedNodeWithId,
+        {
+          doc: rrDocument as unknown as Document,
+          mirror: rrDocument.mirror as unknown as NodeMirror,
+          hackCss: false,
+          cache: createCache(),
+        },
+      );
+      expect(rrInput).not.toBeNull();
+      rrContainer.appendChild(rrInput as unknown as IRRNode);
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      diff(container, rrContainer, replayer, rrDocument.mirror);
+
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      expect(input!.getAttribute('autocomplete')).toEqual('off');
     });
   });
 

--- a/packages/rrweb/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb/rrweb-snapshot/src/rebuild.ts
@@ -435,6 +435,15 @@ function buildNode(
           }
         }
       }
+
+      // The replay iframe is a live document, so the viewer's own browser
+      // offers autofill on these fields. Accepting a suggestion would write the
+      // viewer's saved data into the replay, where it reads as the recorded
+      // user's input.
+      if (tagName === 'input' || tagName === 'textarea') {
+        node.setAttribute('autocomplete', 'off');
+      }
+
       return node;
     }
     case NodeType.Text:

--- a/packages/rrweb/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
@@ -380,17 +380,17 @@ exports[`integration tests > [html file]: form-fields.html 1`] = `
   </head>  <body>
     <form>
       <label for=\\"text\\">
-        <input type=\\"text\\" value=\\"1\\" />
+        <input type=\\"text\\" value=\\"1\\" autocomplete=\\"off\\" />
       </label>
       <label for=\\"radio\\">
-        <input type=\\"radio\\" checked=\\"\\" />
+        <input type=\\"radio\\" checked=\\"\\" autocomplete=\\"off\\" />
       </label>
       <label for=\\"checkbox\\">
-        <input type=\\"checkbox\\" checked=\\"\\" />
+        <input type=\\"checkbox\\" checked=\\"\\" autocomplete=\\"off\\" />
       </label>
       <label for=\\"textarea\\">
-        <textarea name=\\"\\" id=\\"\\" cols=\\"30\\" rows=\\"10\\">1234</textarea>
-        <textarea name=\\"\\" id=\\"\\" cols=\\"30\\" rows=\\"10\\">1234</textarea>
+        <textarea name=\\"\\" id=\\"\\" cols=\\"30\\" rows=\\"10\\" autocomplete=\\"off\\">1234</textarea>
+        <textarea name=\\"\\" id=\\"\\" cols=\\"30\\" rows=\\"10\\" autocomplete=\\"off\\">1234</textarea>
       </label>
       <label for=\\"select\\">
         <select name=\\"\\" id=\\"\\" value=\\"2\\">
@@ -399,7 +399,7 @@ exports[`integration tests > [html file]: form-fields.html 1`] = `
         </select>
       </label>
       <label>
-        <input name=\\"tagName\\" />
+        <input name=\\"tagName\\" autocomplete=\\"off\\" />
       </label>
     </form>
   

--- a/packages/rrweb/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/rebuild.test.ts
@@ -106,6 +106,40 @@ describe('rebuild', function () {
     });
   });
 
+  describe('autocomplete', function () {
+    const build = (tagName: string, attributes: Record<string, string> = {}) =>
+      buildNodeWithSN(
+        {
+          id: 1,
+          tagName,
+          type: NodeType.Element,
+          attributes,
+          childNodes: [],
+        },
+        {
+          doc: document,
+          mirror,
+          hackCss: false,
+          cache,
+        },
+      ) as HTMLElement;
+
+    it('disables autofill on rebuilt text entry fields', function () {
+      expect(build('input').getAttribute('autocomplete')).toBe('off');
+      expect(build('textarea').getAttribute('autocomplete')).toBe('off');
+    });
+
+    it('overrides the recorded autocomplete value', function () {
+      const node = build('input', { autocomplete: 'email' });
+      expect(node.getAttribute('autocomplete')).toBe('off');
+    });
+
+    it('leaves other elements alone', function () {
+      expect(build('div').hasAttribute('autocomplete')).toBe(false);
+      expect(build('select').hasAttribute('autocomplete')).toBe(false);
+    });
+  });
+
   describe('script placeholder', function () {
     it('rebuilds a <script> as an empty <noscript> so the placeholder never renders', function () {
       const node = buildNodeWithSN(

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -2061,6 +2061,15 @@ export class Replayer {
       for (const attributeName in mutation.attributes) {
         if (typeof attributeName === 'string') {
           const value = mutation.attributes[attributeName];
+          // rebuild forces autocomplete="off" on inputs and textareas so the
+          // viewer's browser never offers autofill inside the replay; a
+          // recorded change to that attribute must not undo it
+          if (
+            attributeName === 'autocomplete' &&
+            (target.nodeName === 'INPUT' || target.nodeName === 'TEXTAREA')
+          ) {
+            continue;
+          }
           if (value === null) {
             (target as Element | RRElement).removeAttribute(attributeName);
             if (attributeName === 'open')

--- a/packages/rrweb/rrweb/test/events/input-autocomplete-mutation.ts
+++ b/packages/rrweb/rrweb/test/events/input-autocomplete-mutation.ts
@@ -1,0 +1,102 @@
+import { EventType, IncrementalSource } from '@posthog/rrweb-types';
+import type { eventWithTime } from '@posthog/rrweb-types';
+
+const now = Date.now();
+const events: eventWithTime[] = [
+  {
+    type: EventType.DomContentLoaded,
+    data: {},
+    timestamp: now,
+  },
+  {
+    type: EventType.Load,
+    data: {},
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost',
+      width: 1200,
+      height: 500,
+    },
+    timestamp: now + 100,
+  },
+  // full snapshot with an input and a textarea; rebuild forces
+  // autocomplete="off" on both regardless of what was recorded
+  {
+    data: {
+      node: {
+        id: 1,
+        type: 0,
+        childNodes: [
+          { id: 2, name: 'html', type: 1, publicId: '', systemId: '' },
+          {
+            id: 3,
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              {
+                id: 4,
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+              },
+              {
+                id: 5,
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  {
+                    id: 6,
+                    type: 2,
+                    tagName: 'input',
+                    attributes: { type: 'text', autocomplete: 'off' },
+                    childNodes: [],
+                  },
+                  {
+                    id: 7,
+                    type: 2,
+                    tagName: 'textarea',
+                    attributes: { autocomplete: 'off' },
+                    childNodes: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      initialOffset: { top: 0, left: 0 },
+    },
+    type: EventType.FullSnapshot,
+    timestamp: now + 100,
+  },
+  // the recorded page re-enables autofill on the input and drops the
+  // attribute from the textarea; neither may reach the replay document
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [
+        {
+          id: 6,
+          attributes: { autocomplete: 'email' },
+        },
+        {
+          id: 7,
+          attributes: { autocomplete: null },
+        },
+      ],
+      removes: [],
+      adds: [],
+    },
+    timestamp: now + 150,
+  },
+];
+
+export default events;

--- a/packages/rrweb/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/rrweb/test/replayer.test.ts
@@ -39,6 +39,7 @@ import documentReplacementEvents from './events/document-replacement';
 import hoverInIframeShadowDom from './events/iframe-shadowdom-hover';
 import customElementDefineClass from './events/custom-element-define-class';
 import svgXlinkHrefEvents from './events/svg-xlink-href';
+import inputAutocompleteMutationEvents from './events/input-autocomplete-mutation';
 import readdNodeSubtreeSwapEvents from './events/readd-node-subtree-swap';
 import {
   EventType,
@@ -1041,6 +1042,26 @@ describe('replayer', function () {
         .getAttributeNS('http://www.w3.org/1999/xlink', 'href');
     `);
     expect(href).toBe('#icon-b');
+  });
+
+  it('keeps autocomplete="off" on inputs when a mutation changes the attribute', async () => {
+    await page.evaluate(
+      `events = ${JSON.stringify(inputAutocompleteMutationEvents)}`,
+    );
+    await page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.play();
+    `);
+    await page.waitForTimeout(200);
+
+    const autocompletes = await page.evaluate(`
+      [
+        replayer.iframe.contentDocument.querySelector('input').getAttribute('autocomplete'),
+        replayer.iframe.contentDocument.querySelector('textarea').getAttribute('autocomplete'),
+      ]
+    `);
+    expect(autocompletes).toEqual(['off', 'off']);
   });
 
   it('should destroy the replayer after calling destroy()', async () => {


### PR DESCRIPTION
## Problem

The replay player rebuilds the recorded page into a live iframe. Text entry fields are rebuilt as real `<input>` / `<textarea>` elements, so the **viewer's own browser** offers its autofill suggestions on them. If a viewer accepts one — or their browser fills the field automatically on render — their saved name, email, address, or card lands in the replay, presented as though the recorded user had typed it.

Two problems with that: it puts the viewer's personal data on screen (and into anything captured from that screen), and it silently misrepresents what the recorded user actually did.

**Why:** noticed while re-verifying the upstream tracker for the rrweb `2.1.3` release. This is upstream [rrweb#1771](https://github.com/rrweb-io/rrweb/pull/1771), merged and released in `2.1.3`, and verified absent from our fork.

## Changes

- `buildNode` now sets `autocomplete="off"` on rebuilt `<input>` and `<textarea>` elements. `<select>` is deliberately left alone — browser autofill does not populate it the same way, and it carries a recorded `value` the replayer applies.
- The replayer now skips recorded `autocomplete` mutations on `<input>` / `<textarea>` (`replay/index.ts:2064`). Without this the guard only held until the first recorded change to that attribute, which could set it back to a real value or remove it outright — re-enabling autofill mid-replay. Covered by a puppeteer test in `replayer.test.ts`.
- Unit coverage in `rebuild.test.ts` for the attribute being set, for it overriding a recorded `autocomplete` value, and for other elements being untouched.
- Updated the `form-fields.html` real-browser integration snapshot, which is what actually proves this reaches every rebuilt field.
- A regression test in `rrdom/test/diff.test.ts` covering the virtual-DOM replay path, which the `rebuild.test.ts` cases do not reach — see the third note below.

The first bullet is the same change as upstream. The mutation guard is **not** in upstream #1771 — it is a deliberate divergence that closes a hole upstream still has, so it is also a contribute-back candidate (#3766).

Three things worth a reviewer's attention:

- **This is replay-side only.** `rebuild.ts` is not part of the `@posthog/rrweb-snapshot/record` entrypoint, so nothing changes about what we record or the size of the recorder bundle that ships to customer pages. Recorded data is untouched.
- **It overrides the recorded `autocomplete` value.** A page that set `autocomplete="email"` replays as `off`. That is a small fidelity loss on an attribute that has no visual effect, in exchange for the fields not being autofillable. Upstream made the same trade.
- **It does reach the default (virtual-DOM) replay path, but indirectly.** Worth spelling out, because the one-line diff looks like it only covers a direct rebuild. On fast-forward the replayer passes the `RRDocument` as `doc` (`replay/index.ts:1845`), so this line runs against an `RRElement` (`rrdom/src/document.ts:473`); `createOrGetNode` then makes a bare real element and `diffProps` copies the attribute onto it. `rrdom/test/diff.test.ts` now asserts that round trip, so nobody has to re-derive the chain.

### Verification

`@posthog/rrweb-snapshot`: `tsc -noEmit` clean, `oxlint src` clean, full suite green — 280 passed, 1 skipped, including the puppeteer integration tests.

`@posthog/rrweb`: `tsc -noEmit` clean, `oxlint` clean, `replayer.test.ts` green — 64 passed, including the new mutation test. Verified that test fails without the guard (`expected [ 'email', null ] to deeply equal [ 'off', 'off' ]`), which shows both failure modes: one mutation setting the attribute back, another removing it.

`@posthog/rrdom`: `tsc -noEmit` clean, `oxlint` clean, full suite green — 149 passed. CI runs this suite (`turbo run test --filter='./packages/rrweb/**'`), so the new test guards the fix on every PR rather than only locally.

Per `.agents/skills/replay-incident-risk`, the matcher flagged two classes; both come from the path rather than the failure mode:

- **Class 4 (serialization correctness).** Not style serialization and not the record path — this is one attribute set at rebuild time. The failure mode there is silent corruption of recorded bytes, which this cannot cause. The real-browser integration snapshot is the visible signal, and it did move when the change landed.
- **Class 8 (masking/privacy).** Nothing here touches masking defaults, selector matching, or the order of masking vs serialization, and no new path can bypass `maskAllInputs` — the change runs on replay, long after recording. It moves in the protective direction. Note honestly that I cannot test autofill suppression itself in a headless browser, since that needs a browser profile with saved autofill data; the test asserts the attribute is present on every rebuilt text-entry field, which is the closest testable proxy.

Tracked in #3765.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while updating the rrweb gap trackers (#3765 / #3766) for the upstream `2.1.3` / `2.1.4` releases, then requested as one of three separate adoption PRs. Verified absent from our fork by reading `buildNode` rather than trusting the upstream description.

Decisions worth flagging:

- Placed the attribute set immediately before `return node`, matching upstream's placement, so the two diffs stay easy to compare.
- Left `<select>` out, as upstream did.
- Updated the integration snapshot rather than working around it — the snapshot moving is the evidence the change reaches real rebuilt fields, and its diff shows `<select>` correctly unaffected.
- The mutation guard (third commit) is Paul's, not mine — a hole I left open. The review pass raised "could an attribute mutation during replay undo this?" as one of its questions and I did not chase it, having spent the pass on the virtual-DOM coverage question instead. I have since verified it independently by removing the guard and watching the test fail.
- The second commit came out of a review pass that claimed, at high confidence, that this fix is ineffective in virtual-DOM mode because `createOrGetNode` creates bare elements. Two of its three findings were wrong — the `RRDocument`-as-`doc` chain above is what they missed — but the third was fair: nothing tested that path. Hence the rrdom test. I confirmed it fails without the fix (`expected null to deeply equal 'off'`) rather than assuming; note that needs the `rrweb-snapshot` dist rebuilt, since the cross-package test resolves the built bundle, not `src`.

Tools: Claude Code (Bash, `gh`, vitest, puppeteer). No manual browser testing beyond the automated suites listed above — in particular, actual autofill suppression needs a browser profile with saved autofill data, so every test here asserts the attribute rather than the browser behaviour it controls.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


