### PR TITLE
ci: audit egress on credential-bearing Linux jobs

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -39,6 +39,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Audit runner egress
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,11 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
+    - name: Audit runner egress
+      uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+      with:
+        egress-policy: audit
+
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -7,6 +7,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Audit runner egress
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Check changeset credentials
         id: credentials
         env:

--- a/.github/workflows/generate-references.yml
+++ b/.github/workflows/generate-references.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Audit runner egress
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Get app token
         id: app-token
         uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789 # v4.0.0

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -16,6 +16,11 @@ jobs:
             contents: read
             pull-requests: write
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Check if PR is shame-worthy
               id: is-shame-worthy
               run: |

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -30,6 +30,11 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Get upgrader token
               id: upgrader
               uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789 # v4.0.0

--- a/.github/workflows/posthog-watcher-enqueue.yml
+++ b/.github/workflows/posthog-watcher-enqueue.yml
@@ -36,6 +36,11 @@ jobs:
             }}
         runs-on: ubuntu-24.04
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Enqueue watcher event

--- a/.github/workflows/posthog-watcher-sweep.yml
+++ b/.github/workflows/posthog-watcher-sweep.yml
@@ -29,6 +29,11 @@ jobs:
     sweep:
         runs-on: ubuntu-24.04
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0

--- a/.github/workflows/posthog-watcher-worker.yml
+++ b/.github/workflows/posthog-watcher-worker.yml
@@ -35,6 +35,11 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs['issue-number'] == '' }}
         runs-on: ubuntu-24.04
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
@@ -72,6 +77,11 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs['issue-number'] != '' }}
         runs-on: ubuntu-24.04
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0

--- a/.github/workflows/recover-s3-release.yml
+++ b/.github/workflows/recover-s3-release.yml
@@ -268,6 +268,11 @@ jobs:
         runs-on: ubuntu-latest
         permissions: {}
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Notify Slack - S3 recovery approval needed
               continue-on-error: true
               env:
@@ -518,6 +523,11 @@ jobs:
             matrix:
                 region: ${{ fromJSON(needs.validate.outputs.upload-matrix) }}
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Checkout current release tooling
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,11 @@ jobs:
             # `TOOLBAR_PUBLIC_PATH`) and to double-check the S3 upload path.
             version: ${{ steps.get-version.outputs.version }}
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Notify Slack - Approved
               continue-on-error: true # Don't block release if Slack notification fails
               uses: PostHog/.github/.github/actions/slack-thread-reply@836a5e06cdf40ed2a46b16f131b0a9b03c1ffea1 # main
@@ -278,6 +283,11 @@ jobs:
         runs-on: ubuntu-latest
         if: always() && needs.version-bump.result == 'failure' && needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Check for rejection
               id: check-rejection
               env:
@@ -357,6 +367,11 @@ jobs:
         # Keep npm trusted publishing in this workflow. Reuse these steps for
         # the separately gated posthog-js job below.
         steps: &publish-package-steps
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Checkout repository
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
@@ -541,6 +556,11 @@ jobs:
         runs-on: ubuntu-latest
         if: always() && needs.version-bump.outputs.commit-hash != ''
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Require successful posthog-js S3 release before npm publishing
               env:
                   BUILD_RESULT: ${{ needs.build-s3-artifacts.result }}
@@ -705,6 +725,11 @@ jobs:
                     - name: '@posthog/rollup-plugin'
                       path: packages/rollup-plugin
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Checkout repository
               if: >-
                   needs.recover-posthog-js-s3.result != 'success' ||
@@ -831,6 +856,11 @@ jobs:
         permissions:
             contents: read
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Checkout repository
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
@@ -951,6 +981,11 @@ jobs:
             # it defensively, but we set it correctly here too).
             TOOLBAR_PUBLIC_PATH: https://${{ matrix.region.host }}/static/${{ needs.version-bump.outputs.version }}/
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Checkout posthog/posthog
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
@@ -1160,6 +1195,11 @@ jobs:
                     - { name: us, bucket: us-assets.i.posthog.com, aws_region: us-east-1 }
                     - { name: eu, bucket: eu-assets.i.posthog.com, aws_region: eu-central-1 }
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             # Sparse checkout the release tooling plus the root pnpm files so
             # we can do a locked, filtered install for @posthog-tooling/release.
             - name: Checkout release tooling
