### PR TITLE
fix(replay): send fresh json-ld with its full snapshot

### DIFF
--- a/.changeset/tidy-trees-travel.md
+++ b/.changeset/tidy-trees-travel.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+Send fresh JSON-LD with its full replay snapshot in one request.

--- a/packages/browser/playwright/mocked/session-recording/session-recording-json-ld.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-json-ld.spec.ts
@@ -1,0 +1,117 @@
+import { decompressSync, strFromU8 } from 'fflate'
+import { test, expect } from '../utils/posthog-playwright-test-base'
+import { start, waitForSessionRecordingToStart } from '../utils/setup'
+import { CaptureResult } from '@/types'
+import type { AssignableWindow } from '@/utils/globals'
+
+const options = {
+    api_host: 'https://localhost:1234',
+    persistence: 'localStorage' as const,
+    request_batching: false,
+    session_recording: { captureJsonLd: true },
+}
+const remoteConfig = { sessionRecording: { endpoint: '/ses/' } }
+
+test('sends initial JSON-LD with its full snapshot, including a cached start with delayed config', async ({
+    page,
+    context,
+}) => {
+    const requests: CaptureResult[][] = []
+    await context.route('**/ses/**', async (route) => {
+        const bytes = new Uint8Array(route.request().postDataBuffer()!)
+        const body = JSON.parse(strFromU8(bytes[0] === 0x1f ? decompressSync(bytes) : bytes))
+        requests.push(Array.isArray(body) ? body : [body])
+        await route.fulfill({ status: 200, body: '1' })
+    })
+    await page.addInitScript(() => {
+        // oxlint-disable-next-line posthog-js/no-add-event-listener
+        document.addEventListener('DOMContentLoaded', () => {
+            const product = document.createElement('div')
+            product.id = 'product'
+            document.body.append(product)
+            for (const type of ['Product', 'WebPage']) {
+                const script = document.createElement('script')
+                script.type = 'application/ld+json'
+                script.textContent = JSON.stringify({
+                    '@context': 'https://schema.org',
+                    '@type': type,
+                    '@id': '#product',
+                })
+                document.head.append(script)
+            }
+        })
+    })
+
+    await start({ options, flagsResponseOverrides: remoteConfig, url: '/playground/cypress/index.html' }, page, context)
+    for (const cachedStart of [false, true]) {
+        let releaseConfig = () => {}
+        if (cachedStart) {
+            await start(
+                {
+                    url: '/playground/cypress/index.html',
+                    initPosthog: false,
+                    waitForFlags: false,
+                    flagsResponseOverrides: remoteConfig,
+                },
+                page,
+                context
+            )
+            requests.length = 0
+            const configGate = new Promise<void>((resolve) => {
+                releaseConfig = resolve
+            })
+            let requestedConfig = false
+            await context.route(/\/array\/[^/]+\/config(\?|$)/, async (route) => {
+                requestedConfig = true
+                await configGate
+                await route.fulfill({ json: remoteConfig })
+            })
+            await page.evaluate((config) => (window as AssignableWindow).posthog!.init('test token', config), options)
+            await expect.poll(() => requestedConfig).toBe(true)
+            releaseConfig()
+        }
+        await waitForSessionRecordingToStart(page)
+        await page.locator('[data-cy-input]').fill(cachedStart ? 'cached start' : 'fresh start')
+        const envelopes = () => requests.flat().filter((event) => event.event === '$snapshot')
+        const jsonLdEvents = () =>
+            envelopes()
+                .flatMap((event) => event.properties.$snapshot_data)
+                .filter((event) => event.type === 5 && event.data.tag === '$json_ld')
+        await expect.poll(() => jsonLdEvents().length).toBe(2)
+        for (const jsonLd of jsonLdEvents()) {
+            const envelope = envelopes().find((event) => event.properties.$snapshot_data.includes(jsonLd))!
+            expect(envelope.properties.$snapshot_data).toContainEqual(
+                expect.objectContaining({ type: 2, timestamp: jsonLd.timestamp })
+            )
+            expect(jsonLd.data.href).toBe(page.url())
+            expect(jsonLd.data.payload['@id']).toBe('product')
+        }
+        await page.evaluate(() => (window as AssignableWindow).__PosthogExtensions__!.rrweb!.record.takeFullSnapshot())
+        await expect
+            .poll(
+                () =>
+                    envelopes()
+                        .flatMap((event) => event.properties.$snapshot_data)
+                        .filter((event) => event.type === 2).length
+            )
+            .toBeGreaterThan(1)
+        expect(jsonLdEvents()).toHaveLength(2)
+        await page.evaluate(() => {
+            window.history.pushState({}, '', '/catalog/updated')
+            document.querySelector('script[type="application/ld+json"]')!.textContent = JSON.stringify({
+                '@context': 'https://schema.org',
+                '@type': 'Product',
+                name: 'Updated product',
+            })
+            ;(window as AssignableWindow).__PosthogExtensions__!.rrweb!.record.takeFullSnapshot()
+        })
+        await expect.poll(() => jsonLdEvents().length).toBe(3)
+        const updated = jsonLdEvents()[2]
+        const updatedEnvelope = envelopes().find((event) => event.properties.$snapshot_data.includes(updated))!
+        expect(updatedEnvelope.properties.$snapshot_data).toContainEqual(
+            expect.objectContaining({ type: 2, timestamp: updated.timestamp })
+        )
+        expect(updated.data.href).toBe(page.url())
+        expect(updated.data.payload.name).toBe('Updated product')
+    }
+})

