### PR TITLE
fix(browser): preserve batched event timestamps across retries

### DIFF
--- a/.changeset/quiet-batches-keep-time.md
+++ b/.changeset/quiet-batches-keep-time.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Preserve batched event timestamps so delayed retries do not shift event times and prevent deduplication.

--- a/packages/browser/playwright/mocked/batched-retry-timestamps.spec.ts
+++ b/packages/browser/playwright/mocked/batched-retry-timestamps.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from './utils/posthog-playwright-test-base'
+import { start } from './utils/setup'
+
+// This regression exercises the updated core, not old-core/lazy-extension compatibility.
+test.use({ staticOverrides: {} })
+
+for (const transport of ['fetch', 'XHR'] as const) {
+    test(`preserves batched event timestamps after a lost ${transport} response`, async ({ page, context }) => {
+        const bodies: {
+            batch: { uuid: string; timestamp: string; offset?: number; properties: { target: string } }[]
+            sent_at: string
+        }[] = []
+        const urls: string[] = []
+        await context.route('**/e/**', async (route) => {
+            bodies.push(route.request().postDataJSON())
+            urls.push(route.request().url())
+            if (bodies.length === 1) {
+                await route.abort('failed')
+            } else {
+                await route.fulfill({ status: 200, json: { status: 1 } })
+            }
+        })
+
+        const captureTime = new Date('2026-01-31T23:59:50.000Z')
+        await page.clock.install({ time: new Date(captureTime.getTime() - 60_000) })
+        await start(
+            {
+                options: {
+                    capture_pageview: false,
+                    capture_pageleave: false,
+                    request_batching: true,
+                    disable_compression: true,
+                    disable_session_recording: true,
+                    api_transport: transport,
+                },
+            },
+            page,
+            context
+        )
+        await page.clock.pauseAt(captureTime)
+        await page.evaluate(() => {
+            window.posthog.capture('first click', { target: 'alpha' })
+            window.posthog.capture('second click', { target: 'beta' })
+        })
+        const retryQueued = page.waitForEvent('console', (message) =>
+            message.text().includes('Enqueued failed request for retry')
+        )
+        await page.clock.runFor(3000)
+        await retryQueued
+        expect(bodies).toHaveLength(1)
+
+        const successfulRetry = page.waitForResponse((response) => response.url().includes('retry_count=1'))
+        await page.clock.setSystemTime(new Date('2026-02-01T08:00:00.000Z'))
+        await page.clock.runFor(6000)
+        await (await successfulRetry).finished()
+        expect(bodies).toHaveLength(2)
+
+        expect(bodies[0].batch).toHaveLength(2)
+        expect(bodies[0].batch[0].uuid).not.toBe(bodies[0].batch[1].uuid)
+        expect(bodies[1].batch).toEqual(bodies[0].batch)
+        expect(bodies[0].batch.map((event) => event.properties.target)).toEqual(['alpha', 'beta'])
+        for (const body of bodies) {
+            for (const event of body.batch) {
+                expect(event.timestamp).toBe(captureTime.toISOString())
+                expect(event).not.toHaveProperty('offset')
+            }
+        }
+        expect(Date.parse(bodies[1].sent_at) - Date.parse(bodies[0].sent_at)).toBeGreaterThan(8 * 60 * 60 * 1000)
+        expect(urls[0]).not.toContain('retry_count')
+        expect(urls[1]).toContain('retry_count=1')
+    })
+}

--- a/packages/browser/src/__tests__/posthog-core.batched-retry-timestamps.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.batched-retry-timestamps.test.ts
@@ -76,7 +76,7 @@ describe('batched event timestamps across retries', () => {
         vi.useRealTimers()
     })
 
