### PR TITLE
build(rrweb): make semantic checks explicit in every build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ pnpm clean:dep
 
 ### rrweb declaration builds
 
-All 16 rrweb workspace packages run semantic checking before Vite's JavaScript build and a separate Rolldown declaration build. `build:declarations` only emits types; it is not a substitute for `check-types` or the production build.
+All 16 rrweb workspace packages use `build: pnpm check-types && vite build && pnpm build:declarations`, with `check-types: tsc --noEmit`. This explicit semantic-check step must succeed before JavaScript or declaration generation starts. `build:declarations` only emits types; it is not a substitute for `check-types` or the production build.
 
 The shared `packages/rrweb/rolldown.dts.config.mts` uses Oxc when a package opts into `isolatedDeclarations`. `rrweb`, `rrdom`, and `rrdom-nodejs` retain TypeScript generation because their annotation work is larger (including exported function properties and destructuring in `rrweb`). Keep this opt-in per package rather than enabling it in the shared TSConfig.
 
@@ -145,6 +145,7 @@ Declaration entries remain self-contained, external package imports remain exter
 
 ```sh
 pnpm turbo run build --filter='./packages/rrweb/**'
+pnpm turbo run check-types --filter='./packages/rrweb/**'
 pnpm test:rrweb-declarations
 ```
 

--- a/packages/rrweb/all/package.json
+++ b/packages/rrweb/all/package.json
@@ -3,12 +3,12 @@
     "version": "0.0.27",
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
         "test": "pnpm test:rrweb",
         "test:rrweb": "vitest run",
         "test:watch": "vitest watch",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "lint": "oxlint src"
     },
     "repository": {

--- a/packages/rrweb/packer/package.json
+++ b/packages/rrweb/packer/package.json
@@ -3,12 +3,12 @@
     "version": "0.0.1",
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
         "test": "pnpm test:rrweb",
         "test:rrweb": "vitest run",
         "test:watch": "vitest watch",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "lint": "oxlint src"
     },
     "repository": {

--- a/packages/rrweb/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -25,9 +25,9 @@
     ],
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit"
+        "check-types": "tsc --noEmit"
     },
     "repository": {
         "type": "git",

--- a/packages/rrweb/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -25,9 +25,9 @@
     ],
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit"
+        "check-types": "tsc --noEmit"
     },
     "repository": {
         "type": "git",

--- a/packages/rrweb/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-console-record/package.json
@@ -28,9 +28,9 @@
         "test": "pnpm test:rrweb",
         "test:rrweb": "vitest run",
         "test:watch": "vitest watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit"
+        "check-types": "tsc --noEmit"
     },
     "repository": {
         "type": "git",

--- a/packages/rrweb/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-console-replay/package.json
@@ -25,9 +25,9 @@
     ],
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit"
+        "check-types": "tsc --noEmit"
     },
     "repository": {
         "type": "git",

--- a/packages/rrweb/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -25,9 +25,9 @@
     ],
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit"
+        "check-types": "tsc --noEmit"
     },
     "repository": {
         "type": "git",

--- a/packages/rrweb/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -25,9 +25,9 @@
     ],
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit"
+        "check-types": "tsc --noEmit"
     },
     "repository": {
         "type": "git",

--- a/packages/rrweb/record/package.json
+++ b/packages/rrweb/record/package.json
@@ -8,12 +8,12 @@
         "dev": "pnpm --filter=@posthog/rrweb-record run --parallel \"/^dev:/\"",
         "dev:runtime": "vite build --watch",
         "dev:declarations": "pnpm build:declarations --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
         "test": "pnpm test:rrweb",
         "test:rrweb": "vitest run",
         "test:watch": "vitest watch",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "lint": "oxlint src"
     },
     "repository": {

--- a/packages/rrweb/replay/package.json
+++ b/packages/rrweb/replay/package.json
@@ -3,12 +3,12 @@
     "version": "0.0.46",
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
         "test": "pnpm test:rrweb",
         "test:rrweb": "vitest run",
         "test:watch": "vitest watch",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "lint": "oxlint src"
     },
     "repository": {

--- a/packages/rrweb/rrdom-nodejs/package.json
+++ b/packages/rrweb/rrdom-nodejs/package.json
@@ -3,9 +3,9 @@
     "version": "0.0.8",
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "test": "pnpm test:rrweb",
         "test:rrweb": "vitest run",
         "test:watch": "vitest watch",

--- a/packages/rrweb/rrdom/package.json
+++ b/packages/rrweb/rrdom/package.json
@@ -29,9 +29,9 @@
     },
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "test": "pnpm test:rrweb",
         "test:rrweb": "vitest run",
         "test:watch": "vitest",

