### PR TITLE
fix(react-native): make error boundaries recoverable and resilient

### DIFF
--- a/.changeset/odd-groups-greet.md
+++ b/.changeset/odd-groups-greet.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Handle nullish render errors safely, capture React component stacks, and support retrying from error boundary fallbacks.

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -3368,6 +3368,10 @@
         {
           "type": "string",
           "name": "componentStack"
+        },
+        {
+          "type": "() => void",
+          "name": "resetError"
         }
       ],
       "path": "dist/PostHogErrorBoundary.d.ts"
@@ -3395,6 +3399,10 @@
       "id": "PostHogErrorBoundaryState",
       "name": "PostHogErrorBoundaryState",
       "properties": [
+        {
+          "type": "boolean",
+          "name": "hasError"
+        },
         {
           "type": "string",
           "name": "componentStack"

--- a/packages/react-native/src/PostHogErrorBoundary.tsx
+++ b/packages/react-native/src/PostHogErrorBoundary.tsx
@@ -6,6 +6,7 @@ export type Properties = Record<string, any>
 export type PostHogErrorBoundaryFallbackProps = {
   error: unknown
   componentStack: string
+  resetError: () => void
 }
 
 export type PostHogErrorBoundaryProps = {
@@ -15,11 +16,13 @@ export type PostHogErrorBoundaryProps = {
 }
 
 type PostHogErrorBoundaryState = {
+  hasError: boolean
   componentStack: string | null
   error: unknown
 }
 
 const INITIAL_STATE: PostHogErrorBoundaryState = {
+  hasError: false,
   componentStack: null,
   error: null,
 }
@@ -36,32 +39,34 @@ export class PostHogErrorBoundary extends React.Component<PostHogErrorBoundaryPr
   }
 
   static getDerivedStateFromError(error: unknown): Partial<PostHogErrorBoundaryState> {
-    return { error }
+    return { hasError: true, error }
   }
 
   componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
-    const { additionalProperties } = this.props
-    let currentProperties
-    if (isFunction(additionalProperties)) {
-      currentProperties = additionalProperties(error)
-    } else if (typeof additionalProperties === 'object') {
-      currentProperties = additionalProperties
-    }
-    const { client } = this.context
-    client?.captureException(error, currentProperties)
-
     const { componentStack } = errorInfo
-    this.setState({
-      error,
-      componentStack: componentStack ?? null,
-    })
+    this.setState({ componentStack: componentStack ?? null })
+
+    try {
+      const { additionalProperties } = this.props
+      const currentProperties = isFunction(additionalProperties) ? additionalProperties(error) : additionalProperties
+      this.context.client?.captureException(error, {
+        ...currentProperties,
+        ...(componentStack ? { $exception_component_stack: componentStack } : {}),
+      })
+    } catch {
+      // Reporting failures must not escape the boundary and crash its parent.
+    }
+  }
+
+  private resetError = (): void => {
+    this.setState(INITIAL_STATE)
   }
 
   public render(): React.ReactNode {
     const { children, fallback } = this.props
     const state = this.state
 
-    if (state.error == null) {
+    if (!state.hasError) {
       return isFunction(children) ? children() : children
     }
 
@@ -69,6 +74,7 @@ export class PostHogErrorBoundary extends React.Component<PostHogErrorBoundaryPr
       ? (React.createElement(fallback, {
           error: state.error,
           componentStack: state.componentStack ?? '',
+          resetError: this.resetError,
         }) as React.ReactNode)
       : fallback
 

--- a/packages/react-native/test/PostHogErrorBoundary.spec.tsx
+++ b/packages/react-native/test/PostHogErrorBoundary.spec.tsx
@@ -1,0 +1,115 @@
+/** @vitest-environment jsdom */
+import React from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { PostHogErrorBoundary } from '../src/PostHogErrorBoundary'
+import { PostHogContext } from '../src/PostHogContext'
+import type { PostHog } from '../src/posthog-rn'
+
+function ThrowValue({ value }: { value: unknown }): React.ReactElement {
+  throw value
+}
+
+describe('PostHogErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it.each([null, undefined, false, 0, '', new Error('render failed')])(
+    'renders the fallback for a thrown %s',
+    (value) => {
+      render(
+        <PostHogErrorBoundary fallback={<span>Fallback</span>}>
+          <ThrowValue value={value} />
+        </PostHogErrorBoundary>
+      )
+      expect(screen.getByText('Fallback')).toBeTruthy()
+    }
+  )
+
+  it('captures the component stack with additional properties and preserves the thrown error', () => {
+    const captureException = vi.fn()
+    const error = new Error('render failed')
+    const additionalProperties = vi.fn(() => ({ orderId: '123' }))
+    render(
+      <PostHogContext.Provider value={{ client: { captureException } as unknown as PostHog }}>
+        <PostHogErrorBoundary additionalProperties={additionalProperties} fallback={<span>Fallback</span>}>
+          <ThrowValue value={error} />
+        </PostHogErrorBoundary>
+      </PostHogContext.Provider>
+    )
+    expect(additionalProperties).toHaveBeenCalledWith(error)
+    expect(captureException).toHaveBeenCalledTimes(1)
+    expect(captureException).toHaveBeenCalledWith(error, {
+      orderId: '123',
+      $exception_component_stack: expect.stringContaining('ThrowValue'),
+    })
+  })
+
+  it('can recover and catch another error using resetError', () => {
+    let shouldThrow = true
+    function Child(): React.ReactElement {
+      if (shouldThrow) {
+        throw new Error('render failed')
+      }
+      return <span>Recovered</span>
+    }
+    const fallback = vi.fn(({ resetError }) => <button onClick={resetError}>Retry</button>)
+    const tree = () => (
+      <PostHogErrorBoundary fallback={fallback}>
+        <Child />
+      </PostHogErrorBoundary>
+    )
+    const view = render(tree())
+    expect(fallback).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        error: expect.any(Error),
+        componentStack: expect.stringContaining('Child'),
+        resetError: expect.any(Function),
+      }),
+      expect.anything()
+    )
+    shouldThrow = false
+    fireEvent.click(screen.getByText('Retry'))
+    expect(screen.getByText('Recovered')).toBeTruthy()
+    shouldThrow = true
+    view.rerender(tree())
+    expect(screen.getByText('Retry')).toBeTruthy()
+    fireEvent.click(screen.getByText('Retry'))
+    expect(screen.getByText('Retry')).toBeTruthy()
+  })
+
+  it.each(['properties', 'capture'])('keeps the fallback when %s throws', (source) => {
+    const fail = () => {
+      throw new Error('reporting failed')
+    }
+    render(
+      <PostHogContext.Provider
+        value={{ client: { captureException: source === 'capture' ? fail : vi.fn() } as unknown as PostHog }}
+      >
+        <PostHogErrorBoundary
+          additionalProperties={source === 'properties' ? fail : { orderId: '123' }}
+          fallback={({ componentStack }) => <span>Fallback: {componentStack}</span>}
+        >
+          <ThrowValue value={new Error('render failed')} />
+        </PostHogErrorBoundary>
+      </PostHogContext.Provider>
+    )
+    expect(screen.getByText(/Fallback:/).textContent).toContain('ThrowValue')
+  })
+
+  it('preserves function children and renders nothing without a fallback', () => {
+    const view = render(<PostHogErrorBoundary>{() => <span>Healthy</span>}</PostHogErrorBoundary>)
+    expect(screen.getByText('Healthy')).toBeTruthy()
+    view.rerender(
+      <PostHogErrorBoundary>
+        <ThrowValue value={new Error('render failed')} />
+      </PostHogErrorBoundary>
+    )
+    expect(view.container.textContent).toBe('')
+  })
+})