-    it.each([0, 503])('preserves capture time across a delayed retry after status %s', (status) => {
+    it.each([0, 503])('preserves capture time across multiple delayed retries after status %s', (status) => {
         const first = posthog.capture('first click', { target: 'alpha' })!
         vi.advanceTimersByTime(1000)
         const second = posthog.capture('second click', { target: 'beta' })!
@@ -86,19 +86,29 @@ describe('batched event timestamps across retries', () => {
         expect(network.requests).toHaveLength(1)
         expect(posthog._retryQueue?.length).toBe(1)
 
-        network.status = 200
         vi.setSystemTime(RETRY_TIME)
         vi.advanceTimersByTime(3000)
 
         expect(network.requests).toHaveLength(2)
-        expect(posthog._retryQueue?.length).toBe(0)
+        expect(posthog._retryQueue?.length).toBe(1)
         expect(network.requests[1].url).toContain('retry_count=1')
+
+        network.status = 200
+        vi.setSystemTime(new Date(RETRY_TIME.getTime() + 60_000))
+        vi.advanceTimersByTime(3000)
+
+        expect(network.requests).toHaveLength(3)
+        expect(posthog._retryQueue?.length).toBe(0)
+        expect(network.requests[2].url).toContain('retry_count=2')
         const bodies = network.requests.map(({ body }) => JSON.parse(body) as CaptureBody)
-        expect(bodies[1].batch).toEqual(bodies[0].batch)
-        expect(bodies[1].sent_at).not.toEqual(bodies[0].sent_at)
+        expect(bodies.map((body) => body.sent_at)).toEqual(
+            network.requests.map(({ receivedAt }) => new Date(receivedAt).toISOString())
+        )
+        expect(new Set(bodies.map((body) => body.sent_at)).size).toBe(3)
         expect(first.uuid).not.toEqual(second.uuid)
 
         for (const [index, body] of bodies.entries()) {
+            expect(body.batch).toEqual(bodies[0].batch)
             expect(body.batch.map((event) => event.timestamp)).toEqual([
                 START.toISOString(),
                 new Date(START.getTime() + 1000).toISOString(),

--- a/packages/browser/src/__tests__/posthog-core.batched-retry-timestamps.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.batched-retry-timestamps.test.ts
@@ -1,0 +1,170 @@
+import { isUndefined } from '@posthog/core'
+import { createPosthogInstance } from './helpers/posthog-instance'
+import { PostHog } from '../posthog-core'
+import { navigator } from '@posthog/browser-common/utils/globals'
+
+type WireEvent = { uuid: string; event: string; timestamp?: string; offset?: number; sent_at?: string }
+type CaptureBody = { batch: WireEvent[]; sent_at: string }
+
+const network = vi.hoisted(() => ({
+    status: 200,
+    requests: [] as { url: string; body: string; receivedAt: number }[],
+}))
+
+vi.mock('@posthog/browser-common/utils/globals', async (importOriginal) => {
+    const original = await importOriginal<typeof import('@posthog/browser-common/utils/globals')>()
+    return {
+        ...original,
+        fetch: undefined,
+        CompressionStream: undefined,
+        navigator: { sendBeacon: vi.fn(() => true) },
+        XMLHttpRequest: vi.fn(() => {
+            let url: string
+            const xhr = {
+                open: vi.fn((_method: string, requestUrl: string) => {
+                    url = requestUrl
+                }),
+                setRequestHeader: vi.fn(),
+                send: vi.fn((body: string) => {
+                    network.requests.push({ url, body, receivedAt: Date.now() })
+                    xhr.readyState = 4
+                    xhr.status = network.status
+                    xhr.onreadystatechange?.()
+                }),
+                readyState: 0,
+                status: 0,
+                responseText: '{}',
+                onreadystatechange: undefined as (() => void) | undefined,
+            }
+            return xhr
+        }),
+    }
+})
+
+const START = new Date('2026-01-31T23:59:50.000Z')
+const RETRY_TIME = new Date('2026-02-01T08:00:00.000Z')
+
+// Capture's offset branch overrides timestamp + (receive time - sent_at).
+function normalizedTimestamp(event: WireEvent, sentAt: string, receivedAt: number): number {
+    return isUndefined(event.offset)
+        ? Date.parse(event.timestamp!) + receivedAt - Date.parse(sentAt)
+        : receivedAt - event.offset
+}
+
+describe('batched event timestamps across retries', () => {
+    let posthog: PostHog
+
+    beforeEach(async () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(START)
+        network.status = 200
+        posthog = await createPosthogInstance(undefined, {
+            request_batching: true,
+            disable_compression: true,
+            capture_pageview: false,
+            advanced_disable_flags: true,
+            disable_session_recording: true,
+        })
+        posthog.set_config({ before_send: (event) => event })
+        network.requests = []
+    })
+
+    afterEach(() => {
+        posthog._requestQueue?.unload()
+        posthog._retryQueue?.unload()
+        vi.clearAllTimers()
+        vi.useRealTimers()
+    })
+
+    it.each([0, 503])('preserves capture time across a delayed retry after status %s', (status) => {
+        const first = posthog.capture('first click', { target: 'alpha' })!
+        vi.advanceTimersByTime(1000)
+        const second = posthog.capture('second click', { target: 'beta' })!
+        network.status = status
+        vi.advanceTimersByTime(2000)
+
+        expect(network.requests).toHaveLength(1)
+        expect(posthog._retryQueue?.length).toBe(1)
+
+        network.status = 200
+        vi.setSystemTime(RETRY_TIME)
+        vi.advanceTimersByTime(3000)
+
+        expect(network.requests).toHaveLength(2)
+        expect(posthog._retryQueue?.length).toBe(0)
+        expect(network.requests[1].url).toContain('retry_count=1')
+        const bodies = network.requests.map(({ body }) => JSON.parse(body) as CaptureBody)
+        expect(bodies[1].batch).toEqual(bodies[0].batch)
+        expect(bodies[1].sent_at).not.toEqual(bodies[0].sent_at)
+        expect(first.uuid).not.toEqual(second.uuid)
+
+        for (const [index, body] of bodies.entries()) {
+            expect(body.batch.map((event) => event.timestamp)).toEqual([
+                START.toISOString(),
+                new Date(START.getTime() + 1000).toISOString(),
+            ])
+            expect(body.batch.map((event) => event.uuid)).toEqual([first.uuid, second.uuid])
+            for (const [eventIndex, event] of body.batch.entries()) {
+                expect(event).not.toHaveProperty('offset')
+                expect(normalizedTimestamp(event, body.sent_at, network.requests[index].receivedAt)).toBe(
+                    START.getTime() + eventIndex * 1000
+                )
+            }
+        }
+    })
+
+    it('preserves a backdated timestamp when a failed batch is sent by beacon on unload', async () => {
+        const timestamp = new Date('2026-01-30T12:00:00.000Z')
+        const event = posthog.capture('backdated', {}, { timestamp, _batchKey: 'backdated' })!
+        network.status = 0
+        vi.advanceTimersByTime(3000)
+        expect(posthog._retryQueue?.length).toBe(1)
+        const firstBody = JSON.parse(network.requests[0].body) as CaptureBody
+
+        vi.setSystemTime(RETRY_TIME)
+        posthog._retryQueue?.unload()
+
+        expect(navigator!.sendBeacon).toHaveBeenCalledTimes(1)
+        const blob = vi.mocked(navigator!.sendBeacon!).mock.calls[0][1] as Blob
+        vi.useRealTimers()
+        const text = await new Promise<string>((resolve) => {
+            const reader = new FileReader()
+            reader.onload = () => resolve(reader.result as string)
+            reader.readAsText(blob)
+        })
+        const body = JSON.parse(atob(new URLSearchParams(text).get('data')!)) as CaptureBody
+        expect(body.batch).toEqual(firstBody.batch)
+        expect(body.batch[0]).toMatchObject({ uuid: event.uuid, timestamp: timestamp.toISOString() })
+        expect(body.batch[0]).not.toHaveProperty('offset')
+        expect(body.sent_at).toBe(RETRY_TIME.toISOString())
+        expect(normalizedTimestamp(body.batch[0], body.sent_at, RETRY_TIME.getTime())).toBe(timestamp.getTime())
+    })
+
+    it('preserves recording envelope and snapshot timestamps across batch retries', () => {
+        const snapshot = { type: 2, timestamp: START.getTime(), data: { node: { id: 1 } } }
+        posthog.capture(
+            '$snapshot',
+            { $snapshot_data: [snapshot] },
+            {
+                _url: 'http://localhost/s/',
+                _batchKey: 'recording',
+                _noTruncate: true,
+            }
+        )
+        network.status = 503
+        vi.advanceTimersByTime(3000)
+        expect(posthog._retryQueue?.length).toBe(1)
+        network.status = 200
+        vi.setSystemTime(RETRY_TIME)
+        vi.advanceTimersByTime(3000)
+
+        expect(network.requests).toHaveLength(2)
+        for (const request of network.requests) {
+            const [event] = JSON.parse(request.body)
+            expect(event.timestamp).toBe(START.toISOString())
+            expect(event).not.toHaveProperty('offset')
+            expect(event.properties.$snapshot_data).toEqual([snapshot])
+            expect(event.sent_at).toBe(new Date(request.receivedAt).toISOString())
+        }
+    })
+})

--- a/packages/browser/src/__tests__/request-queue.test.ts
+++ b/packages/browser/src/__tests__/request-queue.test.ts
@@ -82,8 +82,8 @@ describe('RequestQueue', () => {
                     {
                         url: '/e',
                         data: [
-                            { event: 'foo', offset: 3000 },
-                            { event: 'bar', offset: 1000 },
+                            { event: 'foo', timestamp: EPOCH - 3000 },
+                            { event: 'bar', timestamp: EPOCH - 1000 },
                         ],
                         transport: 'XHR',
                     },
@@ -91,17 +91,34 @@ describe('RequestQueue', () => {
                 [
                     {
                         url: '/identify',
-                        data: [{ event: '$identify', offset: 2000 }],
+                        data: [{ event: '$identify', timestamp: EPOCH - 2000 }],
                     },
                 ],
                 [
                     {
                         url: '/e',
-                        data: [{ event: 'zeta', offset: 0 }],
+                        data: [{ event: 'zeta', timestamp: EPOCH }],
                         batchKey: 'sessionRecording',
                     },
                 ],
             ])
+        })
+
+        it('preserves event timestamps and leaves timestamp-free recording payloads unchanged', () => {
+            const timestamp = new Date(EPOCH - 60_000)
+            const event = { event: 'backdated', timestamp }
+            const recording = { recording_payload: 'example' }
+            queue.enqueue({ url: '/e', data: event })
+            queue.enqueue({ url: '/s', data: recording })
+            queue.enable()
+
+            vi.runOnlyPendingTimers()
+
+            expect(sendRequest).toHaveBeenNthCalledWith(1, { url: '/e', data: [{ event: 'backdated', timestamp }] })
+            expect(sendRequest).toHaveBeenNthCalledWith(2, { url: '/s', data: [{ recording_payload: 'example' }] })
+            expect(event.timestamp).toBe(timestamp)
+            expect(event).not.toHaveProperty('offset')
+            expect(recording).not.toHaveProperty('offset')
         })
 
         it('handles unload', () => {

--- a/packages/browser/src/request-queue.ts
+++ b/packages/browser/src/request-queue.ts
@@ -1,7 +1,7 @@
 import { QueuedRequestWithOptions, RequestQueueConfig } from './types'
 import { each } from '@posthog/browser-common/utils/general-utils'
 
-import { isArray, isUndefined, clampToRange } from '@posthog/core'
+import { isUndefined, clampToRange } from '@posthog/core'
 import { logger } from '@posthog/browser-common/utils/logger'
 
 export const DEFAULT_FLUSH_INTERVAL_MS = 3000
@@ -62,16 +62,7 @@ export class RequestQueue {
             if (this._queue.length > 0) {
                 const requests = this._formatQueue()
                 for (const key in requests) {
-                    const req = requests[key]
-                    const now = new Date().getTime()
-
-                    if (req.data && isArray(req.data)) {
-                        each(req.data, (data) => {
-                            data['offset'] = Math.abs(data['timestamp'] - now)
-                            delete data['timestamp']
-                        })
-                    }
-                    this._sendRequestSafely(req)
+                    this._sendRequestSafely(requests[key])
                 }
             }
         }, this._flushTimeoutMs)


### PR DESCRIPTION
## Problem

Batched browser events lose their absolute `timestamp` at the first flush. The request queue replaces it with an `offset`, and retries reuse that offset. Capture calculates the stored timestamp from its receive time minus the offset, so delayed retries move events forward in time. If the first request arrived but its response was lost, both copies can be stored under the same UUID with different timestamps. Copies crossing UTC midnight cannot replace each other in the legacy ClickHouse events table. A delayed successful delivery can also be mis-timed without creating a duplicate.

This supersedes #4871. Pinning `sent_at` does not fix batched events because `offset` takes precedence. It also shifts non-batched timestamps forward by the retry delay. That approach should not merge alongside this fix.

## Changes

- Remove the queue's timestamp-to-offset conversion. Preserve each event's absolute timestamp through batching and retries.
- Keep the existing fresh `sent_at` on each delivery. Do not change UUID generation, retry limits, backoff, jitter, or rate limiting.
- Add regressions for status-zero and HTTP 503 retries across a month boundary, backdated timestamps flushed by beacon, recording envelopes, and unchanged snapshot timestamps. Both failure cases remain active through the first retry and succeed on the second. All three attempts preserve UUIDs and timestamps, omit `offset`, and refresh `sent_at`.
- Add real-browser fetch and XHR regressions that simulate a lost response and an eight-hour delay.

The fix removes retry-delay drift. It does not guarantee exact timestamp equality under varying network latency or changing client clock skew, and it does not repair previously exported rows.

### Validation

- Confirmed the new unit regressions and Chromium fetch/XHR tests fail on the original code because event timestamps are missing, then pass with the fix.
- Browser SDK build passed, including private-property compatibility and source-map checks.
- Browser unit suite: 6,423 passed, 8 skipped. Functional suite: 10 passed.
- New retry regressions: 6 passed across Chromium, Firefox, and WebKit.
- Existing recording smoke tests for `array.js` and `array.full.js`: 6 passed across the same browsers.
- Browser lint and formatting checks passed.
- The separate test-typecheck command fails on missing `dompurify` and `dotenv` type definitions. The same failure was reproduced in the untouched checkout.
- After extending multiple-retry coverage, reran all 119 tests across the five focused capture, request, and retry suites, plus browser lint and formatting checks. All passed. This follow-up changes tests only.
- Autoreview passed on `0beb8a701514d8213cede7b2bc4cf1db92615955` with no actionable findings.

### Recording and transport risk

The request queue is shared with recording traffic. Snapshot contents and timestamps are unchanged, but the outer recording event now retains its absolute timestamp. Retry scheduling and request counts are unchanged, including during a capture outage. No recording-volume increase is expected. Watch duplicate-event, event-time, and recording-volume signals after release. Live backend ingestion and warehouse exports were not tested locally.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Added a `posthog-js` patch changeset at `.changeset/quiet-batches-keep-time.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using local source inspection, Node/JSDOM reproductions, Vitest, and Playwright. An isolated Pi autoreview checked the final committed diff. The human-directed scope is the request queue fix and regression coverage.

The investigation compared the SDK behavior with capture's timestamp normalization and the ClickHouse replacement keys. Keeping absolute timestamps and fresh per-attempt `sent_at` removes the confirmed retry-delay drift. The alternative of pinning `sent_at` was rejected because it does not fix offsets and makes absolute-timestamp retries drift. Human review is required before merge.

