### PR TITLE
feat(replay): include page URLs in JSON-LD events

### DIFF
--- a/.changeset/quiet-cameras-wave.md
+++ b/.changeset/quiet-cameras-wave.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+Include the masked page URL with JSON-LD replay events.

--- a/.github/fixtures/minimum-version-ts/ci-ts-file.ts
+++ b/.github/fixtures/minimum-version-ts/ci-ts-file.ts
@@ -1,6 +1,18 @@
 /* oxlint-disable */
 import { posthog } from 'posthog-js'
+import type { eventWithTime } from 'posthog-js/rrweb-types'
 import * as ts from 'typescript'
 
 console.log(posthog)
 console.log(ts.version)
+
+function jsonLdUrl(event: eventWithTime): string | undefined {
+    const customEventType = 5
+    if (event.type === customEventType && event.data.tag === '$json_ld') {
+        return event.data.href
+    }
+    return undefined
+}
+
+console.log(jsonLdUrl({ type: 5, timestamp: 0, data: { tag: '$json_ld', payload: {}, href: 'https://example.com' } }))
+console.log(jsonLdUrl({ type: 5, timestamp: 0, data: { tag: '$json_ld', payload: {} } }))

--- a/packages/browser/playwright/mocked/session-recording/session-recording-masking.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-masking.spec.ts
@@ -56,6 +56,60 @@ function assertTheConfigIsAsExpected(snapshotEvents: CaptureResult[], expectedMa
 }
 
 test.describe('Session recording - masking', () => {
+    test('captures the new page URL when SPA navigation adds or updates JSON-LD', async ({ page, context }) => {
+        await start(
+            { ...startOptions({ maskAllInputs: true }, true), url: '/playground/cypress/index.html' },
+            page,
+            context
+        )
+        await waitForSessionRecordingToStart(page)
+        await page.locator('[data-cy-input]').fill('start recording')
+
+        const initialUrl = page.url()
+        const capturedJsonLd = async () =>
+            (await page.capturedEvents())
+                .filter((event) => event.event === '$snapshot')
+                .flatMap((event) => event.properties['$snapshot_data'])
+                .filter((event) => event.type === 5 && event.data.tag === '$json_ld')
+                .map((event) => ({ name: event.data.payload.name, href: event.data.href }))
+
+        await page.evaluate(() => {
+            const script = document.createElement('script')
+            script.id = 'spa-json-ld'
+            script.type = 'application/ld+json'
+            script.textContent = JSON.stringify({
+                '@context': 'https://schema.org',
+                '@type': 'Product',
+                name: 'Initial',
+            })
+            document.head.append(script)
+        })
+        const expected = [{ name: 'Initial', href: initialUrl }]
+        await expect.poll(capturedJsonLd).toEqual(expected)
+
+        for (const navigation of [
+            { method: 'pushState', name: 'Camera', path: '/catalog/camera?variant=standard#details' },
+            { method: 'replaceState', name: 'Lens', path: '/catalog/lens?variant=wide#specifications' },
+        ] as const) {
+            await page.evaluate(({ method, name, path }) => {
+                window.history[method]({}, '', path)
+                let script = document.getElementById('spa-json-ld')!
+                if (method === 'pushState') {
+                    script.remove()
+                    script = document.createElement('script')
+                    script.id = 'spa-json-ld'
+                    script.setAttribute('type', 'application/ld+json')
+                    document.head.append(script)
+                }
+                script.textContent = JSON.stringify({ '@context': 'https://schema.org', '@type': 'Product', name })
+            }, navigation)
+            const href = new URL(navigation.path, initialUrl).href
+            await expect(page).toHaveURL(href)
+            expected.push({ name: navigation.name, href })
+            await expect.poll(capturedJsonLd).toEqual(expected)
+        }
+    })
+
     test('emits only sanitized JSON-LD in recording bytes', async ({ page, context }) => {
         await page.addInitScript(() => {
             const appendJsonLd = (value: Record<string, unknown>, className = '') => {

--- a/packages/browser/playwright/mocked/session-recording/session-recording-masking.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-masking.spec.ts
@@ -170,12 +170,14 @@ test.describe('Session recording - masking', () => {
             )
         await expect.poll(getEventBytes).toContain('ALLOWED_DYNAMIC_PRODUCT')
         const eventBytes = await getEventBytes()
-        const jsonLdEventBytes = JSON.stringify(
-            (await page.capturedEvents())
-                .filter((event) => event.event === '$snapshot')
-                .flatMap((event) => event.properties['$snapshot_data'])
-                .filter((event) => event.type === 5 && event.data.tag === '$json_ld')
-        )
+        const jsonLdEvents = (await page.capturedEvents())
+            .filter((event) => event.event === '$snapshot')
+            .flatMap((event) => event.properties['$snapshot_data'])
+            .filter((event) => event.type === 5 && event.data.tag === '$json_ld')
+        const jsonLdEventBytes = JSON.stringify(jsonLdEvents)
+        for (const event of jsonLdEvents) {
+            expect(event.data.href).toBe(page.url())
+        }
         expect(eventBytes).toContain('ALLOWED_PRODUCT_ID')
         expect(eventBytes).toContain('ALLOWED_INITIAL_PRODUCT')
         expect(eventBytes).toContain('ALLOWED_DYNAMIC_PRODUCT')

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -3850,6 +3850,9 @@ describe('Lazy SessionRecording', () => {
                 sessionRecording.onRemoteConfig(makeFlagsResponse({ sessionRecording: { endpoint: '/s/' } }))
 
                 expect(_addCustomEvent).not.toHaveBeenCalledWith('$json_ld', expect.anything())
+                _addCustomEvent.mockImplementation((tag: string, payload: unknown) => {
+                    _emit(createCustomSnapshot({}, payload as Record<string, unknown>, tag))
+                })
                 _emit(createMetaSnapshot())
                 await Promise.resolve()
 
@@ -3859,6 +3862,15 @@ describe('Lazy SessionRecording', () => {
                     '@id': 'product-123',
                     name: 'Camera',
                 })
+
+                _emit(createFullSnapshot())
+                _emit(createFullSnapshot())
+                await Promise.resolve()
+                const jsonLdEvents = sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data.filter(
+                    (event: eventWithTime) => event.type === EventType.Custom && event.data.tag === '$json_ld'
+                )
+                expect(jsonLdEvents).toHaveLength(1)
+                expect(jsonLdEvents[0].data.href).toBe('http://localhost/')
 
                 posthog.config.session_recording.captureJsonLd = false
                 document.body.appendChild(
@@ -3877,6 +3889,7 @@ describe('Lazy SessionRecording', () => {
                     expect.objectContaining({ name: 'After disable' })
                 )
             } finally {
+                _addCustomEvent.mockReset()
                 target.remove()
                 document.querySelectorAll('script[type="application/ld+json"]').forEach((element) => element.remove())
             }
@@ -4019,13 +4032,18 @@ describe('Lazy SessionRecording', () => {
                     expect(bufferedEvents[0]).toEqual(createMetaSnapshot({ data: { href: 'https://test.com/second' } }))
                     expect(jsonLdIndexes).toHaveLength(1)
                     expect(jsonLdIndexes[0]).toBeGreaterThan(fullSnapshotIndex)
-                    expect(bufferedEvents[jsonLdIndexes[0]]).toEqual(
-                        createCustomSnapshot(
+                    expect(bufferedEvents[jsonLdIndexes[0]]).toEqual({
+                        ...createCustomSnapshot(
                             {},
                             { '@context': 'https://schema.org', '@type': 'Product', name: 'Camera' },
                             '$json_ld'
-                        )
-                    )
+                        ),
+                        data: {
+                            tag: '$json_ld',
+                            payload: { '@context': 'https://schema.org', '@type': 'Product', name: 'Camera' },
+                            href: 'http://localhost/',
+                        },
+                    })
                 } finally {
                     pendingTrigger.mockRestore()
                 }
@@ -4033,6 +4051,46 @@ describe('Lazy SessionRecording', () => {
                 _addCustomEvent.mockReset()
                 script.remove()
             }
+        })
+
+        it.each([
+            ['default', false, 'https://example.com/private?secret=<masked>#fragment'],
+            ['modern', true, 'https://example.com/public?secret=<masked>'],
+            ['legacy', true, 'https://example.com/public?secret=<masked>'],
+            ['reject', true, undefined],
+            ['throw', true, undefined],
+        ] as const)('applies %s URL masking to JSON-LD events', (masking, stripHash, expectedHref) => {
+            posthog.config.session_recording.captureJsonLd = true
+            sessionRecording.onRemoteConfig(makeFlagsResponse({ sessionRecording: { endpoint: '/s/' } }))
+            posthog.config.disable_capture_url_hashes = stripHash
+            posthog.config.mask_personal_data_properties = true
+            posthog.config.custom_personal_data_properties = ['secret']
+            if (masking === 'modern') {
+                posthog.config.session_recording.maskCapturedNetworkRequestFn = (request) => ({
+                    ...request,
+                    name: request.name.replace('/private', '/public'),
+                })
+            } else if (masking === 'legacy') {
+                posthog.config.session_recording.maskNetworkRequestFn = (request) => ({
+                    ...request,
+                    url: request.url.replace('/private', '/public'),
+                })
+            } else if (masking === 'reject' || masking === 'throw') {
+                posthog.config.session_recording.maskCapturedNetworkRequestFn = () => {
+                    if (masking === 'throw') {
+                        throw new Error('masking failed')
+                    }
+                    return undefined
+                }
+            }
+            fakeNavigateTo('https://example.com/private?secret=hidden#fragment')
+            const payload = { '@context': 'https://schema.org', '@type': 'Product' }
+            _emit(createCustomSnapshot({}, payload, '$json_ld'))
+            const events = sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data
+            const jsonLd = events.find((event: eventWithTime) => event.type === 5 && event.data.tag === '$json_ld')
+            expect(jsonLd).toBeDefined()
+            expect(jsonLd.data.href).toBe(expectedHref)
+            expect(jsonLd.data.payload).toEqual(payload)
         })
 
         it('does not emit JSON-LD by default', () => {

--- a/packages/browser/src/entrypoints/rrweb-types.es.ts
+++ b/packages/browser/src/entrypoints/rrweb-types.es.ts
@@ -1,3 +1,17 @@
 // Exposed as `posthog-js/rrweb-types` via packages/browser/rrweb-types/package.json.
 // Types-only — the generated rrweb-types.js is effectively empty; the value is in the .d.ts.
 export * from '@posthog/rrweb-types'
+
+import type {
+    customEvent as RrwebCustomEvent,
+    eventWithoutTime as RrwebEventWithoutTime,
+    eventWithTime as RrwebEventWithTime,
+} from '@posthog/rrweb-types'
+import type { customEvent as PostHogCustomEvent } from '../extensions/replay/types/rrweb-types'
+
+type WithJsonLdUrl<T> = T extends RrwebCustomEvent ? T & { data: Pick<PostHogCustomEvent['data'], 'href'> } : T
+
+export type customEvent<T = unknown> = WithJsonLdUrl<RrwebCustomEvent<T>>
+export type eventWithoutTime = WithJsonLdUrl<RrwebEventWithoutTime>
+export type event = eventWithoutTime
+export type eventWithTime = WithJsonLdUrl<RrwebEventWithTime>

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -2068,6 +2068,16 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         const compressionEnabled = this._instance.config.session_recording.compress_events ?? true
 
+        if (event.type === EventType.Custom && event.data.tag === JSON_LD_EVENT_TAG) {
+            let href: string | undefined
+            try {
+                href = window ? this._maskReplayUrl(window.location.href) : undefined
+            } catch {
+                // A masking callback failure must not expose the original URL or interrupt recording.
+            }
+            event.data.href = href
+        }
+
         if (
             this._queuedCompressionEvents > 0 ||
             (compressionEnabled && shouldUseNativeAsyncSessionRecordingGzip(event))

--- a/packages/browser/src/extensions/replay/types/rrweb-types.ts
+++ b/packages/browser/src/extensions/replay/types/rrweb-types.ts
@@ -190,6 +190,7 @@ export type customEvent<T = unknown> = {
     data: {
         tag: string
         payload: T
+        href?: string
     }
 }
 

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -715,6 +715,8 @@ export interface SessionRecordingOptions {
      * It drops every `@id` when `maskAllElementAttributes`, `maskAttributeFn`, or an `attributeFilter` without `id` can hide `id` attributes from replay.
      * It also keeps the containing entity tree, even when it redacts all other fields.
      * The event tag is `$json_ld`. The payload is a JSON-LD object or array.
+     * The event includes the current page URL in `data.href`, subject to replay URL masking and hash capture settings.
+     * The URL is omitted when the masking callback rejects it or throws.
      * The recorder removes all script nodes from snapshots when this option is enabled.
      * The JSON-LD observer starts only when this option is true at recording start.
      * @see https://github.com/PostHog/posthog-js/blob/main/packages/browser/src/extensions/replay/external/json-ld.ts


### PR DESCRIPTION
## Problem

Replay consumers need the page URL alongside each JSON-LD event to group captures by site and page.

## Changes

Add `data.href` to existing JSON-LD events using replay URL masking, query masking, and hash settings.
If masking rejects the URL or throws, set `data.href` to `undefined` in memory. JSON serialization omits this field from the request payload.
Expose the optional field in public replay types and document it.
Capture timing, deduplication, and event counts stay unchanged.

Deploy [ingestion URL support](https://github.com/PostHog/posthog/pull/97197) and [the navigation URL guard](https://github.com/PostHog/posthog/pull/97344) before releasing this SDK change.

Validation passed: production build, focused replay tests, Chromium recording test, lint, and a public-type consumer check.
Tests cover URL masking and confirm that later full snapshots do not resend unchanged JSON-LD.
A browser regression test checks new scripts after `pushState` and script updates after `replaceState`, including paths, query strings, and fragments. It passed in Chromium, Firefox, and WebKit, plus ten Chromium repetitions. Earlier events retain their original URLs.
The URL reflects the address bar when the JSON-LD event is emitted.

The standalone Playwright TypeScript check reports identical errors before and after the new test; none are in the changed file.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a release changeset

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex, Git, and the GitHub CLI from current main in a separate worktree.
This PR contains only URL metadata; it adds no snapshot references or pairing behavior.
Skills: Simplified Technical English, writing-tests, writing-code-comments, writing-user-facing-copy, writing-pr-descriptions, and playwright-test.



