### PR TITLE
fix(react-native): keep exception screen attribution current

### DIFF
--- a/.changeset/tidy-ants-see.md
+++ b/.changeset/tidy-ants-see.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix stale screen names on React Native exceptions and focused nested screen tracking.

--- a/.changeset/tidy-ants-see.md
+++ b/.changeset/tidy-ants-see.md
@@ -2,4 +2,4 @@
 'posthog-react-native': patch
 ---
 
-Fix stale screen names on React Native exceptions and focused nested screen tracking.
+Fix stale screen names on React Native exceptions and missed screen tracking on tab changes.

--- a/examples/example-expo-57/README.md
+++ b/examples/example-expo-57/README.md
@@ -35,6 +35,16 @@ To run from Xcode instead, open `ios/exampleexpo57.xcworkspace`, select an iOS s
 
 Set `EXPO_PUBLIC_POSTHOG_PROJECT_API_KEY` and `EXPO_PUBLIC_POSTHOG_API_HOST` in your environment to enable the PostHog client. The example still launches without them, but PostHog is disabled.
 
+## Screen names on errors
+
+`app/_layout.tsx` disables automatic screen capture and calls `posthog.screen()` when the Expo Router segments change. It uses route templates (for example, `users/[id]`), not resolved pathnames, query strings, or route parameters. The existing pathname check only controls survey presentation.
+
+`screen()` records `$screen_name` for subsequent events, including `captureException()` and `PostHogErrorBoundary` errors. Once the client is initialized, recording a screen updates the context immediately without awaiting the screen event. During initialization, screen registration and event capture retain their call order. Each client keeps its own last recorded screen; explicit exception properties and `before_send` can override or remove it. Screen properties other than the name are not automatically added to errors.
+
+Attribution means **last recorded screen**, not necessarily a destination whose render failed before the tracking effect ran. A root error boundary can catch an error before any route has been recorded. Supply an explicit safe `$screen_name` through the boundary's `additionalProperties` or `captureException()` when that context is known. Skipping a manual screen call leaves the previously recorded name in place.
+
+For React Navigation manual tracking, use the container's `getCurrentRoute()` in **both** `onReady` and `onStateChange`, call `posthog.screen()` with a safe route name, and keep `captureScreens: false` on `PostHogProvider` to avoid duplicates. `getCurrentRoute()` resolves the focused nested route. Do not send route params or resolved URLs as screen names. When using supported automatic tracking, `navigation.routeToName` can return a nonempty safe replacement name; returning an empty string is not a supported suppression mechanism. Disabling automatic screens does not disable explicitly requested manual `screen()` calls.
+
 ## Test local SDK changes
 
 Run the package watcher from the repository root:

--- a/examples/example-expo-57/app/_layout.tsx
+++ b/examples/example-expo-57/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from 'expo-router/react-navigation'
 import { useFonts } from 'expo-font'
-import { Stack, usePathname } from 'expo-router'
+import { Stack, usePathname, useSegments } from 'expo-router'
+import { useEffect } from 'react'
 import { StatusBar } from 'expo-status-bar'
 import 'react-native-reanimated'
 
