### PR TITLE
feat(react-native): add app and Expo update context to exceptions

### DIFF
--- a/.changeset/calm-cups-share.md
+++ b/.changeset/calm-cups-share.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'@posthog/browser-common': patch
+---
+
+Share the trySafe utility through @posthog/core.

--- a/.changeset/giant-bears-scream.md
+++ b/.changeset/giant-bears-scream.md
@@ -1,5 +1,5 @@
 ---
-'posthog-react-native': patch
+'posthog-react-native': minor
 ---
 
 Add optional Expo update metadata and device conditions to React Native JavaScript exceptions.

--- a/.changeset/giant-bears-scream.md
+++ b/.changeset/giant-bears-scream.md
@@ -2,4 +2,4 @@
 'posthog-react-native': minor
 ---
 
-Add optional Expo update metadata and device conditions to React Native JavaScript exceptions.
+Add optional Expo update metadata and app state to React Native JavaScript exceptions.

--- a/.changeset/giant-bears-scream.md
+++ b/.changeset/giant-bears-scream.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Add optional Expo update metadata and device conditions to React Native JavaScript exceptions.

--- a/examples/example-expo-57/README.md
+++ b/examples/example-expo-57/README.md
@@ -52,6 +52,14 @@ pnpm android # or pnpm ios
 
 If changes are still not picked up, remove `node_modules` before reinstalling.
 
+## Test Expo update context on exceptions
+
+The example includes `expo-updates`, but OTA updates are disabled by default. Configure `updates.url` and `runtimeVersion` for your own project, regenerate the native projects, and build in release mode. Set a channel if you also want to test `$expo_channel`.
+
+In the **Error Tracking** tab, press **Capture error manually** and inspect the captured `$exception`. When Updates is enabled, known values are attached as `$expo_update_id`, `$expo_runtime_version`, `$expo_channel`, and `$expo_is_embedded_launch`.
+
+Expo update fields are omitted in development builds or when Updates is disabled. `$app_state` is captured independently of Updates.
+
 ## Build release mode locally
 
 ```bash

--- a/examples/example-expo-57/package.json
+++ b/examples/example-expo-57/package.json
@@ -31,6 +31,7 @@
         "expo-status-bar": "~57.0.1",
         "expo-symbols": "~57.0.2",
         "expo-system-ui": "~57.0.2",
+        "expo-updates": "~57.0.21",
         "expo-web-browser": "~57.0.2",
         "posthog-react-native": "*",
         "react": "19.2.3",

--- a/examples/example-expo-57/pnpm-lock.yaml
+++ b/examples/example-expo-57/pnpm-lock.yaml
@@ -6,8 +6,9 @@ settings:
 
 overrides:
   node-forge: 1.3.2
+  fastq: 1.20.1
 
-pnpmfileChecksum: sha256-f6vDAtfVUQ7ve76eXRJSxDNpBCZVHV6899+eUDXYCAI=
+pnpmfileChecksum: sha256-pW9BqX10sGB/zWY0q7We9bqSVOHSa+kMzZEz27W+bhA=
 
 importers:
 
@@ -70,12 +71,15 @@ importers:
       expo-system-ui:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.15)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))
+      expo-updates:
+        specifier: ~57.0.21
+        version: 57.0.21(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       expo-web-browser:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))
       posthog-react-native:
         specifier: file:../../target/posthog-react-native.tgz
-        version: file:../../target/posthog-react-native.tgz(25a99f437a5ec83f375175a3316b32ae)
+        version: file:../../target/posthog-react-native.tgz(5c0ad5d09075996c1425f31a152dae94)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -880,19 +884,19 @@ packages:
     engines: {node: '>=12.4.0'}
 
   '@posthog/core@file:../../target/posthog-core.tgz':
-    resolution: {integrity: sha512-mEHwILt+wxiO7L/DqXRqJW2Ib0rJxabtHBiKBA3vzFFGyIfsv+ATj9LnT/JRSD6pylF4kEU1YVjr5wdLCOyhKQ==, tarball: file:../../target/posthog-core.tgz}
-    version: 1.48.8
+    resolution: {integrity: sha512-uyBew3Lo8RqPjaRTmWEVCu2G/b4YxdFsFhZ+EKrqWpctvFG0ZwVSCI5eu2OLrtHyM9D9qodpJjpdgn/JDT0j9Q==, tarball: file:../../target/posthog-core.tgz}
+    version: 1.52.1
 
   '@posthog/react-native-plugin@file:../../target/posthog-react-native-plugin.tgz':
-    resolution: {integrity: sha512-GDxG2K8ceGRt6BqR/N/4P1jTYSoi8qFJ09M+MQT/dUBzOkrXm1vkJ3ap1TF9I2p1uVov+mrB2qY4VbB5cVdXdQ==, tarball: file:../../target/posthog-react-native-plugin.tgz}
-    version: 2.4.1
+    resolution: {integrity: sha512-Ykd8TSJZwg40es22+zaeBS6HKRPVdmxwnbxMoDku/TcuP7gUWYIHF6q5T/dF5pfOGvoct535AIhvu7LfAkHWXA==, tarball: file:../../target/posthog-react-native-plugin.tgz}
+    version: 2.5.2
     peerDependencies:
       react: '*'
       react-native: '*'
 
   '@posthog/types@file:../../target/posthog-types.tgz':
-    resolution: {integrity: sha512-VedxKhVpingNzeS1fMiWFUh61DJzLge8aSjQlxFOlzwtEvmaHiRQfGYqSYiRXsZDHZ3HmaZKwPrH7jUXIAbYmw==, tarball: file:../../target/posthog-types.tgz}
-    version: 1.391.1
+    resolution: {integrity: sha512-HgvikDxO+UNezZ7jxSMOX8x39F0iwWhqVa0oC1ufav7xJG2WKPvfZwSfYPcooSgVxpAXTBSLCPldwKUrI+3Aow==, tarball: file:../../target/posthog-types.tgz}
+    version: 1.410.0
 
   '@radix-ui/primitive@1.1.7':
     resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
@@ -1514,6 +1518,9 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -2141,6 +2148,9 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-eas-client@57.0.3:
+    resolution: {integrity: sha512-cyC2AZg85DfAt4Ge7jIRmxmL62dUXob4EnrLZatrl+xJ6AuObqjMYf3hx5JYFfvro4ajkFo25qNREPTdiHCYQQ==}
+
   expo-file-system@57.0.5:
     resolution: {integrity: sha512-XjGrCClF0935y5wLB9qNQQUVptNEy+0OloBstXlCd+IeNXLo3uNOod6cX4N0hofIhNIrN1Al8fwfay7R0Z1a2A==}
     peerDependencies:
@@ -2177,6 +2187,9 @@ packages:
       react-native-web:
         optional: true
 
+  expo-json-utils@57.0.1:
+    resolution: {integrity: sha512-cgTe1NqzQdYs/WN+3nIY5IZg8s0pb0xaTUbhYvxQDn137GbwRfHoGM2se3m3Vsl4Qu+B9G4RPEK5WJDEU2Do7g==}
+
   expo-keep-awake@57.0.1:
     resolution: {integrity: sha512-28lkFImeXTS+bhAjuCFV7w7tW5bXg27BJVrxv+nC/nyYa86qEa0oFeHwqol6ha5k4pdVDQgBF09GM4A1k76Ssg==}
     peerDependencies:
@@ -2194,6 +2207,11 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-manifests@57.0.1:
+    resolution: {integrity: sha512-qB/mDG2dYdl+EvUeQuqP8KFYCFgFCQjJYdWIHo8SFBgDzMYmdF286DFY2M1M9Okr99wkb5M4tgA3aCcwv3aEQA==}
+    peerDependencies:
+      expo: '*'
 
   expo-modules-autolinking@57.0.10:
     resolution: {integrity: sha512-jNqLswMx8QHN8VXRgud+xT+9q+J9U63CEGlx+k4V/IE9Qyt9HrKbWp+pIDma0fOquta5HBfSfsShcI+NkEpTiA==}
@@ -2262,6 +2280,9 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-structured-headers@57.0.0:
+    resolution: {integrity: sha512-//t9UNPbJSEysc2x4VKJG/u7Osvv5DYJWsET5bqt/B+qcD1by/JXvSQzX3Q/YAgA96xFPontrz6OAPLbO4JKEA==}
+
   expo-symbols@57.0.2:
     resolution: {integrity: sha512-qZ0iqOflm5lZGwRsQ5Y8sDksw3GAUKwHSX1bJBoocXf7gu14vafIXXYWte+JT9VfXAUGyKodJhLHP/GoOrcNWg==}
     peerDependencies:
@@ -2278,6 +2299,23 @@ packages:
       react-native-web: '*'
     peerDependenciesMeta:
       react-native-web:
+        optional: true
+
+  expo-updates-interface@57.0.1:
+    resolution: {integrity: sha512-+LUWwJ0gf/TEKMVdQAw/Gjih4dvrk+URgy24X9qEGKuuMDZqjBRm9T4yQyBVALGL5TTdPUaB6ILxx3lshm3pwQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-updates@57.0.21:
+    resolution: {integrity: sha512-JwTmguNvBvISEz9ALwrT8yDLnYuSP4/6kUz0kXkQuC8izebtTGkRPR37Cv39KPheDDA1F+QPhNyvw4lXM/BPvA==}
+    hasBin: true
+    peerDependencies:
+      expo: '*'
+      expo-dev-client: '*'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      expo-dev-client:
         optional: true
 
   expo-web-browser@57.0.2:
@@ -3275,17 +3313,18 @@ packages:
       react-native: '*'
 
   posthog-react-native@file:../../target/posthog-react-native.tgz:
-    resolution: {integrity: sha512-HeGsRvGqEEnCC5sw6vHaASDq7fYa1/jL8bAjtKr7wY7w8+iv0DpRoCoKIEv5v5jtZbq6X2a+AHjPR26DNIs4jQ==, tarball: file:../../target/posthog-react-native.tgz}
-    version: 4.63.5
+    resolution: {integrity: sha512-Zfs0rqNQYA1KzhlxcWqfChZ+9xUNo2F97/5xtYpKMNUSxVgr1wtmbQfCVwhq/ZcOZpTGSJWvnpYooba1yRnp4g==, tarball: file:../../target/posthog-react-native.tgz}
+    version: 4.68.5
     hasBin: true
     peerDependencies:
-      '@posthog/react-native-plugin': '>= 2.3.0'
+      '@posthog/react-native-plugin': '>= 2.4.3'
       '@react-native-async-storage/async-storage': '>=1.0.0'
       '@react-navigation/native': '>= 5.0.0'
       expo-application: '>= 4.0.0'
       expo-device: '>= 4.0.0'
       expo-file-system: '>= 13.0.0'
       expo-localization: '>= 11.0.0'
+      expo-updates: '>= 0.25.0'
       posthog-react-native-session-replay: '>= 1.6.0'
       react-native-device-info: '>= 10.0.0'
       react-native-localize: '>= 3.0.0'
@@ -3306,6 +3345,8 @@ packages:
       expo-file-system:
         optional: true
       expo-localization:
+        optional: true
+      expo-updates:
         optional: true
       posthog-react-native-session-replay:
         optional: true
@@ -5864,6 +5905,8 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  arg@4.1.3: {}
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -6708,6 +6751,8 @@ snapshots:
       expo: 57.0.15(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       ua-parser-js: 0.7.41
 
+  expo-eas-client@57.0.3: {}
+
   expo-file-system@57.0.5(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3)):
     dependencies:
       expo: 57.0.15(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -6739,6 +6784,8 @@ snapshots:
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
+  expo-json-utils@57.0.1: {}
+
   expo-keep-awake@57.0.1(expo@57.0.15)(react@19.2.3):
     dependencies:
       expo: 57.0.15(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -6759,6 +6806,11 @@ snapshots:
       expo: 57.0.15(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react: 19.2.3
       rtl-detect: 1.1.2
+
+  expo-manifests@57.0.1(expo@57.0.15):
+    dependencies:
+      expo: 57.0.15(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-json-utils: 57.0.1
 
   expo-modules-autolinking@57.0.10(typescript@6.0.3):
     dependencies:
@@ -6850,6 +6902,8 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3)
 
+  expo-structured-headers@57.0.0: {}
+
   expo-symbols@57.0.2(expo-font@57.0.1)(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.44
@@ -6867,6 +6921,33 @@ snapshots:
       react-native: 0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3)
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-updates-interface@57.0.1(expo@57.0.15):
+    dependencies:
+      expo: 57.0.15(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+
+  expo-updates@57.0.21(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/plist': 0.8.1
+      '@expo/spawn-async': 1.8.0
+      arg: 4.1.3
+      chalk: 4.1.2
+      debug: 4.4.3
+      expo: 57.0.15(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.12)(expo-router@57.0.15)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-eas-client: 57.0.3
+      expo-manifests: 57.0.1(expo@57.0.15)
+      expo-structured-headers: 57.0.0
+      expo-updates-interface: 57.0.1(expo@57.0.15)
+      getenv: 2.0.0
+      glob: 13.0.6
+      ignore: 5.3.2
+      nullthrows: 1.1.1
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3)
+      resolve-from: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8065,7 +8146,7 @@ snapshots:
       react-native: 0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3)
     optional: true
 
-  posthog-react-native@file:../../target/posthog-react-native.tgz(25a99f437a5ec83f375175a3316b32ae):
+  posthog-react-native@file:../../target/posthog-react-native.tgz(5c0ad5d09075996c1425f31a152dae94):
     dependencies:
       '@posthog/core': file:../../target/posthog-core.tgz
       '@posthog/types': file:../../target/posthog-types.tgz
@@ -8076,6 +8157,7 @@ snapshots:
       expo-device: 57.0.1(expo@57.0.15)
       expo-file-system: 57.0.5(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))
       expo-localization: 57.0.1(expo@57.0.15)(react@19.2.3)
+      expo-updates: 57.0.21(expo@57.0.15)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       posthog-react-native-session-replay: 1.6.0(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-safe-area-context: 5.7.0(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-svg: 15.15.4(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.87.0(@babel/core@7.29.0))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)

--- a/packages/browser-common/src/utils/general-utils.ts
+++ b/packages/browser-common/src/utils/general-utils.ts
@@ -3,6 +3,8 @@ import type { PostHogConfig, Properties } from '@posthog/types'
 
 import { logger } from './logger'
 
+export { trySafe } from '@posthog/core'
+
 export function find<T>(value: T[], predicate: (value: T) => boolean): T | undefined {
     for (let i = 0; i < value.length; i++) {
         if (predicate(value[i]!)) {
@@ -61,14 +63,6 @@ export function entries<T = any>(obj: Record<string, T>): [string, T][] {
         resArray[i] = [ownProps[i]!, obj[ownProps[i]!] as T]
     }
     return resArray
-}
-
-export const trySafe = function <T>(fn: () => T): T | undefined {
-    try {
-        return fn()
-    } catch {
-        return undefined
-    }
 }
 
 export const safewrap = function <F extends (...args: any[]) => any = (...args: any[]) => any>(f: F): F {

--- a/packages/browser-common/tests/utils/general-utils.spec.ts
+++ b/packages/browser-common/tests/utils/general-utils.spec.ts
@@ -4,9 +4,19 @@ import {
     extend,
     migrateConfigField,
     stripEmptyProperties,
+    trySafe,
 } from '../../src/utils/general-utils'
 
 describe('general utils', () => {
+    it('keeps trySafe available from the general utils export', () => {
+        expect(trySafe(() => false)).toBe(false)
+        expect(
+            trySafe(() => {
+                throw new Error('unavailable')
+            })
+        ).toBeUndefined()
+    })
+
     describe('_copyAndTruncateStrings', () => {
         it.each([
             ['same-realm', () => new TypeError('long error message')],

--- a/packages/core/src/__tests__/utils.spec.ts
+++ b/packages/core/src/__tests__/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   currentISOTime,
   currentTimestamp,
   raceWithTimeout,
+  trySafe,
 } from '@/utils'
 
 describe('utils', () => {
@@ -75,6 +76,32 @@ describe('utils', () => {
   })
   describe.skip('retriable', () => {
     it('should do something', () => {})
+  })
+  describe('trySafe', () => {
+    it.each([false, 0, '', null, undefined, { value: 'kept' }])('preserves the returned value %j', (value) => {
+      const callback = vi.fn(() => value)
+
+      expect(trySafe(callback)).toBe(value)
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([new Error('unavailable'), 'failure', null])('returns undefined when the callback throws %j', (error) => {
+      expect(
+        trySafe(() => {
+          throw error
+        })
+      ).toBeUndefined()
+    })
+
+    it('returns undefined when a native-style property getter throws', () => {
+      const nativeModule = {
+        get value(): string {
+          throw new Error('not linked')
+        },
+      }
+
+      expect(trySafe(() => nativeModule.value)).toBeUndefined()
+    })
   })
   describe('raceWithTimeout', () => {
     it('returns the promise value and clears the timeout when the promise resolves first', async () => {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -115,6 +115,14 @@ export function currentISOTime(): string {
   return new Date().toISOString()
 }
 
+export function trySafe<T>(fn: () => T): T | undefined {
+  try {
+    return fn()
+  } catch {
+    return undefined
+  }
+}
+
 export function safeSetTimeout(fn: () => void, timeout: number): any {
   // NOTE: we use this so rarely that it is totally fine to do `safeSetTimeout(fn, 0)``
   // rather than setImmediate.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -96,7 +96,7 @@
     "expo-device": ">= 4.0.0",
     "expo-file-system": ">= 13.0.0",
     "expo-localization": ">= 11.0.0",