--- a/packages/rrweb/rrweb/package.json
+++ b/packages/rrweb/rrweb/package.json
@@ -14,9 +14,9 @@
         "test:update": "pnpm test:headless --update",
         "retest:update": "cross-env PUPPETEER_HEADLESS=true pnpm retest --update",
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "lint": "oxlint src"
     },
     "type": "module",

--- a/packages/rrweb/types/package.json
+++ b/packages/rrweb/types/package.json
@@ -3,9 +3,9 @@
     "version": "0.0.62",
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "lint": "oxlint src"
     },
     "repository": {

--- a/packages/rrweb/utils/package.json
+++ b/packages/rrweb/utils/package.json
@@ -3,9 +3,9 @@
     "version": "0.0.65",
     "scripts": {
         "dev": "vite build --watch",
-        "build": "tsc -noEmit && vite build && pnpm build:declarations",
+        "build": "pnpm check-types && vite build && pnpm build:declarations",
         "build:declarations": "rolldown -c rolldown.dts.config.mts",
-        "check-types": "tsc -noEmit",
+        "check-types": "tsc --noEmit",
         "lint": "oxlint src"
     },
     "repository": {

--- a/scripts/rrweb-declarations.test.mjs
+++ b/scripts/rrweb-declarations.test.mjs
@@ -86,12 +86,8 @@ test('every rrweb production build retains semantic checking before declaration 
     for (const manifest of manifests) {
         const { scripts } = JSON.parse(readFileSync(path.join(root, manifest), 'utf8'))
         assert.equal(scripts.prepublish, undefined, manifest)
-        assert.match(
-            scripts.build,
-            /^(tsc -noEmit|pnpm check-types) && vite build && pnpm build:declarations$/,
-            manifest
-        )
-        assert.match(scripts['check-types'], /^tsc --?noEmit$/, manifest)
+        assert.equal(scripts.build, 'pnpm check-types && vite build && pnpm build:declarations', manifest)
+        assert.equal(scripts['check-types'], 'tsc --noEmit', manifest)
         assert.equal(scripts['build:declarations'], 'rolldown -c rolldown.dts.config.mts', manifest)
         assert.equal(scripts['dev:runtime'] ?? scripts.dev, 'vite build --watch', manifest)
         if (scripts['dev:runtime']) {


### PR DESCRIPTION
## Problem

All 16 rrweb packages already run TypeScript semantic checking before production builds, but most invoke the compiler directly while `rrweb-snapshot` calls its named `check-types` script. This duplicates the command and makes the required build step less explicit.

## Changes

- Make every production build run `pnpm check-types && vite build && pnpm build:declarations`.
- Standardize `check-types` to `tsc --noEmit`. `rrweb-snapshot` already uses this contract and needs no manifest change.
- Tighten the existing regression test to require these exact commands for all 16 packages.
- Document the contract and the standalone workspace type-check command.

This does not add a second type-check pass to production builds, change compiler settings, or change declaration generators. It is independent of the Oxc migration PR. The only shared files are documentation and the declaration regression test.

### Validation

- All 16 package builds and standalone type checks pass.
- Three declaration regression tests and seven build-graph tests pass.
- Injected an invalid typed assignment into each package in turn. All 16 production builds rejected it with TS2322 before bundling. Every temporary probe was removed.
- Isolated autoreview reported no actionable findings at `cf2af93fa111543bedb20ebad3cee8797a1655eb`.

## Release info Sub-libraries affected

### Libraries affected

No package version bump or changeset is needed for this build-script standardization.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used file inspection/editing, shell tools, and an isolated Pi autoreview. The change keeps existing semantic coverage and makes its command explicit. Human review is required.