### PR DESCRIPTION
## Problem

React Native error boundaries treat `throw null` and `throw undefined` as healthy state and render the failing children again. Captured render errors omit React's component stack, and fallback components cannot reset the boundary without remounting it externally. A throwing properties callback or reporter can also escape the boundary and fail its parent.

## Changes

- Track whether an error was caught separately from the thrown value.
- Attach the React component stack as `$exception_component_stack`, keeping the original thrown error unchanged.
- Pass `resetError()` to fallback components so apps can offer a retry action.
- Keep the fallback working even if reporting or the additional-properties callback throws.
- Add regression tests for nullish and primitive throws, component stacks, reset and re-capture, and reporting failures.

This PR contains only the boundary changes. Global uncaught-error handler changes are separate.

### Validation

- Regenerated the React Native API reference JSON and verified that a second generation leaves no diff, fixing the `Generate references` CI failure.

- `pnpm turbo run test:unit lint --filter=posthog-react-native`: 780 tests passed, including the prerequisite build and package lint.
- Formatting checks and `git diff --check` passed.
- `autoreview --mode branch --base origin/main` reported no actionable findings for `23a8695149d10d738d5863aa95d69d39a0dd8f9b`.
- Rendering tests use React DOM with jsdom. No simulator or device testing was performed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using read, bash, edit, and write tools, followed by isolated Pi autoreview. The work was directed by @marandaneto after comparing our error tracking with Expo Observe and expo-app-metrics. The changes were split into independent boundary and global-handler PRs. Human review is required.

