### PR TITLE
feat(replay): apply URL masking to JSON-LD payloads

### DIFF
--- a/.changeset/eleven-spoons-drum.md
+++ b/.changeset/eleven-spoons-drum.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+Apply replay URL privacy settings to URL values in captured JSON-LD payloads.

--- a/.changeset/wild-toes-lay.md
+++ b/.changeset/wild-toes-lay.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': minor
+---
+
+Add a shared isUrl helper for HTTP(S) URLs and explicit relative paths.

--- a/packages/browser/src/__tests__/extensions/replay/json-ld.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/json-ld.test.ts
@@ -21,15 +21,8 @@ describe('JSON-LD replay capture', () => {
 
     addJsonLdContractTests(jsonLdContract, sanitizeJsonLd)
 
-    it.each([
-        'https://example.com/category?token=secret',
-        'HTTP://example.com/category',
-        '//example.com/category',
-        '/category?token=secret',
-        './category',
-        '../category',
-        '  https://example.com/category  ',
-    ])('masks URL values in retained fields: %s', (url) => {
+    it('masks a URL value after trimming whitespace', () => {
+        const url = '  https://example.com/category  '
         const maskUrl = vi.fn(() => 'masked')
         const result = sanitizeJsonLd(
             JSON.stringify({ '@context': 'https://schema.org', '@type': 'Product', category: url }),

--- a/packages/browser/src/__tests__/extensions/replay/json-ld.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/json-ld.test.ts
@@ -21,6 +21,96 @@ describe('JSON-LD replay capture', () => {
 
     addJsonLdContractTests(jsonLdContract, sanitizeJsonLd)
 
+    it.each([
+        'https://example.com/category?token=secret',
+        'HTTP://example.com/category',
+        '//example.com/category',
+        '/category?token=secret',
+        './category',
+        '../category',
+        '  https://example.com/category  ',
+    ])('masks URL values in retained fields: %s', (url) => {
+        const maskUrl = vi.fn(() => 'masked')
+        const result = sanitizeJsonLd(
+            JSON.stringify({ '@context': 'https://schema.org', '@type': 'Product', category: url }),
+            undefined,
+            maskUrl
+        )
+
+        expect(result?.[0]).toEqual({ '@context': 'https://schema.org', '@type': 'Product', category: 'masked' })
+        expect(maskUrl).toHaveBeenCalledTimes(1)
+        expect(maskUrl).toHaveBeenCalledWith(url.trim())
+    })
+
+    it('masks nested scalar arrays without passing schema identifiers or ordinary text to the callback', () => {
+        const maskUrl = vi.fn((url: string) => (url.includes('/drop') ? undefined : 'masked'))
+        const result = sanitizeJsonLd(
+            JSON.stringify({
+                '@context': 'https://schema.org',
+                '@type': 'https://schema.org/Product',
+                '@id': 'https://example.com/product#product-id',
+                name: 'Camera: Pro',
+                category: ['Books/Fiction', 'Visit https://example.com', '', 0, false, null, '/drop', '/keep'],
+                url: 'https://example.com/not-allowlisted',
+                offers: [{ '@type': 'Offer', availability: 'https://schema.org/InStock', price: 10 }],
+                '@graph': [{ '@type': 'Product', name: '/drop' }],
+            }),
+            (id) => id === 'product-id',
+            maskUrl
+        )
+
+        expect(result?.[0]).toEqual({
+            '@context': 'https://schema.org',
+            '@type': 'Product',
+            '@id': 'product-id',
+            name: 'Camera: Pro',
+            category: ['Books/Fiction', 'Visit https://example.com', '', 0, false, null, 'masked'],
+            offers: [{ '@type': 'Offer', availability: 'masked', price: 10 }],
+            '@graph': [{ '@type': 'Product' }],
+        })
+        expect(maskUrl.mock.calls.map(([url]) => url)).toEqual([
+            '/drop',
+            '/keep',
+            'https://schema.org/InStock',
+            '/drop',
+        ])
+    })
+
+    it.each(['throws', 'exceeds output limit'])('drops a script when URL masking %s', (failure) => {
+        expect(
+            sanitizeJsonLd(
+                JSON.stringify({ '@context': 'https://schema.org', '@type': 'Product', category: '/category' }),
+                undefined,
+                () => {
+                    if (failure === 'throws') {
+                        throw new Error('mask failed')
+                    }
+                    return 'x'.repeat(20_001)
+                }
+            )
+        ).toBeNull()
+    })
+
+    it('deduplicates script updates after URL masking', async () => {
+        const value = { '@context': 'https://schema.org', '@type': 'Product', category: '/category?token=first' }
+        const script = jsonLdScript(value)
+        document.body.append(script)
+        const emit = vi.fn(() => true)
+        const capture = startJsonLdCapture(document, MutationObserver, {
+            emit,
+            maskUrl: (url) => url.split('?')[0],
+        })
+        try {
+            capture.scan()
+            script.textContent = JSON.stringify({ ...value, category: '/category?token=second' })
+            await deliverMutations()
+            expect(emit).toHaveBeenCalledTimes(1)
+            expect(emit).toHaveBeenCalledWith({ ...value, category: '/category' })
+        } finally {
+            capture.stop()
+        }
+    })
+
     it('keeps @id only when the fragment resolves to a recorded element', () => {
         document.body.innerHTML = `
             <div id="product-id"></div>

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -3830,6 +3830,53 @@ describe('Lazy SessionRecording', () => {
             )
         })
 
+        it.each(['maskCapturedNetworkRequestFn', 'maskNetworkRequestFn'] as const)(
+            'applies replay URL privacy settings to JSON-LD payloads through %s',
+            async (maskOption) => {
+                const script = document.createElement('script')
+                script.type = 'application/ld+json'
+                script.textContent = JSON.stringify({
+                    '@context': 'https://schema.org',
+                    '@type': 'Product',
+                    category: 'https://example.com/category?gclid=secret&token=private#fragment',
+                    offers: [{ '@type': 'Offer', availability: '/unavailable' }],
+                })
+                document.body.appendChild(script)
+                posthog.config.session_recording.captureJsonLd = true
+                posthog.config.mask_personal_data_properties = true
+                posthog.config.disable_capture_url_hashes = true
+                const maskUrl = vi.fn((url: string) =>
+                    url === '/unavailable' ? undefined : url.replace('token=private', 'token=redacted')
+                )
+                if (maskOption === 'maskCapturedNetworkRequestFn') {
+                    posthog.config.session_recording.maskCapturedNetworkRequestFn = (request) => {
+                        const name = maskUrl(request.name)
+                        return name ? { ...request, name } : null
+                    }
+                } else {
+                    posthog.config.session_recording.maskNetworkRequestFn = (request) => {
+                        const url = maskUrl(request.url)
+                        return url ? { ...request, url } : null
+                    }
+                }
+                try {
+                    sessionRecording.onRemoteConfig(makeFlagsResponse({ sessionRecording: { endpoint: '/s/' } }))
+                    _emit(createMetaSnapshot())
+                    await Promise.resolve()
+
+                    expect(maskUrl).toHaveBeenCalledWith('https://example.com/category?gclid=<masked>&token=private')
+                    expect(_addCustomEvent).toHaveBeenCalledWith('$json_ld', {
+                        '@context': 'https://schema.org',
+                        '@type': 'Product',
+                        category: 'https://example.com/category?gclid=<masked>&token=redacted',
+                        offers: [{ '@type': 'Offer' }],
+                    })
+                } finally {
+                    script.remove()
+                }
+            }
+        )
+
         it('emits sanitized JSON-LD only while capture is enabled', async () => {
             const target = document.createElement('div')
             target.id = 'product-123'

--- a/packages/browser/src/extensions/replay/external/json-ld.ts
+++ b/packages/browser/src/extensions/replay/external/json-ld.ts
@@ -5,6 +5,7 @@ type JsonLdPropertyRule = true | readonly string[]
 type JsonLdEntityRules = Record<string, JsonLdPropertyRule>
 type JsonLdRuleGroup = readonly [readonly string[], JsonLdEntityRules]
 type IsCapturedDomId = (id: string) => boolean
+type MaskJsonLdUrl = (url: string) => string | undefined
 
 const MAX_JSON_LD_LENGTH = 100_000
 const MAX_JSON_LD_OUTPUT_LENGTH = 20_000
@@ -144,8 +145,17 @@ function isScalar(value: unknown): value is JsonLdScalar {
     return isNull(value) || type === 'string' || type === 'number' || type === 'boolean'
 }
 
-function sanitizeScalar(value: unknown): JsonLdScalar | JsonLdScalar[] | undefined {
-    return isScalar(value) || (isArray(value) && value.every(isScalar)) ? value : undefined
+function maskScalarUrl(value: JsonLdScalar, maskUrl?: MaskJsonLdUrl): JsonLdScalar | undefined {
+    return maskUrl && typeof value === 'string' && /^(https?:\/\/|\/|\.\.?\/)/i.test(value.trim())
+        ? maskUrl(value.trim()) || undefined
+        : value
+}
+
+function sanitizeScalar(value: unknown, maskUrl?: MaskJsonLdUrl): JsonLdScalar | JsonLdScalar[] | undefined {
+    if (isArray(value) && value.every(isScalar)) {
+        return value.map((item) => maskScalarUrl(item, maskUrl)).filter((item) => !isUndefined(item))
+    }
+    return isScalar(value) ? maskScalarUrl(value, maskUrl) : undefined
 }
 
 function sanitizeId(value: unknown, isCapturedDomId: IsCapturedDomId): string | undefined {
@@ -200,17 +210,18 @@ function getEntityTypes(value: unknown): string[] {
     return types
 }
 
-type SanitizationBudget = {
+type SanitizationContext = {
+    maskUrl?: MaskJsonLdUrl
     remainingNodes: number
     exceeded: boolean
 }
 
-function takeNode(budget: SanitizationBudget): boolean {
-    if (!budget.remainingNodes) {
-        budget.exceeded = true
+function takeNode(context: SanitizationContext): boolean {
+    if (!context.remainingNodes) {
+        context.exceeded = true
         return false
     }
-    budget.remainingNodes--
+    context.remainingNodes--
     return true
 }
 
@@ -226,26 +237,26 @@ function setOwnProperty(result: Record<string, unknown>, property: string, value
 function sanitizeEntityValue(
     value: unknown,
     isCapturedDomId: IsCapturedDomId,
-    budget: SanitizationBudget,
+    context: SanitizationContext,
     allowedTypes?: readonly string[]
 ): unknown | undefined {
     if (isArray(value)) {
         const items = value
-            .map((item) => sanitizeEntityValue(item, isCapturedDomId, budget, allowedTypes))
+            .map((item) => sanitizeEntityValue(item, isCapturedDomId, context, allowedTypes))
             .filter((item) => !isUndefined(item))
         return items.length ? items : undefined
     }
 
-    return sanitizeEntity(value, isCapturedDomId, budget, allowedTypes) || undefined
+    return sanitizeEntity(value, isCapturedDomId, context, allowedTypes) || undefined
 }
 
 function sanitizeEntity(
     value: unknown,
     isCapturedDomId: IsCapturedDomId,
-    budget: SanitizationBudget,
+    context: SanitizationContext,
     allowedTypes?: readonly string[]
 ): Record<string, unknown> | null {
-    if (!isObject(value) || !takeNode(budget)) {
+    if (!isObject(value) || !takeNode(context)) {
         return null
     }
     const typeValue = getOwnProperty(value, '@type')
@@ -265,7 +276,7 @@ function sanitizeEntity(
                     : undefined
                 : property === '@id'
                   ? sanitizeId(getOwnProperty(value, property), isCapturedDomId)
-                  : sanitizeScalar(getOwnProperty(value, property))
+                  : sanitizeScalar(getOwnProperty(value, property), context.maskUrl)
         if (!isUndefined(propertyValue)) {
             setOwnProperty(result, property, propertyValue)
         }
@@ -277,12 +288,12 @@ function sanitizeEntity(
             const propertyValue = getOwnProperty(value, property)
             const rule = rules[property]
             if (rule === true) {
-                const scalar = sanitizeScalar(propertyValue)
+                const scalar = sanitizeScalar(propertyValue, context.maskUrl)
                 if (!isUndefined(scalar)) {
                     setOwnProperty(result, property, scalar)
                 }
             } else {
-                const nestedValue = sanitizeEntityValue(propertyValue, isCapturedDomId, budget, rule)
+                const nestedValue = sanitizeEntityValue(propertyValue, isCapturedDomId, context, rule)
                 if (!isUndefined(nestedValue)) {
                     setOwnProperty(result, property, nestedValue)
                 }
@@ -290,7 +301,7 @@ function sanitizeEntity(
         }
     }
 
-    const graph = sanitizeEntityValue(getOwnProperty(value, '@graph'), isCapturedDomId, budget)
+    const graph = sanitizeEntityValue(getOwnProperty(value, '@graph'), isCapturedDomId, context)
     if (!isUndefined(graph)) {
         setOwnProperty(result, '@graph', graph)
     }
@@ -301,23 +312,24 @@ function sanitizeEntity(
 function sanitizeRoot(
     value: unknown,
     isCapturedDomId: IsCapturedDomId,
-    budget: SanitizationBudget
+    context: SanitizationContext
 ): Record<string, unknown> | null {
     if (!isObject(value)) {
         return null
     }
-    const context = getOwnProperty(value, '@context')
-    if (typeof context !== 'string' || !/^https?:\/\/schema\.org\/?$/.test(context)) {
+    const schemaContext = getOwnProperty(value, '@context')
+    if (typeof schemaContext !== 'string' || !/^https?:\/\/schema\.org\/?$/.test(schemaContext)) {
         return null
     }
 
-    const entity = sanitizeEntity(value, isCapturedDomId, budget)
+    const entity = sanitizeEntity(value, isCapturedDomId, context)
     return entity ? { '@context': SCHEMA_CONTEXT, ...entity } : null
 }
 
 export function sanitizeJsonLd(
     text: string,
-    isCapturedDomId: IsCapturedDomId = NO_CAPTURED_DOM_IDS
+    isCapturedDomId: IsCapturedDomId = NO_CAPTURED_DOM_IDS,
+    maskUrl?: MaskJsonLdUrl
 ): [unknown, string] | null {
     if (!text || text.length > MAX_JSON_LD_LENGTH) {
         return null
@@ -325,15 +337,16 @@ export function sanitizeJsonLd(
 
     try {
         const value: unknown = JSON.parse(text)
-        const budget: SanitizationBudget = {
+        const context: SanitizationContext = {
+            maskUrl,
             remainingNodes: MAX_JSON_LD_NODES,
             exceeded: false,
         }
         const sanitized = isArray(value)
-            ? value.map((root) => sanitizeRoot(root, isCapturedDomId, budget))
-            : sanitizeRoot(value, isCapturedDomId, budget)
+            ? value.map((root) => sanitizeRoot(root, isCapturedDomId, context))
+            : sanitizeRoot(value, isCapturedDomId, context)
         if (
-            budget.exceeded ||
+            context.exceeded ||
             isNull(sanitized) ||
             (isArray(sanitized) && (!sanitized.length || sanitized.some(isNull)))
         ) {
@@ -355,6 +368,7 @@ function isJsonLdScript(node: Node): node is HTMLScriptElement {
 }
 
 type JsonLdPrivacyOptions = {
+    maskUrl?: MaskJsonLdUrl
     attributeFilter?: string[]
     blockClass?: string | RegExp
     blockSelector?: string | null
@@ -463,7 +477,7 @@ export function startJsonLdCapture(
             ) {
                 return
             }
-            const sanitized = sanitizeJsonLd(script.text, hasCapturedDomId)
+            const sanitized = sanitizeJsonLd(script.text, hasCapturedDomId, options.maskUrl)
             if (!sanitized) {
                 lastJsonByScript.delete(script)
                 return

--- a/packages/browser/src/extensions/replay/external/json-ld.ts
+++ b/packages/browser/src/extensions/replay/external/json-ld.ts
@@ -1,4 +1,4 @@
-import { hasOwnProperty, isArray, isNull, isObject, isUndefined } from '@posthog/core'
+import { hasOwnProperty, isArray, isNull, isObject, isUndefined, isUrl } from '@posthog/core'
 
 type JsonLdScalar = string | number | boolean | null
 type JsonLdPropertyRule = true | readonly string[]
@@ -146,9 +146,7 @@ function isScalar(value: unknown): value is JsonLdScalar {
 }
 
 function maskScalarUrl(value: JsonLdScalar, maskUrl?: MaskJsonLdUrl): JsonLdScalar | undefined {
-    return maskUrl && typeof value === 'string' && /^(https?:\/\/|\/|\.\.?\/)/i.test(value.trim())
-        ? maskUrl(value.trim()) || undefined
-        : value
+    return maskUrl && isUrl(value) ? maskUrl(value.trim()) || undefined : value
 }
 
 function sanitizeScalar(value: unknown, maskUrl?: MaskJsonLdUrl): JsonLdScalar | JsonLdScalar[] | undefined {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -3008,6 +3008,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             !this._jsonLdCapture
         ) {
             this._jsonLdCapture = startJsonLdCapture(document, window.MutationObserver, {
+                maskUrl: (url) => this._maskReplayUrl(url),
                 attributeFilter: sessionRecordingOptions.attributeFilter,
                 blockClass: sessionRecordingOptions.blockClass,
                 blockSelector: sessionRecordingOptions.blockSelector,

--- a/packages/core/src/__tests__/utils.spec.ts
+++ b/packages/core/src/__tests__/utils.spec.ts
@@ -1,4 +1,12 @@
-import { assert, removeTrailingSlash, stripUrlHash, currentISOTime, currentTimestamp, raceWithTimeout } from '@/utils'
+import {
+  isUrl,
+  assert,
+  removeTrailingSlash,
+  stripUrlHash,
+  currentISOTime,
+  currentTimestamp,
+  raceWithTimeout,
+} from '@/utils'
 
 describe('utils', () => {
   describe('assert', () => {
@@ -9,6 +17,36 @@ describe('utils', () => {
     })
     it('should not throw on truthy value', () => {
       expect(() => assert('string', 'error')).not.toThrow('error')
+    })
+  })
+  describe('isUrl', () => {
+    it.each([
+      ['https://example.com/category?token=value#section', true],
+      ['HTTP://example.com/category', true],
+      ['//example.com/category', true],
+      ['/category?token=value', true],
+      ['./category', true],
+      ['../category', true],
+      ['  https://example.com/category  ', true],
+      ['/', true],
+      ['https://', true],
+      ['Camera', false],
+      ['Camera: Pro', false],
+      ['Books/Fiction', false],
+      ['Visit https://example.com', false],
+      ['mailto:hello@example.com', false],
+      ['#section', false],
+      ['?query=value', false],
+      ['', false],
+      ['   ', false],
+      [null, false],
+      [undefined, false],
+      [123, false],
+      [true, false],
+      [{ href: 'https://example.com' }, false],
+      [['https://example.com'], false],
+    ])('detects URL prefixes in %j: %s', (value, expected) => {
+      expect(isUrl(value)).toBe(expected)
     })
   })
   describe('removeTrailingSlash', () => {

--- a/packages/core/src/__tests__/utils.spec.ts
+++ b/packages/core/src/__tests__/utils.spec.ts
@@ -23,6 +23,8 @@ describe('utils', () => {
     it.each([
       ['https://example.com/category?token=value#section', true],
       ['HTTP://example.com/category', true],
+      [Object('https://example.com/category'), true],
+      [Object('Camera'), false],
       ['//example.com/category', true],
       ['/category?token=value', true],
       ['./category', true],

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -60,6 +60,11 @@ function isEmpty(truthyValue: string): boolean {
   return false
 }
 
+/** Detects HTTP(S) URLs and explicit relative paths by prefix; does not validate URL syntax. */
+export function isUrl(value: unknown): value is string {
+  return typeof value === 'string' && /^(https?:\/\/|\/|\.\.?\/)/i.test(value.trim())
+}
+
 export function removeTrailingSlash(url: string): string {
   return url?.replace(/\/+$/, '')
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { FetchLike } from '../types'
+import { isString } from './type-utils'
 
 export * from './bot-detection'
 export * from './browser-utils'
@@ -62,7 +63,7 @@ function isEmpty(truthyValue: string): boolean {
 
 /** Detects HTTP(S) URLs and explicit relative paths by prefix; does not validate URL syntax. */
 export function isUrl(value: unknown): value is string {
-  return typeof value === 'string' && /^(https?:\/\/|\/|\.\.?\/)/i.test(value.trim())
+  return isString(value) && /^(https?:\/\/|\/|\.\.?\/)/i.test(value.trim())
 }
 
 export function removeTrailingSlash(url: string): string {

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -711,6 +711,10 @@ export interface SessionRecordingOptions {
      * JSON-LD inside a text mask or blocked element is never captured.
      * The recorder keeps properties on its universal safe list at every depth. This list includes `@type` values shaped like a Schema.org term, which means letters and digits only.
      * It drops property branches that are not on the allowlist.
+     * Retained strings starting with `http://`, `https://`, `//`, `/`, `./`, or `../` use replay URL masking, including query parameter and hash settings.
+     * This applies to nested entities and scalar arrays, but not to the fixed `@context`, normalized `@type`, or captured DOM IDs.
+     * Other strings, including bare relative paths and URLs embedded in text, are unchanged.
+     * A URL rejected by the masking callback is omitted. If the callback throws, the script is not captured.
      * It keeps an `@id` as a fragment only when replay also captures a DOM element with the same `id` value.
      * It drops every `@id` when `maskAllElementAttributes`, `maskAttributeFn`, or an `attributeFilter` without `id` can hide `id` attributes from replay.
      * It also keeps the containing entity tree, even when it redacts all other fields.


### PR DESCRIPTION
## Problem

Captured JSON-LD can retain URLs in allowed fields such as `category` and `availability`. These values currently bypass replay URL privacy settings, including custom URL masking callbacks.

## Changes

Use the shared `isUrl()` helper from `@posthog/core` to detect URL prefixes, then apply `_maskReplayUrl` during JSON-LD sanitization to retained strings that start with `http://`, `https://`, `//`, `/`, `./`, or `../`, after trimming whitespace. This includes nested entities and scalar arrays. For example, a URL in `Product.category` now uses the same query parameter masking, hash removal, and custom callback as a replay page URL.

Keep the existing property allowlist. The fixed `@context`, normalized `@type`, and captured DOM IDs retain their existing sanitization. Ordinary text, bare relative paths such as `Books/Fiction`, and URLs embedded in prose stay unchanged. Parsing every string against a base URL would classify ordinary text as a relative URL.

A rejected URL is omitted. A callback exception drops that script's capture. Masking happens before output size checks and deduplication, within the existing sanitizer traversal. This change is independent of #4864.

Validation:

- 505 tests pass across the core utility, JSON-LD capture, and lazy recorder suites (one existing test is skipped), including primitive and boxed strings, nested fields, scalar arrays, URL forms, rejected URLs, callback exceptions, output limits, deduplication, and both current and deprecated URL callbacks.
- The production build, targeted lint, formatting, and `git diff --check` pass.
- Against base `21d407a13`, production `array.js` changes by -1 minified byte / +9 gzip bytes (0.01%), and `array.full.js` adds 230 minified bytes / 80 gzip bytes (0.04%).
- The separate `test:typecheck` command stops on missing ambient type definitions for `dompurify` and `dotenv`. The package dependencies and test compiler configuration are unchanged.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/types
- [x] @posthog/core

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used local source inspection, shell tools, Vitest, and the production build. It checked the JSON-LD specification with web search. The implementation uses explicit URL prefixes to avoid treating ordinary text as a relative URL, and reuses the existing sanitizer traversal to limit code and bundle growth. A human must review this PR before merge.