--- a/packages/browser/src/__tests__/extensions/replay/json-ld.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/json-ld.test.ts
@@ -339,6 +339,16 @@ describe('JSON-LD replay capture', () => {
         capture.stop()
     })
 
+    it('drops a deferred mutation capture when the observer stops', async () => {
+        const emit = vi.fn(() => true)
+        const capture = startJsonLdCapture(document, MutationObserver, { emit })
+        document.body.append(jsonLdScript({ '@context': 'https://schema.org', '@type': 'Product' }))
+        await Promise.resolve()
+        capture.stop()
+        await deliverMutations()
+        expect(emit).not.toHaveBeenCalled()
+    })
+
     it('does not deduplicate an event that the recorder rejects', () => {
         let acceptsEvents = false
         const emit = vi.fn(() => acceptsEvents)

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording-compression.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording-compression.test.ts
@@ -2,6 +2,7 @@ import { gzipSync, strToU8 } from 'fflate'
 
 type SetupOptions = {
     gzipSupported: boolean
+    captureJsonLd?: boolean
     gzipCompress?: vi.Mock
 }
 
@@ -26,7 +27,7 @@ const createCustomSnapshot = () => ({
     timestamp: 124,
 })
 
-async function setupLazyLoadedSessionRecording({ gzipSupported, gzipCompress }: SetupOptions) {
+async function setupLazyLoadedSessionRecording({ gzipSupported, gzipCompress, captureJsonLd = false }: SetupOptions) {
     vi.resetModules()
 
     const gzipCompressMock =
@@ -75,6 +76,7 @@ async function setupLazyLoadedSessionRecording({ gzipSupported, gzipCompress }: 
         session_recording: {
             maskAllInputs: false,
             compress_events: true,
+            captureJsonLd,
         },
         persistence: 'memory',
     })
@@ -152,6 +154,62 @@ describe('LazyLoadedSessionRecording compression paths', () => {
         vi.doUnmock('@posthog/core')
         vi.resetModules()
     })
+
+    it.each(['sync', 'async', 'unload'] as const)(
+        'keeps fresh JSON-LD with its snapshot across a size flush using %s compression',
+        async (mode) => {
+            let releaseCompression = () => {}
+            const gate = new Promise<void>((resolve) => {
+                releaseCompression = resolve
+            })
+            const gzipCompress = vi.fn(async (input: string) => {
+                await gate
+                return new Blob([gzipSync(strToU8(input))])
+            })
+            const { emit, posthog, lazyLoadedSessionRecording } = await setupLazyLoadedSessionRecording({
+                gzipSupported: mode !== 'sync',
+                gzipCompress,
+                captureJsonLd: true,
+            })
+            const script = document.createElement('script')
+            script.type = 'application/ld+json'
+            const payload = { '@context': 'https://schema.org', '@type': 'Product', name: 'x'.repeat(2000) }
+            script.textContent = JSON.stringify(payload)
+            document.head.append(script)
+            try {
+                const { RECORDING_MAX_EVENT_SIZE } =
+                    await import('../../../extensions/replay/external/lazy-loaded-session-recorder')
+                emit({
+                    ...createCustomSnapshot(),
+                    data: { tag: 'padding', payload: 'x'.repeat(Math.floor(RECORDING_MAX_EVENT_SIZE) - 1000) },
+                })
+                emit(createFullSnapshot({ content: 'paired snapshot' }))
+                script.remove()
+                if (mode === 'unload') {
+                    lazyLoadedSessionRecording['_onBeforeUnload']()
+                } else if (mode === 'async') {
+                    lazyLoadedSessionRecording['_flushBuffer']()
+                }
+                releaseCompression()
+                await lazyLoadedSessionRecording['_compressionQueue']
+                lazyLoadedSessionRecording['_flushBuffer']()
+                const requests = posthog.capture.mock.calls.filter(([event]: [string]) => event === '$snapshot')
+                const pairedRequest = requests.find(([, properties]: any[]) =>
+                    properties.$snapshot_data.some((event: any) => event.type === 2)
+                )
+                expect(pairedRequest[1].$snapshot_data).toEqual([
+                    expect.objectContaining({ type: 2 }),
+                    { type: 5, timestamp: 123, data: { tag: '$json_ld', payload, href: 'http://localhost/' } },
+                ])
+                const events = requests.flatMap(([, properties]: any[]) => properties.$snapshot_data)
+                expect(events.filter((event: any) => event.data?.tag === '$json_ld')).toHaveLength(1)
+            } finally {
+                releaseCompression()
+                lazyLoadedSessionRecording.stop()
+                script.remove()
+            }
+        }
+    )
 
     it.each([
         {

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -5029,11 +5029,13 @@ describe('Lazy SessionRecording', () => {
                     name: 'Allowed page product',
                 })
                 await Promise.resolve()
-                expect(_addCustomEvent).toHaveBeenCalledWith('$json_ld', {
-                    '@context': 'https://schema.org',
-                    '@type': 'Product',
-                    name: 'Allowed page product',
-                })
+                await vi.waitFor(() =>
+                    expect(_addCustomEvent).toHaveBeenCalledWith('$json_ld', {
+                        '@context': 'https://schema.org',
+                        '@type': 'Product',
+                        name: 'Allowed page product',
+                    })
+                )
             } finally {
                 script.remove()
             }

--- a/packages/browser/src/__tests__/extensions/replay/sessionrecording-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/sessionrecording-utils.test.ts
@@ -266,6 +266,24 @@ describe(`SessionRecording utility functions`, () => {
     })
 
     describe('splitBuffer', () => {
+        it.each([0, 1, 2, 3])('keeps full snapshots and JSON-LD together with %s preceding events', (prefixCount) => {
+            const full = { type: 2, data: {}, timestamp: 10 }
+            const jsonLd = { type: 5, data: { tag: '$json_ld', payload: {} }, timestamp: 10 }
+            const data = [...Array(prefixCount).fill({ type: 3 }), full, jsonLd, jsonLd, { type: 3 }, { type: 3 }]
+            const sizes = data.map(() => SEVEN_MEGABYTES * 0.6)
+            const size = sizes.reduce((sum, value) => sum + value, 0)
+            const chunks = splitBuffer({ data, sizes, size, sessionId: 'session', windowId: 'window' })
+            expect(chunks.flatMap((chunk) => chunk.data)).toEqual(data)
+            const pairedChunk = chunks.find((chunk) => chunk.data.includes(full))!
+            expect(pairedChunk.data.slice(pairedChunk.data.indexOf(full), pairedChunk.data.indexOf(full) + 3)).toEqual([
+                full,
+                jsonLd,
+                jsonLd,
+            ])
+            expect(chunks.reduce((sum, chunk) => sum + chunk.size, 0)).toBe(size)
+            expect(chunks.flatMap((chunk) => chunk.sizes)).toEqual(sizes)
+        })
+
         it('should return the same buffer if size is less than SEVEN_MEGABYTES', () => {
             const perEventSize = (5 * 1024 * 1024) / 100
             const buffer = {

--- a/packages/browser/src/extensions/replay/external/json-ld.ts
+++ b/packages/browser/src/extensions/replay/external/json-ld.ts
@@ -445,13 +445,14 @@ export function startJsonLdCapture(
         // Null updates the deduplication baseline without an event.
         getCaptureState?: () => boolean | null
     }
-): { scan: (force?: boolean) => void; stop: () => void } {
+): { scan: (force?: boolean, emit?: (jsonLd: unknown) => boolean) => void; stop: () => void } {
     const lastJsonByScript = new WeakMap<HTMLScriptElement, string>()
     const getCaptureState = options.getCaptureState || (() => true)
+    let stopped = false
     let remainingLength = MAX_JSON_LD_LENGTH
     const hasCapturedDomId = createCapturedDomIdMatcher(doc, options)
 
-    const captureScript = (script: HTMLScriptElement): void => {
+    const captureScript = (script: HTMLScriptElement, emit = options.emit): void => {
         try {
             const captureState = getCaptureState()
             if (
@@ -478,7 +479,7 @@ export function startJsonLdCapture(
                     remainingLength = 0
                     return
                 }
-                if (options.emit(jsonLd)) {
+                if (emit(jsonLd)) {
                     lastJsonByScript.set(script, json)
                     remainingLength -= json.length
                 }
@@ -489,9 +490,9 @@ export function startJsonLdCapture(
     }
 
     try {
-        const observer = new MutationObserverClass((mutations) => {
+        const captureMutations = (mutations: MutationRecord[]): void => {
             try {
-                if (!remainingLength || getCaptureState() === false) {
+                if (stopped || !remainingLength || getCaptureState() === false) {
                     return
                 }
                 const captureScripts = (node: Node): void => {
@@ -518,6 +519,11 @@ export function startJsonLdCapture(
             } catch {
                 return
             }
+        }
+        const observer = new MutationObserverClass((mutations) => {
+            // rrweb must update its node mirror before JSON-LD resolves captured DOM IDs.
+            // oxlint-disable-next-line compat/compat
+            Promise.resolve().then(() => captureMutations(mutations))
         })
 
         observer.observe(doc, {
@@ -527,19 +533,25 @@ export function startJsonLdCapture(
             childList: true,
             subtree: true,
         })
-        const scan = (force = false): void => {
-            if (!remainingLength || getCaptureState() === false) {
+        const scan = (force = false, emit = options.emit): void => {
+            if (stopped || !remainingLength || getCaptureState() === false) {
                 return
             }
             getJsonLdScripts(doc.documentElement).forEach((script) => {
                 if (force) {
                     lastJsonByScript.delete(script)
                 }
-                captureScript(script)
+                captureScript(script, emit)
             })
         }
 
-        return { scan, stop: () => observer.disconnect() }
+        return {
+            scan,
+            stop: () => {
+                stopped = true
+                observer.disconnect()
+            },
+        }
     } catch {
         return { scan: () => {}, stop: () => {} }
     }

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -506,6 +506,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     private _stopRrweb: listenerHandler | undefined = undefined
     private _jsonLdCapture: ReturnType<typeof startJsonLdCapture> | undefined
     private _jsonLdCaptureReady = false
+    private _jsonLdBySnapshot = new WeakMap<eventWithTime, eventWithTime[]>()
     private _lastActivityTimestamp: number = Date.now()
     private _sessionStartTimestamp: number
     private _isActivatingTrigger: boolean = false
@@ -936,6 +937,15 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             !this._urlTriggerMatching.urlBlocked &&
             this._isIdle !== true
         )
+    }
+
+    private _jsonLdHref(): string | undefined {
+        try {
+            return window ? this._maskReplayUrl(window.location.href) : undefined
+        } catch {
+            // A masking callback failure must not expose the original URL or interrupt recording.
+            return undefined
+        }
     }
 
     private _tryAddJsonLdEvent(jsonLd: unknown): boolean {
@@ -1727,7 +1737,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         this._ensureFullSnapshotForSession(event, targetSessionId)
 
-        this._captureSnapshotBuffered(properties)
+        this._captureSnapshotBuffered(properties, this._jsonLdBySnapshot.get(event))
     }
 
     // snapshot cost tracking is telemetry: an error in it must be visible in debug
@@ -2060,8 +2070,27 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         const jsonLdCaptureWasReady = this._jsonLdCaptureReady
         this._jsonLdCaptureReady = true
-        if (jsonLdRemovedFromPendingBuffer) {
-            this._scheduleJsonLdScan(true)
+        if (event.type === EventType.FullSnapshot && this._canCaptureJsonLd()) {
+            const jsonLdEvents: eventWithTime[] = []
+            const generation = this._compressionQueueGeneration
+            this._jsonLdCapture?.scan(!!jsonLdRemovedFromPendingBuffer, (payload) => {
+                const href = this._jsonLdHref()
+                if (generation !== this._compressionQueueGeneration || !this._canCaptureJsonLd()) {
+                    return false
+                }
+                jsonLdEvents.push({
+                    type: EventType.Custom,
+                    timestamp: event.timestamp,
+                    data: { tag: JSON_LD_EVENT_TAG, payload, href },
+                })
+                return true
+            })
+            if (generation !== this._compressionQueueGeneration) {
+                return
+            }
+            if (jsonLdEvents.length) {
+                this._jsonLdBySnapshot.set(event, jsonLdEvents)
+            }
         } else if (!jsonLdCaptureWasReady) {
             this._scheduleJsonLdScan()
         }
@@ -2069,13 +2098,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         const compressionEnabled = this._instance.config.session_recording.compress_events ?? true
 
         if (event.type === EventType.Custom && event.data.tag === JSON_LD_EVENT_TAG) {
-            let href: string | undefined
-            try {
-                href = window ? this._maskReplayUrl(window.location.href) : undefined
-            } catch {
-                // A masking callback failure must not expose the original URL or interrupt recording.
-            }
-            event.data.href = href
+            event.data.href = this._jsonLdHref()
         }
 
         if (
@@ -2456,8 +2479,10 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         return true
     }
 
-    private _captureSnapshotBuffered(properties: Properties) {
-        const additionalBytes = 2 + (this._buffer?.data.length || 0) // 2 bytes for the array brackets and 1 byte for each comma
+    private _captureSnapshotBuffered(properties: Properties, jsonLdEvents?: eventWithTime[]) {
+        const jsonLdSizes = jsonLdEvents?.map(estimateSize)
+        const totalBytes = properties.$snapshot_bytes + (jsonLdSizes?.reduce((sum, size) => sum + size, 0) || 0)
+        const additionalBytes = 2 + (this._buffer?.data.length || 0) + (jsonLdEvents?.length || 0) // 2 bytes for the array brackets and 1 byte for each comma
 
         // Extract target session ID from properties to ensure we flush when session changes
         // This is critical for lifecycle events ($session_ending, $session_starting) which may
@@ -2473,7 +2498,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             // 'unknown' still captures so its buffer must respect the size cap or it grows unbounded
             (this._isIdle !== true &&
                 !this._holdFlushUntilInteraction &&
-                this._buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE)
+                this._buffer.size + totalBytes + additionalBytes > RECORDING_MAX_EVENT_SIZE)
         ) {
             const sessionBeforeFlush = this._sessionId
             this._buffer = this._flushBuffer()
@@ -2496,8 +2521,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // and stop collecting; a release takes a fresh full snapshot to resume playable
         if (
             this._holdFlushUntilInteraction &&
-            (this._heldBufferOverflowed ||
-                this._buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE)
+            (this._heldBufferOverflowed || this._buffer.size + totalBytes + additionalBytes > RECORDING_MAX_EVENT_SIZE)
         ) {
             if (!this._heldBufferOverflowed) {
                 this._heldBufferOverflowed = true
@@ -2506,9 +2530,13 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             return
         }
 
-        this._buffer.size += properties.$snapshot_bytes
+        this._buffer.size += totalBytes
         this._buffer.data.push(properties.$snapshot_data)
         this._buffer.sizes.push(properties.$snapshot_bytes)
+        if (jsonLdEvents && jsonLdSizes) {
+            this._buffer.data.push(...jsonLdEvents)
+            this._buffer.sizes.push(...jsonLdSizes)
+        }
 
         // Schedule the flush unless confirmed idle or held — a held epoch can't ship anyway
         // (scheduling would just churn a no-op timer every cycle) and every release path
@@ -2979,38 +3007,6 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                 requestFullSnapshot: () => this._tryTakeFullSnapshot(),
             })
 
-        const activePlugins = this._gatherRRWebPlugins()
-        this._stopRrweb = rrwebRecord({
-            emit: (event) => {
-                this.onRRwebEmit(event)
-            },
-            plugins: activePlugins,
-            errorHandler: (error, context) => {
-                // A host API patch shares its callback boundary with the native
-                // operation. Preserve the application's exception semantics when
-                // rrweb cannot reliably distinguish where that error originated.
-                if (context !== 'rrweb') {
-                    return false
-                }
-                if (!this._hasLoggedRecorderCallbackError) {
-                    this._hasLoggedRecorderCallbackError = true
-                    logger.error('rrweb internal error - recording will continue but may be incomplete', error)
-                }
-                return true
-            },
-            ...sessionRecordingOptions,
-        })
-
-        if (!this._stopRrweb) {
-            this._rrwebError = true
-            logger.error(
-                'rrweb failed to start - Loss of recording data is possible. Check the browser console for rrweb errors.'
-            )
-            return
-        }
-
-        this._rrwebError = false
-
         if (
             userSessionRecordingOptions?.captureJsonLd === true &&
             document &&
@@ -3038,6 +3034,39 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                 this._jsonLdCapture.scan()
             }
         }
+
+        const activePlugins = this._gatherRRWebPlugins()
+        this._stopRrweb = rrwebRecord({
+            emit: (event) => {
+                this.onRRwebEmit(event)
+            },
+            plugins: activePlugins,
+            errorHandler: (error, context) => {
+                // A host API patch shares its callback boundary with the native
+                // operation. Preserve the application's exception semantics when
+                // rrweb cannot reliably distinguish where that error originated.
+                if (context !== 'rrweb') {
+                    return false
+                }
+                if (!this._hasLoggedRecorderCallbackError) {
+                    this._hasLoggedRecorderCallbackError = true
+                    logger.error('rrweb internal error - recording will continue but may be incomplete', error)
+                }
+                return true
+            },
+            ...sessionRecordingOptions,
+        })
+
+        if (!this._stopRrweb) {
+            this._stopRecordingProducers()
+            this._rrwebError = true
+            logger.error(
+                'rrweb failed to start - Loss of recording data is possible. Check the browser console for rrweb errors.'
+            )
+            return
+        }
+
+        this._rrwebError = false
 
         // We reset the last activity timestamp, resetting the idle timer
         this._lastActivityTimestamp = Date.now()

--- a/packages/browser/src/extensions/replay/external/sessionrecording-utils.ts
+++ b/packages/browser/src/extensions/replay/external/sessionrecording-utils.ts
@@ -1,3 +1,4 @@
+import { JSON_LD_EVENT_TAG } from './json-ld'
 import type { eventWithTime, pluginEvent } from '../types/rrweb-types'
 
 import { isArray, isNull, isObject, isUndefined } from '@posthog/core'
@@ -178,7 +179,23 @@ export const SEVEN_MEGABYTES = 1024 * 1024 * 7 * 0.9 // ~7mb (with some wiggle r
 // uses a pretty high size limit to avoid splitting too much
 export function splitBuffer(buffer: SnapshotBuffer, sizeLimit: number = SEVEN_MEGABYTES): SnapshotBuffer[] {
     if (buffer.size >= sizeLimit && buffer.data.length > 1) {
-        const half = Math.floor(buffer.data.length / 2)
+        let half = Math.floor(buffer.data.length / 2)
+        while (half > 0 && buffer.data[half].type === 5 && buffer.data[half].data.tag === JSON_LD_EVENT_TAG) {
+            half--
+        }
+        if (!half) {
+            half = 1
+            while (
+                half < buffer.data.length &&
+                buffer.data[half].type === 5 &&
+                buffer.data[half].data.tag === JSON_LD_EVENT_TAG
+            ) {
+                half++
+            }
+            if (half === buffer.data.length) {
+                return [buffer]
+            }
+        }
         const firstHalfSizes = buffer.sizes.slice(0, half)
         const secondHalfSizes = buffer.sizes.slice(half)
         return [

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -715,6 +715,8 @@ export interface SessionRecordingOptions {
      * It drops every `@id` when `maskAllElementAttributes`, `maskAttributeFn`, or an `attributeFilter` without `id` can hide `id` attributes from replay.
      * It also keeps the containing entity tree, even when it redacts all other fields.
      * The event tag is `$json_ld`. The payload is a JSON-LD object or array.
+     * New JSON-LD captured during a full snapshot shares its request and timestamp.
+     * Unchanged JSON-LD is not resent for later full snapshots. Changes between snapshots still emit separate custom events.
      * The event includes the current page URL in `data.href`, subject to replay URL masking and hash capture settings.
      * The URL is omitted when the masking callback rejects it or throws.
      * The recorder removes all script nodes from snapshots when this option is enabled.


### PR DESCRIPTION
## Problem

Replay consumers need a full snapshot and its fresh JSON-LD labels in the same request. Adjacent rrweb events can currently split at a buffer flush or during async compression.

## Changes

Capture fresh JSON-LD during an existing full snapshot and keep the events together through compression, buffering, and request splitting. The events share the snapshot timestamp. A private weak map holds the association; the wire format stays unchanged.

No extra snapshots, snapshot IDs, timers, or compression queues. Unchanged JSON-LD is not resent. JSON-LD changes between snapshots still emit independently, so this does not pair every JSON-LD event. An indivisible snapshot and its labels can exceed the splitter's soft size target, as a single oversized snapshot already can. Existing JSON-LD capture limits still apply.

Depends on [page URL support](https://github.com/PostHog/posthog-js/pull/4864). Its ingestion deployment prerequisite still applies.

Production bundle comparison against that PR: `lazy-recorder.js` +747 bytes minified / +209 bytes gzip; `array.full.js` +743 / +260 bytes. `array.js` has no minified-size change; gzip differs by 13 bytes from private-symbol naming.

Validation: production build, 571 focused unit tests, and nine browser tests across Chromium, Firefox, and WebKit pass. Tests inspect actual request bodies with request batching disabled, check cached startup with delayed config, and cover later snapshots, deduplication, SPA URLs, privacy, size flushes, async compression, unload, and session rotation. The request test also passes with the new recorder and pinned `posthog-js@1.400.0` core. The standalone Playwright type check reports the same existing errors as the base branch.

Replay incident review: no core/extension signature or persisted-state change. Existing sampling, consent, idle holds, and rotation gates remain in place; recording-volume tests pass. The same sanitizer and URL masking run before labels enter the buffer, and browser privacy assertions pass.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a release changeset

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex, Git, the GitHub CLI, and Playwright in an isolated worktree. Scope is limited to fresh JSON-LD captured during an existing full snapshot.
Skills: Simplified Technical English, replay-incident-risk, and gh-stack.