-    "expo-updates": "*",
+    "expo-updates": ">= 0.25.0",
     "@posthog/react-native-plugin": ">= 2.4.3",
     "posthog-react-native-session-replay": ">= 1.6.0",
     "react-native-device-info": ">= 10.0.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -69,6 +69,7 @@
     "expo-device": "^4.0.0",
     "expo-file-system": "^13.0.0",
     "expo-localization": "^11.0.0",
+    "expo-updates": "0.25.0",
     "@testing-library/react": "catalog:",
     "metro": "0.83.1",
     "@expo/config-plugins": "10.1.2",
@@ -95,6 +96,7 @@
     "expo-device": ">= 4.0.0",
     "expo-file-system": ">= 13.0.0",
     "expo-localization": ">= 11.0.0",
+    "expo-updates": "*",
     "@posthog/react-native-plugin": ">= 2.4.3",
     "posthog-react-native-session-replay": ">= 1.6.0",
     "react-native-device-info": ">= 10.0.0",
@@ -120,6 +122,9 @@
       "optional": true
     },
     "expo-localization": {
+      "optional": true
+    },
+    "expo-updates": {
       "optional": true
     },
     "react-native-device-info": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -69,7 +69,7 @@
     "expo-device": "^4.0.0",
     "expo-file-system": "^13.0.0",
     "expo-localization": "^11.0.0",