@@ -1299,6 +1339,11 @@ jobs:
             (needs.upload-s3.result == 'success' || needs.upload-s3.result == 'skipped') &&
             needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Checkout repository
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1326,6 +1371,11 @@ jobs:
              inputs.publish_to_npm == true ||
              inputs.force_overwrite == true)
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Resolve recovery result
               id: result
               env:

--- a/.github/workflows/replay-incident-risk.yml
+++ b/.github/workflows/replay-incident-risk.yml
@@ -32,6 +32,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Audit runner egress
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,6 +13,11 @@ jobs:
     stale:
         runs-on: ubuntu-24.04
         steps:
+            - name: Audit runner egress
+              uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+              with:
+                egress-policy: audit
+
             - name: Check if holiday period
               id: holiday
               run: |

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -46,6 +46,11 @@ jobs:
             name: IE11
 
     steps:
+      - name: Audit runner egress
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Skip TestCafe tests
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository || needs.affected.outputs.is-affected != 'true' }}
         run: echo "Skipping ${{ matrix.name }} TestCafe tests because the browser package is unaffected or required secrets are unavailable for fork PRs."

--- a/.github/workflows/validate-versioning.yml
+++ b/.github/workflows/validate-versioning.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - name: Audit runner egress
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,30 @@ The main unit, functional, local Playwright, MCP, SDK compliance, and native plu
 
 Publishing, S3 recovery, reference-generation, downstream-upgrade, and watcher worker/sweep workflows run in trusted push, manual, or scheduled contexts rather than untrusted PR test jobs. Their required GitHub App, AWS/OIDC, Slack, and OpenAI configuration must not be bypassed to make a release or automation run appear successful.
 
