### PR TITLE
fix(replay): restore public event type compatibility

### DIFF
--- a/.changeset/sparkly-parks-smoke.md
+++ b/.changeset/sparkly-parks-smoke.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix TypeScript compatibility between public replay events and the replay player.

--- a/.github/fixtures/minimum-version-ts/ci-ts-file.ts
+++ b/.github/fixtures/minimum-version-ts/ci-ts-file.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable */
 import { posthog } from 'posthog-js'
-import type { eventWithTime } from 'posthog-js/rrweb-types'
+import type { Replayer, ReplayPlugin, eventWithTime as ReplayerEvent } from 'posthog-js/rrweb'
+import type { EventType, eventWithTime } from 'posthog-js/rrweb-types'
 import * as ts from 'typescript'
 
 console.log(posthog)
@@ -16,3 +17,19 @@ function jsonLdUrl(event: eventWithTime): string | undefined {
 
 console.log(jsonLdUrl({ type: 5, timestamp: 0, data: { tag: '$json_ld', payload: {}, href: 'https://example.com' } }))
 console.log(jsonLdUrl({ type: 5, timestamp: 0, data: { tag: '$json_ld', payload: {} } }))
+
+function replayEvents(ReplayerClass: typeof Replayer, events: eventWithTime[]): eventWithTime[] {
+    const plugin: ReplayPlugin = {
+        handler(event: eventWithTime) {
+            console.log(jsonLdUrl(event))
+        },
+    }
+    const replayer = new ReplayerClass(events, { plugins: [plugin] })
+    const event: ReplayerEvent = events[0]
+    replayer.addEvent(events[0])
+    const type: EventType = event.type
+    console.log(type)
+    return [event]
+}
+
+console.log(replayEvents)

--- a/.github/fixtures/minimum-version-ts/ci-ts-file.ts
+++ b/.github/fixtures/minimum-version-ts/ci-ts-file.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable */
 import { posthog } from 'posthog-js'
 import type { Replayer, ReplayPlugin, eventWithTime as ReplayerEvent } from 'posthog-js/rrweb'
-import type { EventType, eventWithTime } from 'posthog-js/rrweb-types'
+import type { EventType, customEvent, eventWithTime } from 'posthog-js/rrweb-types'
 import * as ts from 'typescript'
 
 console.log(posthog)
@@ -17,6 +17,12 @@ function jsonLdUrl(event: eventWithTime): string | undefined {
 
 console.log(jsonLdUrl({ type: 5, timestamp: 0, data: { tag: '$json_ld', payload: {}, href: 'https://example.com' } }))
 console.log(jsonLdUrl({ type: 5, timestamp: 0, data: { tag: '$json_ld', payload: {} } }))
+
+function customPayload(event: customEvent<{ name: string }>): string {
+    return event.data.payload.name
+}
+
+console.log(customPayload({ type: 5, data: { tag: 'example', payload: { name: 'test' } } }))
 
 function replayEvents(ReplayerClass: typeof Replayer, events: eventWithTime[]): eventWithTime[] {
     const plugin: ReplayPlugin = {

--- a/packages/browser/src/entrypoints/rrweb-types.es.ts
+++ b/packages/browser/src/entrypoints/rrweb-types.es.ts
@@ -7,9 +7,9 @@ import type {
     eventWithoutTime as RrwebEventWithoutTime,
     eventWithTime as RrwebEventWithTime,
 } from '@posthog/rrweb-types'
-import type { customEvent as PostHogCustomEvent } from '../extensions/replay/types/rrweb-types'
 
-type WithJsonLdUrl<T> = T extends RrwebCustomEvent ? T & { data: Pick<PostHogCustomEvent['data'], 'href'> } : T
+// Importing internal event types also bundles their EventType, breaking compatibility with the replayer's enum.
+type WithJsonLdUrl<T> = T extends RrwebCustomEvent ? T & { data: { href?: string } } : T
 
 export type customEvent<T = unknown> = WithJsonLdUrl<RrwebCustomEvent<T>>
 export type eventWithoutTime = WithJsonLdUrl<RrwebEventWithoutTime>

--- a/packages/browser/src/entrypoints/rrweb-types.es.ts
+++ b/packages/browser/src/entrypoints/rrweb-types.es.ts
@@ -7,9 +7,10 @@ import type {
     eventWithoutTime as RrwebEventWithoutTime,
     eventWithTime as RrwebEventWithTime,
 } from '@posthog/rrweb-types'
+import type { customEventData } from '../extensions/replay/types/rrweb-types'
 
-// Importing internal event types also bundles their EventType, breaking compatibility with the replayer's enum.
-type WithJsonLdUrl<T> = T extends RrwebCustomEvent ? T & { data: { href?: string } } : T
+// Sharing only event data avoids bundling the internal EventType and renaming rrweb's enum.
+type WithJsonLdUrl<T> = T extends RrwebCustomEvent ? T & { data: Pick<customEventData, 'href'> } : T
 
 export type customEvent<T = unknown> = WithJsonLdUrl<RrwebCustomEvent<T>>
 export type eventWithoutTime = WithJsonLdUrl<RrwebEventWithoutTime>

--- a/packages/browser/src/extensions/replay/types/rrweb-types.ts
+++ b/packages/browser/src/extensions/replay/types/rrweb-types.ts
@@ -185,13 +185,15 @@ export type metaEvent = {
     }
 }
 
+export type customEventData<T = unknown> = {
+    tag: string
+    payload: T
+    href?: string
+}
+
 export type customEvent<T = unknown> = {
     type: typeof EventType.Custom
-    data: {
-        tag: string
-        payload: T
-        href?: string
-    }
+    data: customEventData<T>
 }
 
 export type pluginEvent<T = unknown> = {


### PR DESCRIPTION
## Problem

Upgrading PostHog to posthog-js 1.428.11 fails TypeScript checking when public replay events are passed to the replay player. This blocks https://github.com/PostHog/posthog/pull/97533.

The JSON-LD URL type added in #4864 imports the internal event model, bringing a second `EventType` into the declaration bundle. The bundler renames the upstream enum to `EventType$1`, making it incompatible with the enum in `posthog-js/rrweb`.

## Changes

Define `customEventData<T>` once for the internal custom event. The public JSON-LD augmentation selects `href` from this data shape, sharing the field definition without importing the internal event discriminant.

Extend the existing packed-package consumer fixture to check the replay constructor, `addEvent`, plugin handlers, both event-assignment directions, and enum compatibility. The fixture also checks generic custom payloads and preserves the existing optional JSON-LD URL checks.

Validation:

- The new consumer fixture fails against published 1.428.11 with the downstream enum incompatibility.
- The fixed tarball passes compilation and Node execution with TypeScript 4.7.4, 5.9.2, 6.0.3, 7.0.2, and 7.1.0-dev.20260715.1.
- `pnpm build --concurrency=2`, `pnpm lint`, `pnpm lint:playground`, `pnpm test:unit --concurrency=2` (64 tasks), and `pnpm test:functional --concurrency=2` pass.
- All 42 browser runtime bundles are byte-identical to the baseline. CodeScene reports no issues.
- `pnpm test:dev-watch` passes.
- Downstream validation on PostHog/posthog #97533 (`b47b8c4a541d86fa5f10df40f570b34c6ed62202`): the published SDK reproduces all 10 CI TypeScript errors; replacing only the installed SDK with this PR's tarball makes the clean frontend typecheck pass with zero errors.
- Downstream Kea typegen produces no source changes. All 68 replay-shared tests pass. Query and mobile schemas regenerate without differences.
- The updater still needs a regenerated web replay schema. Its validation rules are equivalent after resolving the new root reference and ignoring union ordering and deprecated annotations. Other updater CI failures were not validated here.

Coordination with #4881: its new `preserveRrwebEventTypeName` transform forces the incompatible `EventType$1` name back into `rrweb-types.d.ts`. That transform and its legacy-alias assertion need adjusting before both changes land. This PR's cross-entrypoint consumer test covers the actual replay-player contract.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex, Git, pnpm, and the GitHub CLI. Used the CodeScene code-health skill. Separated custom-event data from its internal discriminant so public and internal types share the URL definition without an enum collision. Human review is required.
