### PR TITLE
fix(ci): stop force-pushing an upgrade PR that is in the merge queue

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -183,11 +183,20 @@ jobs:
                   #
                   # So when the open PR is already in the queue, leave it alone and open a
                   # separate one for this version. It costs an extra PR and keeps the queue whole.
+                  # A failed lookup must not read as "not queued". `|| true` on the whole
+                  # pipeline would absorb a gh error the same way it absorbs grep's ordinary
+                  # no-match, and force-push the queued PR anyway. So the API call is checked
+                  # on its own, and an unreadable status falls through to the safe branch.
                   QUEUED=""
                   if [ -n "$EXISTING_PR" ]; then
-                      QUEUED=$(gh api "repos/PostHog/posthog/issues/${EXISTING_PR}/comments?per_page=100" \
-                          --jq '[.[] | select(.user.login == "trunk-io[bot]") | .body] | last // ""' \
-                          | grep -oE "Running tests on this pull request|waiting to start tests" | head -n 1 || true)
+                      if TRUNK_STATUS=$(gh api "repos/PostHog/posthog/issues/${EXISTING_PR}/comments?per_page=100" \
+                          --jq '[.[] | select(.user.login == "trunk-io[bot]") | .body] | last // ""'); then
+                          QUEUED=$(printf '%s' "$TRUNK_STATUS" \
+                              | grep -oE "Running tests on this pull request|waiting to start tests" | head -n 1 || true)
+                      else
+                          echo "::warning::Could not read the queue status of PR #${EXISTING_PR}; treating it as queued."
+                          QUEUED="unknown"
+                      fi
                   fi
 
                   if [ -n "$EXISTING_BRANCH" ] && [ -z "$QUEUED" ]; then

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -167,15 +167,34 @@ jobs:
                   PACKAGE_NAME_SANITIZED=$(echo "$PACKAGE_NAME" | sed 's/@//g' | sed 's/\//-/g')
                   TITLE_PREFIX="chore(deps): Update ${PACKAGE_NAME} to "
                   PR_TITLE="${TITLE_PREFIX}${PACKAGE_VERSION}"
-                  EXISTING_BRANCH=$(gh pr list \
+                  EXISTING=$(gh pr list \
                       --repo PostHog/posthog \
                       --state open \
                       --limit 100 \
-                      --json title,headRefName,headRepositoryOwner \
-                      --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")) | select(.headRepositoryOwner.login == \"PostHog\") | .headRefName" | head -n 1)
+                      --json title,number,headRefName,headRepositoryOwner \
+                      --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")) | select(.headRepositoryOwner.login == \"PostHog\") | \"\(.number) \(.headRefName)\"" | head -n 1)
+                  EXISTING_PR="${EXISTING%% *}"
+                  EXISTING_BRANCH="${EXISTING#* }"
 
-                  if [ -n "$EXISTING_BRANCH" ]; then
+                  # Reusing the open upgrade PR's branch means force-pushing it. Trunk drops a
+                  # pull request from the merge queue the moment it is pushed to, and every pull
+                  # request behind it loses its in-flight run and starts again. On 2026-09-08 this
+                  # workflow did exactly that and took 37 other pull requests down with it.
+                  #
+                  # So when the open PR is already in the queue, leave it alone and open a
+                  # separate one for this version. It costs an extra PR and keeps the queue whole.
+                  QUEUED=""
+                  if [ -n "$EXISTING_PR" ]; then
+                      QUEUED=$(gh api "repos/PostHog/posthog/issues/${EXISTING_PR}/comments?per_page=100" \
+                          --jq '[.[] | select(.user.login == "trunk-io[bot]") | .body] | last // ""' \
+                          | grep -oE "Running tests on this pull request|waiting to start tests" | head -n 1 || true)
+                  fi
+
+                  if [ -n "$EXISTING_BRANCH" ] && [ -z "$QUEUED" ]; then
                       BRANCH_NAME="$EXISTING_BRANCH"
+                  elif [ -n "$QUEUED" ]; then
+                      echo "::notice::PR #${EXISTING_PR} is in the merge queue; opening a separate PR instead of force-pushing its branch."
+                      BRANCH_NAME="${PACKAGE_NAME_SANITIZED}-upgrade-${PACKAGE_VERSION}"
                   else
                       BRANCH_NAME="${PACKAGE_NAME_SANITIZED}-upgrade"
                   fi


### PR DESCRIPTION
## Problem

When this workflow bumps a package while the previous upgrade PR is still open, it reuses that PR's branch, so `create-pull-request` force-pushes it. Trunk drops a pull request from the merge queue the moment it is pushed to, and every pull request behind it loses its in-flight test run and starts again.

That happened on 2026-09-08. The upgrader force-pushed [PostHog/posthog#96330](https://github.com/PostHog/posthog/pull/96330) at 12:54:31Z while the queue was testing it, and 37 other pull requests had their runs interrupted 90 seconds later. Roughly 1,300 test-minutes were discarded across that day from queue ejections.

It is not a one-off. On 2026-09-09 Trunk recorded this on [PostHog/posthog#97028](https://github.com/PostHog/posthog/pull/97028):

> This pull request was removed from the merge queue because it was pushed to by posthog-js-upgrader[bot].

The upgrader was the single most frequent source of queue ejections in the window measured, ahead of every human.

## Changes

- A new version no longer disturbs an upgrade PR that is waiting in the merge queue. The queued PR merges on its own, and the new version gets its own pull request.
- The branch lookup now also returns the existing PR number, so the workflow can read that PR's Trunk status comment and tell a queued PR from an idle one.
- Branch reuse is unchanged when the open PR is not in the queue, which is the common case.

The cost is one extra pull request in the rare overlap. That is cheaper than restarting every other pull request's test run.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them

CI-only change. No library code is touched and no version bump is needed.

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Found while auditing PostHog/posthog merge-queue data for why the queue kept resetting: 196 interrupted test runs in 24 hours, 69% of them within three minutes of a pull request being ejected, and this bot at the top of the ejection list.

Queue membership is read from Trunk's sticky comment rather than the Trunk API, because the API needs an org token this workflow does not have, and `trunk merge status` currently returns `User not authorized` even for logged-in users. The comment's three states (running, merged, removed) were checked against real examples before matching on them.

There is no test for this. The repository has no harness for workflow shell, so the branch parsing and the three comment states were exercised by hand instead.

https://claude.ai/code/session_01DJHaLt3bFjcxgbAoJPaCjy