@@ -21,8 +22,18 @@ export default function RootLayout() {
     const autoPresentSurveys = pathname !== '/surveys'
 
     const [loaded] = useFonts({
+        // oxlint-disable-next-line typescript/no-require-imports -- Metro loads font assets through static require calls.
         SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
     })
+
+    // Segments retain route templates such as [id], unlike a pathname containing user identifiers.
+    const segments = useSegments()
+    const screenName = segments.join('/') || 'index'
+    useEffect(() => {
+        if (loaded) {
+            void posthog.screen(screenName)
+        }
+    }, [loaded, screenName])
 
     if (!loaded) {
         // Async font loading only occurs in development.

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -1089,7 +1089,7 @@
         {
           "category": "Capture",
           "description": "Captures a screen view event.",
-          "details": "This function requires a name. You may also pass in an optional properties object. Screen name is automatically registered for the session and will be included in subsequent events.",
+          "details": "This function requires a name. You may also pass in an optional properties object. Once initialized, the screen name is registered immediately for subsequent events, including exceptions. During initialization, screen registration and event capture retain their call order. Exceptions use the last recorded screen, not a destination that has not yet been tracked.",
           "id": "screen",
           "showDocs": true,
           "title": "screen",

--- a/packages/react-native/src/hooks/useNavigationTracker.ts
+++ b/packages/react-native/src/hooks/useNavigationTracker.ts
@@ -84,16 +84,6 @@ function _useNavigationTracker(
       return
     }
 
-    // Follow the focused child, not the last mounted tab or stack route.
-    // Partial navigation state can omit index, in which case the first route is focused.
-    while (currentRoute.state?.routes?.length) {
-      const state = currentRoute.state
-      const route = state.routes[state.index ?? 0]
-      if (!route) {
-        return
-      }
-      currentRoute = route
-    }
     const { name, params } = currentRoute
 
     const currentRouteName = options?.routeToName?.(name, params) || name || 'Unknown'

--- a/packages/react-native/src/hooks/useNavigationTracker.ts
+++ b/packages/react-native/src/hooks/useNavigationTracker.ts
@@ -22,12 +22,12 @@ function _useNavigationTracker(
     throw new Error('No OptionalReactNativeNavigation')
   }
 
-  let routes: any = undefined
+  let navigationState: any = undefined
   let navigation: any = navigationRef
 
   try {
     // oxlint-disable-next-line react/rules-of-hooks
-    routes = OptionalReactNativeNavigation.useNavigationState((state: any) => state?.routes)
+    navigationState = OptionalReactNativeNavigation.useNavigationState((state: any) => state)
   } catch (error) {
     // useNavigationState might not be available in static navigation setups
     // We'll rely on the navigation object to get the current route
@@ -58,7 +58,7 @@ function _useNavigationTracker(
       currentNavigation = navigation.current
     }
 
-    let currentRoute = undefined
+    let currentRoute: any = undefined
 
     // NOTE: This method is not typed correctly but is available and takes care of parsing the router state correctly
     try {
@@ -84,14 +84,17 @@ function _useNavigationTracker(
       return
     }
 
-    const { state } = currentRoute
-    let { name, params } = currentRoute
-
-    if (state?.routes?.length) {
-      const route = state.routes[state.routes.length - 1]
-      name = route.name
-      params = route.params
+    // Follow the focused child, not the last mounted tab or stack route.
+    // Partial navigation state can omit index, in which case the first route is focused.
+    while (currentRoute.state?.routes?.length) {
+      const state = currentRoute.state
+      const route = state.routes[state.index ?? 0]
+      if (!route) {
+        return
+      }
+      currentRoute = route
     }
+    const { name, params } = currentRoute
 
     const currentRouteName = options?.routeToName?.(name, params) || name || 'Unknown'
 
@@ -105,12 +108,12 @@ function _useNavigationTracker(
   useEffect(() => {
     // NOTE: The navigation stacks may not be fully rendered initially. This means the first route can be missed (it doesn't update useNavigationState)
     // If missing we simply wait a tick and call it again.
-    if (!routes) {
-      setTimeout(trackRoute, 1)
-      return
+    if (!navigationState) {
+      const timeout = setTimeout(trackRoute, 1)
+      return () => clearTimeout(timeout)
     }
     trackRoute()
-  }, [routes, trackRoute])
+  }, [navigationState, trackRoute])
 }
 
 export const useNavigationTracker = OptionalReactNativeNavigation

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1465,7 +1465,9 @@ export class PostHog extends PostHogCore {
    *
    * @remarks
    * This function requires a name. You may also pass in an optional properties object.
-   * Screen name is automatically registered for the session and will be included in subsequent events.
+   * Once initialized, the screen name is registered immediately for subsequent events, including exceptions.
+   * During initialization, screen registration and event capture retain their call order.
+   * Exceptions use the last recorded screen, not a destination that has not yet been tracked.
    *
    * {@label Capture}
    *
@@ -1491,8 +1493,10 @@ export class PostHog extends PostHogCore {
    * @param options - Optional capture options
    */
   async screen(name: string, properties?: PostHogEventProperties, options?: PostHogCaptureOptions): Promise<void> {
-    await this._initPromise
-    // Screen name is good to know for all other subsequent events
+    // Keep queued captures in order during initialization, without yielding once the client is ready.
+    if (!this._isInitialized) {
+      await this._initPromise
+    }
     this.registerForSession({
       $screen_name: name,
     })

--- a/packages/react-native/test/screen-error-attribution.spec.tsx
+++ b/packages/react-native/test/screen-error-attribution.spec.tsx
@@ -1,0 +1,300 @@
+/** @vitest-environment jsdom */
+import React from 'react'
+import { cleanup, render } from '@testing-library/react'
+import { AppState, Linking } from 'react-native'
+import { PostHog, PostHogErrorBoundary, PostHogProvider } from '../src'
+import type { PostHogOptions } from '../src'
+
+// Screen context does not depend on Expo or a navigation integration being installed.
+vi.mock('../src/optional/OptionalReactNativeNavigation', () => ({ OptionalReactNativeNavigation: undefined }))
+vi.mock('../src/optional/OptionalExpoApplication', () => ({ OptionalExpoApplication: undefined }))
+vi.mock('../src/optional/OptionalExpoDevice', () => ({ OptionalExpoDevice: undefined }))
+vi.mock('../src/optional/OptionalExpoLocalization', () => ({ OptionalExpoLocalization: undefined }))
+
+Linking.getInitialURL = vi.fn(() => Promise.resolve(null))
+AppState.addEventListener = vi.fn()
+vi.useRealTimers()
+
+const clients: PostHog[] = []
+function createClient(options: PostHogOptions = {}): { client: PostHog; events: any[] } {
+  const events: any[] = []
+  const client = new PostHog('test-token', {
+    persistence: 'memory',
+    flushInterval: 0,
+    captureAppLifecycleEvents: false,
+    preloadFeatureFlags: false,
+    before_send: (event) => {
+      events.push(event)
+      return event
+    },
+    ...options,
+  })
+  clients.push(client)
+  return { client, events }
+}
+
+const exceptions = (events: any[]): any[] => events.filter((event) => event.event === '$exception')
+
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({ status: 200, json: async () => ({}) })) as any
+})
+
+afterEach(async () => {
+  cleanup()
+  await Promise.all(clients.splice(0).map((client) => client.shutdown()))
+  vi.restoreAllMocks()
+})
+
+describe('screen error attribution', () => {
+  it('attributes same-turn exceptions to the initial screen and subsequent screen', async () => {
+    const { client, events } = createClient()
+    await client.ready()
+
+    const initialScreen = client.screen('Home', { privateParam: 'not exception context' })
+    client.captureException(new Error('initial'))
+    const nextScreen = client.screen('users/[id]')
+    client.captureException(new Error('next'))
+    await Promise.all([initialScreen, nextScreen])
+
+    expect(exceptions(events).map((event) => event.properties.$screen_name)).toEqual(['Home', 'users/[id]'])
+    expect(exceptions(events)[0].properties).not.toHaveProperty('privateParam')
+    expect(events.filter((event) => event.event === '$screen').map((event) => event.properties.$screen_name)).toEqual([
+      'Home',
+      'users/[id]',
+    ])
+  })
+
+  it('preserves screen call order across asynchronous storage initialization', async () => {
+    let resolveStorage!: (value: null) => void
+    const storageReady = new Promise<null>((resolve) => {
+      resolveStorage = resolve
+    })
+    const { client, events } = createClient({
+      persistence: 'file',
+      customStorage: { getItem: () => storageReady, setItem: async () => {} },
+    })
+    const initialScreen = client.screen('Initial')
+    client.captureException(new Error('before ready'))
+    resolveStorage(null)
+    await client.ready()
+    await initialScreen
+    expect(exceptions(events)[0].properties.$screen_name).toBe('Initial')
+
+    const nextScreen = client.screen('Next')
+    client.captureException(new Error('after ready'))
+    await nextScreen
+    expect(exceptions(events)[1].properties.$screen_name).toBe('Next')
+  })
+
+  it('does not retroactively attribute queued exceptions to later screens during initialization', async () => {
+    let resolveStorage!: (value: null) => void
+    const storageReady = new Promise<null>((resolve) => {
+      resolveStorage = resolve
+    })
+    const { client, events } = createClient({
+      persistence: 'file',
+      customStorage: { getItem: () => storageReady, setItem: async () => {} },
+    })
+    client.captureException(new Error('before any screen'))
+    const first = client.screen('First')
+    client.captureException(new Error('first'))
+    const second = client.screen('Second')
+    client.captureException(new Error('second'))
+    resolveStorage(null)
+    await Promise.all([first, second, client.ready()])
+
+    const captured = exceptions(events)
+    expect(captured.map((event) => event.properties.$screen_name)).toEqual([undefined, 'First', 'Second'])
+    expect(captured[0].properties).not.toHaveProperty('$screen_name')
+  })
+
+  it('preserves persisted, pending registered, and session screen properties during initialization', async () => {
+    let resolveStorage!: (value: string) => void
+    const storageReady = new Promise<string>((resolve) => {
+      resolveStorage = resolve
+    })
+    const { client, events } = createClient({
+      persistence: 'file',
+      customStorage: { getItem: () => storageReady, setItem: async () => {} },
+    })
+    client.captureException(new Error('persisted context'))
+    const registration = client.register({ $screen_name: 'Registered' })
+    client.captureException(new Error('registered context'))
+    const screen = client.screen('Screen')
+    client.captureException(new Error('screen context'))
+    client.captureException(new Error('caller override'), { $screen_name: 'Caller' })
+    client.captureException(new Error('caller undefined'), { $screen_name: undefined })
+    client.captureException(new Error('caller null'), { $screen_name: null })
+    resolveStorage(JSON.stringify({ version: 'v1', content: { props: { $screen_name: 'Persisted' } } }))
+    await Promise.all([registration, screen, client.ready()])
+    expect(exceptions(events).map((event) => event.properties.$screen_name)).toEqual([
+      'Persisted',
+      'Registered',
+      'Screen',
+      'Caller',
+      undefined,
+      null,
+    ])
+
+    client.registerForSession({ $screen_name: 'Session registered' })
+    client.captureException(new Error('explicit session context'))
+    expect(exceptions(events)[6].properties.$screen_name).toBe('Session registered')
+  })
+
+  it('preserves common screen-property precedence over registered and caller properties', async () => {
+    let resolveStorage!: (value: null) => void
+    const storageReady = new Promise<null>((resolve) => {
+      resolveStorage = resolve
+    })
+    const { client, events } = createClient({
+      persistence: 'file',
+      customStorage: { getItem: () => storageReady, setItem: async () => {} },
+      customAppProperties: () => ({ $screen_name: 'Common' }),
+    })
+    const registration = client.register({ $screen_name: 'Registered' })
+    client.captureException(new Error('before screen'))
+    const screen = client.screen('Screen')
+    client.captureException(new Error('caller'), { $screen_name: 'Caller' })
+    resolveStorage(null)
+    await Promise.all([registration, screen, client.ready()])
+    expect(exceptions(events).map((event) => event.properties.$screen_name)).toEqual(['Common', 'Common'])
+  })
+
+  it('preserves before_send filtering of exceptions queued during initialization', async () => {
+    let resolveStorage!: (value: null) => void
+    const storageReady = new Promise<null>((resolve) => {
+      resolveStorage = resolve
+    })
+    const filtered: any[] = []
+    const { client } = createClient({
+      persistence: 'file',
+      customStorage: { getItem: () => storageReady, setItem: async () => {} },
+      before_send: (event) => {
+        if (event.event === '$exception') {
+          delete event.properties.$screen_name
+          filtered.push(event)
+        }
+        return event
+      },
+    })
+    const screen = client.screen('Screen')
+    client.captureException(new Error('filtered'))
+    resolveStorage(null)
+    await Promise.all([screen, client.ready()])
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].properties).not.toHaveProperty('$screen_name')
+  })
+
+  it('does not restore an older screen when pending screen calls finish initializing', async () => {
+    let resolveStorage!: (value: null) => void
+    const storageReady = new Promise<null>((resolve) => {
+      resolveStorage = resolve
+    })
+    const { client, events } = createClient({
+      persistence: 'file',
+      customStorage: { getItem: () => storageReady, setItem: async () => {} },
+    })
+    const first = client.screen('First')
+    const second = client.screen('Second')
+    resolveStorage(null)
+    await Promise.all([first, second, client.ready()])
+    client.captureException(new Error('initialized'))
+    expect(exceptions(events)[0].properties.$screen_name).toBe('Second')
+  })
+
+  it('preserves caller overrides and isolates clients without a recorded route', async () => {
+    const first = createClient()
+    const second = createClient()
+    await Promise.all([first.client.ready(), second.client.ready()])
+    void first.client.screen('Safe name')
+    first.client.captureException(new Error('overridden'), { $screen_name: 'Caller name' })
+    second.client.captureException(new Error('no navigation or Expo required'))
+    expect(exceptions(first.events)[0].properties.$screen_name).toBe('Caller name')
+    expect(exceptions(second.events)[0].properties).not.toHaveProperty('$screen_name')
+  })
+
+  it('allows before_send to remove the screen name from exceptions', async () => {
+    const captured: any[] = []
+    const { client } = createClient({
+      before_send: (event) => {
+        delete event.properties.$screen_name
+        captured.push(event)
+        return event
+      },
+    })
+    await client.ready()
+    void client.screen('Safe name')
+    client.captureException(new Error('redacted'))
+    expect(exceptions(captured)[0].properties).not.toHaveProperty('$screen_name')
+  })
+
+  it('attributes automatically captured uncaught errors through the existing exception path', async () => {
+    let handler = vi.fn() as (error: Error, fatal: boolean) => void
+    vi.stubGlobal('ErrorUtils', {
+      getGlobalHandler: () => handler,
+      setGlobalHandler: (next: typeof handler) => {
+        handler = next
+      },
+    })
+    const { client, events } = createClient({ errorTracking: { autocapture: { uncaughtExceptions: true } } })
+    try {
+      await client.ready()
+      void client.screen('Uncaught screen')
+      handler(new Error('uncaught'), false)
+      expect(exceptions(events)[0].properties.$screen_name).toBe('Uncaught screen')
+    } finally {
+      await client.shutdown()
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('does not send screen or exception events while opted out', async () => {
+    const { client, events } = createClient({ defaultOptIn: false })
+    await client.ready()
+    await client.screen('Home')
+    client.captureException(new Error('not consented'))
+    expect(events).toEqual([])
+  })
+
+  it('does not infer a failed destination before its tracking effect commits', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client, events } = createClient()
+    await client.ready()
+    await client.screen('Previous screen')
+    const FailedDestination = (): React.ReactElement => {
+      React.useEffect(() => {
+        void client.screen('Uncommitted destination')
+      }, [])
+      throw new Error('render failed before effect')
+    }
+    render(
+      <PostHogProvider client={client} autocapture={false}>
+        <PostHogErrorBoundary fallback={<div>Fallback</div>}>
+          <FailedDestination />
+        </PostHogErrorBoundary>
+      </PostHogProvider>
+    )
+    expect(exceptions(events)[0].properties.$screen_name).toBe('Previous screen')
+    expect(events.filter((event) => event.event === '$screen')).toHaveLength(1)
+  })
+
+  it('attributes a render exception to a screen recorded before rendering', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client, events } = createClient()
+    await client.ready()
+    const screen = client.screen('Safe render screen')
+    const Throw = (): React.ReactElement => {
+      throw new Error('render failed')
+    }
+    render(
+      <PostHogProvider client={client} autocapture={false}>
+        <PostHogErrorBoundary fallback={<div>Fallback</div>}>
+          <Throw />
+        </PostHogErrorBoundary>
+      </PostHogProvider>
+    )
+    await screen
+    expect(exceptions(events)).toHaveLength(1)
+    expect(exceptions(events)[0].properties.$screen_name).toBe('Safe render screen')
+  })
+})

--- a/packages/react-native/test/useNavigationTracker.optional.spec.tsx
+++ b/packages/react-native/test/useNavigationTracker.optional.spec.tsx
@@ -1,13 +1,16 @@
 /** @vitest-environment jsdom */
 import { renderHook } from '@testing-library/react'
 import { useNavigationTracker } from '../src/hooks/useNavigationTracker'
-import type { PostHog } from '../src/posthog-rn'
+import { PostHog } from '../src/posthog-rn'
 
 vi.mock('../src/optional/OptionalReactNativeNavigation', () => ({ OptionalReactNativeNavigation: undefined }))
 
-it('does nothing when the optional navigation package is not installed', () => {
-  const screen = vi.fn()
-  const { unmount } = renderHook(() => useNavigationTracker(undefined, undefined, { screen } as unknown as PostHog))
+it('does nothing when the optional navigation package is not installed', async () => {
+  const client = new PostHog('test-token', { disabled: true, persistence: 'memory' })
+  const screen = vi.spyOn(client, 'screen').mockResolvedValue(undefined)
+  const { unmount } = renderHook(() => useNavigationTracker(undefined, undefined, client))
   unmount()
+  await client.shutdown()
   expect(screen).not.toHaveBeenCalled()
+  vi.restoreAllMocks()
 })

--- a/packages/react-native/test/useNavigationTracker.optional.spec.tsx
+++ b/packages/react-native/test/useNavigationTracker.optional.spec.tsx
@@ -1,0 +1,13 @@
+/** @vitest-environment jsdom */
+import { renderHook } from '@testing-library/react'
+import { useNavigationTracker } from '../src/hooks/useNavigationTracker'
+import type { PostHog } from '../src/posthog-rn'
+
+vi.mock('../src/optional/OptionalReactNativeNavigation', () => ({ OptionalReactNativeNavigation: undefined }))
+
+it('does nothing when the optional navigation package is not installed', () => {
+  const screen = vi.fn()
+  const { unmount } = renderHook(() => useNavigationTracker(undefined, undefined, { screen } as unknown as PostHog))
+  unmount()
+  expect(screen).not.toHaveBeenCalled()
+})

--- a/packages/react-native/test/useNavigationTracker.spec.tsx
+++ b/packages/react-native/test/useNavigationTracker.spec.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, render, renderHook } from '@testing-library/react'
 import { renderToString } from 'react-dom/server'
 import { useNavigationTracker } from '../src/hooks/useNavigationTracker'
 import { PostHogProvider } from '../src/PostHogProvider'
-import type { PostHog } from '../src/posthog-rn'
+import { PostHog } from '../src/posthog-rn'
 
 const mock = vi.hoisted(() => ({ state: undefined as any, navigation: undefined as any }))
 vi.mock('../src/optional/OptionalReactNativeNavigation', () => ({
@@ -17,15 +17,18 @@ vi.mock('../src/optional/OptionalReactNativeNavigation', () => ({
 let client: PostHog
 beforeEach(() => {
   vi.useFakeTimers()
-  client = { screen: vi.fn(), debug: vi.fn() } as unknown as PostHog
+  client = new PostHog('test-token', { disabled: true, persistence: 'memory' })
+  vi.spyOn(client, 'screen').mockResolvedValue(undefined)
   mock.state = { index: 0, routes: [{ name: 'Home' }] }
   mock.navigation = {
     isReady: vi.fn(() => true),
     getCurrentRoute: vi.fn(() => mock.state.routes[mock.state.index]),
   }
 })
-afterEach(() => {
+afterEach(async () => {
   cleanup()
+  await client.shutdown()
+  vi.restoreAllMocks()
   vi.useRealTimers()
 })
 

--- a/packages/react-native/test/useNavigationTracker.spec.tsx
+++ b/packages/react-native/test/useNavigationTracker.spec.tsx
@@ -1,0 +1,144 @@
+/** @vitest-environment jsdom */
+import React from 'react'
+import { act, cleanup, render, renderHook } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
+import { useNavigationTracker } from '../src/hooks/useNavigationTracker'
+import { PostHogProvider } from '../src/PostHogProvider'
+import type { PostHog } from '../src/posthog-rn'
+
+const mock = vi.hoisted(() => ({ state: undefined as any, navigation: undefined as any }))
+vi.mock('../src/optional/OptionalReactNativeNavigation', () => ({
+  OptionalReactNativeNavigation: {
+    useNavigationState: (selector: (state: any) => any) => selector(mock.state),
+    useNavigation: () => mock.navigation,
+  },
+}))
+
+let client: PostHog
+beforeEach(() => {
+  vi.useFakeTimers()
+  client = { screen: vi.fn(), debug: vi.fn() } as unknown as PostHog
+  mock.state = { index: 0, routes: [{ name: 'Home' }] }
+  mock.navigation = {
+    isReady: vi.fn(() => true),
+    getCurrentRoute: vi.fn(() => mock.state.routes[mock.state.index]),
+  }
+})
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('useNavigationTracker', () => {
+  it('tracks the initial route and index-only tab transitions with the same routes array', () => {
+    mock.state.routes.push({ name: 'Settings' })
+    const { rerender } = renderHook(() => useNavigationTracker(undefined, undefined, client))
+    expect(client.screen).toHaveBeenLastCalledWith('Home', undefined)
+    mock.state = { ...mock.state, index: 1 }
+    rerender()
+    expect(client.screen).toHaveBeenLastCalledWith('Settings', undefined)
+    expect(client.screen).toHaveBeenCalledTimes(2)
+  })
+
+  it('selects the focused nested leaf rather than the last mounted sibling and preserves mapping', () => {
+    const params = { id: 'private-id' }
+    mock.state.routes = [
+      {
+        name: 'Root',
+        state: {
+          index: 0,
+          routes: [
+            { name: 'Tabs', state: { index: 1, routes: [{ name: 'Home' }, { name: 'users/[id]', params }] } },
+            { name: 'Inactive' },
+          ],
+        },
+      },
+    ]
+    const routeToName = vi.fn(() => 'Redacted screen')
+    const routeToProperties = vi.fn(() => ({ safe: true }))
+    renderHook(() => useNavigationTracker({ routeToName, routeToProperties }, undefined, client))
+    expect(routeToName).toHaveBeenCalledWith('users/[id]', params)
+    expect(routeToProperties).toHaveBeenCalledWith('Redacted screen', params)
+    expect(client.screen).toHaveBeenCalledWith('Redacted screen', { safe: true })
+  })
+
+  it('uses index zero for partial nested state without an index', () => {
+    mock.state.routes = [{ name: 'Root', state: { routes: [{ name: 'First' }, { name: 'Last' }] } }]
+    renderHook(() => useNavigationTracker(undefined, undefined, client))
+    expect(client.screen).toHaveBeenCalledWith('First', undefined)
+  })
+
+  it('does not guess a nested screen when the focused index is invalid', () => {
+    mock.state.routes = [{ name: 'Root', state: { index: 5, routes: [{ name: 'Not focused' }] } }]
+    renderHook(() => useNavigationTracker(undefined, undefined, client))
+    expect(client.screen).not.toHaveBeenCalled()
+  })
+
+  it('does not capture screens during server rendering', () => {
+    const Tracker = (): null => {
+      useNavigationTracker(undefined, undefined, client)
+      return null
+    }
+    renderToString(<Tracker />)
+    expect(client.screen).not.toHaveBeenCalled()
+  })
+
+  it('does not capture until navigation is ready and state updates', () => {
+    mock.navigation.isReady.mockReturnValue(false)
+    const { rerender } = renderHook(() => useNavigationTracker(undefined, undefined, client))
+    expect(client.screen).not.toHaveBeenCalled()
+    mock.navigation.isReady.mockReturnValue(true)
+    mock.state = { ...mock.state }
+    rerender()
+    expect(client.screen).toHaveBeenCalledWith('Home', undefined)
+  })
+
+  it('supports a ready root ref and older navigation without isReady', () => {
+    delete mock.navigation.isReady
+    renderHook(() => useNavigationTracker(undefined, { current: mock.navigation } as any, client))
+    expect(client.screen).toHaveBeenCalledWith('Home', undefined)
+  })
+
+  it('does not capture without a navigation object or current route', () => {
+    mock.navigation = undefined
+    const { rerender } = renderHook(() => useNavigationTracker(undefined, undefined, client))
+    expect(client.screen).not.toHaveBeenCalled()
+    mock.navigation = { getCurrentRoute: () => undefined }
+    rerender()
+    expect(client.screen).not.toHaveBeenCalled()
+  })
+
+  it('retries initial tracking once when state is not yet available', () => {
+    mock.state = undefined
+    mock.navigation.getCurrentRoute.mockReturnValue({ name: 'Initial' })
+    renderHook(() => useNavigationTracker(undefined, undefined, client))
+    expect(client.screen).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(client.screen).toHaveBeenCalledWith('Initial', undefined)
+  })
+
+  it('cancels the pending initial retry on unmount', () => {
+    mock.state = undefined
+    mock.navigation.getCurrentRoute.mockReturnValue({ name: 'Unmounted' })
+    const { unmount } = renderHook(() => useNavigationTracker(undefined, undefined, client))
+    unmount()
+    act(() => {
+      vi.runAllTimers()
+    })
+    expect(client.screen).not.toHaveBeenCalled()
+  })
+
+  it.each([false, { captureScreens: false }])('preserves provider screen opt-out %j', (autocapture) => {
+    render(
+      <PostHogProvider client={client} autocapture={autocapture}>
+        <div />
+      </PostHogProvider>
+    )
+    act(() => {
+      vi.runAllTimers()
+    })
+    expect(client.screen).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-native/test/useNavigationTracker.spec.tsx
+++ b/packages/react-native/test/useNavigationTracker.spec.tsx
@@ -43,38 +43,28 @@ describe('useNavigationTracker', () => {
     expect(client.screen).toHaveBeenCalledTimes(2)
   })
 
-  it('selects the focused nested leaf rather than the last mounted sibling and preserves mapping', () => {
+  it('maps the focused leaf returned by getCurrentRoute rather than the subscribed parent route', () => {
     const params = { id: 'private-id' }
+    const focusedRoute = { name: 'users/[id]', params }
     mock.state.routes = [
       {
         name: 'Root',
         state: {
           index: 0,
           routes: [
-            { name: 'Tabs', state: { index: 1, routes: [{ name: 'Home' }, { name: 'users/[id]', params }] } },
+            { name: 'Tabs', state: { index: 1, routes: [{ name: 'Home' }, focusedRoute] } },
             { name: 'Inactive' },
           ],
         },
       },
     ]
+    mock.navigation.getCurrentRoute.mockReturnValue(focusedRoute)
     const routeToName = vi.fn(() => 'Redacted screen')
     const routeToProperties = vi.fn(() => ({ safe: true }))
     renderHook(() => useNavigationTracker({ routeToName, routeToProperties }, undefined, client))
     expect(routeToName).toHaveBeenCalledWith('users/[id]', params)
     expect(routeToProperties).toHaveBeenCalledWith('Redacted screen', params)
     expect(client.screen).toHaveBeenCalledWith('Redacted screen', { safe: true })
-  })
-
-  it('uses index zero for partial nested state without an index', () => {
-    mock.state.routes = [{ name: 'Root', state: { routes: [{ name: 'First' }, { name: 'Last' }] } }]
-    renderHook(() => useNavigationTracker(undefined, undefined, client))
-    expect(client.screen).toHaveBeenCalledWith('First', undefined)
-  })
-
-  it('does not guess a nested screen when the focused index is invalid', () => {
-    mock.state.routes = [{ name: 'Root', state: { index: 5, routes: [{ name: 'Not focused' }] } }]
-    renderHook(() => useNavigationTracker(undefined, undefined, client))
-    expect(client.screen).not.toHaveBeenCalled()
   })
 
   it('does not capture screens during server rendering', () => {


### PR DESCRIPTION
## Problem

React Native exceptions can retain the previous screen when `screen()` and `captureException()` run in the same turn. Automatic navigation tracking can also miss a focused-index change when the routes array stays the same.

## Changes

Register screens immediately once the client is initialized, while preserving queued screen and event order during initialization. Track the full navigation state to detect index-only tab changes, read the focused leaf directly from React Navigation’s `getCurrentRoute()`, and cancel the pending initial retry when the tracker unmounts. React Navigation already resolves nested focus; no additional traversal is needed.

The Expo example records safe route templates with `useSegments()` and keeps automatic screen capture disabled. Documentation explains that errors use the last recorded screen, not a destination whose tracking effect has not run. This preserves existing property precedence, opt-out behavior, and explicit overrides. It does not add screen deduplication or change HTTP delivery or fatal persistence.

### Validation

Latest review follow-up (`197a8340f`) removes the redundant traversal and corrects the navigation mock to return a focused leaf independently of the subscribed parent state. Two tests for nested state returned by `getCurrentRoute()` were removed because they modeled a contract React Navigation does not expose. The corrected 24 focused screen/navigation tests passed both before and after removing the loop. This was a static simplification, not a reproduced runtime defect. On Node 24.18.1 and pnpm 11.7.0, `pnpm turbo run build test:unit lint generate-references --filter=posthog-react-native --force` passed all eight tasks without cache hits: 824 tests across 55 files, build, lint, and reference generation. Formatting passed and generated references are unchanged. The changeset now describes stale exception screen names and missed tab tracking rather than nested-route selection.

#### Earlier validation

On Node 24.18.1 and pnpm 11.7.0, `pnpm turbo run build test:unit lint generate-references --filter=posthog-react-native --force` passed all eight tasks without cache hits after the review fix. All 55 test files and 826 tests passed, including 26 screen/navigation regressions and the three fatal-persistence tests from #4896. Source lint and formatting hooks passed. Regenerated references match the committed bytes.

The navigation tests now use real disabled, in-memory PostHog clients with typed screen spies instead of incomplete objects cast to PostHog. This is a test-only follow-up. Its 13 focused tests passed before and after the change; no SDK runtime code changed.

Commit `2a1f2ba1` was tested directly on an Android emulator in release apps using the packaged SDK, RN 0.79.6, React Navigation 6 with a JS stack, and manual Expo 53 / Router 5 tracking. A controlled delay around real native AsyncStorage reads confirmed that screen calls wait for initialization and then retain their call order. Same-turn screen attribution, tab-index changes, opt-out/remount, real error boundaries and route-parameter privacy passed. The prior base-hook-only comparison established that nested duplicate screens are pre-existing.

A subsequent run sent 20 screen events and 22 exceptions to US Cloud. All SDK flushes succeeded, and @marandaneto confirmed the events matched the expected sequences. See the [emulator results and screen sequences](https://github.com/PostHog/posthog-js/pull/4900#issuecomment-5618299629). Those emulator runs predate the latest traversal simplification; they have not been rerun on `197a8340f`.

Coverage does not include iOS, physical devices, the Expo 57 example build, universal Navigation 7 automatic tracking, or native fatal delivery. Initial-retry cancellation at the exact timer boundary remains unit-test coverage.

Isolated autoreview of `2a1f2ba1` against `origin/main` reported no actionable findings. The subsequent test-only change and latest traversal simplification were reviewed directly and validated with the checks above. Human review is still required.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

The existing patch changeset is preserved.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi assisted with implementation and PR preparation using Git, pnpm, and the isolated autoreview helper. The human directed the scope and approved preserving the candidate while integrating #4896. The final change keeps the existing screen and exception ownership boundaries instead of changing exception enrichment or delivery. A line-level lint comment preserves Metro's existing static font-asset require in the example.

After the initial validation and PR preparation, the parent assistant directly tested the committed SDK on Android and sent the test events to US Cloud at the human driver’s request. The human driver confirmed the results. An earlier follow-up replaced incomplete client mocks in two test files. The latest human-requested follow-up removes redundant traversal after `getCurrentRoute()`, corrects the tests, and narrows the release note and PR description. It was implemented and validated directly in the existing isolated worktree without subagents. Human review is required before merge.

