### PR TITLE
chore: update PostHog watcher action

### DIFF
--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -39,7 +39,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Enqueue watcher event
-              uses: PostHog/posthog-watcher-action@2a52bc42a5c60b415218da3d9705fd4c4fc0e76c
+              uses: PostHog/posthog-watcher-action@c14844661c889811bd633e0263320c33c100f4ee
               with:
                   mode: enqueue
                   trigger-drain-workflow: 'true'

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -45,7 +45,7 @@ jobs:
                   sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 
             - name: Sweep issues
-              uses: PostHog/posthog-watcher-action@2a52bc42a5c60b415218da3d9705fd4c4fc0e76c
+              uses: PostHog/posthog-watcher-action@c14844661c889811bd633e0263320c33c100f4ee
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: sweep

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -51,7 +51,7 @@ jobs:
                   sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 
             - name: Drain watcher queue
-              uses: PostHog/posthog-watcher-action@2a52bc42a5c60b415218da3d9705fd4c4fc0e76c
+              uses: PostHog/posthog-watcher-action@c14844661c889811bd633e0263320c33c100f4ee
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   mode: drain-queue
@@ -88,7 +88,7 @@ jobs:
                   sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 
             - name: Process watcher issue
-              uses: PostHog/posthog-watcher-action@2a52bc42a5c60b415218da3d9705fd4c4fc0e76c
+              uses: PostHog/posthog-watcher-action@c14844661c889811bd633e0263320c33c100f4ee
               with:
                   openai-api-key: ${{ secrets.POSTHOG_WATCHER_OPENAI_API_KEY }}
                   issue-number: ${{ inputs['issue-number'] }}


### PR DESCRIPTION
## Problem

The watcher workflows use an older upstream commit of `PostHog/posthog-watcher-action`.

## Changes

Updated all four watcher action references in the enqueue, sweep, and worker workflows from `2a52bc42a5c60b415218da3d9705fd4c4fc0e76c` to the latest upstream SHA, `c14844661c889811bd633e0263320c33c100f4ee`. All references now use the same SHA. Workflow inputs and permissions are unchanged.

Verification: `git ls-remote` confirmed upstream HEAD. `rg` checks confirmed all references use the new SHA and no stale references remain. `git diff --check` passed. SDK builds and tests were not run because only action pins changed.

## Release info Sub-libraries affected

### Libraries affected

None. This workflow-only update does not need a changeset or SDK release.

## Checklist

- [ ] Tests for new code (not applicable, action pins only)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not applicable)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used file read/edit tools, Git, and GitHub CLI to update the watcher pins in a dedicated worktree and create this PR. Autoreview was skipped because the entire diff is limited to GitHub Action version pins. Human review is required. No session link was published.