-    "expo-updates": "0.25.0",
+    "expo-updates": "^0.25.0",
     "@testing-library/react": "catalog:",
     "metro": "0.83.1",
     "@expo/config-plugins": "10.1.2",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -154,7 +154,7 @@
         },
         {
           "category": "Error tracking",
-          "description": "Capture a caught exception manually",
+          "description": "Capture a caught exception manually\nExceptions also include capture-time `$app_state` (active, background, inactive or extension) on any platform where React Native AppState provides a known value. On iOS and Android, optional `expo-updates` (= 0.25.0) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel` and `$expo_is_embedded_launch` for enabled updates outside development mode. Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by `customAppProperties`, including the existing `$app_version` and `$app_build`. Override these fields with `additionalProperties`, or remove them using `before_send`.",
           "details": null,
           "id": "captureException",
           "showDocs": true,
@@ -168,7 +168,7 @@
             {
               "id": "with_additional_properties",
               "name": "With additional properties",
-              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\nExceptions also include capture-time  (active, background or inactive) on any platform where React Native AppState provides a known value. On iOS and Android, optional  (>= 0.25.0) adds , ,  and  for enabled updates outside development mode. Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by , including the existing  and . Override these fields with , or remove them using .\n\n\n\n"
+              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\n\n\n"
             }
           ],
           "releaseTag": "public",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -168,7 +168,7 @@
             {
               "id": "with_additional_properties",
               "name": "With additional properties",
-              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\nOn iOS and Android, exceptions also include capture-time  (active, background or inactive). When available, optional  (>= 0.25.0) adds , ,  and  for enabled updates outside development mode. Optional  adds  (0–1),  (including full) and . Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by , including the existing  and . Override these fields with , or remove them using .\n\n\n\n"
+              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\nExceptions also include capture-time  (active, background or inactive) on any platform where React Native AppState provides a known value. On iOS and Android, optional  (>= 0.25.0) adds , ,  and  for enabled updates outside development mode. On those platforms, optional  adds  (0–1),  (including full) and . Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by , including the existing  and . Override these fields with , or remove them using .\n\n\n\n"
             }
           ],
           "releaseTag": "public",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -168,7 +168,7 @@
             {
               "id": "with_additional_properties",
               "name": "With additional properties",
-              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\n\n\n"
+              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\nOn iOS and Android, exceptions also include capture-time  (active, background or inactive). When available, optional  (>= 0.25.0) adds , ,  and  for enabled updates outside development mode. Optional  adds  (0–1),  (including full) and . Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by , including the existing  and . Override these fields with , or remove them using .\n\n\n\n"
             }
           ],
           "releaseTag": "public",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -168,7 +168,7 @@
             {
               "id": "with_additional_properties",
               "name": "With additional properties",
-              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\nExceptions also include capture-time  (active, background or inactive) on any platform where React Native AppState provides a known value. On iOS and Android, optional  (>= 0.25.0) adds , ,  and  for enabled updates outside development mode. On those platforms, optional  adds  (0–1),  (including full) and . Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by , including the existing  and . Override these fields with , or remove them using .\n\n\n\n"
+              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\nExceptions also include capture-time  (active, background or inactive) on any platform where React Native AppState provides a known value. On iOS and Android, optional  (>= 0.25.0) adds , ,  and  for enabled updates outside development mode. Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by , including the existing  and . Override these fields with , or remove them using .\n\n\n\n"
             }
           ],
           "releaseTag": "public",

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -154,7 +154,7 @@
         },
         {
           "category": "Error tracking",
-          "description": "Capture a caught exception manually\nExceptions also include capture-time `$app_state` (active, background, inactive or extension) on any platform where React Native AppState provides a known value. On iOS and Android, optional `expo-updates` (= 0.25.0) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel` and `$expo_is_embedded_launch` for enabled updates outside development mode. Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by `customAppProperties`, including the existing `$app_version` and `$app_build`. Override these fields with `additionalProperties`, or remove them using `before_send`.",
+          "description": "Capture a caught exception manually\nExceptions also include capture-time `$app_state` (active, background, inactive or extension) on any platform where React Native AppState provides a known value. On iOS and Android, optional `expo-updates` (0.25.0 or newer) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel` and `$expo_is_embedded_launch` for enabled updates outside development mode. Unknown values are omitted. These exception-only fields are separate from the static app metadata controlled by `customAppProperties`, including the existing `$app_version` and `$app_build`. Override these fields with `additionalProperties`, or remove them using `before_send`.",
           "details": null,
           "id": "captureException",
           "showDocs": true,

--- a/packages/react-native/src/error-tracking/exception-context.ts
+++ b/packages/react-native/src/error-tracking/exception-context.ts
@@ -1,16 +1,7 @@
-import type { PostHogEventProperties } from '@posthog/core'
+import { trySafe, type PostHogEventProperties } from '@posthog/core'
 import { AppState, Platform } from 'react-native'
 import { OptionalExpoUpdates } from '../optional/OptionalExpoUpdates'
 import { OptionalReactNativeDeviceInfo } from '../optional/OptionalReactNativeDeviceInfo'
-
-// Optional native modules can throw even on property access (e.g. an unlinked proxy).
-const read = <T>(getter: () => T): T | undefined => {
-  try {
-    return getter()
-  } catch {
-    return undefined
-  }
-}
 
 const knownString = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0 && value !== 'unknown'
@@ -22,16 +13,16 @@ export const getExceptionContext = (): PostHogEventProperties => {
     return properties
   }
 
-  const appState = read(() => AppState.currentState)
+  const appState = trySafe(() => AppState.currentState)
   if (appState === 'active' || appState === 'background' || appState === 'inactive') {
     properties.$app_state = appState
   }
 
-  if (!(typeof __DEV__ !== 'undefined' && __DEV__) && read(() => OptionalExpoUpdates?.isEnabled) === true) {
-    const updateId = read(() => OptionalExpoUpdates?.updateId)
-    const runtimeVersion = read(() => OptionalExpoUpdates?.runtimeVersion)
-    const channel = read(() => OptionalExpoUpdates?.channel)
-    const isEmbeddedLaunch = read(() => OptionalExpoUpdates?.isEmbeddedLaunch)
+  if (!(typeof __DEV__ !== 'undefined' && __DEV__) && trySafe(() => OptionalExpoUpdates?.isEnabled) === true) {
+    const updateId = trySafe(() => OptionalExpoUpdates?.updateId)
+    const runtimeVersion = trySafe(() => OptionalExpoUpdates?.runtimeVersion)
+    const channel = trySafe(() => OptionalExpoUpdates?.channel)
+    const isEmbeddedLaunch = trySafe(() => OptionalExpoUpdates?.isEmbeddedLaunch)
     if (knownString(updateId)) properties.$expo_update_id = updateId
     if (knownString(runtimeVersion)) properties.$expo_runtime_version = runtimeVersion
     if (knownString(channel)) properties.$expo_channel = channel
@@ -39,10 +30,10 @@ export const getExceptionContext = (): PostHogEventProperties => {
   }
 
   // One synchronous snapshot per exception; no monitoring, polling or async work on the error path.
-  const powerState = read(() => OptionalReactNativeDeviceInfo?.getPowerStateSync?.())
-  const batteryLevel = read(() => powerState?.batteryLevel)
-  const batteryState = read(() => powerState?.batteryState)
-  const lowPowerMode = read(() => powerState?.lowPowerMode)
+  const powerState = trySafe(() => OptionalReactNativeDeviceInfo?.getPowerStateSync?.())
+  const batteryLevel = trySafe(() => powerState?.batteryLevel)
+  const batteryState = trySafe(() => powerState?.batteryState)
+  const lowPowerMode = trySafe(() => powerState?.lowPowerMode)
   if (typeof batteryLevel === 'number' && Number.isFinite(batteryLevel) && batteryLevel >= 0 && batteryLevel <= 1) {
     properties.$battery_level = batteryLevel
   }

--- a/packages/react-native/src/error-tracking/exception-context.ts
+++ b/packages/react-native/src/error-tracking/exception-context.ts
@@ -1,7 +1,6 @@
 import { isEmptyString, trySafe, type PostHogEventProperties } from '@posthog/core'
 import { AppState, Platform } from 'react-native'
 import { OptionalExpoUpdates } from '../optional/OptionalExpoUpdates'
-import { OptionalReactNativeDeviceInfo } from '../optional/OptionalReactNativeDeviceInfo'
 
 const knownString = (value: unknown): value is string =>
   typeof value === 'string' && !isEmptyString(value) && value !== 'unknown'
@@ -28,19 +27,6 @@ export const getExceptionContext = (): PostHogEventProperties => {
     if (knownString(channel)) properties.$expo_channel = channel
     if (typeof isEmbeddedLaunch === 'boolean') properties.$expo_is_embedded_launch = isEmbeddedLaunch
   }
-
-  // One synchronous snapshot per exception; no monitoring, polling or async work on the error path.
-  const powerState = trySafe(() => OptionalReactNativeDeviceInfo?.getPowerStateSync?.())
-  const batteryLevel = trySafe(() => powerState?.batteryLevel)
-  const batteryState = trySafe(() => powerState?.batteryState)
-  const lowPowerMode = trySafe(() => powerState?.lowPowerMode)
-  if (typeof batteryLevel === 'number' && Number.isFinite(batteryLevel) && batteryLevel >= 0 && batteryLevel <= 1) {
-    properties.$battery_level = batteryLevel
-  }
-  if (batteryState === 'charging' || batteryState === 'full' || batteryState === 'unplugged') {
-    properties.$battery_charging = batteryState !== 'unplugged'
-  }
-  if (typeof lowPowerMode === 'boolean') properties.$low_power_mode = lowPowerMode
 
   return properties
 }

--- a/packages/react-native/src/error-tracking/exception-context.ts
+++ b/packages/react-native/src/error-tracking/exception-context.ts
@@ -1,10 +1,10 @@
-import { trySafe, type PostHogEventProperties } from '@posthog/core'
+import { isEmptyString, trySafe, type PostHogEventProperties } from '@posthog/core'
 import { AppState, Platform } from 'react-native'
 import { OptionalExpoUpdates } from '../optional/OptionalExpoUpdates'
 import { OptionalReactNativeDeviceInfo } from '../optional/OptionalReactNativeDeviceInfo'
 
 const knownString = (value: unknown): value is string =>
-  typeof value === 'string' && value.trim().length > 0 && value !== 'unknown'
+  typeof value === 'string' && !isEmptyString(value) && value !== 'unknown'
 
 /** Capture-time, exception-only context, separate from the static customAppProperties. */
 export const getExceptionContext = (): PostHogEventProperties => {

--- a/packages/react-native/src/error-tracking/exception-context.ts
+++ b/packages/react-native/src/error-tracking/exception-context.ts
@@ -1,0 +1,55 @@
+import type { PostHogEventProperties } from '@posthog/core'
+import { AppState, Platform } from 'react-native'
+import { OptionalExpoUpdates } from '../optional/OptionalExpoUpdates'
+import { OptionalReactNativeDeviceInfo } from '../optional/OptionalReactNativeDeviceInfo'
+
+// Optional native modules can throw even on property access (e.g. an unlinked proxy).
+const read = <T>(getter: () => T): T | undefined => {
+  try {
+    return getter()
+  } catch {
+    return undefined
+  }
+}
+
+const knownString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0 && value !== 'unknown'
+
+/** Capture-time, exception-only context, separate from the static customAppProperties. */
+export const getExceptionContext = (): PostHogEventProperties => {
+  const properties: PostHogEventProperties = {}
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+    return properties
+  }
+
+  const appState = read(() => AppState.currentState)
+  if (appState === 'active' || appState === 'background' || appState === 'inactive') {
+    properties.$app_state = appState
+  }
+
+  if (!(typeof __DEV__ !== 'undefined' && __DEV__) && read(() => OptionalExpoUpdates?.isEnabled) === true) {
+    const updateId = read(() => OptionalExpoUpdates?.updateId)
+    const runtimeVersion = read(() => OptionalExpoUpdates?.runtimeVersion)
+    const channel = read(() => OptionalExpoUpdates?.channel)
+    const isEmbeddedLaunch = read(() => OptionalExpoUpdates?.isEmbeddedLaunch)
+    if (knownString(updateId)) properties.$expo_update_id = updateId
+    if (knownString(runtimeVersion)) properties.$expo_runtime_version = runtimeVersion
+    if (knownString(channel)) properties.$expo_channel = channel
+    if (typeof isEmbeddedLaunch === 'boolean') properties.$expo_is_embedded_launch = isEmbeddedLaunch
+  }
+
+  // One synchronous snapshot per exception; no monitoring, polling or async work on the error path.
+  const powerState = read(() => OptionalReactNativeDeviceInfo?.getPowerStateSync?.())
+  const batteryLevel = read(() => powerState?.batteryLevel)
+  const batteryState = read(() => powerState?.batteryState)
+  const lowPowerMode = read(() => powerState?.lowPowerMode)
+  if (typeof batteryLevel === 'number' && Number.isFinite(batteryLevel) && batteryLevel >= 0 && batteryLevel <= 1) {
+    properties.$battery_level = batteryLevel
+  }
+  if (batteryState === 'charging' || batteryState === 'full' || batteryState === 'unplugged') {
+    properties.$battery_charging = batteryState !== 'unplugged'
+  }
+  if (typeof lowPowerMode === 'boolean') properties.$low_power_mode = lowPowerMode
+
+  return properties
+}

--- a/packages/react-native/src/error-tracking/exception-context.ts
+++ b/packages/react-native/src/error-tracking/exception-context.ts
@@ -9,13 +9,13 @@ const knownString = (value: unknown): value is string =>
 /** Capture-time, exception-only context, separate from the static customAppProperties. */
 export const getExceptionContext = (): PostHogEventProperties => {
   const properties: PostHogEventProperties = {}
-  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
-    return properties
-  }
-
   const appState = trySafe(() => AppState.currentState)
   if (appState === 'active' || appState === 'background' || appState === 'inactive') {
     properties.$app_state = appState
+  }
+
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+    return properties
   }
 
   if (!(typeof __DEV__ !== 'undefined' && __DEV__) && trySafe(() => OptionalExpoUpdates?.isEnabled) === true) {

--- a/packages/react-native/src/error-tracking/exception-context.ts
+++ b/packages/react-native/src/error-tracking/exception-context.ts
@@ -9,7 +9,7 @@ const knownString = (value: unknown): value is string =>
 export const getExceptionContext = (): PostHogEventProperties => {
   const properties: PostHogEventProperties = {}
   const appState = trySafe(() => AppState.currentState)
-  if (appState === 'active' || appState === 'background' || appState === 'inactive') {
+  if (appState === 'active' || appState === 'background' || appState === 'inactive' || appState === 'extension') {
     properties.$app_state = appState
   }
 

--- a/packages/react-native/src/optional/OptionalExpoUpdates.ts
+++ b/packages/react-native/src/optional/OptionalExpoUpdates.ts
@@ -1,0 +1,19 @@
+import { Platform } from 'react-native'
+
+// Only read the public constants we use; older or unlinked modules may omit them.
+type ExpoUpdatesContext = {
+  isEnabled?: boolean
+  updateId?: string | null
+  runtimeVersion?: string | null
+  channel?: string | null
+  isEmbeddedLaunch?: boolean
+}
+
+export let OptionalExpoUpdates: ExpoUpdatesContext | undefined
+
+if (Platform.OS === 'ios' || Platform.OS === 'android') {
+  try {
+    // Metro recognizes optional dependencies only when require is directly inside the try block.
+    OptionalExpoUpdates = require('expo-updates')
+  } catch {}
+}

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1863,11 +1863,12 @@ export class PostHog extends PostHogCore {
    * })
    * ```
    *
-   * On iOS and Android, exceptions also include capture-time `$app_state` (active, background or
-   * inactive). When available, optional `expo-updates` (>= 0.25.0) adds `$expo_update_id`,
-   * `$expo_runtime_version`, `$expo_channel` and `$expo_is_embedded_launch` for enabled updates
-   * outside development mode. Optional `react-native-device-info` adds `$battery_level` (0–1),
-   * `$battery_charging` (including full) and `$low_power_mode`. Unknown values are omitted.
+   * Exceptions also include capture-time `$app_state` (active, background or inactive) on any
+   * platform where React Native AppState provides a known value. On iOS and Android, optional
+   * `expo-updates` (>= 0.25.0) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel`
+   * and `$expo_is_embedded_launch` for enabled updates outside development mode. On those platforms,
+   * optional `react-native-device-info` adds `$battery_level` (0–1), `$battery_charging` (including full)
+   * and `$low_power_mode`. Unknown values are omitted.
    * These exception-only fields are separate from the static app metadata controlled by
    * `customAppProperties`, including the existing `$app_version` and `$app_build`.
    * Override these fields with `additionalProperties`, or remove them using `before_send`.

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1841,7 +1841,7 @@ export class PostHog extends PostHogCore {
    *
    * Exceptions also include capture-time `$app_state` (active, background, inactive or extension) on any
    * platform where React Native AppState provides a known value. On iOS and Android, optional
-   * `expo-updates` (>= 0.25.0) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel`
+   * `expo-updates` (0.25.0 or newer) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel`
    * and `$expo_is_embedded_launch` for enabled updates outside development mode. Unknown values
    * are omitted.
    * These exception-only fields are separate from the static app metadata controlled by

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1886,9 +1886,7 @@ export class PostHog extends PostHogCore {
       syntheticException: new Error('Synthetic Error'),
     }
 
-    if (!this.isDisabled && !this.optedOut) {
-      additionalProperties = { ...getExceptionContext(), ...additionalProperties }
-    }
+    additionalProperties = { ...getExceptionContext(), ...additionalProperties }
 
     // Attach the rolling exception-steps buffer (no-op if the caller already provided their own).
     additionalProperties = this._errorTracking.attachExceptionSteps(additionalProperties)

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -48,6 +48,7 @@ import { getRemoteConfigBool, getRemoteConfigNumber, isHermes, isMacOS, isValidS
 import { withReactNativeNavigation } from './frameworks/wix-navigation'
 import { OptionalReactNativePlugin, OptionalReactNativePluginVersion } from './optional/OptionalPlugin'
 import { ErrorTracking, ErrorTrackingOptions } from './error-tracking'
+import { getExceptionContext } from './error-tracking/exception-context'
 
 export { PostHogPersistedProperty }
 
@@ -1862,6 +1863,15 @@ export class PostHog extends PostHogCore {
    * })
    * ```
    *
+   * On iOS and Android, exceptions also include capture-time `$app_state` (active, background or
+   * inactive). When available, optional `expo-updates` (>= 0.25.0) adds `$expo_update_id`,
+   * `$expo_runtime_version`, `$expo_channel` and `$expo_is_embedded_launch` for enabled updates
+   * outside development mode. Optional `react-native-device-info` adds `$battery_level` (0–1),
+   * `$battery_charging` (including full) and `$low_power_mode`. Unknown values are omitted.
+   * These exception-only fields are separate from the static app metadata controlled by
+   * `customAppProperties`, including the existing `$app_version` and `$app_build`.
+   * Override these fields with `additionalProperties`, or remove them using `before_send`.
+   *
    * @param {Error} error The error to capture
    * @param {Object} [additionalProperties] Any additional properties to add to the error event
    * @returns {void}
@@ -1874,6 +1884,10 @@ export class PostHog extends PostHogCore {
     const resolvedHint: CoreErrorTracking.EventHint = hint ?? {
       mechanism: { handled: true, type: 'generic' },
       syntheticException: new Error('Synthetic Error'),
+    }
+
+    if (!this.isDisabled && !this.optedOut) {
+      additionalProperties = { ...getExceptionContext(), ...additionalProperties }
     }
 
     // Attach the rolling exception-steps buffer (no-op if the caller already provided their own).

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1866,9 +1866,8 @@ export class PostHog extends PostHogCore {
    * Exceptions also include capture-time `$app_state` (active, background or inactive) on any
    * platform where React Native AppState provides a known value. On iOS and Android, optional
    * `expo-updates` (>= 0.25.0) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel`
-   * and `$expo_is_embedded_launch` for enabled updates outside development mode. On those platforms,
-   * optional `react-native-device-info` adds `$battery_level` (0–1), `$battery_charging` (including full)
-   * and `$low_power_mode`. Unknown values are omitted.
+   * and `$expo_is_embedded_launch` for enabled updates outside development mode. Unknown values
+   * are omitted.
    * These exception-only fields are separate from the static app metadata controlled by
    * `customAppProperties`, including the existing `$app_version` and `$app_build`.
    * Override these fields with `additionalProperties`, or remove them using `before_send`.

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1839,6 +1839,15 @@ export class PostHog extends PostHogCore {
   /**
    * Capture a caught exception manually
    *
+   * Exceptions also include capture-time `$app_state` (active, background, inactive or extension) on any
+   * platform where React Native AppState provides a known value. On iOS and Android, optional
+   * `expo-updates` (>= 0.25.0) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel`
+   * and `$expo_is_embedded_launch` for enabled updates outside development mode. Unknown values
+   * are omitted.
+   * These exception-only fields are separate from the static app metadata controlled by
+   * `customAppProperties`, including the existing `$app_version` and `$app_build`.
+   * Override these fields with `additionalProperties`, or remove them using `before_send`.
+   *
    * {@label Error tracking}
    *
    * @public
@@ -1862,15 +1871,6 @@ export class PostHog extends PostHogCore {
    *   ...
    * })
    * ```
-   *
-   * Exceptions also include capture-time `$app_state` (active, background or inactive) on any
-   * platform where React Native AppState provides a known value. On iOS and Android, optional
-   * `expo-updates` (>= 0.25.0) adds `$expo_update_id`, `$expo_runtime_version`, `$expo_channel`
-   * and `$expo_is_embedded_launch` for enabled updates outside development mode. Unknown values
-   * are omitted.
-   * These exception-only fields are separate from the static app metadata controlled by
-   * `customAppProperties`, including the existing `$app_version` and `$app_build`.
-   * Override these fields with `additionalProperties`, or remove them using `before_send`.
    *
    * @param {Error} error The error to capture
    * @param {Object} [additionalProperties] Any additional properties to add to the error event

--- a/packages/react-native/test/__snapshots__/event-snapshots.spec.ts.snap
+++ b/packages/react-native/test/__snapshots__/event-snapshots.spec.ts.snap
@@ -164,6 +164,7 @@ exports[`PostHog React Native event and request snapshots > snapshots complete e
           "$app_build": "42",
           "$app_name": "Snapshot App",
           "$app_namespace": "com.posthog.snapshot",
+          "$app_state": "active",
           "$app_version": "1.2.3",
           "$device_manufacturer": "PostHog",
           "$device_name": "Snapshot Phone",

--- a/packages/react-native/test/exception-context-capture.spec.ts
+++ b/packages/react-native/test/exception-context-capture.spec.ts
@@ -1,0 +1,150 @@
+import { PostHog, PostHogOptions, PostHogPersistedProperty } from '../src'
+import { AppState } from 'react-native'
+
+const updates = vi.hoisted(() => ({
+  isEnabled: true,
+  updateId: 'ota-id',
+  runtimeVersion: 'runtime',
+  channel: 'production',
+  isEmbeddedLaunch: false,
+}))
+vi.mock('../src/optional/OptionalExpoUpdates', () => ({ OptionalExpoUpdates: updates }))
+const getPowerStateSync = vi.hoisted(() => vi.fn())
+vi.mock('../src/optional/OptionalReactNativeDeviceInfo', () => ({
+  OptionalReactNativeDeviceInfo: { getPowerStateSync },
+}))
+
+vi.useRealTimers()
+const clients: PostHog[] = []
+const newPostHog = (options: PostHogOptions = {}): PostHog => {
+  const client = new PostHog('test-token', {
+    persistence: 'memory',
+    flushInterval: 0,
+    captureAppLifecycleEvents: false,
+    preloadFeatureFlags: false,
+    disableRemoteConfig: true,
+    ...options,
+  })
+  clients.push(client)
+  return client
+}
+const exceptions = (client: PostHog): any[] =>
+  ((client.getPersistedProperty(PostHogPersistedProperty.Queue) as any[]) ?? [])
+    .map((item) => item.message)
+    .filter((message) => message.event === '$exception')
+
+beforeEach(() => {
+  AppState.currentState = 'active'
+  updates.updateId = 'ota-id'
+  getPowerStateSync.mockReset().mockReturnValue({ batteryLevel: 0.5, batteryState: 'charging', lowPowerMode: true })
+  global.fetch = vi.fn(async () => ({ status: 200, json: async () => ({}) })) as any
+})
+afterEach(async () => {
+  await Promise.all(clients.splice(0).map((client) => client.shutdown()))
+  vi.unstubAllGlobals()
+  AppState.currentState = 'active'
+})
+
+describe('PostHog.captureException context', () => {
+  it('survives the real first JS exception path alongside existing app and exception metadata', () => {
+    const client = newPostHog()
+    expect(getPowerStateSync).not.toHaveBeenCalled()
+    client.captureException(new Error('boom'))
+    expect(exceptions(client)[0].properties).toMatchObject({
+      $app_version: 'mock',
+      $app_build: 'mock',
+      $app_state: 'active',
+      $expo_update_id: 'ota-id',
+      $expo_runtime_version: 'runtime',
+      $expo_channel: 'production',
+      $expo_is_embedded_launch: false,
+      $battery_level: 0.5,
+      $battery_charging: true,
+      $low_power_mode: true,
+      $exception_list: [expect.objectContaining({ value: 'boom' })],
+    })
+    updates.updateId = 'next-id'
+    AppState.currentState = 'background'
+    client.captureException(new Error('next'))
+    expect(exceptions(client)[1].properties).toMatchObject({ $expo_update_id: 'next-id', $app_state: 'background' })
+    client.capture('ordinary event')
+    const queue = client.getPersistedProperty(PostHogPersistedProperty.Queue) as any[]
+    expect(queue.at(-1).message.properties).not.toHaveProperty('$expo_update_id')
+    expect(queue.at(-1).message.properties).not.toHaveProperty('$app_state')
+  })
+
+  it('preserves caller overrides, custom static app properties and exception steps', () => {
+    const client = newPostHog({ customAppProperties: { $app_version: 'custom-version', $app_build: 'custom-build' } })
+    const properties = { $expo_update_id: 'caller-id', $app_state: null, $battery_level: 0.75, custom: true }
+    client.addExceptionStep('before error')
+    client.captureException(new Error('boom'), properties)
+    expect(exceptions(client)[0].properties).toMatchObject({
+      ...properties,
+      $app_version: 'custom-version',
+      $app_build: 'custom-build',
+      $exception_steps: [expect.objectContaining({ $message: 'before error' })],
+    })
+    expect(properties).not.toHaveProperty('$expo_channel')
+  })
+
+  it('allows before_send to strip context or suppress the event', () => {
+    const before_send = vi.fn((event) => {
+      if (event.properties.drop) return null
+      delete event.properties.$expo_update_id
+      delete event.properties.$app_state
+      return event
+    })
+    const client = newPostHog({ before_send })
+    client.captureException(new Error('keep'))
+    client.captureException(new Error('drop'), { drop: true })
+    expect(before_send).toHaveBeenCalled()
+    expect(exceptions(client)).toHaveLength(1)
+    expect(exceptions(client)[0].properties).not.toHaveProperty('$expo_update_id')
+    expect(exceptions(client)[0].properties).not.toHaveProperty('$app_state')
+  })
+
+  it.each([{ disabled: true }, { defaultOptIn: false }])('respects suppression %j', (options) => {
+    const client = newPostHog(options)
+    client.captureException(new Error('not sent'))
+    expect(exceptions(client)).toEqual([])
+    expect(getPowerStateSync).not.toHaveBeenCalled()
+  })
+
+  it('keeps the exception and OTA metadata when power collection throws', () => {
+    getPowerStateSync.mockImplementation(() => {
+      throw new Error('unlinked')
+    })
+    const client = newPostHog()
+    client.captureException(new Error('original exception'))
+    expect(exceptions(client)[0].properties).toMatchObject({
+      $expo_update_id: 'ota-id',
+      $exception_list: [expect.objectContaining({ value: 'original exception' })],
+    })
+    expect(exceptions(client)[0].properties).not.toHaveProperty('$battery_level')
+  })
+
+  it('respects runtime consent changes', async () => {
+    const client = newPostHog()
+    await client.optOut()
+    client.captureException(new Error('not sent'))
+    expect(exceptions(client)).toEqual([])
+    await client.optIn()
+    client.captureException(new Error('sent'))
+    expect(exceptions(client)).toHaveLength(1)
+  })
+
+  it('enriches auto-captured JS errors and still calls the previous error handler', () => {
+    const previous = vi.fn()
+    let handler = previous
+    vi.stubGlobal('ErrorUtils', {
+      getGlobalHandler: () => handler,
+      setGlobalHandler: (next: typeof handler) => {
+        handler = next
+      },
+    })
+    const client = newPostHog({ errorTracking: { autocapture: { uncaughtExceptions: true } } })
+    handler(new Error('uncaught'), false)
+    expect(exceptions(client)[0].properties).toMatchObject({ $expo_update_id: 'ota-id', $app_state: 'active' })
+    expect(previous).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-native/test/exception-context-capture.spec.ts
+++ b/packages/react-native/test/exception-context-capture.spec.ts
@@ -1,18 +1,17 @@
 import { PostHog, PostHogOptions, PostHogPersistedProperty } from '../src'
 import { AppState } from 'react-native'
 
+const readUpdateId = vi.hoisted(() => vi.fn())
 const updates = vi.hoisted(() => ({
   isEnabled: true,
-  updateId: 'ota-id',
+  get updateId() {
+    return readUpdateId()
+  },
   runtimeVersion: 'runtime',
   channel: 'production',
   isEmbeddedLaunch: false,
 }))
 vi.mock('../src/optional/OptionalExpoUpdates', () => ({ OptionalExpoUpdates: updates }))
-const getPowerStateSync = vi.hoisted(() => vi.fn())
-vi.mock('../src/optional/OptionalReactNativeDeviceInfo', () => ({
-  OptionalReactNativeDeviceInfo: { getPowerStateSync },
-}))
 
 vi.useRealTimers()
 const clients: PostHog[] = []
@@ -35,8 +34,7 @@ const exceptions = (client: PostHog): any[] =>
 
 beforeEach(() => {
   AppState.currentState = 'active'
-  updates.updateId = 'ota-id'
-  getPowerStateSync.mockReset().mockReturnValue({ batteryLevel: 0.5, batteryState: 'charging', lowPowerMode: true })
+  readUpdateId.mockReset().mockReturnValue('ota-id')
   global.fetch = vi.fn(async () => ({ status: 200, json: async () => ({}) })) as any
 })
 afterEach(async () => {
@@ -48,7 +46,7 @@ afterEach(async () => {
 describe('PostHog.captureException context', () => {
   it('survives the real first JS exception path alongside existing app and exception metadata', () => {
     const client = newPostHog()
-    expect(getPowerStateSync).not.toHaveBeenCalled()
+    expect(readUpdateId).not.toHaveBeenCalled()
     client.captureException(new Error('boom'))
     expect(exceptions(client)[0].properties).toMatchObject({
       $app_version: 'mock',
@@ -58,12 +56,9 @@ describe('PostHog.captureException context', () => {
       $expo_runtime_version: 'runtime',
       $expo_channel: 'production',
       $expo_is_embedded_launch: false,
-      $battery_level: 0.5,
-      $battery_charging: true,
-      $low_power_mode: true,
       $exception_list: [expect.objectContaining({ value: 'boom' })],
     })
-    updates.updateId = 'next-id'
+    readUpdateId.mockReturnValue('next-id')
     AppState.currentState = 'background'
     client.captureException(new Error('next'))
     expect(exceptions(client)[1].properties).toMatchObject({ $expo_update_id: 'next-id', $app_state: 'background' })
@@ -75,7 +70,7 @@ describe('PostHog.captureException context', () => {
 
   it('preserves caller overrides, custom static app properties and exception steps', () => {
     const client = newPostHog({ customAppProperties: { $app_version: 'custom-version', $app_build: 'custom-build' } })
-    const properties = { $expo_update_id: 'caller-id', $app_state: null, $battery_level: 0.75, custom: true }
+    const properties = { $expo_update_id: 'caller-id', $app_state: null, custom: true }
     client.addExceptionStep('before error')
     client.captureException(new Error('boom'), properties)
     expect(exceptions(client)[0].properties).toMatchObject({
@@ -107,20 +102,21 @@ describe('PostHog.captureException context', () => {
     const client = newPostHog(options)
     client.captureException(new Error('not sent'))
     expect(exceptions(client)).toEqual([])
-    expect(getPowerStateSync).not.toHaveBeenCalled()
+    expect(readUpdateId).not.toHaveBeenCalled()
   })
 
-  it('keeps the exception and OTA metadata when power collection throws', () => {
-    getPowerStateSync.mockImplementation(() => {
+  it('keeps the exception and other context when an OTA metadata getter throws', () => {
+    readUpdateId.mockImplementation(() => {
       throw new Error('unlinked')
     })
     const client = newPostHog()
     client.captureException(new Error('original exception'))
     expect(exceptions(client)[0].properties).toMatchObject({
-      $expo_update_id: 'ota-id',
+      $app_state: 'active',
+      $expo_channel: 'production',
       $exception_list: [expect.objectContaining({ value: 'original exception' })],
     })
-    expect(exceptions(client)[0].properties).not.toHaveProperty('$battery_level')
+    expect(exceptions(client)[0].properties).not.toHaveProperty('$expo_update_id')
   })
 
   it('respects runtime consent changes', async () => {

--- a/packages/react-native/test/exception-context-capture.spec.ts
+++ b/packages/react-native/test/exception-context-capture.spec.ts
@@ -102,7 +102,6 @@ describe('PostHog.captureException context', () => {
     const client = newPostHog(options)
     client.captureException(new Error('not sent'))
     expect(exceptions(client)).toEqual([])
-    expect(readUpdateId).not.toHaveBeenCalled()
   })
 
   it('keeps the exception and other context when an OTA metadata getter throws', () => {

--- a/packages/react-native/test/exception-context.spec.ts
+++ b/packages/react-native/test/exception-context.spec.ts
@@ -35,10 +35,22 @@ describe('getExceptionContext', () => {
     expect(getExceptionContext()).toEqual({ $app_state: 'active' })
   })
 
-  it.each(['web', 'macos', 'windows'])('does not read native context on %s', (platform) => {
+  it.each(['web', 'macos', 'windows'])('captures app state without reading native context on %s', (platform) => {
     Platform.OS = platform as typeof Platform.OS
-    modules.updates = new Proxy({}, { get: fail })
-    modules.deviceInfo = new Proxy({}, { get: fail })
+    const readNative = vi.fn(fail)
+    modules.updates = new Proxy({}, { get: readNative })
+    modules.deviceInfo = new Proxy({}, { get: readNative })
+
+    for (const appState of ['active', 'background', 'inactive'] as const) {
+      AppState.currentState = appState
+      expect(getExceptionContext()).toEqual({ $app_state: appState })
+    }
+    expect(readNative).not.toHaveBeenCalled()
+  })
+
+  it.each(['web', 'macos', 'windows'])('omits unknown app state on %s', (platform) => {
+    Platform.OS = platform as typeof Platform.OS
+    AppState.currentState = 'unknown'
     expect(getExceptionContext()).toEqual({})
   })
 

--- a/packages/react-native/test/exception-context.spec.ts
+++ b/packages/react-native/test/exception-context.spec.ts
@@ -29,6 +29,11 @@ describe('getExceptionContext', () => {
     expect(getExceptionContext()).toEqual({ $app_state: 'active' })
   })
 
+  it.each(['active', 'background', 'inactive', 'extension'] as const)('preserves known app state %s', (appState) => {
+    AppState.currentState = appState
+    expect(getExceptionContext()).toEqual({ $app_state: appState })
+  })
+
   it.each(['web', 'macos', 'windows'])('captures app state without reading native context on %s', (platform) => {
     Platform.OS = platform as typeof Platform.OS
     const readNative = vi.fn(fail)

--- a/packages/react-native/test/exception-context.spec.ts
+++ b/packages/react-native/test/exception-context.spec.ts
@@ -1,15 +1,10 @@
 import { AppState, Platform } from 'react-native'
 import { getExceptionContext } from '../src/error-tracking/exception-context'
 
-const modules = vi.hoisted(() => ({ updates: undefined as any, deviceInfo: undefined as any }))
+const modules = vi.hoisted(() => ({ updates: undefined as any }))
 vi.mock('../src/optional/OptionalExpoUpdates', () => ({
   get OptionalExpoUpdates() {
     return modules.updates
-  },
-}))
-vi.mock('../src/optional/OptionalReactNativeDeviceInfo', () => ({
-  get OptionalReactNativeDeviceInfo() {
-    return modules.deviceInfo
   },
 }))
 
@@ -19,7 +14,6 @@ const fail = (): never => {
 
 beforeEach(() => {
   modules.updates = undefined
-  modules.deviceInfo = undefined
   Platform.OS = 'ios'
   AppState.currentState = 'active'
 })
@@ -39,7 +33,6 @@ describe('getExceptionContext', () => {
     Platform.OS = platform as typeof Platform.OS
     const readNative = vi.fn(fail)
     modules.updates = new Proxy({}, { get: readNative })
-    modules.deviceInfo = new Proxy({}, { get: readNative })
 
     for (const appState of ['active', 'background', 'inactive'] as const) {
       AppState.currentState = appState
@@ -54,7 +47,7 @@ describe('getExceptionContext', () => {
     expect(getExceptionContext()).toEqual({})
   })
 
-  it('includes only allowlisted known OTA and power values', () => {
+  it('includes only allowlisted known OTA values', () => {
     modules.updates = {
       isEnabled: true,
       updateId: 'update-id',
@@ -64,18 +57,12 @@ describe('getExceptionContext', () => {
       manifest: { secret: 'do not collect' },
       requestHeaders: { Authorization: 'secret' },
     }
-    modules.deviceInfo = {
-      getPowerStateSync: () => ({ batteryLevel: 0, batteryState: 'unplugged', lowPowerMode: false }),
-    }
     expect(getExceptionContext()).toEqual({
       $app_state: 'active',
       $expo_update_id: 'update-id',
       $expo_runtime_version: '1.2.3',
       $expo_channel: 'production',
       $expo_is_embedded_launch: false,
-      $battery_level: 0,
-      $battery_charging: false,
-      $low_power_mode: false,
     })
   })
 
@@ -90,31 +77,17 @@ describe('getExceptionContext', () => {
     expect(getExceptionContext()).toEqual({ $app_state: 'active' })
   })
 
-  it.each([null, undefined, {}])('tolerates an unavailable power snapshot %s', (power) => {
-    modules.deviceInfo = { getPowerStateSync: () => power }
-    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
-  })
-
   it('also reads known values on Android', () => {
     Platform.OS = 'android'
     modules.updates = { isEnabled: true, isEmbeddedLaunch: true }
-    modules.deviceInfo = { getPowerStateSync: () => ({ batteryState: 'unplugged' }) }
-    expect(getExceptionContext()).toEqual({
-      $app_state: 'active',
-      $expo_is_embedded_launch: true,
-      $battery_charging: false,
-    })
+    expect(getExceptionContext()).toEqual({ $app_state: 'active', $expo_is_embedded_launch: true })
   })
 
   it('omits unsupported, unknown and incorrectly typed values', () => {
     AppState.currentState = 'unknown'
     modules.updates = { isEnabled: true, updateId: '', runtimeVersion: {}, channel: '  ', isEmbeddedLaunch: 1 }
-    modules.deviceInfo = {
-      getPowerStateSync: () => ({ batteryLevel: -1, batteryState: 'unknown', lowPowerMode: 'false' }),
-    }
     expect(getExceptionContext()).toEqual({})
     modules.updates = { isEnabled: true, updateId: 'unknown', channel: null }
-    modules.deviceInfo = {}
     expect(getExceptionContext()).toEqual({})
   })
 
@@ -128,32 +101,15 @@ describe('getExceptionContext', () => {
     expect(getExceptionContext()).toEqual({ $app_state: 'active' })
   })
 
-  it.each([-1, 1.1, NaN, Infinity, '0.5', null, undefined])('omits invalid battery level %s', (batteryLevel) => {
-    modules.deviceInfo = { getPowerStateSync: () => ({ batteryLevel }) }
-    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
-  })
-
-  it.each(['charging', 'full'])('reports %s as charging', (batteryState) => {
-    modules.deviceInfo = { getPowerStateSync: () => ({ batteryState, batteryLevel: 1, lowPowerMode: true }) }
-    expect(getExceptionContext()).toMatchObject({ $battery_charging: true, $battery_level: 1, $low_power_mode: true })
-  })
-
-  it('reads fresh conditions and OTA values rather than caching a snapshot', () => {
-    const power = { batteryLevel: 0.5 }
-    modules.deviceInfo = { getPowerStateSync: () => power }
+  it('reads fresh app state and OTA values rather than caching a snapshot', () => {
     modules.updates = { isEnabled: true, updateId: 'first' }
-    expect(getExceptionContext()).toMatchObject({ $battery_level: 0.5, $expo_update_id: 'first', $app_state: 'active' })
-    power.batteryLevel = 0.25
+    expect(getExceptionContext()).toEqual({ $expo_update_id: 'first', $app_state: 'active' })
     modules.updates.updateId = 'second'
     AppState.currentState = 'background'
-    expect(getExceptionContext()).toMatchObject({
-      $battery_level: 0.25,
-      $expo_update_id: 'second',
-      $app_state: 'background',
-    })
+    expect(getExceptionContext()).toEqual({ $expo_update_id: 'second', $app_state: 'background' })
   })
 
-  it('isolates throwing getters and native methods', () => {
+  it('isolates throwing native getters', () => {
     modules.updates = {
       isEnabled: true,
       get updateId() {
@@ -161,20 +117,8 @@ describe('getExceptionContext', () => {
       },
       channel: 'production',
     }
-    modules.deviceInfo = { getPowerStateSync: fail }
     expect(getExceptionContext()).toEqual({ $app_state: 'active', $expo_channel: 'production' })
     modules.updates = new Proxy({}, { get: fail })
-    modules.deviceInfo = {
-      getPowerStateSync: () => ({
-        batteryLevel: 0.5,
-        get batteryState() {
-          return fail()
-        },
-        lowPowerMode: true,
-      }),
-    }
-    expect(getExceptionContext()).toEqual({ $app_state: 'active', $battery_level: 0.5, $low_power_mode: true })
-    modules.deviceInfo = new Proxy({}, { get: fail })
     expect(getExceptionContext()).toEqual({ $app_state: 'active' })
   })
 

--- a/packages/react-native/test/exception-context.spec.ts
+++ b/packages/react-native/test/exception-context.spec.ts
@@ -106,6 +106,16 @@ describe('getExceptionContext', () => {
     expect(getExceptionContext()).toEqual({})
   })
 
+  it('omits boxed OTA strings', () => {
+    modules.updates = {
+      isEnabled: true,
+      updateId: Object('update-id'),
+      runtimeVersion: Object('1.2.3'),
+      channel: Object('production'),
+    }
+    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
+  })
+
   it.each([-1, 1.1, NaN, Infinity, '0.5', null, undefined])('omits invalid battery level %s', (batteryLevel) => {
     modules.deviceInfo = { getPowerStateSync: () => ({ batteryLevel }) }
     expect(getExceptionContext()).toEqual({ $app_state: 'active' })

--- a/packages/react-native/test/exception-context.spec.ts
+++ b/packages/react-native/test/exception-context.spec.ts
@@ -1,0 +1,165 @@
+import { AppState, Platform } from 'react-native'
+import { getExceptionContext } from '../src/error-tracking/exception-context'
+
+const modules = vi.hoisted(() => ({ updates: undefined as any, deviceInfo: undefined as any }))
+vi.mock('../src/optional/OptionalExpoUpdates', () => ({
+  get OptionalExpoUpdates() {
+    return modules.updates
+  },
+}))
+vi.mock('../src/optional/OptionalReactNativeDeviceInfo', () => ({
+  get OptionalReactNativeDeviceInfo() {
+    return modules.deviceInfo
+  },
+}))
+
+const fail = (): never => {
+  throw new Error('Native module unavailable')
+}
+
+beforeEach(() => {
+  modules.updates = undefined
+  modules.deviceInfo = undefined
+  Platform.OS = 'ios'
+  AppState.currentState = 'active'
+})
+
+afterEach(() => {
+  Platform.OS = 'ios'
+  AppState.currentState = 'active'
+  vi.unstubAllGlobals()
+})
+
+describe('getExceptionContext', () => {
+  it('works without optional modules, including the first app state', () => {
+    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
+  })
+
+  it.each(['web', 'macos', 'windows'])('does not read native context on %s', (platform) => {
+    Platform.OS = platform as typeof Platform.OS
+    modules.updates = new Proxy({}, { get: fail })
+    modules.deviceInfo = new Proxy({}, { get: fail })
+    expect(getExceptionContext()).toEqual({})
+  })
+
+  it('includes only allowlisted known OTA and power values', () => {
+    modules.updates = {
+      isEnabled: true,
+      updateId: 'update-id',
+      runtimeVersion: '1.2.3',
+      channel: 'production',
+      isEmbeddedLaunch: false,
+      manifest: { secret: 'do not collect' },
+      requestHeaders: { Authorization: 'secret' },
+    }
+    modules.deviceInfo = {
+      getPowerStateSync: () => ({ batteryLevel: 0, batteryState: 'unplugged', lowPowerMode: false }),
+    }
+    expect(getExceptionContext()).toEqual({
+      $app_state: 'active',
+      $expo_update_id: 'update-id',
+      $expo_runtime_version: '1.2.3',
+      $expo_channel: 'production',
+      $expo_is_embedded_launch: false,
+      $battery_level: 0,
+      $battery_charging: false,
+      $low_power_mode: false,
+    })
+  })
+
+  it.each([false, undefined, null, 'true'])('omits OTA when isEnabled is %s', (isEnabled) => {
+    modules.updates = { isEnabled, updateId: 'dev-id', runtimeVersion: 'dev', isEmbeddedLaunch: false }
+    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
+  })
+
+  it('omits OTA in development even if an optional module reports enabled', () => {
+    vi.stubGlobal('__DEV__', true)
+    modules.updates = { isEnabled: true, updateId: 'dev-id' }
+    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
+  })
+
+  it.each([null, undefined, {}])('tolerates an unavailable power snapshot %s', (power) => {
+    modules.deviceInfo = { getPowerStateSync: () => power }
+    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
+  })
+
+  it('also reads known values on Android', () => {
+    Platform.OS = 'android'
+    modules.updates = { isEnabled: true, isEmbeddedLaunch: true }
+    modules.deviceInfo = { getPowerStateSync: () => ({ batteryState: 'unplugged' }) }
+    expect(getExceptionContext()).toEqual({
+      $app_state: 'active',
+      $expo_is_embedded_launch: true,
+      $battery_charging: false,
+    })
+  })
+
+  it('omits unsupported, unknown and incorrectly typed values', () => {
+    AppState.currentState = 'unknown'
+    modules.updates = { isEnabled: true, updateId: '', runtimeVersion: {}, channel: '  ', isEmbeddedLaunch: 1 }
+    modules.deviceInfo = {
+      getPowerStateSync: () => ({ batteryLevel: -1, batteryState: 'unknown', lowPowerMode: 'false' }),
+    }
+    expect(getExceptionContext()).toEqual({})
+    modules.updates = { isEnabled: true, updateId: 'unknown', channel: null }
+    modules.deviceInfo = {}
+    expect(getExceptionContext()).toEqual({})
+  })
+
+  it.each([-1, 1.1, NaN, Infinity, '0.5', null, undefined])('omits invalid battery level %s', (batteryLevel) => {
+    modules.deviceInfo = { getPowerStateSync: () => ({ batteryLevel }) }
+    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
+  })
+
+  it.each(['charging', 'full'])('reports %s as charging', (batteryState) => {
+    modules.deviceInfo = { getPowerStateSync: () => ({ batteryState, batteryLevel: 1, lowPowerMode: true }) }
+    expect(getExceptionContext()).toMatchObject({ $battery_charging: true, $battery_level: 1, $low_power_mode: true })
+  })
+
+  it('reads fresh conditions and OTA values rather than caching a snapshot', () => {
+    const power = { batteryLevel: 0.5 }
+    modules.deviceInfo = { getPowerStateSync: () => power }
+    modules.updates = { isEnabled: true, updateId: 'first' }
+    expect(getExceptionContext()).toMatchObject({ $battery_level: 0.5, $expo_update_id: 'first', $app_state: 'active' })
+    power.batteryLevel = 0.25
+    modules.updates.updateId = 'second'
+    AppState.currentState = 'background'
+    expect(getExceptionContext()).toMatchObject({
+      $battery_level: 0.25,
+      $expo_update_id: 'second',
+      $app_state: 'background',
+    })
+  })
+
+  it('isolates throwing getters and native methods', () => {
+    modules.updates = {
+      isEnabled: true,
+      get updateId() {
+        return fail()
+      },
+      channel: 'production',
+    }
+    modules.deviceInfo = { getPowerStateSync: fail }
+    expect(getExceptionContext()).toEqual({ $app_state: 'active', $expo_channel: 'production' })
+    modules.updates = new Proxy({}, { get: fail })
+    modules.deviceInfo = {
+      getPowerStateSync: () => ({
+        batteryLevel: 0.5,
+        get batteryState() {
+          return fail()
+        },
+        lowPowerMode: true,
+      }),
+    }
+    expect(getExceptionContext()).toEqual({ $app_state: 'active', $battery_level: 0.5, $low_power_mode: true })
+    modules.deviceInfo = new Proxy({}, { get: fail })
+    expect(getExceptionContext()).toEqual({ $app_state: 'active' })
+  })
+
+  it('omits unknown initial app state and accepts inactive', () => {
+    AppState.currentState = null as any
+    expect(getExceptionContext()).toEqual({})
+    AppState.currentState = 'inactive'
+    expect(getExceptionContext()).toEqual({ $app_state: 'inactive' })
+  })
+})

--- a/packages/react-native/test/optional-expo-updates.spec.ts
+++ b/packages/react-native/test/optional-expo-updates.spec.ts
@@ -1,0 +1,93 @@
+import { execFileSync } from 'child_process'
+import { mkdtempSync, mkdirSync, copyFileSync, writeFileSync, rmSync, readFileSync, realpathSync } from 'fs'
+import { createRequire } from 'module'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+
+// test:unit depends on build in Turbo. Exercise the emitted loader with Node's actual require
+// resolution, outside this workspace's installed Expo modules and Vitest's module mocks.
+const loadOptionalExpoUpdates = (platform: string, moduleSource?: string): unknown => {
+  const directory = mkdtempSync(join(tmpdir(), 'posthog-optional-expo-updates-'))
+  try {
+    copyFileSync(resolve(__dirname, '../dist/optional/OptionalExpoUpdates.js'), join(directory, 'loader.cjs'))
+    const nativeDirectory = join(directory, 'node_modules/react-native')
+    mkdirSync(nativeDirectory, { recursive: true })
+    writeFileSync(join(nativeDirectory, 'index.js'), `exports.Platform = { OS: ${JSON.stringify(platform)} }`)
+    if (moduleSource !== undefined) {
+      const updatesDirectory = join(directory, 'node_modules/expo-updates')
+      mkdirSync(updatesDirectory, { recursive: true })
+      writeFileSync(join(updatesDirectory, 'index.js'), moduleSource)
+    }
+    return JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          '-e',
+          "console.log(JSON.stringify({ value: require('./loader.cjs').OptionalExpoUpdates, loaded: global.updatesLoaded === true }))",
+        ],
+        { cwd: directory, encoding: 'utf8' }
+      )
+    )
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+describe('OptionalExpoUpdates built loader', () => {
+  it('marks expo-updates as optional in the emitted Metro dependency graph', () => {
+    // Resolve from Metro's real location so pnpm's transitive Babel dependency is available.
+    const metroRequire = createRequire(realpathSync(resolve(__dirname, '../node_modules/metro/package.json')))
+    const parser = metroRequire('@babel/parser')
+    const collectDependencies = metroRequire('./src/ModuleGraph/worker/collectDependencies.js')
+    const source = readFileSync(resolve(__dirname, '../dist/optional/OptionalExpoUpdates.js'), 'utf8')
+    const { dependencies } = collectDependencies(parser.parse(source), {
+      asyncRequireModulePath: 'metro-runtime/src/modules/asyncRequire',
+      dynamicRequires: 'reject',
+      inlineableCalls: [],
+      keepRequireNames: true,
+      allowOptionalDependencies: true,
+      unstable_allowRequireContext: false,
+    })
+
+    expect(dependencies).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'expo-updates', data: expect.objectContaining({ isOptional: true }) }),
+      ])
+    )
+  })
+
+  it.each(['ios', 'android'])('tolerates an actually missing module on %s', (platform) => {
+    expect(loadOptionalExpoUpdates(platform)).toEqual({ loaded: false })
+  })
+
+  it('loads available public constants', () => {
+    expect(
+      loadOptionalExpoUpdates(
+        'ios',
+        "global.updatesLoaded = true; exports.isEnabled = true; exports.updateId = 'ota-id'"
+      )
+    ).toEqual({
+      loaded: true,
+      value: { isEnabled: true, updateId: 'ota-id' },
+    })
+  })
+
+  it('tolerates module initialization failure (e.g. unlinked or Expo Go)', () => {
+    expect(loadOptionalExpoUpdates('ios', "global.updatesLoaded = true; throw new Error('unlinked')")).toEqual({
+      loaded: true,
+    })
+  })
+
+  it('accepts older modules with missing APIs', () => {
+    expect(loadOptionalExpoUpdates('ios', "global.updatesLoaded = true; exports.updateId = 'old-id'")).toEqual({
+      loaded: true,
+      value: { updateId: 'old-id' },
+    })
+  })
+
+  it.each(['web', 'macos', 'windows'])('does not even initialize the optional module on %s', (platform) => {
+    expect(loadOptionalExpoUpdates(platform, "global.updatesLoaded = true; throw new Error('unsupported')")).toEqual({
+      loaded: false,
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1022,6 +1022,9 @@ importers:
       expo-localization:
         specifier: ^11.0.0
         version: 11.0.0
+      expo-updates:
+        specifier: 0.25.0
+        version: 0.25.0(expo@45.0.8(@babel/core@7.28.5))
       jsdom:
         specifier: 'catalog:'
         version: 26.1.0
@@ -4430,14 +4433,23 @@ packages:
   '@expo/code-signing-certificates@0.0.2':
     resolution: {integrity: sha512-vnPHFjwOqxQ1VLztktY+fYCfwvLzjqpzKn09rchcQE7Sdf0wtW5fFtIZBEFOOY5wasp8tXSnp627zrAwazPHzg==}
 
+  '@expo/code-signing-certificates@0.0.5':
+    resolution: {integrity: sha512-BNhXkY1bblxKZpltzAx98G2Egj9g1Q+JRcvR7E99DOj862FTCX+ZPsAUtPTr7aHxwtrL7+fL3r0JSmM9kBm+Bw==}
+
   '@expo/config-plugins@10.1.2':
     resolution: {integrity: sha512-IMYCxBOcnuFStuK0Ay+FzEIBKrwW8OVUMc65+v0+i7YFIIe8aL342l7T4F8lR4oCfhXn7d6M5QPgXvjtc/gAcw==}
 
   '@expo/config-plugins@4.1.5':
     resolution: {integrity: sha512-RVvU40RtZt12HavuDAe+LDIq9lHj7sheOfMEHdmpJ/uTA8pgvkbc56XF6JHQD+yRr6+uhhb+JnAasGq49dsQbw==}
 
+  '@expo/config-plugins@8.0.11':
+    resolution: {integrity: sha512-oALE1HwnLFthrobAcC9ocnR9KXLzfWEjgIe4CPe+rDsfC6GDs8dGYCXfRFoCEzoLN4TGYs9RdZ8r0KoCcNrm2A==}
+
   '@expo/config-types@45.0.0':
     resolution: {integrity: sha512-/QGhhLWyaGautgEyU50UJr5YqKJix5t77ePTwreOVAhmZH+ff3nrrtYTTnccx+qF08ZNQmfAyYMCD3rQfzpiJA==}
+
+  '@expo/config-types@51.0.3':
+    resolution: {integrity: sha512-hMfuq++b8VySb+m9uNNrlpbvGxYc8OcFCUX9yTmi9tlx6A4k8SDabWFBgmnr4ao3wEArvWrtUQIfQCVtPRdpKA==}
 
   '@expo/config-types@53.0.5':
     resolution: {integrity: sha512-kqZ0w44E+HEGBjy+Lpyn0BVL5UANg/tmNixxaRMLS6nf37YsDrLk2VMAmeKMMk5CKG0NmOdVv3ngeUjRQMsy9g==}
@@ -4448,6 +4460,9 @@ packages:
   '@expo/config@6.0.26':
     resolution: {integrity: sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==}
 
+  '@expo/config@9.0.4':
+    resolution: {integrity: sha512-g5ns5u1JSKudHYhjo1zaSfkJ/iZIcWmUmIQptMJZ6ag1C0ShL2sj8qdfU8MmAMuKLOgcIfSaiWlQnm4X3VJVkg==}
+
   '@expo/dev-server@0.1.116':
     resolution: {integrity: sha512-jUyOv3S55wBsYiFhiYVz35Ui8QTnUGVKlsPRgQHnKU70Ey4jxJqObtGkNnrgazzDfy9S7qFJKiyJQro7621ipA==}
 
@@ -4456,6 +4471,10 @@ packages:
 
   '@expo/env@1.0.7':
     resolution: {integrity: sha512-qSTEnwvuYJ3umapO9XJtrb1fAqiPlmUUg78N0IZXXGwQRt+bkp0OBls+Y5Mxw/Owj8waAM0Z3huKKskRADR5ow==}
+
+  '@expo/fingerprint@0.7.1':
+    resolution: {integrity: sha512-lbTwFiIk0lOm9zzPRvnC45GfPqXqPB3w4hDDKVma+8FDAbPCWhNN42ltLhx/ekwcHFQxURmg0fHm59k0Vy+jtw==}
+    hasBin: true
 
   '@expo/image-utils@0.3.21':
     resolution: {integrity: sha512-Ha7pNcpl52RJIeYz3gR1ajOgPPl7WLZWiLqtLi94s9J0a7FvmNBMqd/VKrfHNj8QmtZxXcmXr7y7tPhZbVFg7w==}
@@ -4489,6 +4508,9 @@ packages:
   '@expo/plist@0.0.18':
     resolution: {integrity: sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==}
 
+  '@expo/plist@0.1.3':
+    resolution: {integrity: sha512-GW/7hVlAylYg1tUrEASclw1MMk9FP4ZwyFAY/SUTJIhPDQHtfOlXREyWV3hhrHdX/K+pS73GNgdfT6E/e+kBbg==}
+
   '@expo/plist@0.3.5':
     resolution: {integrity: sha512-9RYVU1iGyCJ7vWfg3e7c/NVyMFs8wbl+dMWZphtFtsqyN9zppGREU3ctlD3i8KUE0sCUTVnLjCWr+VeUIDep2g==}
 
@@ -4508,6 +4530,10 @@ packages:
 
   '@expo/spawn-async@1.7.2':
     resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
+    engines: {node: '>=12'}
+
+  '@expo/spawn-async@1.8.0':
+    resolution: {integrity: sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==}
     engines: {node: '>=12'}
 
   '@expo/sudo-prompt@9.3.2':
@@ -10735,6 +10761,9 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-eas-client@0.12.0:
+    resolution: {integrity: sha512-Jkww9Cwpv0z7DdLYiRX0r4fqBEcI9cKqTn7cHx63S09JaZ2rcwEE4zYHgrXwjahO+tU2VW8zqH+AJl6RhhW4zA==}
+
   expo-error-recovery@3.1.0:
     resolution: {integrity: sha512-qUxCW7kPB6AVX5h3ZPVnxw4LLZWsRwAPBtRDlh1UDN7GWZ+CQN1SNk0w0BPotjNtSlXEZSFDqKqtoDDAUYjNmg==}
     peerDependencies:
@@ -10755,6 +10784,9 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-json-utils@0.13.1:
+    resolution: {integrity: sha512-mlfaSArGVb+oJmUcR22jEONlgPp0wj4iNIHfQ2je9Q8WTOqMc0Ws9tUciz3JdJnhffdHqo/k8fpvf0IRmN5HPA==}
+
   expo-keep-awake@10.1.1:
     resolution: {integrity: sha512-9zC0sdhQljUeMr2yQ7o4kzEZXVAy82fFOAZE1+TwPL7qR0b0sphe7OJ5T1GX1qLcwuVaJ8YewaPoLSHRk79+Rg==}
     peerDependencies:
@@ -10762,6 +10794,11 @@ packages:
 
   expo-localization@11.0.0:
     resolution: {integrity: sha512-LLK7+pYScM5ob8/IsnCb4JVQb6AvWP5anTIikaZmpz7XCUJ0KHaCPY8YfUjVSSwWspSMLxpqKEZtAra+bHxYZA==}
+
+  expo-manifests@0.14.3:
+    resolution: {integrity: sha512-L3b5/qocBPiQjbW0cpOHfnqdKZbTJS7sA3mgeDJT+mWga/xYsdpma1EfNmsuvrOzjLGjStr1k1fceM9Bl49aqQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-modules-autolinking@0.8.1:
     resolution: {integrity: sha512-S8qfaXCv//7tQWV9M+JKx3CF7ypYhDdSUbkUQdaVO/r8D76/aRTArY/aRw1yEfaAOzyK8C8diDToV1itl51DfQ==}
@@ -10773,6 +10810,20 @@ packages:
 
   expo-modules-core@0.9.2:
     resolution: {integrity: sha512-p/C0GJxFIIDGwmrWi70Q0ggfsgeUFS25ZkkBgoaHT7MVgiMjlKA/DCC3D6ZUkHl/JlzUm0aTftIGS8LWXsnZBw==}
+
+  expo-structured-headers@3.8.0:
+    resolution: {integrity: sha512-R+gFGn0x5CWl4OVlk2j1bJTJIz4KO8mPoCHpRHmfqMjmrMvrOM0qQSY3V5NHXwp1yT/L2v8aUmFQsBRIdvi1XA==}
+
+  expo-updates-interface@0.16.2:
+    resolution: {integrity: sha512-929XBU70q5ELxkKADj1xL0UIm3HvhYhNAOZv5DSk7rrKvLo7QDdPyl+JVnwZm9LrkNbH4wuE2rLoKu1KMgZ+9A==}
+    peerDependencies:
+      expo: '*'
+
+  expo-updates@0.25.0:
+    resolution: {integrity: sha512-21qr+I6cKes5ToTz9FFYLqcSYNXH2GJL4bLWfP0MVijLAqbO5yhGDeSuMOhQ0UhimGDrgVpbLtVS2S6iZyfCog==}
+    hasBin: true
+    peerDependencies:
+      expo: '*'
 
   expo@45.0.8:
     resolution: {integrity: sha512-1dSMiodS7t44+1jijPL6ky1CRR/L2pPhrDoaSDo4WBS9ntEa1hEBhC+qa1Th5VkjqG9qkR73AGRgx4h8ozRvsA==}
@@ -16348,6 +16399,11 @@ packages:
     peerDependencies:
       postcss: ^8.5.15
 
+  sucrase@3.34.0:
+    resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -21853,6 +21909,11 @@ snapshots:
       node-forge: 1.3.2
       nullthrows: 1.1.1
 
+  '@expo/code-signing-certificates@0.0.5':
+    dependencies:
+      node-forge: 1.3.2
+      nullthrows: 1.1.1
+
   '@expo/config-plugins@10.1.2':
     dependencies:
       '@expo/config-types': 53.0.5
@@ -21892,7 +21953,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config-plugins@8.0.11':
+    dependencies:
+      '@expo/config-types': 51.0.3
+      '@expo/json-file': 8.3.3
+      '@expo/plist': 0.1.3
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      find-up: 5.0.0
+      getenv: 1.0.0
+      glob: 7.1.6
+      resolve-from: 5.0.0
+      semver: 7.8.5
+      slash: 3.0.0
+      slugify: 1.6.9
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/config-types@45.0.0': {}
+
+  '@expo/config-types@51.0.3': {}
 
   '@expo/config-types@53.0.5': {}
 
@@ -21930,6 +22013,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config@9.0.4':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@expo/config-plugins': 8.0.11
+      '@expo/config-types': 51.0.3
+      '@expo/json-file': 8.3.3
+      getenv: 1.0.0
+      glob: 7.1.6
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
+      semver: 7.8.5
+      slugify: 1.6.9
+      sucrase: 3.34.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/dev-server@0.1.116':
     dependencies:
       '@expo/bunyan': 4.0.0
@@ -21964,6 +22063,19 @@ snapshots:
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
       getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/fingerprint@0.7.1':
+    dependencies:
+      '@expo/spawn-async': 1.8.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      find-up: 5.0.0
+      minimatch: 3.1.5
+      p-limit: 3.1.0
+      resolve-from: 5.0.0
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -22066,6 +22178,12 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 14.0.0
 
+  '@expo/plist@0.1.3':
+    dependencies:
+      '@xmldom/xmldom': 0.7.13
+      base64-js: 1.5.1
+      xmlbuilder: 14.0.0
+
   '@expo/plist@0.3.5':
     dependencies:
       '@xmldom/xmldom': 0.8.14
@@ -22108,6 +22226,10 @@ snapshots:
       cross-spawn: 6.0.6
 
   '@expo/spawn-async@1.7.2':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@expo/spawn-async@1.8.0':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -29923,6 +30045,8 @@ snapshots:
       expo: 45.0.8(@babel/core@7.28.5)
       ua-parser-js: 0.7.40
 
+  expo-eas-client@0.12.0: {}
+
   expo-error-recovery@3.1.0(expo@45.0.8(@babel/core@7.28.5)):
     dependencies:
       expo: 45.0.8(@babel/core@7.28.5)
@@ -29949,6 +30073,8 @@ snapshots:
       expo: 45.0.8(@babel/core@7.28.5)
       fontfaceobserver: 2.3.0
 
+  expo-json-utils@0.13.1: {}
+
   expo-keep-awake@10.1.1(expo@45.0.8(@babel/core@7.28.5)):
     dependencies:
       expo: 45.0.8(@babel/core@7.28.5)
@@ -29956,6 +30082,14 @@ snapshots:
   expo-localization@11.0.0:
     dependencies:
       rtl-detect: 1.1.2
+
+  expo-manifests@0.14.3(expo@45.0.8(@babel/core@7.28.5)):
+    dependencies:
+      '@expo/config': 9.0.4
+      expo: 45.0.8(@babel/core@7.28.5)
+      expo-json-utils: 0.13.1
+    transitivePeerDependencies:
+      - supports-color
 
   expo-modules-autolinking@0.8.1:
     dependencies:
@@ -29977,6 +30111,34 @@ snapshots:
     dependencies:
       compare-versions: 3.6.0
       invariant: 2.2.4
+
+  expo-structured-headers@3.8.0: {}
+
+  expo-updates-interface@0.16.2(expo@45.0.8(@babel/core@7.28.5)):
+    dependencies:
+      expo: 45.0.8(@babel/core@7.28.5)
+
+  expo-updates@0.25.0(expo@45.0.8(@babel/core@7.28.5)):
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.5
+      '@expo/config': 9.0.4
+      '@expo/config-plugins': 8.0.11
+      '@expo/fingerprint': 0.7.1
+      '@expo/spawn-async': 1.8.0
+      arg: 4.1.0
+      chalk: 4.1.2
+      expo: 45.0.8(@babel/core@7.28.5)
+      expo-eas-client: 0.12.0
+      expo-manifests: 0.14.3(expo@45.0.8(@babel/core@7.28.5))
+      expo-structured-headers: 3.8.0
+      expo-updates-interface: 0.16.2(expo@45.0.8(@babel/core@7.28.5))
+      fast-glob: 3.3.3
+      fbemitter: 3.0.0
+      ignore: 5.3.2
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   expo@45.0.8(@babel/core@7.28.5):
     dependencies:
@@ -37166,6 +37328,16 @@ snapshots:
       browserslist: 4.28.7
       postcss: 8.5.24
       postcss-selector-parser: 7.1.4
+
+  sucrase@3.34.0:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      glob: 7.1.6
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      ts-interface-checker: 0.1.13
 
   sucrase@3.35.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1023,7 +1023,7 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       expo-updates:
-        specifier: 0.25.0
+        specifier: ^0.25.0
         version: 0.25.0(expo@45.0.8(@babel/core@7.28.5))
       jsdom:
         specifier: 'catalog:'


### PR DESCRIPTION
## Problem

React Native JavaScript exceptions include native app metadata, but do not show which Expo update was running or the app state when the exception occurred. This makes it harder to distinguish errors after an OTA update or while the app is backgrounded.

## Changes

Add capture-time app state to JavaScript exceptions on any platform where React Native AppState provides a known value. On iOS and Android, when the app already has `expo-updates` installed, include its four public update fields. Unknown or failing fields are omitted. Expo update fields are omitted in development or when Updates is not enabled.

Explicit `additionalProperties` override the new context defaults. Context enrichment runs alongside exception steps without an extra disabled/opt-out guard. Core still suppresses events for disabled or opted-out clients, and `before_send` keeps its existing behavior. The customer-facing Expo Updates peer is optional with a minimum version of `>= 0.25.0`, matching the range convention used by the other Expo peers. Its development range is `^0.25.0`, consistent with the other Expo devDependencies, with the test lockfile still resolving `0.25.0`. The optional loader keeps its `require` directly inside `try` so Metro can recognize it as optional. This does not change native crash collection, HTTP retries or persistence. The branch includes the fatal-persistence fix from #4896 unchanged. Battery, charging and low-power context are deferred to a separate PR; this PR does not call `getPowerStateSync`.

The existing `trySafe` helper now lives in `@posthog/core` and is reused by exception context. Browser-common keeps its existing export as a re-export, so browser imports continue to work. Both packages already depend on core; this adds no dependency. String validation also reuses core’s empty-string check while keeping primitive-string validation and the Expo-specific `"unknown"` exclusion local.

The Expo 57 sample now includes compatible `expo-updates ~57.0.21` and documents how to enable Updates for release-mode exception testing. Default sample OTA configuration remains disabled; test app IDs, URLs, instrumentation and tokens are not committed.

### Validation

- Review fixes in `aa1b3c859`: preserved the valid `extension` app state with a regression that failed before the fix, and moved exception-context prose out of `@example` into the method description. All 840 RN tests in 55 files and all eight forced build/test/lint/reference tasks passed. Verified all 11 inline-code identifiers remain in the generated description, both code examples are preserved, and a second generation is byte-identical. These follow-up changes were validated directly without subagents; no new native iOS-extension run was performed.
- With Node 24.18.1 and pnpm 11.7.0, ran `pnpm turbo run build test:unit lint generate-references --filter=posthog-react-native --force` after the capture-path and development-range updates. All eight tasks passed without cache hits. All 836 tests in 55 files passed, including the fatal-persistence regressions and 36 exception-context tests. The new boxed-string regression passed before and after the refactor, confirming that validation still accepts only primitive strings.
- Cross-platform app-state regressions failed on web, macOS and Windows before the fix and passed afterward. Tests cover active/background/inactive states, omission of unknown states, and no Expo access on those platforms. This is unit-test coverage, not native execution on those operating systems.
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts --offline` passed. The optional peer is `>= 0.25.0`, the dev range is `^0.25.0`, and the locked test version remains `0.25.0`. No resolved dependency versions changed in the root lockfile. The peer-minimum-only update was validated with this frozen-lockfile check and manifest assertions.
- Core: 1,246 tests passed, one existing skip. Browser-common: 119 tests passed. The browser toolbar consumer passed all 12 tests. Built CommonJS and ESM checks confirmed browser-common re-exports the core function.
- Regenerated references after committing and verified they match committed bytes. Source lint and formatting passed.
- Isolated Pi autoreview of the initial implementation, `fae87fe4`, against `origin/main` reported no actionable findings. The later utility-reuse, app-state platform, power-scope removal, capture-path, dependency-range and release-metadata updates were reviewed directly and validated with the checks above, without subagents.
- Historical Android emulator validation of the pre-sync candidate used the full SDK in bare RN 0.79.6 with Expo absent and Expo 53 / Updates 0.28.18 release and debug apps. Its relevant coverage includes app state, embedded updates and a downloaded local OTA update. That validation did not execute this final merged commit.

- Direct follow-up validation used the full Expo 57 sample on Android emulator `emulator-5554` (API 36, arm64): Expo 57.0.15 / RN 0.86.2 / Updates 57.0.21. Fresh SDK tarballs from `b70e8635a` matched installed files and release Metro source contents; `e7c8d76ba` changes only the example dependency, lockfile and README, leaving that SDK source unchanged. A non-debuggable release copy with test-only Updates configuration captured three exceptions across foreground → background → foreground. All four Expo fields matched native exports and `$app_state` matched active/background/active. Existing app version/build were retained and power fields absent.
- Those three exceptions successfully flushed through actual SDK US Cloud transport. Evidence is successful SDK flush notifications, not a backend query. The first attempt encountered a network error; the instrumented retry passed without changing SDK retry/drop behavior. The test app and collector were removed; battery, low-power and adb reverse state were unchanged, and unrelated Metro was untouched. Sample formatting and frozen/offline installation passed. No additional unit-suite run was needed for the example-only changes.

Current Expo 57 coverage is an embedded Android release launch, not a downloaded OTA or development-mode test. iOS, physical devices, Expo Go, older installed Expo APIs and signed or remote OTA updates remain unvalidated. Bare Metro validation used `allowOptionalDependencies: true`. Fatal native delivery was not validated by these context tests.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [x] @posthog/browser-common
- [x] @posthog/core

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

The React Native changeset requests a minor release for this new exception context. Core and browser-common have patch changesets for the shared utility.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi assisted with implementation, tests, source review and PR preparation. The isolated autoreview helper used Pi with tools disabled. The human-directed scope is Expo update metadata, app state and sharing the existing safe-call utility through core. Power collection was removed for a separate PR. Initial Android evidence is retained separately from the later full Expo 57 sample run, which was performed directly without subagents against the current SDK source. The latest fatal-persistence change was integrated without changing its behavior. Human review is required before merging.
