### PR TITLE
fix(react-native): safely share uncaught error handlers

### DIFF
--- a/.changeset/loud-bears-cheer.md
+++ b/.changeset/loud-bears-cheer.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Safely share uncaught-error handlers across SDK instances and preserve React Native error handling when reporting fails.

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -69,6 +69,7 @@ export class ErrorTracking {
   private _exceptionStepsConfig: CoreErrorTracking.ResolvedExceptionStepsConfig
   private _exceptionStepsBuffer: CoreErrorTracking.ExceptionStepsBuffer
   private _nativeForwardingEnabled: boolean = false
+  private _unsubscribeUncaughtExceptions?: () => void
 
   /**
    * Controls whether autocaptured exceptions are actually sent.
@@ -200,6 +201,13 @@ export class ErrorTracking {
     this._exceptionStepsBuffer.clear()
   }
 
+  shutdown(): void {
+    this._autocaptureEnabled = false
+    this._unsubscribeUncaughtExceptions?.()
+    this._unsubscribeUncaughtExceptions = undefined
+    this.clearExceptionSteps()
+  }
+
   /**
    * Called when remote config is loaded.
    * If errorTracking.autocaptureExceptions is explicitly false, autocapture is disabled.
@@ -281,7 +289,7 @@ export class ErrorTracking {
       }
     }
     try {
-      trackUncaughtExceptions(onUncaughtException)
+      this._unsubscribeUncaughtExceptions = trackUncaughtExceptions(onUncaughtException)
     } catch (err) {
       this.logger.warn('Failed to track uncaught exceptions: ', err)
     }

--- a/packages/react-native/src/error-tracking/utils.ts
+++ b/packages/react-native/src/error-tracking/utils.ts
@@ -20,15 +20,54 @@ export function trackUnhandledRejections(tracker: ExceptionHook): void {
   }
 }
 
-export function trackUncaughtExceptions(tracker: ExceptionHook): void {
-  if (GLOBAL_OBJ?.ErrorUtils && GLOBAL_OBJ.ErrorUtils?.setGlobalHandler && GLOBAL_OBJ.ErrorUtils?.getGlobalHandler) {
-    const globalHandler = ErrorUtils.getGlobalHandler()
-    ErrorUtils.setGlobalHandler((error, isFatal) => {
-      tracker(error as Error, isFatal ?? false)
-      globalHandler?.(error, isFatal)
-    })
-  } else {
+const uncaughtExceptionSubscriptions = new WeakMap<
+  NonNullable<typeof GLOBAL_OBJ.ErrorUtils>,
+  { trackers: Set<ExceptionHook>; restore: () => void }
+>()
+
+export function trackUncaughtExceptions(tracker: ExceptionHook): () => void {
+  const errorUtils = GLOBAL_OBJ?.ErrorUtils
+  if (!errorUtils?.setGlobalHandler || !errorUtils.getGlobalHandler) {
     throw new Error('ErrorUtils globalHandlers are not defined')
+  }
+
+  let subscription = uncaughtExceptionSubscriptions.get(errorUtils)
+  if (!subscription) {
+    const previousHandler = errorUtils.getGlobalHandler()
+    const trackers = new Set<ExceptionHook>()
+    const handler = (error: Error, isFatal: boolean): void => {
+      try {
+        for (const callback of Array.from(trackers)) {
+          try {
+            callback(error, isFatal ?? false)
+          } catch {
+            // One reporter must not prevent other reporters or React Native from handling the error.
+          }
+        }
+      } finally {
+        previousHandler?.(error, isFatal)
+      }
+    }
+    subscription = {
+      trackers,
+      restore: () => {
+        // Another SDK may wrap our handler. Leave that chain intact and reuse our subscription set.
+        if (errorUtils.getGlobalHandler?.() === handler) {
+          errorUtils.setGlobalHandler?.(previousHandler)
+          uncaughtExceptionSubscriptions.delete(errorUtils)
+        }
+      },
+    }
+    errorUtils.setGlobalHandler(handler)
+    uncaughtExceptionSubscriptions.set(errorUtils, subscription)
+  }
+
+  const { trackers, restore } = subscription
+  trackers.add(tracker)
+  return () => {
+    if (trackers.delete(tracker) && trackers.size === 0) {
+      restore()
+    }
   }
 }
 

--- a/packages/react-native/src/error-tracking/utils.ts
+++ b/packages/react-native/src/error-tracking/utils.ts
@@ -51,11 +51,11 @@ export function trackUncaughtExceptions(tracker: ExceptionHook): () => void {
     subscription = {
       trackers,
       restore: () => {
-        // Another SDK may wrap our handler. Leave that chain intact and reuse our subscription set.
+        // Leave another SDK's chain intact, but retire this empty subscription in case it is later detached.
         if (errorUtils.getGlobalHandler?.() === handler) {
           errorUtils.setGlobalHandler?.(previousHandler)
-          uncaughtExceptionSubscriptions.delete(errorUtils)
         }
+        uncaughtExceptionSubscriptions.delete(errorUtils)
       },
     }
     errorUtils.setGlobalHandler(handler)

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -616,7 +616,7 @@ export class PostHog extends PostHogCore {
    * SLA so a hung storage backend can't run past it.
    */
   async _shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {
-    this._errorTracking.clearExceptionSteps()
+    this._errorTracking.shutdown()
     const start = Date.now()
     const logsBudgetMs = Math.min(shutdownTimeoutMs, this._resolvedLogsConfig.terminationFlushBudgetMs)
     try {

--- a/packages/react-native/test/error-tracking-utils.spec.ts
+++ b/packages/react-native/test/error-tracking-utils.spec.ts
@@ -1,0 +1,142 @@
+import { trackUncaughtExceptions } from '../src/error-tracking/utils'
+import { ErrorTracking } from '../src/error-tracking'
+import { createMockLogger, createMockPostHog } from './test-utils'
+
+type Handler = (error: Error, isFatal?: boolean) => void
+
+describe('uncaught exception subscriptions', () => {
+  let previous: ReturnType<typeof vi.fn>
+  let current: Handler
+  let errorUtils: { getGlobalHandler: () => Handler; setGlobalHandler: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    previous = vi.fn()
+    current = previous
+    errorUtils = {
+      getGlobalHandler: () => current,
+      setGlobalHandler: vi.fn((handler: Handler) => {
+        current = handler
+      }),
+    }
+    vi.stubGlobal('ErrorUtils', errorUtils)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('always calls the previous handler even when a subscriber throws', () => {
+    const error = new Error('app failed')
+    trackUncaughtExceptions(() => {
+      throw new Error('capture failed')
+    })
+    expect(() => current(error, true)).not.toThrow()
+    expect(previous.mock.calls).toEqual([[error, true]])
+  })
+
+  it('preserves the previous handler error', () => {
+    const previousError = new Error('native fatal handler')
+    previous.mockImplementation(() => {
+      throw previousError
+    })
+    trackUncaughtExceptions(vi.fn())
+    expect(() => current(new Error('app failed'), true)).toThrow(previousError)
+  })
+
+  it('normalizes missing fatal flags only for subscribers', () => {
+    const tracker = vi.fn()
+    const error = new Error('app failed')
+    trackUncaughtExceptions(tracker)
+    current(error)
+    expect(tracker).toHaveBeenCalledWith(error, false)
+    expect(previous).toHaveBeenCalledWith(error, undefined)
+  })
+
+  it('uses one wrapper for multiple subscribers and isolates their failures', () => {
+    const first = vi.fn(() => {
+      throw new Error('first reporter failed')
+    })
+    const second = vi.fn()
+    trackUncaughtExceptions(first)
+    const wrapper = current
+    trackUncaughtExceptions(second)
+    expect(current).toBe(wrapper)
+    expect(errorUtils.setGlobalHandler).toHaveBeenCalledTimes(1)
+    const error = new Error('app failed')
+    expect(() => current(error, true)).not.toThrow()
+    expect(first.mock.calls).toEqual([[error, true]])
+    expect(second.mock.calls).toEqual([[error, true]])
+    expect(previous.mock.calls).toEqual([[error, true]])
+  })
+
+  it('does not capture twice when the same tracker is registered again', () => {
+    const tracker = vi.fn()
+    trackUncaughtExceptions(tracker)
+    trackUncaughtExceptions(tracker)
+    current(new Error('app failed'), false)
+    expect(tracker).toHaveBeenCalledTimes(1)
+    expect(previous).toHaveBeenCalledTimes(1)
+    expect(errorUtils.setGlobalHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribes independently and restores the previous handler after the last subscriber', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const removeFirst = trackUncaughtExceptions(first)
+    const removeSecond = trackUncaughtExceptions(second)
+    removeFirst()
+    removeFirst()
+    current(new Error('app failed'), false)
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+    removeSecond()
+    expect(current).toBe(previous)
+    const third = vi.fn()
+    const removeThird = trackUncaughtExceptions(third)
+    current(new Error('next error'), false)
+    expect(third).toHaveBeenCalledTimes(1)
+    removeThird()
+    expect(current).toBe(previous)
+  })
+
+  it('does not overwrite another SDK handler on unsubscribe or wrap it again on resubscribe', () => {
+    const remove = trackUncaughtExceptions(vi.fn())
+    const wrapper = current
+    const otherSdk = vi.fn((error: Error, isFatal?: boolean) => wrapper(error, isFatal))
+    errorUtils.setGlobalHandler(otherSdk)
+    remove()
+    expect(current).toBe(otherSdk)
+    const tracker = vi.fn()
+    const removeNext = trackUncaughtExceptions(tracker)
+    expect(current).toBe(otherSdk)
+    current(new Error('app failed'), true)
+    expect(tracker).toHaveBeenCalledTimes(1)
+    expect(otherSdk).toHaveBeenCalledTimes(1)
+    expect(previous).toHaveBeenCalledTimes(1)
+    removeNext()
+  })
+
+  it('removes only the shutting-down ErrorTracking instance', () => {
+    const firstClient = createMockPostHog()
+    const secondClient = createMockPostHog()
+    const options = { autocapture: { uncaughtExceptions: true } }
+    const first = new ErrorTracking(firstClient, options, createMockLogger() as any)
+    const second = new ErrorTracking(secondClient, options, createMockLogger() as any)
+    first.shutdown()
+    current(new Error('app failed'), false)
+    expect(firstClient.captureException).not.toHaveBeenCalled()
+    expect(secondClient.captureException).toHaveBeenCalledTimes(1)
+    second.shutdown()
+    expect(current).toBe(previous)
+  })
+
+  it('reports missing ErrorUtils without preventing a later installation', () => {
+    vi.stubGlobal('ErrorUtils', undefined)
+    expect(() => trackUncaughtExceptions(vi.fn())).toThrow('ErrorUtils globalHandlers are not defined')
+    vi.stubGlobal('ErrorUtils', errorUtils)
+    const tracker = vi.fn()
+    trackUncaughtExceptions(tracker)
+    current(new Error('app failed'), false)
+    expect(tracker).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-native/test/error-tracking-utils.spec.ts
+++ b/packages/react-native/test/error-tracking-utils.spec.ts
@@ -99,8 +99,9 @@ describe('uncaught exception subscriptions', () => {
     expect(current).toBe(previous)
   })
 
-  it('does not overwrite another SDK handler on unsubscribe or wrap it again on resubscribe', () => {
-    const remove = trackUncaughtExceptions(vi.fn())
+  it('preserves another SDK handler and captures once through a fresh subscription', () => {
+    const oldTracker = vi.fn()
+    const remove = trackUncaughtExceptions(oldTracker)
     const wrapper = current
     const otherSdk = vi.fn((error: Error, isFatal?: boolean) => wrapper(error, isFatal))
     errorUtils.setGlobalHandler(otherSdk)
@@ -108,12 +109,36 @@ describe('uncaught exception subscriptions', () => {
     expect(current).toBe(otherSdk)
     const tracker = vi.fn()
     const removeNext = trackUncaughtExceptions(tracker)
-    expect(current).toBe(otherSdk)
+    expect(current).not.toBe(otherSdk)
     current(new Error('app failed'), true)
+    expect(oldTracker).not.toHaveBeenCalled()
     expect(tracker).toHaveBeenCalledTimes(1)
     expect(otherSdk).toHaveBeenCalledTimes(1)
     expect(previous).toHaveBeenCalledTimes(1)
     removeNext()
+    expect(current).toBe(otherSdk)
+  })
+
+  it('reinstalls capture after another SDK detaches an unsubscribed wrapper', () => {
+    const oldTracker = vi.fn()
+    const remove = trackUncaughtExceptions(oldTracker)
+    const wrapper = current
+    const otherSdk = vi.fn((error: Error, isFatal?: boolean) => wrapper(error, isFatal))
+    errorUtils.setGlobalHandler(otherSdk)
+    remove()
+    expect(current).toBe(otherSdk)
+    errorUtils.setGlobalHandler(previous)
+
+    const tracker = vi.fn()
+    const removeNext = trackUncaughtExceptions(tracker)
+    const error = new Error('app failed')
+    current(error, true)
+    expect(tracker.mock.calls).toEqual([[error, true]])
+    expect(oldTracker).not.toHaveBeenCalled()
+    expect(otherSdk).not.toHaveBeenCalled()
+    expect(previous.mock.calls).toEqual([[error, true]])
+    removeNext()
+    expect(current).toBe(previous)
   })
 
   it('removes only the shutting-down ErrorTracking instance', () => {

--- a/packages/react-native/test/exception-steps-capture.spec.ts
+++ b/packages/react-native/test/exception-steps-capture.spec.ts
@@ -76,6 +76,32 @@ describe('PostHog React Native exception steps capture', () => {
     expect(steps.map((s: any) => s.$message)).toEqual(['caller'])
   })
 
+  it('unsubscribes uncaught-error capture on shutdown without affecting another client', async () => {
+    const previous = vi.fn()
+    let handler = previous
+    vi.stubGlobal('ErrorUtils', {
+      getGlobalHandler: () => handler,
+      setGlobalHandler: (next: typeof handler) => {
+        handler = next
+      },
+    })
+    try {
+      const first = newPostHog({ autocapture: { uncaughtExceptions: true } })
+      const second = newPostHog({ autocapture: { uncaughtExceptions: true } })
+      const firstCapture = vi.spyOn(first, 'captureException')
+      const secondCapture = vi.spyOn(second, 'captureException')
+      await first.shutdown()
+      handler(new Error('app failed'), false)
+      expect(firstCapture).not.toHaveBeenCalled()
+      expect(secondCapture).toHaveBeenCalledTimes(1)
+      expect(previous).toHaveBeenCalledTimes(1)
+      await second.shutdown()
+      expect(handler).toBe(previous)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('attaches nothing when disabled', () => {
     const posthog = newPostHog({ exceptionSteps: { enabled: false } })
     const spy = captureSpy(posthog)


### PR DESCRIPTION
## Problem

Each React Native SDK instance installs another wrapper around `ErrorUtils`. If an error reporter throws, it prevents the previous handler from running. Closed instances also remain in the handler chain.

## Changes

- Share one uncaught-error wrapper across instances using the same `ErrorUtils` object.
- Isolate subscriber failures and always call the previous handler. Errors thrown by that previous handler still propagate.
- Remove each instance's subscription on shutdown and restore the previous handler when the final subscriber leaves.
- Preserve another SDK's wrapper if it was installed after ours. Retire the empty subscription on final unsubscribe so a later client installs a fresh wrapper, even if another SDK has detached the old one.
- Add handler-level regression tests and a two-client shutdown integration test. Cover both detached wrappers and retained third-party chains without duplicate capture.

This PR does not change error boundaries, promise rejection hooks, console wrappers, or event delivery.

### Validation

- `pnpm turbo run build test:unit lint generate-references --filter=posthog-react-native`: 780 tests passed, along with build, lint, and API reference generation. Generated references did not change.
- Formatting checks and `git diff --check` passed.
- `autoreview --mode branch --base origin/main` reported no actionable findings for `6ed353791`. The detached-wrapper regression test failed before the fix because the new tracker received no exception, and passes after it.
- Handler tests use a mocked React Native `ErrorUtils`. No simulator or device testing was performed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using read, bash, edit, and write tools, followed by isolated Pi autoreview. The work was directed by @marandaneto after comparing our error tracking with Expo Observe and expo-app-metrics. The changes were split into independent boundary and global-handler PRs. Human review is required.