+### CI egress auditing
+
+Credential-bearing GitHub-hosted Ubuntu jobs run the SHA-pinned `step-security/harden-runner` action as their first step, before checkout, dependency installation, or token creation. Coverage includes jobs with write-capable `GITHUB_TOKEN` permissions, OIDC access, GitHub App credentials, or service secrets, including secrets used only in failure notifications. Read-only jobs without service secrets are intentionally outside this rollout.
+
+The initial policy is `egress-policy: audit`. It reports network activity to StepSecurity but does not enforce a job-specific outbound allowlist. Audit mode requires StepSecurity telemetry; review the service's data handling before adding sensitive destinations. Do not interpret a successful audit step as proof that exfiltration is prevented, and do not add token permissions just for auditing.
+
+Before enabling `egress-policy: block` for a job:
+
+1. Review the report linked from the job summary after representative successful runs, including cold dependency downloads, matrix variants, and relevant failure/recovery paths. Do not trigger a production release solely to collect a baseline.
+2. Review every observed destination and commit a narrow `allowed-endpoints` list for that job. Do not automatically approve unexplained traffic or share publishing destinations with unrelated build jobs.
+3. Verify required traffic succeeds and an unlisted destination is blocked in a disposable, credential-free job on the same runner type before using the policy with real credentials.
+
+The following credential-bearing jobs are not covered by this setup:
+
+| Jobs                                                                                                      | Reason and follow-up                                                                                                                                                                                                   |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `integration.yml` / `browsers`                                                                            | Runs in a job container. Harden-Runner does not support this layout on standard GitHub-hosted runners. Move enforcement to a supported host or runner image.                                                           |
+| `library-ci.yml` / `compat`                                                                               | Uses Depot and a job container. Verify provider-level enforcement or a supported agent deployment separately.                                                                                                          |
+| Feature Flags project board, changeset hygiene, release approval notification, and SDK compliance callers | Their steps live in pinned reusable workflows in `PostHog/.github` or `PostHog/posthog-sdk-test-harness`. Add monitoring there, then update the caller pins. A caller cannot prepend steps to a reusable workflow job. |
+
+The local S3 recovery reusable workflow is covered inside its credential-bearing jobs. macOS native builds currently have no declared service secrets or write permissions and remain outside this rollout. Hosted macOS/Windows monitoring does not provide the same blocking support as hosted Linux. See the [Harden-Runner compatibility matrix](https://github.com/step-security/harden-runner#environment-compatibility-matrix) and [limitations](https://github.com/step-security/harden-runner/blob/main/docs/limitations.md) before expanding coverage.
+
+Network auditing or blocking does not replace least-privilege tokens or build/publish separation. An allowed destination such as the GitHub API can still be abused with a stolen token.
+
 ## Configuration Files
 
 - `package.json` - Root workspace scripts and dependencies


### PR DESCRIPTION
## Problem

CI jobs that can publish packages, upload assets, modify GitHub resources, or access service credentials currently have no job-level network monitoring. We need to understand their outbound traffic before introducing endpoint allowlists without breaking releases.

## Changes

Add SHA-pinned StepSecurity Harden-Runner v2.21.0 as the first step in 28 credential-bearing GitHub-hosted Ubuntu job definitions across 15 workflows. The shared publish-step anchor also covers normal browser publishing and npm recovery publishing.

Coverage includes write-capable GitHub tokens, npm/AWS OIDC, GitHub App credentials, PostHog and BrowserStack credentials, watcher credentials, and Slack notifications. Read-only jobs without service secrets remain unchanged. Existing permissions, triggers, job dependencies, and steps are preserved.

**This rollout uses `egress-policy: audit`, not a default-deny outbound allowlist.** It sends monitoring telemetry to StepSecurity. We must review representative CI reports before committing per-job endpoint allowlists and enabling blocking. It does not replace token scoping or build/publish isolation.

Document coverage, telemetry, limitations, and the path to blocking in `CONTRIBUTING.md`. The following need separate work:

- The PostHog integration job runs in a job container, which this setup does not support.
- Backward-compatibility tests run on Depot in a job container.
- Feature Flags project board, changeset hygiene, release approval notification, and SDK compliance steps live in externally maintained reusable workflows. Monitoring must be added there before updating the caller pins. The local S3 recovery workflow is covered inside its credential-bearing jobs.

This PR is independent of the job-permission scoping change in #4889.

### Validation

- Verified the pinned SHA against the upstream v2.21.0 tag and reviewed its action inputs and documented runner limitations.
- A local YAML coverage audit failed for all 28 eligible job definitions before the change and passed afterward. It verifies an unconditional, pinned first step, explicit audit mode, unchanged existing workflow behavior, and no additions to unsupported or read-only jobs.
- Actionlint passed with shell/Python linting disabled and the existing `depot-ubuntu-latest-8` custom runner label excluded from label validation.
- Documentation formatting and `git diff --check` passed.
- Reviewed the release-incident match. No PR trigger, package lifecycle script, permission grant, or OIDC publishing configuration changed. Harden-Runner is a new third-party runtime dependency, so pinning does not remove the need to trust its agent and telemetry service.

No production workflow was triggered to gather a baseline. Runtime monitoring and report generation still need verification in GitHub Actions.

## Release info Sub-libraries affected

### Libraries affected

None. This changes CI configuration and documentation only. No package release or changeset is needed.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code (no SDK code changed; local workflow validation is listed above)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not applicable)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using file read/edit tools, Git, GitHub CLI, curl, a local Python YAML audit, actionlint, and Oxfmt. The scope was limited to credential-bearing jobs on supported runners. Audit mode was chosen to collect reviewed endpoint baselines before enforcing blocking. Unsupported and externally defined jobs were documented rather than given a step that might not activate monitoring.

Autoreview was skipped because the final diff contains only GitHub workflow administration and contributor documentation. No session transcript was published.
