### PR TITLE
build(rrweb): generate all production declarations with Oxc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ pnpm clean:dep
 
 All 16 rrweb workspace packages run semantic checking before Vite's JavaScript build and a separate Rolldown declaration build. `build:declarations` only emits types; it is not a substitute for `check-types` or the production build.
 
-The shared `packages/rrweb/rolldown.dts.config.mts` uses Oxc when a package opts into `isolatedDeclarations`. `rrweb`, `rrdom`, and `rrdom-nodejs` retain TypeScript generation because their annotation work is larger (including exported function properties and destructuring in `rrweb`). Keep this opt-in per package rather than enabling it in the shared TSConfig.
+The shared `packages/rrweb/rolldown.dts.config.mts` explicitly uses Oxc for all 16 packages, each of which enables `isolatedDeclarations` in its TSConfig. Exported declarations must have sufficient type annotations for isolated generation. Keep semantic checking enabled: Oxc does not replace TypeScript's type checker.
 
 Declaration entries remain self-contained, external package imports remain external, and each `.d.ts` has an identical `.d.cts` sibling. Watch mode uses Vite's declaration plugin except for `rrweb-record`, which runs a separate Rolldown declaration watcher. The alternate rrweb entrypoint config also retains Vite's declaration plugin.
 

--- a/packages/rrweb/rolldown.dts.config.mts
+++ b/packages/rrweb/rolldown.dts.config.mts
@@ -34,7 +34,7 @@ export default function declarations(
     plugins: [
       ...dts({
         emitDtsOnly: true,
-        // The generator follows each package's isolatedDeclarations opt-in.
+        generator: 'oxc',
         incremental: false,
       }),
       copyDeclarationsForCommonJs(),

--- a/packages/rrweb/rrdom-nodejs/src/document-nodejs.ts
+++ b/packages/rrweb/rrdom-nodejs/src/document-nodejs.ts
@@ -13,6 +13,7 @@ import {
   ClassList,
   type IRRDocument,
   type CSSStyleDeclaration,
+  type IRRNode,
 } from '@posthog/rrdom';
 const nwsapi = require('nwsapi');
 const cssom = require('cssom');
@@ -21,7 +22,7 @@ const cssstyle = require('cssstyle');
 export class RRWindow {
   scrollLeft = 0;
   scrollTop = 0;
-  scrollTo(options?: ScrollToOptions) {
+  scrollTo(options?: ScrollToOptions): void {
     if (!options) return;
     if (typeof options.left === 'number') this.scrollLeft = options.left;
     if (typeof options.top === 'number') this.scrollTop = options.top;
@@ -74,11 +75,11 @@ export class RRDocument extends BaseRRDocument implements IRRDocument {
     return this.documentElement;
   }
 
-  appendChild(childNode: BaseRRNode) {
+  appendChild(childNode: BaseRRNode): IRRNode {
     return super.appendChild(childNode);
   }
 
-  insertBefore(newChild: BaseRRNode, refChild: BaseRRNode | null) {
+  insertBefore(newChild: BaseRRNode, refChild: BaseRRNode | null): IRRNode {
     return super.insertBefore(newChild, refChild);
   }
 
@@ -108,7 +109,7 @@ export class RRDocument extends BaseRRDocument implements IRRDocument {
     _namespace: string | null,
     _qualifiedName: string | null,
     _doctype?: DocumentType | null,
-  ) {
+  ): RRDocument {
     return new RRDocument();
   }
 
@@ -116,7 +117,7 @@ export class RRDocument extends BaseRRDocument implements IRRDocument {
     qualifiedName: string,
     publicId: string,
     systemId: string,
-  ) {
+  ): RRDocumentType {
     const documentTypeNode = new RRDocumentType(
       qualifiedName,
       publicId,
@@ -158,23 +159,32 @@ export class RRDocument extends BaseRRDocument implements IRRDocument {
     return element;
   }
 
-  createElementNS(_namespaceURI: string, qualifiedName: string) {
+  createElementNS(
+    _namespaceURI: string,
+    qualifiedName: string,
+  ):
+    | RRElement
+    | RRMediaElement
+    | RRCanvasElement
+    | RRIFrameElement
+    | RRImageElement
+    | RRStyleElement {
     return this.createElement(qualifiedName as keyof HTMLElementTagNameMap);
   }
 
-  createComment(data: string) {
+  createComment(data: string): RRComment {
     const commentNode = new RRComment(data);
     commentNode.ownerDocument = this;
     return commentNode;
   }
 
-  createCDATASection(data: string) {
+  createCDATASection(data: string): RRCDATASection {
     const sectionNode = new RRCDATASection(data);
     sectionNode.ownerDocument = this;
     return sectionNode;
   }
 
-  createTextNode(data: string) {
+  createTextNode(data: string): RRText {
     const textNode = new RRText(data);
     textNode.ownerDocument = this;
     return textNode;
@@ -216,17 +226,17 @@ export class RRElement extends BaseRRElement {
     return super.insertBefore(newChild, refChild) as BaseRRNode;
   }
 
-  getAttribute(name: string) {
+  getAttribute(name: string): string | null {
     const upperName = name && name.toLowerCase();
     if (upperName in this.attributes) return this.attributes[upperName];
     return null;
   }
 
-  setAttribute(name: string, attribute: string) {
+  setAttribute(name: string, attribute: string): void {
     this.attributes[name.toLowerCase()] = attribute;
   }
 
-  removeAttribute(name: string) {
+  removeAttribute(name: string): void {
     delete this.attributes[name.toLowerCase()];
   }
 
@@ -324,7 +334,7 @@ export class RRCanvasElement extends RRElement {
 export class RRStyleElement extends RRElement {
   private _sheet: CSSStyleSheet | null = null;
 
-  get sheet() {
+  get sheet(): CSSStyleSheet | null {
     if (!this._sheet) {
       let result = '';
       for (const child of this.childNodes)

--- a/packages/rrweb/rrdom-nodejs/src/polyfill.ts
+++ b/packages/rrweb/rrdom-nodejs/src/polyfill.ts
@@ -6,7 +6,7 @@ import { RRDocument } from './document-nodejs';
  * Note: The performance api is available through the global object from nodejs v16.0.0.
  * https://github.com/nodejs/node/pull/37970
  */
-export function polyfillPerformance() {
+export function polyfillPerformance(): void {
   if (typeof window !== 'undefined' || 'performance' in global) return;
   const performance = require('perf_hooks').performance;
   ((global as Window & typeof globalThis).performance as unknown) = performance;
@@ -15,7 +15,7 @@ export function polyfillPerformance() {
 /**
  * Polyfill requestAnimationFrame and cancelAnimationFrame for nodejs.
  */
-export function polyfillRAF() {
+export function polyfillRAF(): void {
   if (typeof window !== 'undefined' || 'requestAnimationFrame' in global)
     return;
 
@@ -62,7 +62,7 @@ export function polyfillRAF() {
  * The implementation of Event so far is empty because rrweb doesn't strongly depend on it in nodejs mode.
  * Note: The Event class is available through the global object from nodejs v15.0.0.
  */
-export function polyfillEvent() {
+export function polyfillEvent(): void {
   if (typeof Event !== 'undefined') return;
   (global.Event as unknown) = function () {
     //
@@ -72,7 +72,7 @@ export function polyfillEvent() {
 /**
  * Polyfill Node type with BaseRRNode for nodejs.
  */
-export function polyfillNode() {
+export function polyfillNode(): void {
   if (typeof Node !== 'undefined') return;
   (global.Node as unknown) = BaseRRNode;
 }
@@ -80,7 +80,7 @@ export function polyfillNode() {
 /**
  *  Polyfill document object with RRDocument for nodejs.
  */
-export function polyfillDocument() {
+export function polyfillDocument(): void {
   if (typeof document !== 'undefined') return;
   const rrdom = new RRDocument();
   (() => {

--- a/packages/rrweb/rrdom-nodejs/tsconfig.json
+++ b/packages/rrweb/rrdom-nodejs/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "rootDir": "src",
+    "isolatedDeclarations": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "types": ["node", "vite/client"]
   },

--- a/packages/rrweb/rrdom/src/diff.ts
+++ b/packages/rrweb/rrdom/src/diff.ts
@@ -110,7 +110,7 @@ export function diff(
   replayer: ReplayerHandler,
   rrnodeMirror: Mirror = (newTree as RRDocument).mirror ||
     (newTree.ownerDocument as RRDocument).mirror,
-) {
+): void {
   oldTree = diffBeforeUpdatingChildren(
     oldTree,
     newTree,
@@ -592,7 +592,7 @@ export function createOrGetNode(
 /**
  * To check whether two nodes are the same type of node. If they are both Elements, check wether their tagNames are same or not.
  */
-export function sameNodeType(node1: Node, node2: IRRNode) {
+export function sameNodeType(node1: Node, node2: IRRNode): boolean {
   if (node1.nodeType !== node2.nodeType) return false;
   return (
     node1.nodeType !== node1.ELEMENT_NODE ||

--- a/packages/rrweb/rrdom/src/document.ts
+++ b/packages/rrweb/rrdom/src/document.ts
@@ -156,7 +156,7 @@ export abstract class BaseRRNode implements IRRNode {
     return childNodes;
   }
 
-  public contains(node: IRRNode) {
+  public contains(node: IRRNode): boolean {
     if (!(node instanceof BaseRRNode)) return false;
     else if (node.ownerDocument !== this.ownerDocument) return false;
     else if (node === this) return true;
@@ -195,7 +195,7 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
   public readonly nodeType: number = NodeType.DOCUMENT_NODE;
   public readonly nodeName = '#document' as const;
   public readonly compatMode: 'BackCompat' | 'CSS1Compat' = 'CSS1Compat';
-  public readonly RRNodeType = RRNodeType.Document;
+  public readonly RRNodeType: RRNodeType.Document = RRNodeType.Document;
   public textContent: string | null = null;
 
   constructor(...args: any[]) {
@@ -285,12 +285,12 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
     return removeChild(this, node);
   }
 
-  public open() {
+  public open(): void {
     this.firstChild = null;
     this.lastChild = null;
   }
 
-  public close() {
+  public close(): void {
     //
   }
 
@@ -300,7 +300,7 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
    * 1. doc.write('\<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" ""\>')
    * 2. doc.write('\<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" ""\>')
    */
-  public write(content: string) {
+  public write(content: string): void {
     let publicId;
     if (
       content ===
@@ -372,7 +372,7 @@ export class BaseRRDocument extends BaseRRNode implements IRRDocument {
 
 export class BaseRRDocumentType extends BaseRRNode implements IRRDocumentType {
   public readonly nodeType: number = NodeType.DOCUMENT_TYPE_NODE;
-  public readonly RRNodeType = RRNodeType.DocumentType;
+  public readonly RRNodeType: RRNodeType.DocumentType = RRNodeType.DocumentType;
   declare readonly nodeName: string;
   public readonly name: string;
   public readonly publicId: string;
@@ -394,7 +394,7 @@ export class BaseRRDocumentType extends BaseRRNode implements IRRDocumentType {
 
 export class BaseRRElement extends BaseRRNode implements IRRElement {
   public readonly nodeType: number = NodeType.ELEMENT_NODE;
-  public readonly RRNodeType = RRNodeType.Element;
+  public readonly RRNodeType: RRNodeType.Element = RRNodeType.Element;
   declare readonly nodeName: string;
   public tagName: string;
   public attributes: Record<string, string> = {};
@@ -429,15 +429,15 @@ export class BaseRRElement extends BaseRRNode implements IRRElement {
     );
   }
 
-  public get id() {
+  public get id(): string {
     return this.attributes.id || '';
   }
 
-  public get className() {
+  public get className(): string {
     return this.attributes.class || '';
   }
 
-  public get style() {
+  public get style(): CSSStyleDeclaration {
     const style = (
       this.attributes.style ? parseCSSText(this.attributes.style) : {}
     ) as CSSStyleDeclaration;
@@ -470,7 +470,7 @@ export class BaseRRElement extends BaseRRNode implements IRRElement {
     return this.attributes[name];
   }
 
-  public setAttribute(name: string, attribute: string) {
+  public setAttribute(name: string, attribute: string): void {
     this.attributes[name] = attribute;
   }
 
@@ -482,7 +482,7 @@ export class BaseRRElement extends BaseRRNode implements IRRElement {
     this.setAttribute(qualifiedName, value);
   }
 
-  public removeAttribute(name: string) {
+  public removeAttribute(name: string): void {
     delete this.attributes[name];
   }
 
@@ -529,10 +529,10 @@ export class BaseRRMediaElement extends BaseRRElement {
       `RRDomException: Failed to execute 'attachShadow' on 'RRElement': This RRElement does not support attachShadow`,
     );
   }
-  public play() {
+  public play(): void {
     this.paused = false;
   }
-  public pause() {
+  public pause(): void {
     this.paused = true;
   }
 }
@@ -541,21 +541,21 @@ export class BaseRRDialogElement extends BaseRRElement {
   public readonly tagName = 'DIALOG' as const;
   public readonly nodeName = 'DIALOG' as const;
 
-  get isModal() {
+  get isModal(): boolean {
     return this.getAttribute('rr_open_mode') === 'modal';
   }
-  get open() {
+  get open(): boolean {
     return this.getAttribute('open') !== null;
   }
-  public close() {
+  public close(): void {
     this.removeAttribute('open');
     this.removeAttribute('rr_open_mode');
   }
-  public show() {
+  public show(): void {
     this.setAttribute('open', '');
     this.setAttribute('rr_open_mode', 'non-modal');
   }
-  public showModal() {
+  public showModal(): void {
     this.setAttribute('open', '');
     this.setAttribute('rr_open_mode', 'modal');
   }
@@ -564,7 +564,7 @@ export class BaseRRDialogElement extends BaseRRElement {
 export class BaseRRText extends BaseRRNode implements IRRText {
   public readonly nodeType: number = NodeType.TEXT_NODE;
   public readonly nodeName = '#text' as const;
-  public readonly RRNodeType = RRNodeType.Text;
+  public readonly RRNodeType: RRNodeType.Text = RRNodeType.Text;
   public data: string;
 
   constructor(data: string) {
@@ -589,7 +589,7 @@ export class BaseRRText extends BaseRRNode implements IRRText {
 export class BaseRRComment extends BaseRRNode implements IRRComment {
   public readonly nodeType: number = NodeType.COMMENT_NODE;
   public readonly nodeName = '#comment' as const;
-  public readonly RRNodeType = RRNodeType.Comment;
+  public readonly RRNodeType: RRNodeType.Comment = RRNodeType.Comment;
   public data: string;
 
   constructor(data: string) {
@@ -614,7 +614,7 @@ export class BaseRRComment extends BaseRRNode implements IRRComment {
 export class BaseRRCDATASection extends BaseRRNode implements IRRCDATASection {
   public readonly nodeName = '#cdata-section' as const;
   public readonly nodeType: number = NodeType.CDATA_SECTION_NODE;
-  public readonly RRNodeType = RRNodeType.CDATA;
+  public readonly RRNodeType: RRNodeType.CDATA = RRNodeType.CDATA;
   public data: string;
 
   constructor(data: string) {
@@ -651,7 +651,7 @@ export class ClassList {
     this.onChange = onChange;
   }
 
-  add = (...classNames: string[]) => {
+  add = (...classNames: string[]): void => {
     for (const item of classNames) {
       const className = String(item);
       if (this.classes.indexOf(className) >= 0) continue;
@@ -660,7 +660,7 @@ export class ClassList {
     this.onChange && this.onChange(this.classes.join(' '));
   };
 
-  remove = (...classNames: string[]) => {
+  remove = (...classNames: string[]): void => {
     this.classes = this.classes.filter(
       (item) => classNames.indexOf(item) === -1,
     );

--- a/packages/rrweb/rrdom/src/index.ts
+++ b/packages/rrweb/rrdom/src/index.ts
@@ -62,7 +62,7 @@ export class RRDocument extends BaseRRDocument {
     _namespace: string | null,
     _qualifiedName: string | null,
     _doctype?: DocumentType | null,
-  ) {
+  ): RRDocument {
     return new RRDocument();
   }
 
@@ -70,7 +70,7 @@ export class RRDocument extends BaseRRDocument {
     qualifiedName: string,
     publicId: string,
     systemId: string,
-  ) {
+  ): BaseRRDocumentType {
     const documentTypeNode = new RRDocumentType(
       qualifiedName,
       publicId,
@@ -112,37 +112,37 @@ export class RRDocument extends BaseRRDocument {
     return element;
   }
 
-  createComment(data: string) {
+  createComment(data: string): BaseRRComment {
     const commentNode = new RRComment(data);
     commentNode.ownerDocument = this;
     return commentNode;
   }
 
-  createCDATASection(data: string) {
+  createCDATASection(data: string): BaseRRCDATASection {
     const sectionNode = new RRCDATASection(data);
     sectionNode.ownerDocument = this;
     return sectionNode;
   }
 
-  createTextNode(data: string) {
+  createTextNode(data: string): BaseRRText {
     const textNode = new RRText(data);
     textNode.ownerDocument = this;
     return textNode;
   }
 
-  destroyTree() {
+  destroyTree(): void {
     this.firstChild = null;
     this.lastChild = null;
     this.mirror.reset();
   }
 
-  open() {
+  open(): void {
     super.open();
     this._unserializedId = this.UNSERIALIZED_STARTING_ID;
   }
 }
 
-export const RRDocumentType = BaseRRDocumentType;
+export const RRDocumentType: typeof BaseRRDocumentType = BaseRRDocumentType;
 
 export class RRElement extends BaseRRElement {
   inputData: inputData | null = null;
@@ -179,13 +179,13 @@ export class RRIFrameElement extends RRElement {
   }
 }
 
-export const RRText = BaseRRText;
+export const RRText: typeof BaseRRText = BaseRRText;
 export type RRText = typeof RRText;
 
-export const RRComment = BaseRRComment;
+export const RRComment: typeof BaseRRComment = BaseRRComment;
 export type RRComment = typeof RRComment;
 
-export const RRCDATASection = BaseRRCDATASection;
+export const RRCDATASection: typeof BaseRRCDATASection = BaseRRCDATASection;
 export type RRCDATASection = typeof RRCDATASection;
 
 interface RRElementTagNameMap {
@@ -302,7 +302,7 @@ export function buildFromDom(
   dom: Document,
   domMirror: NodeMirror = createNodeMirror(),
   rrdom: IRRDocument = new RRDocument(),
-) {
+): IRRDocument {
   function walk(node: Node, parentRRNode: IRRNode | null) {
     const rrNode = buildFromNode(node, rrdom, domMirror, parentRRNode);
     if (rrNode === null) return;
@@ -370,7 +370,7 @@ export class Mirror implements IMirror<RRNode> {
 
   // removes the node from idNodeMap
   // doesn't remove the node from nodeMetaMap
-  removeNodeFromMap(n: RRNode) {
+  removeNodeFromMap(n: RRNode): void {
     const id = this.getId(n);
     this.idNodeMap.delete(id);
 
@@ -386,13 +386,13 @@ export class Mirror implements IMirror<RRNode> {
     return this.nodeMetaMap.has(node);
   }
 
-  add(n: RRNode, meta: serializedNodeWithId) {
+  add(n: RRNode, meta: serializedNodeWithId): void {
     const id = meta.id;
     this.idNodeMap.set(id, n);
     this.nodeMetaMap.set(n, meta);
   }
 
-  replace(id: number, n: RRNode) {
+  replace(id: number, n: RRNode): void {
     const oldNode = this.getNode(id);
     if (oldNode) {
       const meta = this.nodeMetaMap.get(oldNode);
@@ -401,7 +401,7 @@ export class Mirror implements IMirror<RRNode> {
     this.idNodeMap.set(id, n);
   }
 
-  reset() {
+  reset(): void {
     this.idNodeMap = new Map();
     this.nodeMetaMap = new WeakMap();
   }
@@ -464,7 +464,7 @@ export function getDefaultSN(node: IRRNode, id: number): serializedNodeWithId {
  * @param mirror - a rrweb or rrdom Mirror
  * @returns printed string
  */
-export function printRRDom(rootNode: IRRNode, mirror: IMirror<IRRNode>) {
+export function printRRDom(rootNode: IRRNode, mirror: IMirror<IRRNode>): string {
   return walk(rootNode, mirror, '');
 }
 function walk(node: IRRNode, mirror: IMirror<IRRNode>, blankSpace: string) {

--- a/packages/rrweb/rrdom/tsconfig.json
+++ b/packages/rrweb/rrdom/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "rootDir": "src",
+    "isolatedDeclarations": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "references": [

--- a/packages/rrweb/rrweb/src/index.ts
+++ b/packages/rrweb/rrweb/src/index.ts
@@ -35,9 +35,9 @@ import './replay/styles/style.css';
 
 export type { recordOptions, ReplayPlugin } from './types';
 
-const { addCustomEvent } = record;
-const { freezePage } = record;
-const { takeFullSnapshot } = record;
+const addCustomEvent: typeof record.addCustomEvent = record.addCustomEvent;
+const freezePage: typeof record.freezePage = record.freezePage;
+const takeFullSnapshot: typeof record.takeFullSnapshot = record.takeFullSnapshot;
 
 export {
   record,

--- a/packages/rrweb/rrweb/src/record/cross-origin-iframe-mirror.ts
+++ b/packages/rrweb/rrweb/src/record/cross-origin-iframe-mirror.ts
@@ -68,7 +68,7 @@ export default class CrossOriginIframeMirror
     );
   }
 
-  reset(iframe?: HTMLIFrameElement) {
+  reset(iframe?: HTMLIFrameElement): void {
     if (!iframe) {
       this.iframeRemoteIdToLocalIdMap = new WeakMap();
       this.iframeLocalIdToRemoteIdMap = new WeakMap();

--- a/packages/rrweb/rrweb/src/record/error-handler.ts
+++ b/packages/rrweb/rrweb/src/record/error-handler.ts
@@ -4,11 +4,11 @@ type Callback = (...args: unknown[]) => unknown;
 
 let errorHandler: ErrorHandler | undefined;
 
-export function registerErrorHandler(handler: ErrorHandler | undefined) {
+export function registerErrorHandler(handler: ErrorHandler | undefined): void {
   errorHandler = handler;
 }
 
-export function unregisterErrorHandler() {
+export function unregisterErrorHandler(): void {
   errorHandler = undefined;
 }
 

--- a/packages/rrweb/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/rrweb/src/record/iframe-manager.ts
@@ -17,7 +17,8 @@ export class IframeManager {
   private iframes: WeakMap<HTMLIFrameElement, true> = new WeakMap();
   private crossOriginIframeMap: WeakMap<MessageEventSource, HTMLIFrameElement> =
     new WeakMap();
-  public crossOriginIframeMirror = new CrossOriginIframeMirror(genId);
+  public crossOriginIframeMirror: CrossOriginIframeMirror =
+    new CrossOriginIframeMirror(genId);
   public crossOriginIframeStyleMirror: CrossOriginIframeMirror;
   public crossOriginIframeRootIdMap: WeakMap<HTMLIFrameElement, number> =
     new WeakMap();
@@ -76,7 +77,7 @@ export class IframeManager {
     }
   }
 
-  public addIframe(iframeEl: HTMLIFrameElement) {
+  public addIframe(iframeEl: HTMLIFrameElement): void {
     this.iframes.set(iframeEl, true);
     if (iframeEl.contentWindow)
       this.crossOriginIframeMap.set(iframeEl.contentWindow, iframeEl);
@@ -85,7 +86,7 @@ export class IframeManager {
   public registerLoadListenerDisposer(
     iframeEl: HTMLIFrameElement,
     disposer: () => void,
-  ) {
+  ): void {
     let bucket = this.loadListenerDisposers.get(iframeEl);
     if (!bucket) {
       bucket = new Set();
@@ -106,7 +107,7 @@ export class IframeManager {
   }
 
   // Drops the id mapping for a moved iframe; element-keyed state survives.
-  public forgetIframeId(iframeId: number) {
+  public forgetIframeId(iframeId: number): void {
     this.attachedIframes.delete(iframeId);
     this.iframeElementsById.delete(iframeId);
   }
@@ -127,15 +128,15 @@ export class IframeManager {
     this.pageHideHandlers.delete(iframeEl);
   }
 
-  public addLoadListener(cb: (iframeEl: HTMLIFrameElement) => unknown) {
+  public addLoadListener(cb: (iframeEl: HTMLIFrameElement) => unknown): void {
     this.loadListener = cb;
   }
 
-  public addPageHideListener(cb: (iframeEl: HTMLIFrameElement) => unknown) {
+  public addPageHideListener(cb: (iframeEl: HTMLIFrameElement) => unknown): void {
     this.pageHideListener = cb;
   }
 
-  public removeLoadListener() {
+  public removeLoadListener(): void {
     this.loadListener = undefined;
   }
 
@@ -151,7 +152,7 @@ export class IframeManager {
   public attachIframe(
     iframeEl: HTMLIFrameElement,
     childSn: serializedNodeWithId,
-  ) {
+  ): void {
     const iframeId = this.trackIframeContent(iframeEl, childSn);
     // Accumulate every contentDocument across loads (blank → src → blank).
     if (iframeEl.contentDocument) {
@@ -452,7 +453,7 @@ export class IframeManager {
     }
   }
 
-  public removeIframeById(iframeId: number) {
+  public removeIframeById(iframeId: number): void {
     const entry = this.attachedIframes.get(iframeId);
     // attachedIframes / mirror may both be empty for iframes removed
     // before first load; iframeElementsById covers that case.
@@ -515,7 +516,7 @@ export class IframeManager {
 
   // Catches iframes removed inside a removed subtree (only the
   // ancestor's id appears in m.removes).
-  public cleanupDetachedIframes() {
+  public cleanupDetachedIframes(): void {
     if (this.attachedIframes.size === 0) return;
     const orphaned: number[] = [];
     this.attachedIframes.forEach((_entry, iframeId) => {
@@ -526,7 +527,7 @@ export class IframeManager {
     orphaned.forEach((iframeId) => this.removeIframeById(iframeId));
   }
 
-  public reattachIframes() {
+  public reattachIframes(): void {
     this.attachedIframes.forEach(({ content }, iframeId) => {
       // Verify the iframe ID is still in the mirror (still being tracked by rrweb)
       // If removed, the mirror would have been cleaned up via removeNodeFromMap()
@@ -551,7 +552,7 @@ export class IframeManager {
     });
   }
 
-  public destroy() {
+  public destroy(): void {
     if (this.recordCrossOriginIframes) {
       removeEventListenerSafely(window, 'message', this.messageHandler);
     }

--- a/packages/rrweb/rrweb/src/record/index.ts
+++ b/packages/rrweb/rrweb/src/record/index.ts
@@ -1,6 +1,7 @@
 import {
   snapshot,
   type MaskInputOptions,
+  type Mirror,
   slimDOMDefaults,
   createMirror,
   takeDeferredStylesheetLinks,
@@ -1134,7 +1135,16 @@ function record<T = eventWithTime>(
   }
 }
 
-record.addCustomEvent = <T>(tag: string, payload: T) => {
+// Describe the callable API's attached properties without emitting a runtime namespace.
+// oxlint-disable-next-line typescript/no-namespace
+declare namespace record {
+  var addCustomEvent: <T>(tag: string, payload: T) => void;
+  var freezePage: () => void;
+  var takeFullSnapshot: (isCheckout?: boolean) => void;
+  var mirror: Mirror;
+}
+
+record.addCustomEvent = (<T>(tag: string, payload: T) => {
   if (!recording) {
     throw new Error('please add custom event after start recording');
   }
@@ -1145,18 +1155,18 @@ record.addCustomEvent = <T>(tag: string, payload: T) => {
       payload,
     },
   });
-};
+}) satisfies typeof record.addCustomEvent;
 
-record.freezePage = () => {
+record.freezePage = (() => {
   mutationBuffers.forEach((buf) => buf.freeze());
-};
+}) satisfies typeof record.freezePage;
 
-record.takeFullSnapshot = (isCheckout?: boolean) => {
+record.takeFullSnapshot = ((isCheckout?: boolean) => {
   if (!recording) {
     throw new Error('please take full snapshot after start recording');
   }
   takeFullSnapshot(isCheckout);
-};
+}) satisfies typeof record.takeFullSnapshot;
 
 record.mirror = mirror;
 

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -227,7 +227,7 @@ export default class MutationBuffer {
   private unattachedDoc: HTMLDocument;
   private canvasManagerReleased = false;
 
-  public init(options: MutationBufferParam) {
+  public init(options: MutationBufferParam): void {
     (
       [
         'mutationCb',
@@ -263,39 +263,39 @@ export default class MutationBuffer {
     this.canvasManager.acquire();
   }
 
-  public freeze() {
+  public freeze(): void {
     this.frozen = true;
     this.canvasManager.freeze();
   }
 
-  public unfreeze() {
+  public unfreeze(): void {
     this.frozen = false;
     this.canvasManager.unfreeze();
     this.emit();
   }
 
-  public isFrozen() {
+  public isFrozen(): boolean {
     return this.frozen;
   }
 
-  public lock() {
+  public lock(): void {
     this.locked = true;
     this.canvasManager.lock();
   }
 
-  public unlock() {
+  public unlock(): void {
     this.locked = false;
     this.canvasManager.unlock();
     this.emit();
   }
 
-  public reset() {
+  public reset(): void {
     // Don't reset the shared shadowDomManager here — that would disconnect every shadow-root observer on the page when any single buffer is torn down.
     this.releaseCanvasManager();
   }
 
   // Idempotent so teardown can run twice (iframe pagehide + stop); shadow restore handlers call this directly, not reset(), per the recursion-guard unit test.
-  public releaseCanvasManager() {
+  public releaseCanvasManager(): void {
     if (this.canvasManagerReleased) {
       return;
     }
@@ -312,7 +312,7 @@ export default class MutationBuffer {
     return this.doc;
   }
 
-  public destroy() {
+  public destroy(): void {
     for (const node of this.mapRemoves) {
       // Consume before traversal, as shift() did, including when it throws.
       this.mapRemoves.delete(node);
@@ -320,12 +320,12 @@ export default class MutationBuffer {
     }
   }
 
-  public processMutations = (mutations: mutationRecord[]) => {
+  public processMutations = (mutations: mutationRecord[]): void => {
     mutations.forEach(this.processMutation); // adds mutations to the buffer
     this.emit(); // clears buffer if not locked/frozen
   };
 
-  public emit = () => {
+  public emit = (): void => {
     if (this.frozen || this.locked) {
       return;
     }
@@ -671,7 +671,7 @@ export default class MutationBuffer {
     this.mutationCb(payload);
   };
 
-  public bufferBelongsToIframe = (iframeEl: HTMLIFrameElement) => {
+  public bufferBelongsToIframe = (iframeEl: HTMLIFrameElement): boolean => {
     return this.doc === iframeEl.contentDocument;
   };
 

--- a/packages/rrweb/rrweb/src/record/observer.ts
+++ b/packages/rrweb/rrweb/src/record/observer.ts
@@ -410,7 +410,7 @@ function initViewportResizeObserver(
 export function findAndRemoveIframeBuffer(
   iframeEl: HTMLIFrameElement,
   knownDocs?: Set<Document>,
-) {
+): void {
   for (let i = mutationBuffers.length - 1; i >= 0; i--) {
     const buf = mutationBuffers[i];
     if (!buf) continue;
@@ -425,7 +425,7 @@ export function findAndRemoveIframeBuffer(
   }
 }
 
-export const INPUT_TAGS = ['INPUT', 'TEXTAREA', 'SELECT'];
+export const INPUT_TAGS: string[] = ['INPUT', 'TEXTAREA', 'SELECT'];
 const lastInputValueMap: WeakMap<EventTarget, inputValue> = new WeakMap();
 function initInputObserver({
   inputCb,

--- a/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -50,17 +50,17 @@ export class CanvasManager {
   // map would otherwise keep suppressing an idle canvas forever — leaving the
   // new snapshot's epoch without any frame to repaint that canvas from after
   // a seek. Called after each full snapshot so every canvas re-emits one frame.
-  public onFullSnapshot() {
+  public onFullSnapshot(): void {
     this.resetFrameDedup?.();
   }
 
   // Shared by the main document and every iframe/shadow-root observer, so reference-count
   // teardown: a single root cleaning up must not unpatch getContext / stop the FPS loop globally.
-  public acquire() {
+  public acquire(): void {
     this.refCount += 1;
   }
 
-  public reset() {
+  public reset(): void {
     if (this.refCount > 0) {
       this.refCount -= 1;
     }
@@ -87,19 +87,19 @@ export class CanvasManager {
     }
   }
 
-  public freeze() {
+  public freeze(): void {
     this.frozen = true;
   }
 
-  public unfreeze() {
+  public unfreeze(): void {
     this.frozen = false;
   }
 
-  public lock() {
+  public lock(): void {
     this.locked = true;
   }
 
-  public unlock() {
+  public unlock(): void {
     this.locked = false;
   }
 
@@ -464,7 +464,7 @@ export class CanvasManager {
     this.rafIdTimestamp = requestAnimationFrame(setLatestRAFTimestamp);
   }
 
-  flushPendingCanvasMutations() {
+  flushPendingCanvasMutations(): void {
     this.pendingCanvasMutations.forEach(
       (_values: canvasMutationCommand[], canvas: HTMLCanvasElement) => {
         const id = this.mirror.getId(canvas);
@@ -476,7 +476,7 @@ export class CanvasManager {
     );
   }
 
-  flushPendingCanvasMutationFor(canvas: HTMLCanvasElement, id: number) {
+  flushPendingCanvasMutationFor(canvas: HTMLCanvasElement, id: number): void {
     if (this.frozen || this.locked) {
       return;
     }

--- a/packages/rrweb/rrweb/src/record/observers/canvas/serialize-args.ts
+++ b/packages/rrweb/rrweb/src/record/observers/canvas/serialize-args.ts
@@ -138,7 +138,7 @@ export const serializeArgs = (
   win: IWindow,
   ctx: RenderingContext,
   dataURLOptions: DataURLOptions,
-) => {
+): CanvasArg[] => {
   return args.map((arg) => serializeArg(arg, win, ctx, dataURLOptions));
 };
 

--- a/packages/rrweb/rrweb/src/record/processed-node-manager.ts
+++ b/packages/rrweb/rrweb/src/record/processed-node-manager.ts
@@ -8,14 +8,17 @@ export default class ProcessedNodeManager {
 
   private active = false;
 
-  public inOtherBuffer(node: Node, thisBuffer: MutationBuffer) {
+  public inOtherBuffer(
+    node: Node,
+    thisBuffer: MutationBuffer,
+  ): boolean | undefined {
     const buffers = this.nodeMap.get(node);
     return (
       buffers && Array.from(buffers).some((buffer) => buffer !== thisBuffer)
     );
   }
 
-  public add(node: Node, buffer: MutationBuffer) {
+  public add(node: Node, buffer: MutationBuffer): void {
     if (!this.active) {
       this.active = true;
       requestAnimationFrame(() => {
@@ -26,7 +29,7 @@ export default class ProcessedNodeManager {
     this.nodeMap.set(node, (this.nodeMap.get(node) || new Set()).add(buffer));
   }
 
-  public destroy() {
+  public destroy(): void {
     // cleanup no longer needed
   }
 }

--- a/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
@@ -46,13 +46,13 @@ export class ShadowDomManager {
     this.init();
   }
 
-  public init() {
+  public init(): void {
     this.reset();
     // Patch 'attachShadow' to observe newly added shadow doms.
     this.patchAttachShadow(Element, document);
   }
 
-  public addShadowRoot(shadowRoot: ShadowRoot, doc: Document) {
+  public addShadowRoot(shadowRoot: ShadowRoot, doc: Document): void {
     if (!isNativeShadowDom(shadowRoot)) return;
     if (this.shadowDoms.has(shadowRoot)) return;
     this.shadowDoms.add(shadowRoot);
@@ -120,7 +120,7 @@ export class ShadowDomManager {
   /**
    * Monkey patch 'attachShadow' of an IFrameElement to observe newly added shadow doms.
    */
-  public observeAttachShadow(iframeElement: HTMLIFrameElement) {
+  public observeAttachShadow(iframeElement: HTMLIFrameElement): void {
     if (!iframeElement.contentWindow || !iframeElement.contentDocument) return;
 
     this.patchAttachShadow(
@@ -164,7 +164,7 @@ export class ShadowDomManager {
     });
   }
 
-  public reset() {
+  public reset(): void {
     this.restoreHandlers.forEach(({ handler }) => {
       try {
         handler();
@@ -177,7 +177,7 @@ export class ShadowDomManager {
   }
 
   // Tear down only the shadow observers owned by `doc` (e.g. one iframe being removed), leaving the rest of the page's shadow observation intact.
-  public resetForDoc(doc: Document) {
+  public resetForDoc(doc: Document): void {
     const remaining: { doc: Document; handler: () => void }[] = [];
     for (const entry of this.restoreHandlers) {
       if (entry.doc === doc) {

--- a/packages/rrweb/rrweb/src/record/stylesheet-manager.ts
+++ b/packages/rrweb/rrweb/src/record/stylesheet-manager.ts
@@ -54,7 +54,7 @@ export class StylesheetManager {
   private adoptedStyleSheetCb: adoptedStyleSheetCallback;
   private maskAllElementAttributes: boolean;
   private maskAttributeFn: MaskAttributeFn | undefined;
-  public styleMirror = new StyleSheetMirror();
+  public styleMirror: StyleSheetMirror = new StyleSheetMirror();
 
   constructor(options: {
     mutationCb: mutationCallBack;
@@ -71,7 +71,7 @@ export class StylesheetManager {
   public attachLinkElement(
     linkEl: HTMLLinkElement,
     childSn: serializedNodeWithId,
-  ) {
+  ): void {
     if ('_cssText' in (childSn as elementNode).attributes)
       this.mutationCb({
         adds: [],
@@ -232,7 +232,7 @@ export class StylesheetManager {
   }
 
   /** One-call variant of {@link beginDeferredLinkInlining}: the whole sheet in a single slice. */
-  public inlineDeferredLinkElement(linkEl: HTMLLinkElement, id: number) {
+  public inlineDeferredLinkElement(linkEl: HTMLLinkElement, id: number): void {
     this.beginDeferredLinkInlining(linkEl, id)?.advance(Infinity);
   }
 
@@ -264,7 +264,7 @@ export class StylesheetManager {
     });
   }
 
-  public trackLinkElement(linkEl: HTMLLinkElement) {
+  public trackLinkElement(linkEl: HTMLLinkElement): void {
     if (this.trackedLinkElements.has(linkEl)) return;
 
     this.trackedLinkElements.add(linkEl);
@@ -274,7 +274,7 @@ export class StylesheetManager {
   public adoptStyleSheets(
     sheets: CSSStyleSheet[] | readonly CSSStyleSheet[],
     hostId: number,
-  ) {
+  ): void {
     if (sheets.length === 0) return;
     const adoptedStyleSheetData: adoptedStyleSheetParam = {
       id: hostId,
@@ -319,7 +319,7 @@ export class StylesheetManager {
     this.adoptedStyleSheetCb(adoptedStyleSheetData);
   }
 
-  public reset() {
+  public reset(): void {
     this.styleMirror.reset();
     this.trackedLinkElements = new WeakSet();
     // any surviving deferral registrations belong to tasks the recorder

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -123,7 +123,7 @@ export class Replayer {
 
   public service: ReturnType<typeof createPlayerService>;
   public speedService: ReturnType<typeof createSpeedService>;
-  public get timer() {
+  public get timer(): Timer {
     return this.service.state.context.timer;
   }
 
@@ -484,12 +484,12 @@ export class Replayer {
     }
   }
 
-  public on(event: string, handler: Handler) {
+  public on(event: string, handler: Handler): this {
     this.emitter.on(event, handler);
     return this;
   }
 
-  public off(event: string, handler: Handler) {
+  public off(event: string, handler: Handler): this {
     this.emitter.off(event, handler);
     return this;
   }
@@ -517,7 +517,7 @@ export class Replayer {
     return timeout;
   }
 
-  public setConfig(config: Partial<playerConfig>) {
+  public setConfig(config: Partial<playerConfig>): void {
     Object.keys(config).forEach((key) => {
       const newConfigValue = config[key as keyof playerConfig];
       (this.config as Record<keyof playerConfig, typeof newConfigValue>)[
@@ -594,7 +594,7 @@ export class Replayer {
    * and cast event after the offset asynchronously with timer.
    * @param timeOffset - number
    */
-  public play(timeOffset = 0) {
+  public play(timeOffset = 0): void {
     if (this.seekRebuildInFlight) {
       // the superseded rebuild left the DOM with only part of
       // lastPlayedEvent's history, so a full rebuild is needed
@@ -612,7 +612,7 @@ export class Replayer {
     this.emitter.emit(ReplayerEvents.Start);
   }
 
-  public pause(timeOffset?: number) {
+  public pause(timeOffset?: number): void {
     if (timeOffset === undefined && this.service.state.matches('playing')) {
       this.service.send({ type: 'PAUSE' });
     }
@@ -626,7 +626,7 @@ export class Replayer {
     this.emitter.emit(ReplayerEvents.Pause);
   }
 
-  public resume(timeOffset = 0) {
+  public resume(timeOffset = 0): void {
     this.warn(
       `The 'resume' was deprecated in 1.0. Please use 'play' method which has the same interface.`,
     );
@@ -638,7 +638,7 @@ export class Replayer {
    * Totally destroy this replayer and please be careful that this operation is irreversible.
    * Memory occupation can be released by removing all references to this replayer.
    */
-  public destroy() {
+  public destroy(): void {
     // Make destroy() idempotent - return early if already destroyed
     if (!this.wrapper || !this.wrapper.parentNode) {
       return;
@@ -692,7 +692,7 @@ export class Replayer {
     this.emitter.emit(ReplayerEvents.Destroy);
   }
 
-  public startLive(baselineTime?: number) {
+  public startLive(baselineTime?: number): void {
     // cancel any chunked seek rebuild still in flight — its remaining
     // chunks would interleave stale seek-time events with live DOM writes
     this.applyGeneration++;
@@ -716,7 +716,7 @@ export class Replayer {
     this.service.send({ type: 'TO_LIVE', payload: { baselineTime } });
   }
 
-  public addEvent(rawEvent: eventWithTime | string) {
+  public addEvent(rawEvent: eventWithTime | string): void {
     const event = this.config.unpackFn
       ? this.config.unpackFn(rawEvent as string)
       : (rawEvent as eventWithTime);
@@ -734,12 +734,12 @@ export class Replayer {
     );
   }
 
-  public enableInteract() {
+  public enableInteract(): void {
     this.iframe.setAttribute('scrolling', 'auto');
     this.iframe.style.pointerEvents = 'auto';
   }
 
-  public disableInteract() {
+  public disableInteract(): void {
     this.iframe.setAttribute('scrolling', 'no');
     this.iframe.style.pointerEvents = 'none';
   }
@@ -748,7 +748,7 @@ export class Replayer {
    * Empties the replayer's cache and reclaims memory.
    * The replayer will use this cache to speed up the playback.
    */
-  public resetCache() {
+  public resetCache(): void {
     this.cache = createCache();
   }
 

--- a/packages/rrweb/rrweb/src/replay/machine.ts
+++ b/packages/rrweb/rrweb/src/replay/machine.ts
@@ -107,7 +107,7 @@ type PlayerAssets = {
 export function createPlayerService(
   context: PlayerContext,
   { getCastFn, applyEvents, emitter }: PlayerAssets,
-) {
+): StateMachine.Service<PlayerContext, PlayerEvent, PlayerState> {
   const playerMachine = createMachine<PlayerContext, PlayerEvent, PlayerState>(
     {
       id: 'player',
@@ -389,7 +389,9 @@ export type SpeedState =
       context: SpeedContext;
     };
 
-export function createSpeedService(context: SpeedContext) {
+export function createSpeedService(
+  context: SpeedContext,
+): StateMachine.Service<SpeedContext, SpeedEvent, SpeedState> {
   const speedMachine = createMachine<SpeedContext, SpeedEvent, SpeedState>(
     {
       id: 'speed',

--- a/packages/rrweb/rrweb/src/replay/media/index.ts
+++ b/packages/rrweb/rrweb/src/replay/media/index.ts
@@ -209,7 +209,7 @@ export class MediaManager {
     }
   }
 
-  public addMediaElements(node: Node, timeOffset: number, mirror: Mirror) {
+  public addMediaElements(node: Node, timeOffset: number, mirror: Mirror): void {
     if (!this.isSupportedMediaElement(node)) return;
     const target = node;
     const serializedNode = mirror.getMeta(target);
@@ -276,7 +276,7 @@ export class MediaManager {
     target: HTMLMediaElement | RRMediaElement;
     timeOffset: number;
     mutation: mediaInteractionData;
-  }) {
+  }): void {
     if (!SUPPORTED_MEDIA_ELEMENT_NAMES.includes(target.nodeName)) {
       return;
     }
@@ -297,7 +297,7 @@ export class MediaManager {
     return SUPPORTED_MEDIA_ELEMENT_NAMES.includes(node.nodeName);
   }
 
-  public reset() {
+  public reset(): void {
     this.mediaMap.clear();
   }
 }

--- a/packages/rrweb/rrweb/src/replay/smoothscroll.ts
+++ b/packages/rrweb/rrweb/src/replay/smoothscroll.ts
@@ -5,7 +5,7 @@
 
 /* oxlint-disable */
 // @ts-nocheck
-export function polyfill(w: Window = window, d = document) {
+export function polyfill(w: Window = window, d: Document = document): void {
   // return if scroll behavior is supported and polyfill is not forced
   if (
     'scrollBehavior' in d.documentElement.style &&

--- a/packages/rrweb/rrweb/src/replay/timer.ts
+++ b/packages/rrweb/rrweb/src/replay/timer.ts
@@ -25,7 +25,7 @@ export class Timer {
   /**
    * Add an action, possibly after the timer starts.
    */
-  public addAction(action: actionWithDelay) {
+  public addAction(action: actionWithDelay): void {
     const rafWasActive = this.raf === true;
     if (
       !this.actions.length ||
@@ -43,7 +43,7 @@ export class Timer {
     }
   }
 
-  public start() {
+  public start(): void {
     this.timeOffset = 0;
     this.lastTimestamp = performance.now();
     this.raf = requestAnimationFrame(this.rafCheck.bind(this));
@@ -70,7 +70,7 @@ export class Timer {
     }
   }
 
-  public clear() {
+  public clear(): void {
     if (this.raf) {
       if (this.raf !== true) {
         cancelAnimationFrame(this.raf);
@@ -80,11 +80,11 @@ export class Timer {
     this.actions.length = 0;
   }
 
-  public setSpeed(speed: number) {
+  public setSpeed(speed: number): void {
     this.speed = speed;
   }
 
-  public isActive() {
+  public isActive(): boolean {
     return this.raf !== null;
   }
 

--- a/packages/rrweb/rrweb/src/utils.ts
+++ b/packages/rrweb/rrweb/src/utils.ts
@@ -130,7 +130,7 @@ export function throttle<T>(
 ) {
   let timeout: ReturnType<typeof setTimeout> | null = null;
   let previous = 0;
-  return function (...args: T[]) {
+  return function (...args: T[]): void {
     const now = Date.now();
     if (!previous && options.leading === false) {
       previous = now;
@@ -159,7 +159,7 @@ export function hookSetter<T>(
   key: string | number | symbol,
   d: PropertyDescriptor,
   isRevoked?: boolean,
-  win = window,
+  win: Window & typeof globalThis = window,
 ): hookResetter {
   const original = win.Object.getOwnPropertyDescriptor(target, key);
   win.Object.defineProperty(
@@ -206,7 +206,7 @@ export function hookSetter<T>(
 }
 
 // guard against old third party libraries which redefine Date.now
-let nowTimestamp = Date.now;
+let nowTimestamp: () => number = Date.now;
 
 if (!(/*@__PURE__*/ /[1-9][0-9]{12}/.test(Date.now().toString()))) {
   // they have already redefined it! use a fallback
@@ -214,7 +214,7 @@ if (!(/*@__PURE__*/ /[1-9][0-9]{12}/.test(Date.now().toString()))) {
 }
 export { nowTimestamp };
 
-export function getWindowScroll(win: Window) {
+export function getWindowScroll(win: Window): { left: number; top: number } {
   const doc = win.document;
   return {
     left: doc.scrollingElement
@@ -354,7 +354,7 @@ export function legacy_isTouchEvent(
   return Boolean((event as TouchEvent).changedTouches);
 }
 
-export function polyfill(win = window) {
+export function polyfill(win: Window & typeof globalThis = window): void {
   if ('NodeList' in win && !win.NodeList.prototype.forEach) {
     win.NodeList.prototype.forEach = Array.prototype
       .forEach as unknown as NodeList['forEach'];
@@ -419,7 +419,7 @@ export function queueToResolveTrees(queue: addedNodeMutation[]): ResolveTree[] {
 export function iterateResolveTree(
   tree: ResolveTree,
   cb: (mutation: addedNodeMutation) => unknown,
-) {
+): void {
   cb(tree.value);
   /**
    * The resolve tree was designed to reflect the DOM layout,
@@ -511,7 +511,10 @@ export function getNestedRule(
   }
 }
 
-export function getPositionsAndIndex(nestedIndex: number[]) {
+export function getPositionsAndIndex(nestedIndex: number[]): {
+  positions: number[];
+  index: number | undefined;
+} {
   const positions = [...nestedIndex];
   const index = positions.pop();
   return { positions, index };

--- a/packages/rrweb/rrweb/tsconfig.json
+++ b/packages/rrweb/rrweb/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "rootDir": "src",
+    "isolatedDeclarations": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "types": [
       // from tsconfig.base.json

--- a/scripts/rrweb-declarations.test.mjs
+++ b/scripts/rrweb-declarations.test.mjs
@@ -5,81 +5,124 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { test } from 'node:test'
 import { rolldown } from 'rolldown'
+import ts from 'typescript'
 import declarations from '../packages/rrweb/rolldown.dts.config.mts'
 
 const root = path.resolve(import.meta.dirname, '..')
 const manifests = globSync(['packages/rrweb/*/package.json', 'packages/rrweb/plugins/*/package.json'], { cwd: root })
 
-for (const isolatedDeclarations of [true, false]) {
-    test(`self-contained dual declarations with ${isolatedDeclarations ? 'Oxc' : 'TypeScript'}`, async () => {
-        const cwd = process.cwd()
-        const fixture = mkdtempSync(path.join(tmpdir(), 'rrweb-declarations-'))
-        try {
-            symlinkSync(path.join(root, 'node_modules'), path.join(fixture, 'node_modules'), 'dir')
-            writeFileSync(path.join(fixture, 'package.json'), '{"type":"module"}')
-            writeFileSync(
-                path.join(fixture, 'tsconfig.json'),
-                JSON.stringify({
-                    compilerOptions: {
-                        isolatedDeclarations,
-                        declaration: true,
-                        strict: true,
-                        skipLibCheck: true,
-                        target: 'ESNext',
-                        module: 'ESNext',
-                        moduleResolution: 'Node',
-                        types: [],
-                    },
-                    include: ['*.ts'],
-                })
-            )
-            writeFileSync(path.join(fixture, 'shared.ts'), 'export interface Shared { value: string }')
-            writeFileSync(
-                path.join(fixture, 'index.ts'),
-                `
+test('self-contained dual declarations with Oxc', async () => {
+    const cwd = process.cwd()
+    const fixture = mkdtempSync(path.join(tmpdir(), 'rrweb-declarations-'))
+    try {
+        symlinkSync(path.join(root, 'node_modules'), path.join(fixture, 'node_modules'), 'dir')
+        writeFileSync(path.join(fixture, 'package.json'), '{"type":"module"}')
+        writeFileSync(
+            path.join(fixture, 'tsconfig.json'),
+            JSON.stringify({
+                compilerOptions: {
+                    isolatedDeclarations: true,
+                    declaration: true,
+                    strict: true,
+                    skipLibCheck: true,
+                    target: 'ESNext',
+                    module: 'ESNext',
+                    moduleResolution: 'Node',
+                    types: [],
+                },
+                include: ['*.ts'],
+            })
+        )
+        writeFileSync(path.join(fixture, 'shared.ts'), 'export interface Shared { value: string }')
+        writeFileSync(
+            path.join(fixture, 'index.ts'),
+            `
                 import './style.css';
                 export type { CompilerOptions } from 'typescript';
                 export type { Shared } from './shared';
                 export const value: number = 1;
-            `
-            )
-            writeFileSync(path.join(fixture, 'secondary.ts'), "export type { Shared } from './shared';")
-            process.chdir(fixture)
-            for (const config of declarations({ index: 'index.ts', secondary: 'secondary.ts' })) {
-                const build = await rolldown(config)
-                try {
-                    await build.write(config.output)
-                } finally {
-                    await build.close()
+                function record(): void {}
+                export { record };
+                declare namespace record {
+                    var addCustomEvent: <T>(tag: string, payload: T) => void;
                 }
+                record.addCustomEvent = (<T>(tag: string, payload: T) => {}) satisfies typeof record.addCustomEvent;
+                export const addCustomEvent: typeof record.addCustomEvent = record.addCustomEvent;
+            `
+        )
+        writeFileSync(path.join(fixture, 'secondary.ts'), "export type { Shared } from './shared';")
+        process.chdir(fixture)
+        for (const config of declarations({ index: 'index.ts', secondary: 'secondary.ts' })) {
+            const build = await rolldown(config)
+            try {
+                await build.write(config.output)
+            } finally {
+                await build.close()
             }
-            assert.deepEqual(readdirSync('dist').sort(), [
-                'index.d.cts',
-                'index.d.ts',
-                'secondary.d.cts',
-                'secondary.d.ts',
-            ])
-            for (const name of ['index', 'secondary']) {
-                const esm = readFileSync(`dist/${name}.d.ts`, 'utf8')
-                assert.equal(readFileSync(`dist/${name}.d.cts`, 'utf8'), esm)
-                assert.match(esm, /interface Shared/)
-                assert.doesNotMatch(esm, /["']\.\.?\//)
-            }
-            assert.match(readFileSync('dist/index.d.ts', 'utf8'), /from ["']typescript["']/)
-            writeFileSync('invalid.ts', 'export const invalid: number = "not a number";')
-            assert.throws(
-                () =>
-                    execFileSync(process.execPath, [path.join(root, 'node_modules/typescript/bin/tsc'), '--noEmit'], {
-                        stdio: 'pipe',
-                    }),
-                (error) => error.status !== 0 && error.stdout.toString().includes('TS2322')
-            )
-        } finally {
-            process.chdir(cwd)
-            rmSync(fixture, { recursive: true, force: true })
         }
-    })
-}
+        assert.deepEqual(readdirSync('dist').sort(), ['index.d.cts', 'index.d.ts', 'secondary.d.cts', 'secondary.d.ts'])
+        for (const name of ['index', 'secondary']) {
+            const esm = readFileSync(`dist/${name}.d.ts`, 'utf8')
+            assert.equal(readFileSync(`dist/${name}.d.cts`, 'utf8'), esm)
+            assert.match(esm, /interface Shared/)
+            assert.doesNotMatch(esm, /["']\.\.?\//)
+        }
+        assert.match(readFileSync('dist/index.d.ts', 'utf8'), /from ["']typescript["']/)
+        for (const [extension, entry] of [
+            ['mts', 'js'],
+            ['cts', 'cjs'],
+        ]) {
+            writeFileSync(
+                `consumer.${extension}`,
+                `import { record, addCustomEvent, type Shared } from './dist/index.${entry}';
+                    record();
+                    record.addCustomEvent<Shared>('event', { value: 'test' });
+                    addCustomEvent<number>('event', 1);
+                    // @ts-expect-error Explicit payload types must be preserved.
+                    record.addCustomEvent<number>('event', 'invalid');
+                    // @ts-expect-error The exported alias must retain the same generic signature.
+                    addCustomEvent<Shared>('event', { value: 1 });`
+            )
+            execFileSync(
+                process.execPath,
+                [
+                    path.join(root, 'node_modules/typescript/bin/tsc'),
+                    `consumer.${extension}`,
+                    '--noEmit',
+                    '--strict',
+                    '--target',
+                    'ES2020',
+                    '--module',
+                    'NodeNext',
+                    '--moduleResolution',
+                    'NodeNext',
+                ],
+                { stdio: 'pipe' }
+            )
+        }
+        writeFileSync('invalid.ts', 'export const invalid: number = "not a number";')
+        assert.throws(
+            () =>
+                execFileSync(process.execPath, [path.join(root, 'node_modules/typescript/bin/tsc'), '--noEmit'], {
+                    stdio: 'pipe',
+                }),
+            (error) => error.status !== 0 && error.stdout.toString().includes('TS2322')
+        )
+    } finally {
+        process.chdir(cwd)
+        rmSync(fixture, { recursive: true, force: true })
+    }
+})
+
+test('every rrweb package enables isolated declarations for Oxc', () => {
+    for (const manifest of manifests) {
+        const configPath = path.join(root, path.dirname(manifest), 'tsconfig.json')
+        const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile)
+        assert.equal(error, undefined, manifest)
+        const parsed = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(configPath))
+        assert.equal(parsed.options.isolatedDeclarations, true, manifest)
+    }
+})
 
 test('every rrweb production build retains semantic checking before declaration emission', () => {
     assert.equal(manifests.length, 16)


### PR DESCRIPTION
## Problem

The shared rrweb declaration pipeline still uses TypeScript for `rrweb`, `rrdom`, and `rrdom-nodejs`. The other 13 packages already use Oxc. Finishing the migration requires explicit types for the remaining exported declarations without changing their public API.

## Changes

- Enable `isolatedDeclarations` in the remaining three packages and select Oxc explicitly in the shared production declaration config.
- Add the required annotations. Describe the recorder's attached methods with a type-only namespace and preserve their generic signatures.
- Test all 16 package configs, dual declarations, and ESM/CommonJS consumers. Keep semantic TypeScript checking before production builds.
- Leave watch-mode declaration tooling unchanged.

### Validation

- All rrweb builds and the browser SDK build pass on the latest `main`.
- The rrweb suites pass with 1,101 tests and four skips. Declaration tests and build-graph checks pass.
- Fresh before/after builds and 21 packed-package comparisons preserved file lists, exports, and dependency versions. All 42 browser runtime bundles were byte-identical. Changed rrweb runtime output was equivalent after syntax normalization.
- Compared 2,180 resolved declaration/signature entries with no public API differences. Installed ESM/CommonJS consumers pass with TypeScript 4.7.4, 5.8.2, and 6.0.3 using `skipLibCheck`.
- Existing export-path, native ESM, and strict dependency-typing failures reproduced unchanged on both sides and are separate follow-ups.
- Isolated autoreview reported no actionable findings at `984b272608065390571a878af2d20db027cd5ad1`.

The semantic-check standardization is a separate PR against `main`. Only documentation and the declaration regression test overlap.

## Release info Sub-libraries affected

### Libraries affected

No version bump is needed for this build-tooling change. There is no changeset for vendored rrweb packages.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used file inspection/editing, shell tools, and an isolated Pi autoreview. The migration was checked against fresh baseline builds and installed tarball consumers. Existing vendored formatting was retained instead of including a repository-wide formatting rewrite. Human review is required.
