### PR TITLE
feat(react-native): expose rageClickConfig for native iOS rage click detection

### DIFF
--- a/.changeset/expose-rn-rage-click-config.md
+++ b/.changeset/expose-rn-rage-click-config.md
@@ -1,0 +1,6 @@
+---
+'posthog-react-native': minor
+'@posthog/react-native-plugin': minor
+---
+
+Expose rageClickConfig for tuning or disabling native iOS rage click detection from React Native.

--- a/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
+++ b/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
@@ -100,6 +100,7 @@ public class PosthogReactNativePlugin: RCTEventEmitter {
             nativeErrorTrackingAutocapture: errorTrackingConfig["nativeAutocapture"] as? Bool ?? false,
             exceptionStepsConfig: exceptionStepsConfig,
             pushConfig: pluginConfig["push"] as? [String: Any] ?? [:],
+            rageClickConfig: pluginConfig["rageClick"] as? [String: Any] ?? [:],
             resolve: resolve
         )
     }
@@ -120,6 +121,7 @@ public class PosthogReactNativePlugin: RCTEventEmitter {
             nativeErrorTrackingAutocapture: false,
             exceptionStepsConfig: [:],
             pushConfig: [:],
+            rageClickConfig: [:],
             resolve: resolve
         )
     }
@@ -134,6 +136,7 @@ public class PosthogReactNativePlugin: RCTEventEmitter {
         nativeErrorTrackingAutocapture: Bool,
         exceptionStepsConfig: [String: Any],
         pushConfig: [String: Any],
+        rageClickConfig: [String: Any],
         resolve: RCTPromiseResolveBlock
     ) {
         if sessionId.isEmpty {
@@ -163,6 +166,19 @@ public class PosthogReactNativePlugin: RCTEventEmitter {
         }
         if let maxBytes = exceptionStepsConfig["maxBytes"] as? Int {
             config.errorTrackingConfig.exceptionSteps.maxBytes = maxBytes
+        }
+
+        if let enabled = rageClickConfig["enabled"] as? Bool {
+            config.rageClickConfig.enabled = enabled
+        }
+        if let minimumTapCount = rageClickConfig["minimumTapCount"] as? Int {
+            config.rageClickConfig.minimumTapCount = minimumTapCount
+        }
+        if let thresholdPoints = rageClickConfig["thresholdPoints"] as? Double {
+            config.rageClickConfig.thresholdPoints = CGFloat(thresholdPoints)
+        }
+        if let timeoutInterval = rageClickConfig["timeoutInterval"] as? Double {
+            config.rageClickConfig.timeoutInterval = timeoutInterval
         }
 
         // React Native rethrows fatal JS errors natively (RCTFatalException / ExceptionsManager).

--- a/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
+++ b/packages/react-native-plugin/ios/PosthogReactNativePlugin.swift
@@ -168,18 +168,20 @@ public class PosthogReactNativePlugin: RCTEventEmitter {
             config.errorTrackingConfig.exceptionSteps.maxBytes = maxBytes
         }
 
-        if let enabled = rageClickConfig["enabled"] as? Bool {
-            config.rageClickConfig.enabled = enabled
-        }
-        if let minimumTapCount = rageClickConfig["minimumTapCount"] as? Int {
-            config.rageClickConfig.minimumTapCount = minimumTapCount
-        }
-        if let thresholdPoints = rageClickConfig["thresholdPoints"] as? Double {
-            config.rageClickConfig.thresholdPoints = CGFloat(thresholdPoints)
-        }
-        if let timeoutInterval = rageClickConfig["timeoutInterval"] as? Double {
-            config.rageClickConfig.timeoutInterval = timeoutInterval
-        }
+        #if os(iOS) || targetEnvironment(macCatalyst)
+            if let enabled = rageClickConfig["enabled"] as? Bool {
+                config.rageClickConfig.enabled = enabled
+            }
+            if let minimumTapCount = rageClickConfig["minimumTapCount"] as? Int {
+                config.rageClickConfig.minimumTapCount = minimumTapCount
+            }
+            if let thresholdPoints = rageClickConfig["thresholdPoints"] as? Double {
+                config.rageClickConfig.thresholdPoints = CGFloat(thresholdPoints)
+            }
+            if let timeoutInterval = rageClickConfig["timeoutInterval"] as? Double {
+                config.rageClickConfig.timeoutInterval = timeoutInterval
+            }
+        #endif
 
         // React Native rethrows fatal JS errors natively (RCTFatalException / ExceptionsManager).
         // The JS layer already captured them, so drop the native duplicate.

--- a/packages/react-native-plugin/src/index.tsx
+++ b/packages/react-native-plugin/src/index.tsx
@@ -48,10 +48,18 @@ export interface PostHogReactNativePluginPushConfig {
   pushIdentityProviderEnabled?: boolean
 }
 
+export interface PostHogReactNativePluginRageClickConfig {
+  enabled?: boolean
+  minimumTapCount?: number
+  thresholdPoints?: number
+  timeoutInterval?: number
+}
+
 export interface PostHogReactNativePluginConfig {
   sessionReplay?: PostHogReactNativePluginSessionReplayConfig
   errorTracking?: PostHogReactNativePluginErrorTrackingConfig
   push?: PostHogReactNativePluginPushConfig
+  rageClick?: PostHogReactNativePluginRageClickConfig
 }
 
 export function setup(

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -3849,6 +3849,11 @@
           "name": "pushIdentityProvider"
         },
         {
+          "description": "Configure rage click (rage tap) detection on iOS.\nThe native iOS SDK fires a `$rageclick` event when a user taps the same area repeatedly in quick succession. The default thresholds (3 taps, 30 points, 1 second) were tuned for web and frequently produce false positives on mobile. Raise the thresholds or set `enabled: false` to suppress them.\nAndroid is unaffected — posthog-android does not have native rage click detection.\nRequires `@posthog/react-native-plugin` version 2.7.0 or newer.",
+          "type": "PostHogRageClickConfig",
+          "name": "rageClickConfig"
+        },
+        {
           "description": "A list of headers that should be sent with requests to the PostHog API.",
           "type": "{\n        [header_name: string]: string;\n    }",
           "name": "requestHeaders"
@@ -4053,6 +4058,33 @@
       "properties": [],
       "path": "dist/types.d.ts",
       "example": "(distinctId: string, appId: string) => Promise<string | null>"
+    },
+    {
+      "id": "PostHogRageClickConfig",
+      "name": "PostHogRageClickConfig",
+      "properties": [
+        {
+          "description": "Enable or disable rage click (rage tap) detection.\n\nWhen enabled the native SDK emits a `$rageclick` event whenever a user\ntaps the same area repeatedly in quick succession.",
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "description": "Number of consecutive taps required to trigger a rage click.",
+          "type": "number",
+          "name": "minimumTapCount"
+        },
+        {
+          "description": "Maximum pixel distance between consecutive taps for them to still\ncount toward a rage click.",
+          "type": "number",
+          "name": "thresholdPoints"
+        },
+        {
+          "description": "Maximum time in seconds allowed between consecutive taps.",
+          "type": "number",
+          "name": "timeoutInterval"
+        }
+      ],
+      "path": "dist/types.d.ts"
     },
     {
       "id": "PostHogReactNativePluginExtended",

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -42,6 +42,7 @@ import {
   PostHogCustomAppProperties,
   PostHogCustomStorage,
   PostHogPushIdentityProvider,
+  PostHogRageClickConfig,
   PostHogSessionReplayConfig,
 } from './types'
 import { getRemoteConfigBool, getRemoteConfigNumber, isHermes, isMacOS, isValidSampleRate, isWeb } from './utils'
@@ -131,6 +132,22 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * Error Tracking Configuration
    */
   errorTracking?: ErrorTrackingOptions
+
+  /**
+   * Configure rage click (rage tap) detection on iOS.
+   *
+   * The native iOS SDK fires a `$rageclick` event when a user taps the same
+   * area repeatedly in quick succession. The default thresholds (3 taps,
+   * 30 points, 1 second) were tuned for web and frequently produce false
+   * positives on mobile. Raise the thresholds or set `enabled: false` to
+   * suppress them.
+   *
+   * Android is unaffected — posthog-android does not have native rage click
+   * detection.
+   *
+   * Requires `@posthog/react-native-plugin` >= 2.6.0.
+   */
+  rageClickConfig?: PostHogRageClickConfig
 
   /**
    * Automatically include common device and app properties in feature flag evaluation.
@@ -2604,6 +2621,7 @@ export class PostHog extends PostHogCore {
             capturePushNotificationOpened: options?.capturePushNotificationOpened ?? true,
             pushIdentityProviderEnabled,
           },
+          ...(options?.rageClickConfig && { rageClick: options.rageClickConfig }),
         }
         await OptionalReactNativePlugin.setup(String(sessionId), sdkOptions, pluginConfig)
         // Native resolves its own persisted opt-out over the config value passed above, so an

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -145,7 +145,7 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * Android is unaffected — posthog-android does not have native rage click
    * detection.
    *
-   * Requires `@posthog/react-native-plugin` >= 2.7.0.
+   * Requires `@posthog/react-native-plugin` version 2.7.0 or newer.
    */
   rageClickConfig?: PostHogRageClickConfig
 

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -145,7 +145,7 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * Android is unaffected — posthog-android does not have native rage click
    * detection.
    *
-   * Requires `@posthog/react-native-plugin` >= 2.6.0.
+   * Requires `@posthog/react-native-plugin` >= 2.7.0.
    */
   rageClickConfig?: PostHogRageClickConfig
 

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -12,6 +12,37 @@ export type PostHogNavigationRef = {
   current?: PostHogNavigationRef | any | undefined
 }
 
+export type PostHogRageClickConfig = {
+  /**
+   * Enable or disable rage click (rage tap) detection.
+   *
+   * When enabled the native SDK emits a `$rageclick` event whenever a user
+   * taps the same area repeatedly in quick succession.
+   *
+   * @default true
+   */
+  enabled?: boolean
+  /**
+   * Number of consecutive taps required to trigger a rage click.
+   *
+   * @default 3
+   */
+  minimumTapCount?: number
+  /**
+   * Maximum pixel distance between consecutive taps for them to still
+   * count toward a rage click.
+   *
+   * @default 30
+   */
+  thresholdPoints?: number
+  /**
+   * Maximum time in seconds allowed between consecutive taps.
+   *
+   * @default 1.0
+   */
+  timeoutInterval?: number
+}
+
 export type PostHogAutocaptureOptions = {
   /**
    * Enable autocapture of touch events.

--- a/packages/react-native/test/rage-click-config.spec.ts
+++ b/packages/react-native/test/rage-click-config.spec.ts
@@ -1,0 +1,102 @@
+import { PostHog } from '../src/posthog-rn'
+import { OptionalReactNativePlugin } from '../src/optional/OptionalPlugin'
+import { setupFetch, waitForExpect } from './test-utils'
+
+vi.mock('../src/optional/OptionalPlugin', () => ({
+  OptionalReactNativePluginVersion: undefined,
+  OptionalReactNativePlugin: {
+    start: vi.fn(() => Promise.resolve()),
+    setup: vi.fn(() => Promise.resolve()),
+    startSession: vi.fn(() => Promise.resolve()),
+    endSession: vi.fn(() => Promise.resolve()),
+    isEnabled: vi.fn(() => Promise.resolve(false)),
+    identify: vi.fn(() => Promise.resolve()),
+    startRecording: vi.fn(() => Promise.resolve()),
+    stopRecording: vi.fn(() => Promise.resolve()),
+    addExceptionStep: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+vi.useRealTimers()
+
+const mockPlugin = OptionalReactNativePlugin as unknown as {
+  setup: vi.Mock
+}
+
+describe('rageClickConfig', () => {
+  beforeEach(() => {
+    mockPlugin.setup = mockPlugin.setup ?? vi.fn()
+    mockPlugin.setup.mockImplementation(() => Promise.resolve())
+    vi.clearAllMocks()
+    setupFetch()
+  })
+
+  it('passes rageClickConfig through pluginConfig when provided', async () => {
+    const posthog = new PostHog('test-token', {
+      persistence: 'memory',
+      flushInterval: 0,
+      errorTracking: { autocapture: { nativeCrashes: true } },
+      rageClickConfig: { enabled: false },
+    })
+
+    await posthog.ready()
+
+    await waitForExpect(100, () => {
+      expect(mockPlugin.setup).toHaveBeenCalledTimes(1)
+    })
+
+    const [, , pluginConfig] = mockPlugin.setup.mock.calls[0]
+    expect(pluginConfig.rageClick).toEqual({ enabled: false })
+
+    await posthog.shutdown()
+  })
+
+  it('passes all rageClickConfig fields through pluginConfig', async () => {
+    const posthog = new PostHog('test-token', {
+      persistence: 'memory',
+      flushInterval: 0,
+      errorTracking: { autocapture: { nativeCrashes: true } },
+      rageClickConfig: {
+        enabled: true,
+        minimumTapCount: 5,
+        thresholdPoints: 50,
+        timeoutInterval: 2.0,
+      },
+    })
+
+    await posthog.ready()
+
+    await waitForExpect(100, () => {
+      expect(mockPlugin.setup).toHaveBeenCalledTimes(1)
+    })
+
+    const [, , pluginConfig] = mockPlugin.setup.mock.calls[0]
+    expect(pluginConfig.rageClick).toEqual({
+      enabled: true,
+      minimumTapCount: 5,
+      thresholdPoints: 50,
+      timeoutInterval: 2.0,
+    })
+
+    await posthog.shutdown()
+  })
+
+  it('does not include rageClick in pluginConfig when rageClickConfig is not set', async () => {
+    const posthog = new PostHog('test-token', {
+      persistence: 'memory',
+      flushInterval: 0,
+      errorTracking: { autocapture: { nativeCrashes: true } },
+    })
+
+    await posthog.ready()
+
+    await waitForExpect(100, () => {
+      expect(mockPlugin.setup).toHaveBeenCalledTimes(1)
+    })
+
+    const [, , pluginConfig] = mockPlugin.setup.mock.calls[0]
+    expect(pluginConfig.rageClick).toBeUndefined()
+
+    await posthog.shutdown()
+  })
+})


### PR DESCRIPTION
## Problem

The native iOS SDK captures `$rageclick` events by default when a user taps the same area 3 times within 30 points and 1 second. These thresholds were designed for web mouse clicks and produce frequent false positives on mobile — normal navigation taps, scrolling, and tab switching routinely qualify. The React Native SDK has no way to tune or disable this because `rageClickConfig` was never wired through to the native plugin.

Closes #3811

## Changes

Adds `PostHogRageClickConfig` to `PostHogOptions` with `enabled`, `minimumTapCount`, `thresholdPoints`, and `timeoutInterval`, following the existing config passthrough pattern used by `errorTracking` and `push`. The config flows through `pluginConfig` to the iOS native plugin, which applies it to `PostHogConfig.rageClickConfig` before setup.

Android is unaffected — `posthog-android` does not have native rage click detection.

**Usage:**
```ts
const posthog = new PostHog(apiKey, {
  rageClickConfig: { enabled: false },
  // or tune thresholds:
  // rageClickConfig: { minimumTapCount: 5, timeoutInterval: 0.5 },
})
```

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude Code to investigate false-positive rage clicks in a React Native app, trace the detection to the native iOS SDK layer, identify the missing config passthrough, and implement the wiring following the existing `errorTracking`/`push` config pattern in the monorepo.