### PR TITLE
feat(ai): add prompts.getAll to fetch all prompts at a label

### DIFF
--- a/.changeset/prompts-get-all-by-label.md
+++ b/.changeset/prompts-get-all-by-label.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': minor
+---
+
+`prompts.getAll({ label: 'production' })` fetches every prompt that carries a label in one request and stores them in the prompt cache, so later `get(name, { label })` calls are cache hits. Apps with many prompts no longer need one request per prompt per cache cycle. Against a PostHog server that does not support labels on the prompt list endpoint yet, the call fails with a clear error instead of caching wrong versions.

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -93,24 +93,29 @@ function isSameOrigin(url: string, host: string): boolean {
 }
 
 /**
- * Check that the server resolved this list row through the requested label.
+ * Classify how a list row relates to the requested label, via its all_labels
+ * field.
  *
- * An older server ignores the label param on the list endpoint and returns the
- * latest version of every prompt. A row that was resolved through a label
- * carries a matching name and version entry in its all_labels field.
+ * 'resolved': the row is the version the label points to.
+ * 'moved': the prompt carries the label, but on another version. Happens when
+ * the label moves between the query and the response.
+ * 'absent': the prompt does not carry the label at any version. A server that
+ * filters by label never returns such a row, so this means the server ignored
+ * the label param (an older PostHog release) and served latest versions.
  */
-function rowResolvesLabel(row: PromptApiResponse, label: string): boolean {
+function rowLabelState(row: PromptApiResponse, label: string): 'resolved' | 'moved' | 'absent' {
   const allLabels = (row as unknown as Record<string, unknown>).all_labels
   if (!Array.isArray(allLabels)) {
-    return false
+    return 'absent'
   }
-  return allLabels.some(
-    (entry) =>
-      typeof entry === 'object' &&
-      entry !== null &&
-      (entry as Record<string, unknown>).name === label &&
-      (entry as Record<string, unknown>).version === row.version
+  const entry = allLabels.find(
+    (candidate) =>
+      typeof candidate === 'object' && candidate !== null && (candidate as Record<string, unknown>).name === label
   )
+  if (entry === undefined) {
+    return 'absent'
+  }
+  return (entry as Record<string, unknown>).version === row.version ? 'resolved' : 'moved'
 }
 
 export interface PromptsWithPostHogOptions {
@@ -268,19 +273,36 @@ export class Prompts {
     const label = options.label
     const rows = await this.fetchPromptListFromApi(label)
 
-    const now = Date.now()
-    const results: Record<string, PromptRemoteResult> = {}
+    // Validate every row before caching any, so a rejected batch leaves the
+    // cache untouched.
+    const resolvedRows: PromptApiResponse[] = []
     const skipped: string[] = []
-
     for (const row of rows) {
       if (!isPromptApiResponse(row)) {
         throw new Error(`[PostHog Prompts] Invalid response format for prompts with label "${label}"`)
       }
-      if (!rowResolvesLabel(row, label)) {
+      const labelState = rowLabelState(row, label)
+      if (labelState === 'absent') {
+        // Even one unlabeled row proves the server did not filter, and then
+        // rows that look resolved are only labels that happen to point at the
+        // latest version. A partial result here would hide the rest, so fail
+        // loudly instead.
+        throw new Error(
+          `[PostHog Prompts] The server returned a prompt that does not carry label "${label}". ` +
+            'It may not support fetching prompts by label on the list endpoint yet. ' +
+            'Upgrade PostHog, or fetch prompts one by one with get().'
+        )
+      }
+      if (labelState === 'moved') {
         skipped.push(row.name)
         continue
       }
+      resolvedRows.push(row)
+    }
 
+    const now = Date.now()
+    const results: Record<string, PromptRemoteResult> = {}
+    for (const row of resolvedRows) {
       const config = extractConfig((row as unknown as Record<string, unknown>).config)
       this.getOrCreatePromptCache(row.name).set(label, {
         prompt: row.prompt,
@@ -298,18 +320,6 @@ export class Prompts {
         label,
         config: cloneConfig(config),
       }
-    }
-
-    if (rows.length > 0 && Object.keys(results).length === 0) {
-      // Nothing resolved the label, so the server most likely ignored the
-      // label param and served latest versions. Caching those under the label
-      // would be the silent wrong-version failure labels exist to prevent, so
-      // fail loudly instead.
-      throw new Error(
-        `[PostHog Prompts] The server returned prompts, but none resolve label "${label}". ` +
-          'It may not support fetching prompts by label on the list endpoint yet. ' +
-          'Upgrade PostHog, or fetch prompts one by one with get().'
-      )
     }
 
     if (skipped.length > 0) {

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -301,7 +301,11 @@ export class Prompts {
     }
 
     const now = Date.now()
-    const results: Record<string, PromptRemoteResult> = {}
+    // Collected in a Map first: prompt names like __proto__ are valid, and
+    // assigning them into a plain object would change its prototype instead of
+    // adding an entry. Object.fromEntries defines own properties, so the
+    // returned object carries every name safely.
+    const results = new Map<string, PromptRemoteResult>()
     for (const row of resolvedRows) {
       const config = extractConfig((row as unknown as Record<string, unknown>).config)
       this.getOrCreatePromptCache(row.name).set(label, {
@@ -312,14 +316,14 @@ export class Prompts {
         config,
         fetchedAt: now,
       })
-      results[row.name] = {
+      results.set(row.name, {
         source: 'api',
         prompt: row.prompt,
         name: row.name,
         version: row.version,
         label,
         config: cloneConfig(config),
-      }
+      })
     }
 
     if (skipped.length > 0) {
@@ -328,7 +332,7 @@ export class Prompts {
       )
     }
 
-    return results
+    return Object.fromEntries(results)
   }
 
   /**

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -273,9 +273,11 @@ export class Prompts {
     const skipped: string[] = []
 
     for (const row of rows) {
-      if (!isPromptApiResponse(row) || !rowResolvesLabel(row, label)) {
-        const name = typeof row === 'object' && row !== null ? (row as Record<string, unknown>).name : undefined
-        skipped.push(typeof name === 'string' ? name : '?')
+      if (!isPromptApiResponse(row)) {
+        throw new Error(`[PostHog Prompts] Invalid response format for prompts with label "${label}"`)
+      }
+      if (!rowResolvesLabel(row, label)) {
+        skipped.push(row.name)
         continue
       }
 

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -14,6 +14,10 @@ import type {
 
 const DEFAULT_CACHE_TTL_SECONDS = 300 // 5 minutes
 const DEFAULT_PROMPTS_HOST = 'https://us.posthog.com'
+// Backstop against a server whose pagination never terminates. 100 pages of the
+// default page size covers 10,000 prompts; past that getAll throws rather than
+// returning a truncated result.
+const MAX_PROMPT_LIST_PAGES = 100
 // After a failed refetch the stale entry is served for this long before the next network attempt.
 // The server's tightest prompt limit is per-minute, so a minute lets the bucket refill.
 const DEFAULT_REFETCH_COOLDOWN_SECONDS = 60
@@ -80,6 +84,35 @@ function isPromptApiResponse(data: unknown): data is PromptApiResponse {
   )
 }
 
+function isSameOrigin(url: string, host: string): boolean {
+  try {
+    return new URL(url).origin === new URL(host).origin
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check that the server resolved this list row through the requested label.
+ *
+ * An older server ignores the label param on the list endpoint and returns the
+ * latest version of every prompt. A row that was resolved through a label
+ * carries a matching name and version entry in its all_labels field.
+ */
+function rowResolvesLabel(row: PromptApiResponse, label: string): boolean {
+  const allLabels = (row as unknown as Record<string, unknown>).all_labels
+  if (!Array.isArray(allLabels)) {
+    return false
+  }
+  return allLabels.some(
+    (entry) =>
+      typeof entry === 'object' &&
+      entry !== null &&
+      (entry as Record<string, unknown>).name === label &&
+      (entry as Record<string, unknown>).version === row.version
+  )
+}
+
 export interface PromptsWithPostHogOptions {
   posthog: PostHog
   defaultCacheTtlSeconds?: number
@@ -121,6 +154,9 @@ function isPromptsWithPostHog(options: PromptsOptions): options is PromptsWithPo
  * const prod = await prompts.get('support-system-prompt', {
  *   label: 'production',
  * })
+ *
+ * // Or fetch all prompts at a label in one request and warm the cache
+ * const prodPrompts = await prompts.getAll({ label: 'production' })
  *
  * // Compile with variables
  * const systemPrompt = prompts.compile(result.prompt, {
@@ -210,6 +246,77 @@ export class Prompts {
 
       throw error
     }
+  }
+
+  /**
+   * Fetch every prompt that carries a label, in one batch.
+   *
+   * Returns an object mapping prompt name to `PromptRemoteResult`, with each
+   * prompt at the version the label points to. Prompts without the label are
+   * not included.
+   *
+   * Each fetched prompt is stored in the cache, so later
+   * `get(name, { label })` calls are served from cache within the TTL. An app
+   * with many prompts can call this once per cache cycle instead of making one
+   * `get()` request per prompt.
+   *
+   * Throws if the request fails, or if the server does not support fetching
+   * prompts by label on the list endpoint (PostHog releases from before
+   * September 2026).
+   */
+  async getAll(options: { label: string }): Promise<Record<string, PromptRemoteResult>> {
+    const label = options.label
+    const rows = await this.fetchPromptListFromApi(label)
+
+    const now = Date.now()
+    const results: Record<string, PromptRemoteResult> = {}
+    const skipped: string[] = []
+
+    for (const row of rows) {
+      if (!isPromptApiResponse(row) || !rowResolvesLabel(row, label)) {
+        const name = typeof row === 'object' && row !== null ? (row as Record<string, unknown>).name : undefined
+        skipped.push(typeof name === 'string' ? name : '?')
+        continue
+      }
+
+      const config = extractConfig((row as unknown as Record<string, unknown>).config)
+      this.getOrCreatePromptCache(row.name).set(label, {
+        prompt: row.prompt,
+        name: row.name,
+        version: row.version,
+        label,
+        config,
+        fetchedAt: now,
+      })
+      results[row.name] = {
+        source: 'api',
+        prompt: row.prompt,
+        name: row.name,
+        version: row.version,
+        label,
+        config: cloneConfig(config),
+      }
+    }
+
+    if (rows.length > 0 && Object.keys(results).length === 0) {
+      // Nothing resolved the label, so the server most likely ignored the
+      // label param and served latest versions. Caching those under the label
+      // would be the silent wrong-version failure labels exist to prevent, so
+      // fail loudly instead.
+      throw new Error(
+        `[PostHog Prompts] The server returned prompts, but none resolve label "${label}". ` +
+          'It may not support fetching prompts by label on the list endpoint yet. ' +
+          'Upgrade PostHog, or fetch prompts one by one with get().'
+      )
+    }
+
+    if (skipped.length > 0) {
+      console.warn(
+        `[PostHog Prompts] Skipped ${skipped.length} prompt(s) that did not resolve label "${label}": ${skipped.join(', ')}`
+      )
+    }
+
+    return results
   }
 
   /**
@@ -327,11 +434,7 @@ export class Prompts {
     }
   }
 
-  private async fetchPromptFromApi(
-    name: string,
-    version?: number,
-    label?: string
-  ): Promise<Omit<PromptRemoteResult, 'source'>> {
+  private requireCredentials(): void {
     if (!this.personalApiKey) {
       throw new Error(
         '[PostHog Prompts] personalApiKey is required to fetch prompts. ' +
@@ -344,6 +447,82 @@ export class Prompts {
           'Please provide it when initializing the Prompts instance.'
       )
     }
+  }
+
+  /**
+   * Fetch all prompts at a label from the paginated list endpoint.
+   * Follows pagination links until the last page and returns the raw rows.
+   */
+  private async fetchPromptListFromApi(label: string): Promise<unknown[]> {
+    this.requireCredentials()
+
+    const query = `token=${encodeURIComponent(this.projectApiKey)}&label=${encodeURIComponent(label)}&content=full`
+    let url: string | undefined = `${this.host}/api/environments/@current/llm_prompts/?${query}`
+    const reference = `prompts with label "${label}"`
+
+    const rows: unknown[] = []
+    let pages = 0
+    while (url !== undefined) {
+      if (pages >= MAX_PROMPT_LIST_PAGES) {
+        // A truncated result must not look complete: callers would cache a
+        // partial prompt set and treat missing prompts as unlabeled.
+        throw new Error(
+          `[PostHog Prompts] ${reference} spans more than ${MAX_PROMPT_LIST_PAGES} pages. ` +
+            'Refusing to return an incomplete result.'
+        )
+      }
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.personalApiKey}`,
+        },
+      })
+
+      if (!response.ok) {
+        if (response.status === 403) {
+          throw new Error(
+            `[PostHog Prompts] Access denied for ${reference}. ` +
+              'Check that your personalApiKey has the correct permissions and the LLM prompts feature is enabled.'
+          )
+        }
+        throw new PromptFetchError(
+          `[PostHog Prompts] Failed to fetch ${reference}: HTTP ${response.status}`,
+          response.status === 429 ? parseRetryAfterSeconds(response.headers?.get('Retry-After')) : undefined
+        )
+      }
+
+      const data: unknown = await response.json()
+      if (typeof data !== 'object' || data === null || !Array.isArray((data as Record<string, unknown>).results)) {
+        throw new Error(`[PostHog Prompts] Invalid response format for ${reference}`)
+      }
+      rows.push(...((data as Record<string, unknown>).results as unknown[]))
+
+      // The Authorization header goes to every followed link, so a link off
+      // the configured host must never be requested.
+      const nextUrl = (data as Record<string, unknown>).next
+      if (
+        nextUrl !== null &&
+        nextUrl !== undefined &&
+        (typeof nextUrl !== 'string' || !isSameOrigin(nextUrl, this.host))
+      ) {
+        throw new Error(
+          `[PostHog Prompts] Refusing to follow a pagination link off the configured host while fetching ${reference}.`
+        )
+      }
+      url = nextUrl === null || nextUrl === undefined ? undefined : (nextUrl as string)
+      pages += 1
+    }
+
+    return rows
+  }
+
+  private async fetchPromptFromApi(
+    name: string,
+    version?: number,
+    label?: string
+  ): Promise<Omit<PromptRemoteResult, 'source'>> {
+    this.requireCredentials()
 
     const encodedPromptName = encodeURIComponent(name)
     const encodedProjectApiKey = encodeURIComponent(this.projectApiKey)

--- a/packages/ai/tests/prompts.test.ts
+++ b/packages/ai/tests/prompts.test.ts
@@ -1331,14 +1331,16 @@ describe('Prompts', () => {
     })
 
     it('throws when the server ignores the label', async () => {
-      // An old server ignores ?label= and returns latest versions; none of the
-      // rows resolve the label, and caching them would serve wrong versions.
-      const row = { ...labeledRow('prompt-a'), all_labels: [] }
-      mockFetch.mockResolvedValueOnce(listResponse([row]))
+      // An old server ignores ?label= and returns latest versions of every
+      // prompt, including prompts without the label. Even when some labels
+      // happen to point at latest, a partial result would hide the rest.
+      const looksResolved = labeledRow('prompt-a')
+      const unlabeled = { ...labeledRow('prompt-b'), all_labels: [] }
+      mockFetch.mockResolvedValueOnce(listResponse([looksResolved, unlabeled]))
 
       const prompts = new Prompts({ posthog: createMockPostHog() })
 
-      await expect(prompts.getAll({ label: 'production' })).rejects.toThrow(/none resolve label/)
+      await expect(prompts.getAll({ label: 'production' })).rejects.toThrow(/does not carry label/)
 
       // Nothing was cached: a labeled get() goes to the network.
       mockFetch.mockResolvedValueOnce({

--- a/packages/ai/tests/prompts.test.ts
+++ b/packages/ai/tests/prompts.test.ts
@@ -1361,6 +1361,15 @@ describe('Prompts', () => {
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
     })
 
+    it('throws on a malformed row instead of skipping it', async () => {
+      const malformed = { ...labeledRow('prompt-a'), prompt: 42 }
+      mockFetch.mockResolvedValueOnce(listResponse([malformed, labeledRow('prompt-b')]))
+
+      const prompts = new Prompts({ posthog: createMockPostHog() })
+
+      await expect(prompts.getAll({ label: 'production' })).rejects.toThrow(/Invalid response format/)
+    })
+
     it('refuses a pagination link off the configured host', async () => {
       mockFetch.mockResolvedValueOnce(listResponse([labeledRow('prompt-a')], 'https://attacker.example.com/collect'))
 

--- a/packages/ai/tests/prompts.test.ts
+++ b/packages/ai/tests/prompts.test.ts
@@ -1275,4 +1275,107 @@ describe('Prompts', () => {
       expect(mockFetch).toHaveBeenCalledTimes(3)
     })
   })
+
+  describe('getAll()', () => {
+    const labeledRow = (name: string, version = 1, label = 'production', config: unknown = null) => ({
+      id: `id-${name}`,
+      name,
+      prompt: `Prompt for ${name}`,
+      version,
+      all_labels: [{ name: label, version }],
+      config,
+    })
+
+    const listResponse = (rows: unknown[], nextUrl: string | null = null) => ({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ count: rows.length, next: nextUrl, previous: null, results: rows }),
+    })
+
+    it('fetches all pages and seeds the cache', async () => {
+      const nextUrl =
+        'https://us.posthog.com/api/environments/@current/llm_prompts/?token=phc_test_key&label=production&content=full&limit=100&offset=100'
+      mockFetch
+        .mockResolvedValueOnce(listResponse([labeledRow('prompt-a', 1, 'production', { temperature: 0 })], nextUrl))
+        .mockResolvedValueOnce(listResponse([labeledRow('prompt-b', 3)]))
+
+      const prompts = new Prompts({ posthog: createMockPostHog() })
+      const results = await prompts.getAll({ label: 'production' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(mockFetch.mock.calls[1][0]).toBe(nextUrl)
+      expect(results).toEqual({
+        'prompt-a': {
+          source: 'api',
+          prompt: 'Prompt for prompt-a',
+          name: 'prompt-a',
+          version: 1,
+          label: 'production',
+          config: { temperature: 0 },
+        },
+        'prompt-b': {
+          source: 'api',
+          prompt: 'Prompt for prompt-b',
+          name: 'prompt-b',
+          version: 3,
+          label: 'production',
+          config: null,
+        },
+      })
+
+      // Later labeled get() calls are cache hits, not new requests.
+      const cached = await prompts.get('prompt-b', { label: 'production' })
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(cached.source).toBe('cache')
+      expect(cached.version).toBe(3)
+    })
+
+    it('throws when the server ignores the label', async () => {
+      // An old server ignores ?label= and returns latest versions; none of the
+      // rows resolve the label, and caching them would serve wrong versions.
+      const row = { ...labeledRow('prompt-a'), all_labels: [] }
+      mockFetch.mockResolvedValueOnce(listResponse([row]))
+
+      const prompts = new Prompts({ posthog: createMockPostHog() })
+
+      await expect(prompts.getAll({ label: 'production' })).rejects.toThrow(/none resolve label/)
+
+      // Nothing was cached: a labeled get() goes to the network.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ...mockPromptResponse, name: 'prompt-a', label: 'production' }),
+      })
+      await prompts.get('prompt-a', { label: 'production' })
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('skips a row whose label moved and keeps the rest', async () => {
+      const moved = { ...labeledRow('prompt-a'), all_labels: [{ name: 'production', version: 2 }] }
+      mockFetch.mockResolvedValueOnce(listResponse([moved, labeledRow('prompt-b')]))
+
+      const prompts = new Prompts({ posthog: createMockPostHog() })
+      const results = await prompts.getAll({ label: 'production' })
+
+      expect(Object.keys(results)).toEqual(['prompt-b'])
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses a pagination link off the configured host', async () => {
+      mockFetch.mockResolvedValueOnce(listResponse([labeledRow('prompt-a')], 'https://attacker.example.com/collect'))
+
+      const prompts = new Prompts({ posthog: createMockPostHog() })
+
+      await expect(prompts.getAll({ label: 'production' })).rejects.toThrow(/off the configured host/)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws on an HTTP error', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500, headers: { get: () => null } })
+
+      const prompts = new Prompts({ posthog: createMockPostHog() })
+
+      await expect(prompts.getAll({ label: 'production' })).rejects.toThrow(/HTTP 500/)
+    })
+  })
 })

--- a/packages/ai/tests/prompts.test.ts
+++ b/packages/ai/tests/prompts.test.ts
@@ -1363,6 +1363,17 @@ describe('Prompts', () => {
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
     })
 
+    it('preserves a prompt named __proto__ as an own entry', async () => {
+      mockFetch.mockResolvedValueOnce(listResponse([labeledRow('__proto__')]))
+
+      const prompts = new Prompts({ posthog: createMockPostHog() })
+      const results = await prompts.getAll({ label: 'production' })
+
+      expect(Object.keys(results)).toEqual(['__proto__'])
+      expect(results['__proto__'].prompt).toBe('Prompt for __proto__')
+      expect(JSON.parse(JSON.stringify(results))['__proto__']).toBeDefined()
+    })
+
     it('throws on a malformed row instead of skipping it', async () => {
       const malformed = { ...labeledRow('prompt-a'), prompt: 42 }
       mockFetch.mockResolvedValueOnce(listResponse([malformed, labeledRow('prompt-b')]))


### PR DESCRIPTION
## Problem

- Apps that resolve prompts through a label make one request per prompt per cache cycle. With a few dozen prompts this runs into the API rate limit (PostHog/posthog#95460).
- The PostHog list endpoint can now return all prompts at a label in one request (PostHog/posthog#96137). This adds the SDK side, mirroring PostHog/posthog-python#938.

## Changes

- `prompts.getAll({ label: 'production' })` fetches every prompt at that label in one call, following pagination, and returns an object of name to result.
- Each fetched prompt is stored in the existing cache, so later `prompts.get(name, { label })` calls are cache hits. One call per cache cycle instead of one per prompt.
- Old servers ignore the `label` param on the list endpoint and return latest versions. Each row is checked against its `all_labels` field; if nothing resolves the label, the call throws a clear error instead of caching wrong versions. A single row whose label moved mid-request is skipped with a warning.
- Pagination links are only followed on the configured host (the personal API key travels in the Authorization header), and the page safety cap throws instead of returning a truncated result. Both mirror review findings on the Python PR.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Changeset added in `.changeset/` (written by hand, same format as `pnpm changeset`)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code, directed by the assignee. Port of PostHog/posthog-python#938, including the fixes from its review (same-origin pagination guard, fail on the page cap, fail loudly on old servers).
- Design choice: `getAll` always fetches (no cache read) so one call refreshes everything, like a feature flag poller.
