### PR TITLE
feat(react-native): support partial survey responses and persistent resume

### DIFF
--- a/.changeset/react-native-survey-progress.md
+++ b/.changeset/react-native-survey-progress.md
@@ -1,0 +1,6 @@
+---
+'posthog-react-native': minor
+'@posthog/core': patch
+---
+
+Support partial survey responses and persistent resume in React Native, moving surveys toward feature parity across SDKs. When partial responses are enabled, send cumulative answers after each submitted question with a stable submission ID and completion status. Restore unfinished surveys at the next question after restarting the app; clear progress on completion, dismissal, reset, or opt-out.

--- a/.changeset/react-native-survey-progress.md
+++ b/.changeset/react-native-survey-progress.md
@@ -3,4 +3,4 @@
 '@posthog/core': patch
 ---
 
-Support partial survey responses and persistent resume in React Native, moving surveys toward feature parity across SDKs. When partial responses are enabled, send cumulative answers after each submitted question with a stable submission ID and completion status. Restore unfinished surveys at the next question after restarting the app; clear progress on completion, dismissal, reset, or opt-out.
+Support partial survey responses and persistent resume in React Native, moving surveys toward feature parity across SDKs.

--- a/.changeset/shared-survey-response-events.md
+++ b/.changeset/shared-survey-response-events.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Share survey answer snapshots and response event properties with React Native for consistent partial response reporting.

--- a/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
@@ -6,6 +6,8 @@ import {
     getSurveySeen,
     hasWaitPeriodPassed,
     sendSurveyEvent,
+    setInProgressSurveyState,
+    getInProgressSurveyState,
 } from '../../extensions/surveys/surveys-extension-utils'
 import { PostHog } from '../../posthog-core'
 import { Survey, SurveySchedule, SurveyType } from '../../posthog-surveys-types'
@@ -769,6 +771,8 @@ describe('sendSurveyEvent', () => {
                 $ai_generation_id: 'gen-456',
                 $ai_trace_id: 'trace-789',
                 custom_field: 'custom_value',
+                $survey_name: 'Custom survey name',
+                $set: { custom_person_property: true },
             },
         })
 
@@ -780,6 +784,8 @@ describe('sendSurveyEvent', () => {
         expect(eventProperties.$ai_generation_id).toBe('gen-456')
         expect(eventProperties.$ai_trace_id).toBe('trace-789')
         expect(eventProperties.custom_field).toBe('custom_value')
+        expect(eventProperties.$survey_name).toBe('Custom survey name')
+        expect(eventProperties.$set).toEqual({ '$survey_responded/test-survey-id': true })
     })
 
     it('works without custom properties', () => {
@@ -804,41 +810,46 @@ describe('sendSurveyEvent', () => {
         expect(eventProperties.$ai_generation_id).toBeUndefined()
     })
 
-    it('reloads feature flags when the survey is completed so the internal targeting flag recomputes', () => {
-        const mockReload = vi.fn()
-        const mockPostHog = {
-            capture: vi.fn(),
-            reloadFeatureFlags: mockReload,
-            is_capturing: () => true,
-        } as unknown as PostHog
+    it.each([false, true])(
+        'emits completion=%s and only clears progress and reloads flags on completion',
+        (completed) => {
+            const mockPostHog = {
+                capture: vi.fn(),
+                reloadFeatureFlags: vi.fn(),
+                is_capturing: () => true,
+                get_session_replay_url: () => 'https://us.posthog.com/replay/session-1',
+            } as unknown as PostHog
+            const progress = {
+                surveySubmissionId: 'submission-123',
+                lastQuestionIndex: 0,
+                responses: { $survey_response_q1: 'Great!' },
+                surveyLanguage: 'fr',
+                questionSnapshots: { q1: 'Votre avis ?' },
+            }
+            setInProgressSurveyState(baseSurvey, progress)
 
-        sendSurveyEvent({
-            responses: { $survey_response_q1: 'Great!' },
-            survey: baseSurvey,
-            surveySubmissionId: 'submission-123',
-            isSurveyCompleted: true,
-            posthog: mockPostHog,
-        })
+            sendSurveyEvent({
+                ...progress,
+                survey: baseSurvey,
+                isSurveyCompleted: completed,
+                posthog: mockPostHog,
+            })
 
-        expect(mockReload).toHaveBeenCalledTimes(1)
-    })
-
-    it('does not reload feature flags for a partial (not completed) response', () => {
-        const mockReload = vi.fn()
-        const mockPostHog = {
-            capture: vi.fn(),
-            reloadFeatureFlags: mockReload,
-            is_capturing: () => true,
-        } as unknown as PostHog
-
-        sendSurveyEvent({
-            responses: { $survey_response_q1: 'Great!' },
-            survey: baseSurvey,
-            surveySubmissionId: 'submission-123',
-            isSurveyCompleted: false,
-            posthog: mockPostHog,
-        })
-
-        expect(mockReload).not.toHaveBeenCalled()
-    })
+            expect(mockPostHog.capture).toHaveBeenCalledWith('survey sent', {
+                $survey_id: baseSurvey.id,
+                $survey_name: baseSurvey.name,
+                $survey_iteration: null,
+                $survey_iteration_start_date: null,
+                $survey_submission_id: 'submission-123',
+                $survey_completed: completed,
+                $survey_language: 'fr',
+                $survey_response_q1: 'Great!',
+                $survey_questions: [{ id: 'q1', question: 'Votre avis ?', response: 'Great!' }],
+                sessionRecordingUrl: 'https://us.posthog.com/replay/session-1',
+                $set: { '$survey_responded/test-survey-id': true },
+            })
+            expect(getInProgressSurveyState(baseSurvey)).toEqual(completed ? null : progress)
+            expect(mockPostHog.reloadFeatureFlags).toHaveBeenCalledTimes(completed ? 1 : 0)
+        }
+    )
 })

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -31,6 +31,7 @@ import {
     SURVEY_CAPTURING_DISABLED,
 } from '../utils/survey-utils'
 import { isArray, isNull, isNumber, isUndefined } from '@posthog/core'
+import { recordSurveyAnswer } from '@posthog/core/surveys'
 import { Properties } from '../types'
 import { FeatureFlagsExtension } from '../extension-tokens'
 import type { PostHogFeatureFlags } from '../posthog-featureflags'
@@ -1834,18 +1835,13 @@ export function Questions({
             return
         }
 
-        const responseKey = getSurveyResponseKey(questionId)
-
-        const newResponses = { ...questionsResponses, [responseKey]: res }
+        const { responses: newResponses, questionSnapshots: newSnapshots } = recordSurveyAnswer(
+            { responses: questionsResponses, questionSnapshots },
+            questionId,
+            res,
+            surveyQuestions[displayQuestionIndex]
+        )
         setQuestionsResponses(newResponses)
-
-        // Snapshot the question text as it appeared to the user right now, so that
-        // $survey_questions[].question in sent/dismissed events reflects the language
-        // the user saw when they answered, not the language active at event-fire time.
-        const currentQuestion = surveyQuestions[displayQuestionIndex]
-        const newSnapshots = currentQuestion?.id
-            ? { ...questionSnapshots, [currentQuestion.id]: currentQuestion.question }
-            : questionSnapshots
         setQuestionSnapshots(newSnapshots)
 
         const nextStep = getNextSurveyStep(survey, displayQuestionIndex, res)

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -24,10 +24,9 @@ import {
 } from '../../utils/survey-utils'
 import { isNullish, type SurveyResponses } from '@posthog/core'
 import {
-    buildSurveyResponseProperties,
+    buildSurveyResponseEventProperties,
     canSurveyActivateRepeatedly,
     getSurveyResponseKey,
-    surveyHasResponses,
 } from '@posthog/core/surveys'
 
 import { propertyComparisons } from '@posthog/browser-common/utils/property-utils'
@@ -445,11 +444,16 @@ export const sendSurveyEvent = ({
         [SurveyEventProperties.SURVEY_ID]: survey.id,
         [SurveyEventProperties.SURVEY_ITERATION]: survey.current_iteration,
         [SurveyEventProperties.SURVEY_ITERATION_START_DATE]: survey.current_iteration_start_date,
-        [SurveyEventProperties.SURVEY_SUBMISSION_ID]: surveySubmissionId,
-        [SurveyEventProperties.SURVEY_COMPLETED]: isSurveyCompleted,
-        ...(surveyLanguage && { [SurveyEventProperties.SURVEY_LANGUAGE]: surveyLanguage }),
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
-        ...buildSurveyResponseProperties(responses, survey, questionSnapshots),
+        ...buildSurveyResponseEventProperties({
+            event: 'sent',
+            survey,
+            responses,
+            submissionId: surveySubmissionId,
+            completed: isSurveyCompleted,
+            surveyLanguage,
+            questionSnapshots,
+        }),
         ...properties,
         $set: {
             [getSurveyInteractionProperty(survey, 'responded')]: true,
@@ -467,6 +471,7 @@ export const sendSurveyEvent = ({
 }
 
 const _buildSurveyEventProperties = (
+    event: 'dismissed' | 'abandoned',
     survey: Survey,
     inProgressSurvey: InProgressSurveyState | null,
     posthog: PostHog
@@ -475,13 +480,15 @@ const _buildSurveyEventProperties = (
     [SurveyEventProperties.SURVEY_ID]: survey.id,
     [SurveyEventProperties.SURVEY_ITERATION]: survey.current_iteration,
     [SurveyEventProperties.SURVEY_ITERATION_START_DATE]: survey.current_iteration_start_date,
-    [SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED]: surveyHasResponses(inProgressSurvey?.responses),
-    ...(inProgressSurvey?.surveyLanguage && {
-        [SurveyEventProperties.SURVEY_LANGUAGE]: inProgressSurvey.surveyLanguage,
-    }),
     sessionRecordingUrl: posthog.get_session_replay_url?.(),
-    [SurveyEventProperties.SURVEY_SUBMISSION_ID]: inProgressSurvey?.surveySubmissionId,
-    ...buildSurveyResponseProperties(inProgressSurvey?.responses, survey, inProgressSurvey?.questionSnapshots),
+    ...buildSurveyResponseEventProperties({
+        event,
+        survey,
+        responses: inProgressSurvey?.responses,
+        submissionId: inProgressSurvey?.surveySubmissionId,
+        surveyLanguage: inProgressSurvey?.surveyLanguage,
+        questionSnapshots: inProgressSurvey?.questionSnapshots,
+    }),
 })
 
 export const dismissedSurveyEvent = (
@@ -506,7 +513,7 @@ export const dismissedSurveyEvent = (
     // answering any question), so check for the record's presence, not its value.
     const effectiveLanguage = inProgressSurvey ? inProgressSurvey.surveyLanguage : surveyLanguage
     posthog.capture(SurveyEventName.DISMISSED, {
-        ..._buildSurveyEventProperties(survey, inProgressSurvey, posthog),
+        ..._buildSurveyEventProperties('dismissed', survey, inProgressSurvey, posthog),
         ...(effectiveLanguage && { [SurveyEventProperties.SURVEY_LANGUAGE]: effectiveLanguage }),
         $set: {
             [getSurveyInteractionProperty(survey, 'dismissed')]: true,
@@ -544,9 +551,13 @@ export const sendSurveyAbandonedEvent = (survey: Survey, posthog?: PostHog) => {
         // localStorage not available
     }
 
-    posthog.capture(SurveyEventName.ABANDONED, _buildSurveyEventProperties(survey, inProgressSurvey, posthog), {
-        transport: 'sendBeacon',
-    })
+    posthog.capture(
+        SurveyEventName.ABANDONED,
+        _buildSurveyEventProperties('abandoned', survey, inProgressSurvey, posthog),
+        {
+            transport: 'sendBeacon',
+        }
+    )
 }
 
 // Use the Fisher-yates algorithm to shuffle this array

--- a/packages/core/src/surveys/events.spec.ts
+++ b/packages/core/src/surveys/events.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildSurveyResponseProperties,
+  buildSurveyResponseEventProperties,
+  recordSurveyAnswer,
   getSurveyInteractionProperty,
   getSurveyResponseKey,
   getSurveyResponseValue,
@@ -90,4 +92,92 @@ describe('survey event helpers', () => {
     expect(surveyHasResponses({ $survey_response_q1: 0 })).toBe(true)
     expect(getSurveyInteractionProperty(survey, 'responded')).toBe('$survey_responded/survey-1/2')
   })
+})
+
+describe('recordSurveyAnswer', () => {
+  it.each([0, '', null, ['fast', 'clear']])('records %j without mutating previous answers or snapshots', (response) => {
+    const previous = {
+      responses: { $survey_response_q1: 5 },
+      questionSnapshots: { q1: 'Rate us (French)' },
+    }
+    expect(recordSurveyAnswer(previous, 'q2', response, { id: 'q2', question: 'Anything else?' })).toEqual({
+      responses: { $survey_response_q1: 5, $survey_response_q2: response },
+      questionSnapshots: { q1: 'Rate us (French)', q2: 'Anything else?' },
+    })
+    expect(previous).toEqual({
+      responses: { $survey_response_q1: 5 },
+      questionSnapshots: { q1: 'Rate us (French)' },
+    })
+  })
+
+  it('replaces the answer and its snapshot when a question is answered again', () => {
+    expect(
+      recordSurveyAnswer(
+        {
+          responses: { $survey_response_q1: 5 },
+          questionSnapshots: { q1: 'Rate us (French)' },
+        },
+        'q1',
+        0,
+        { id: 'q1', question: '' }
+      )
+    ).toEqual({
+      responses: { $survey_response_q1: 0 },
+      questionSnapshots: { q1: '' },
+    })
+  })
+
+  it('accepts progress without snapshots and does not invent missing question text', () => {
+    expect(recordSurveyAnswer({ responses: {} }, 'q1', 5)).toEqual({
+      responses: { $survey_response_q1: 5 },
+      questionSnapshots: {},
+    })
+  })
+})
+
+describe('buildSurveyResponseEventProperties', () => {
+  const survey = { questions: [{ id: 'q1', question: 'Rate us', originalQuestionIndex: 0 }] }
+
+  it.each([
+    ['sent', false, { $survey_completed: false }],
+    ['sent', true, { $survey_completed: true }],
+    ['dismissed', undefined, { $survey_partially_completed: true }],
+    ['abandoned', undefined, { $survey_partially_completed: true }],
+  ] as const)('builds %s event properties (completed=%s) with answer-time text', (event, completed, metadata) => {
+    expect(
+      buildSurveyResponseEventProperties({
+        event,
+        survey,
+        completed,
+        submissionId: 'submission-1',
+        surveyLanguage: 'fr',
+        responses: { $survey_response_q1: 0 },
+        questionSnapshots: { q1: 'Notez-nous' },
+      })
+    ).toEqual({
+      ...metadata,
+      $survey_submission_id: 'submission-1',
+      $survey_language: 'fr',
+      $survey_questions: [{ id: 'q1', question: 'Notez-nous', response: 0 }],
+      $survey_response_q1: 0,
+      $survey_response: 0,
+    })
+  })
+
+  it('keeps metadata optional for callers without submission state or a matched language', () => {
+    const properties = buildSurveyResponseEventProperties({ event: 'sent', survey, surveyLanguage: null })
+    expect(properties).not.toHaveProperty('$survey_submission_id')
+    expect(properties).not.toHaveProperty('$survey_completed')
+    expect(properties).not.toHaveProperty('$survey_partially_completed')
+    expect(properties).not.toHaveProperty('$survey_language')
+  })
+
+  it.each([{}, { $survey_response_q1: null }])(
+    'does not count absent or skipped answers as partial completion',
+    (responses) => {
+      expect(buildSurveyResponseEventProperties({ event: 'dismissed', survey, responses })).toMatchObject({
+        $survey_partially_completed: false,
+      })
+    }
+  )
 })

--- a/packages/core/src/surveys/events.ts
+++ b/packages/core/src/surveys/events.ts
@@ -54,6 +54,48 @@ export function buildSurveyResponseProperties(
   }
 }
 
+export function recordSurveyAnswer(
+  { responses, questionSnapshots = {} }: { responses: SurveyResponses; questionSnapshots?: Record<string, string> },
+  questionId: string,
+  response: SurveyResponseValue,
+  question?: SurveyQuestionForResponses
+): { responses: SurveyResponses; questionSnapshots: Record<string, string> } {
+  // Snapshot the question text as it appeared to the user right now, so that
+  // $survey_questions[].question in sent/dismissed events reflects the language
+  // the user saw when they answered, not the language active at event-fire time.
+  return {
+    responses: { ...responses, [getSurveyResponseKey(questionId)]: response },
+    questionSnapshots: question?.id ? { ...questionSnapshots, [question.id]: question.question } : questionSnapshots,
+  }
+}
+
+export function buildSurveyResponseEventProperties({
+  event,
+  survey,
+  responses = {},
+  submissionId,
+  completed,
+  surveyLanguage,
+  questionSnapshots,
+}: {
+  event: 'sent' | 'dismissed' | 'abandoned'
+  survey: SurveyForResponses
+  responses?: SurveyResponses
+  submissionId?: string
+  completed?: boolean
+  surveyLanguage?: string | null
+  questionSnapshots?: Record<string, string>
+}): Record<string, unknown> {
+  return {
+    ...(!isUndefined(submissionId) && { $survey_submission_id: submissionId }),
+    ...(event === 'sent'
+      ? !isUndefined(completed) && { $survey_completed: completed }
+      : { $survey_partially_completed: surveyHasResponses(responses) }),
+    ...(surveyLanguage && { [SURVEY_LANGUAGE_PROPERTY]: surveyLanguage }),
+    ...buildSurveyResponseProperties(responses, survey, questionSnapshots),
+  }
+}
+
 export function surveyHasResponses(responses: SurveyResponses = {}): boolean {
   return Object.values(responses).some((response) => !isNullish(response))
 }

--- a/packages/core/src/surveys/index.ts
+++ b/packages/core/src/surveys/index.ts
@@ -1,6 +1,8 @@
 export { getValidationError, getLengthFromRules, getRequirementsHint } from './validation'
 export {
   buildSurveyResponseProperties,
+  buildSurveyResponseEventProperties,
+  recordSurveyAnswer,
   getSurveyInteractionProperty,
   getSurveyOldResponseKey,
   getSurveyResponseKey,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -292,6 +292,7 @@ export enum PostHogPersistedProperty {
   // Session id for which an event trigger has activated session replay. only used by posthog-react-native
   SessionReplayEventTriggerActivatedSession = 'session_replay_event_trigger_activated_session',
   SurveyLastSeenDate = 'survey_last_seen_date', // only used by posthog-react-native
+  SurveysInProgress = 'surveys_in_progress', // only used by posthog-react-native
   SurveysSeen = 'surveys_seen', // only used by posthog-react-native
   Surveys = 'surveys', // only used by posthog-react-native
   RemoteConfig = 'remote_config',
@@ -912,6 +913,7 @@ export type Survey = {
   current_iteration?: number | null
   current_iteration_start_date?: string | null
   schedule?: SurveySchedule | null
+  enable_partial_responses?: boolean | null
 }
 
 export type SurveyActionType = {

--- a/packages/node/.oxfmtrc.json
+++ b/packages/node/.oxfmtrc.json
@@ -6,5 +6,5 @@
   "quoteProps": "preserve",
   "printWidth": 120,
   "sortPackageJson": false,
-  "ignorePatterns": []
+  "ignorePatterns": ["references/*.json"]
 }

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -3734,6 +3734,10 @@
           "name": "Surveys"
         },
         {
+          "type": "\"surveys_in_progress\"",
+          "name": "SurveysInProgress"
+        },
+        {
           "type": "\"surveys_seen\"",
           "name": "SurveysSeen"
         }
@@ -4231,6 +4235,10 @@
         {
           "type": "SurveySchedule",
           "name": "schedule"
+        },
+        {
+          "type": "boolean",
+          "name": "enable_partial_responses"
         }
       ],
       "path": "../core/src/types.ts"

--- a/packages/react-native/.oxfmtrc.json
+++ b/packages/react-native/.oxfmtrc.json
@@ -6,5 +6,5 @@
   "quoteProps": "preserve",
   "printWidth": 120,
   "sortPackageJson": false,
-  "ignorePatterns": ["src/version.ts"]
+  "ignorePatterns": ["src/version.ts", "references/*.json"]
 }

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -4007,6 +4007,10 @@
           "name": "Surveys"
         },
         {
+          "type": "\"surveys_in_progress\"",
+          "name": "SurveysInProgress"
+        },
+        {
           "type": "\"surveys_seen\"",
           "name": "SurveysSeen"
         }
@@ -4643,6 +4647,10 @@
         {
           "type": "SurveySchedule",
           "name": "schedule"
+        },
+        {
+          "type": "boolean",
+          "name": "enable_partial_responses"
         }
       ],
       "path": "../core/src/types.ts"
@@ -4939,6 +4947,18 @@
           "name": "survey"
         },
         {
+          "type": "PostHog",
+          "name": "client"
+        },
+        {
+          "type": "SurveyProgress",
+          "name": "initialProgress"
+        },
+        {
+          "type": "(progress: SurveyProgress, completed: boolean) => boolean",
+          "name": "onProgressChange"
+        },
+        {
           "type": "string",
           "name": "surveyLanguage"
         },
@@ -4967,6 +4987,37 @@
       "properties": [],
       "path": "../core/src/types.ts",
       "example": "(typeof SurveyPosition)[keyof typeof SurveyPosition]"
+    },
+    {
+      "id": "SurveyProgress",
+      "name": "SurveyProgress",
+      "properties": [
+        {
+          "type": "string",
+          "name": "submissionId"
+        },
+        {
+          "type": "number",
+          "name": "questionIndex"
+        },
+        {
+          "type": "number[]",
+          "name": "questionOrder"
+        },
+        {
+          "type": "SurveyResponses",
+          "name": "responses"
+        },
+        {
+          "type": "Record<string, string>",
+          "name": "questionSnapshots"
+        },
+        {
+          "type": "string",
+          "name": "surveyLanguage"
+        }
+      ],
+      "path": "dist/surveys/survey-progress.d.ts"
     },
     {
       "id": "SurveyQuestion",

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -585,6 +585,9 @@ export class PostHog extends PostHogCore {
   setPersistedProperty<T>(key: PostHogPersistedProperty, value: T | null): void {
     const storage = this._storageForKey(key)
     value !== null ? storage.setItem(key, value) : storage.removeItem(key)
+    if (key === PostHogPersistedProperty.SurveysInProgress && value === null) {
+      this._events.emit('surveysReset', undefined)
+    }
     if (key === PostHogPersistedProperty.PersonProperties) {
       // Notify surveys after the in-memory write, including unsets and resets,
       // without waiting for a feature flag reload.
@@ -1029,6 +1032,7 @@ export class PostHog extends PostHogCore {
   optOut(): Promise<void> {
     // Consent must be durable. See reset()/identify().
     const result = super.optOut()
+    this.setPersistedProperty(PostHogPersistedProperty.SurveysInProgress, null)
     void this._eventsStorage.waitForPersist()
     // A device token registered before opt-out would otherwise survive consent withdrawal: the
     // native subscription handler keeps its own persisted record and retry loop. unregister is

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { dismissedSurveyEvent, sendSurveyShownEvent } from './components/Surveys'
 
 import { getActiveMatchingSurveys } from './getActiveMatchingSurveys'
 import { useSurveyStorage } from './useSurveyStorage'
+import { canCaptureSurvey, createSurveyProgress, SurveyProgress, SurveyProgressStore } from './survey-progress'
+import { getSurveyIterationKey } from '@posthog/core/surveys'
 import { useActivatedSurveys } from './useActivatedSurveys'
 import { SurveyModal } from './components/SurveyModal'
 import { defaultSurveyAppearance, getContrastingTextColor, SurveyAppearanceTheme } from './surveys-utils'
@@ -97,13 +99,21 @@ export type PostHogSurveyProviderProps = {
 export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.Element {
   const posthogFromHook = usePostHog()
   const posthog = props.client ?? posthogFromHook
-  const { seenSurveys, setSeenSurvey, setLastSeenSurveyDate } = useSurveyStorage()
+  const { seenSurveys, setSeenSurvey, setLastSeenSurveyDate, isReady } = useSurveyStorage(posthog)
+  const progressStore = useMemo(() => new SurveyProgressStore(posthog), [posthog])
   const [surveys, setSurveys] = useState<Survey[]>([])
   const [activeSurvey, setActiveSurvey] = useState<Survey | undefined>(undefined)
   // Latches the id of the survey once its modal has actually painted, so deferring presentation
   // (autoPresentSurveys=false) never tears down a survey the user is already interacting with.
   const shownSurveyIdRef = useRef<string | undefined>(undefined)
+  const sessionEpochRef = useRef(0)
+  const activeSessionRef = useRef<object | undefined>(undefined)
   const activatedSurveys = useActivatedSurveys(posthog, surveys)
+  const invalidateSession = useCallback(() => {
+    sessionEpochRef.current++
+    activeSessionRef.current = undefined
+    shownSurveyIdRef.current = undefined
+  }, [])
 
   const flags = useFeatureFlags(posthog)
   const [userLanguage, setUserLanguage] = useState(() => detectUserLanguage(posthog))
@@ -115,8 +125,22 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
     return unsubscribe
   }, [posthog])
 
+  useEffect(
+    () =>
+      posthog.on('surveysReset', () => {
+        invalidateSession()
+        setActiveSurvey(undefined)
+      }),
+    [posthog, invalidateSession]
+  )
+
   // Load surveys once
   useEffect(() => {
+    let mounted = true
+    setActiveSurvey(undefined)
+    setSurveys([])
+    activeSessionRef.current = undefined
+    shownSurveyIdRef.current = undefined
     posthog
       .ready()
       .then(() => posthog._onSurveysReady())
@@ -124,14 +148,23 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
         setUserLanguage(detectUserLanguage(posthog))
         return posthog.getSurveys()
       })
-      .then(setSurveys)
+      .then((loadedSurveys) => {
+        if (!mounted) return
+        progressStore.reconcile(loadedSurveys)
+        setSurveys(loadedSurveys)
+      })
       .catch(() => {})
-  }, [posthog])
+    return () => {
+      mounted = false
+      invalidateSession()
+    }
+  }, [posthog, progressStore, invalidateSession])
 
   // Whenever state changes, re-select the popover survey to show. A survey that has already
   // painted is left alone; an armed-but-deferred one is re-validated so it can't be presented
   // after it stops matching (e.g. its targeting flag flips off during a long deferral).
   useEffect(() => {
+    if (!isReady || !canCaptureSurvey(posthog)) return
     const isShown = !!activeSurvey && shownSurveyIdRef.current === activeSurvey.id
     if (isShown) {
       return
@@ -141,11 +174,14 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
       surveys,
       flags ?? {},
       seenSurveys,
-      activatedSurveys
+      activatedSurveys,
+      new Set(surveys.filter((survey) => progressStore.load(survey)).map(getSurveyIterationKey))
       // lastSeenSurveyDate
     )
 
-    const popoverSurveys = activeSurveys.filter((survey: Survey) => survey.type === SurveyType.Popover)
+    const popoverSurveys = activeSurveys
+      .filter((survey: Survey) => survey.type === SurveyType.Popover)
+      .sort((a, b) => Number(!!progressStore.load(b)) - Number(!!progressStore.load(a)))
     // TODO: sort by appearance delay, implement delay
     // const popoverSurveyQueue = sortSurveysByAppearanceDelay(popoverSurveys)
 
@@ -154,7 +190,7 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
     }
 
     setActiveSurvey(popoverSurveys.length > 0 ? popoverSurveys[0] : undefined)
-  }, [activeSurvey, flags, surveys, seenSurveys, activatedSurveys])
+  }, [activeSurvey, flags, surveys, seenSurveys, activatedSurveys, isReady, posthog, progressStore])
 
   const translatedActiveSurvey = useMemo(() => {
     return activeSurvey ? applySurveyTranslationForUser(activeSurvey, posthog, userLanguage) : undefined
@@ -183,32 +219,86 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
     }
   }, [translatedActiveSurvey, props.defaultSurveyAppearance, props.overrideAppearanceWithDefault])
 
+  const activeSession = useMemo(
+    () =>
+      activeSurvey
+        ? {
+            progress: progressStore.load(activeSurvey) ?? createSurveyProgress(activeSurvey),
+            completed: false,
+            epoch: sessionEpochRef.current,
+          }
+        : undefined,
+    [activeSurvey, progressStore]
+  )
+
   const activeContext = useMemo(() => {
-    if (!activeSurvey || !translatedActiveSurvey) {
+    if (!activeSurvey || !translatedActiveSurvey || !activeSession) {
       return undefined
     }
     return {
+      client: posthog,
+      initialProgress: activeSession.progress,
+      onProgressChange: (progress: SurveyProgress, completed: boolean) => {
+        if (
+          activeSessionRef.current !== activeSession ||
+          !canCaptureSurvey(posthog) ||
+          progressStore.load(activeSurvey)?.submissionId !== activeSession.progress.submissionId
+        )
+          return false
+        activeSession.progress = progress
+        activeSession.completed = completed
+        if (completed) {
+          progressStore.remove(activeSurvey)
+          setSeenSurvey(activeSurvey)
+        } else {
+          progressStore.save(activeSurvey, progress)
+        }
+        return true
+      },
       survey: translatedActiveSurvey.survey,
       surveyLanguage: translatedActiveSurvey.language,
       onShow: () => {
         // Updating translated copy changes this callback, but does not show a new survey.
+        if (activeSession.epoch !== sessionEpochRef.current || !canCaptureSurvey(posthog)) return
         if (shownSurveyIdRef.current === activeSurvey.id) {
           return
         }
+        activeSessionRef.current = activeSession
+        progressStore.save(activeSurvey, activeSession.progress)
         shownSurveyIdRef.current = activeSurvey.id
         sendSurveyShownEvent(translatedActiveSurvey.survey, posthog, translatedActiveSurvey.language)
         setLastSeenSurveyDate(new Date())
       },
       onClose: (submitted: boolean, responses: SurveyResponses) => {
+        if (activeSessionRef.current !== activeSession) return
+        activeSessionRef.current = undefined
+        progressStore.remove(activeSurvey)
         shownSurveyIdRef.current = undefined
         setSeenSurvey(activeSurvey)
         setActiveSurvey(undefined)
-        if (!submitted) {
-          dismissedSurveyEvent(translatedActiveSurvey.survey, responses, posthog, translatedActiveSurvey.language)
+        if (submitted || activeSession.completed) return
+        if (canCaptureSurvey(posthog)) {
+          dismissedSurveyEvent(
+            translatedActiveSurvey.survey,
+            responses,
+            posthog,
+            Object.keys(activeSession.progress.responses).length > 0
+              ? activeSession.progress.surveyLanguage
+              : translatedActiveSurvey.language,
+            activeSession.progress
+          )
         }
       },
     }
-  }, [activeSurvey, posthog, setLastSeenSurveyDate, setSeenSurvey, translatedActiveSurvey])
+  }, [
+    activeSurvey,
+    activeSession,
+    posthog,
+    progressStore,
+    setLastSeenSurveyDate,
+    setSeenSurvey,
+    translatedActiveSurvey,
+  ])
 
   // Present a popover survey when autoPresentSurveys is on. Once it has painted (shownSurveyIdRef),
   // keep it mounted regardless of the gate so a mid-interaction survey is never yanked — the gate
@@ -224,6 +314,7 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
         {props.children}
         {shouldShowModal && (
           <SurveyModal
+            key={activeSession?.progress.submissionId}
             appearance={surveyAppearance}
             androidKeyboardBehavior={props.androidKeyboardBehavior}
             {...activeContext}

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -9,9 +9,14 @@ import { SurveyAppearanceTheme, resolveSurveyAlignment } from '../surveys-utils'
 import { Survey, type SurveyResponses } from '@posthog/core'
 import { useOptionalSafeAreaInsets } from '../../optional/OptionalReactNativeSafeArea'
 import { Questions } from './Surveys'
+import type { SurveyProgress } from '../survey-progress'
+import type { PostHog } from '../../posthog-rn'
 
 export type SurveyModalProps = {
   survey: Survey
+  client?: PostHog
+  initialProgress?: SurveyProgress
+  onProgressChange?: (progress: SurveyProgress, completed: boolean) => boolean
   surveyLanguage: string | null
   appearance: SurveyAppearanceTheme
   onShow: () => void
@@ -34,16 +39,21 @@ const MODAL_FADE_DURATION_MS = 250
 // real onDismiss stays the primary path on the happy path.
 const IOS_DISMISS_FALLBACK_MS = 1000
 
+function shouldShowIntro(appearance: SurveyAppearanceTheme, progress?: SurveyProgress): boolean {
+  if (Object.keys(progress?.responses ?? {}).length > 0) return false
+  return (
+    Boolean(appearance.displayIntroScreen) && Boolean(appearance.introScreenHeader || appearance.introScreenDescription)
+  )
+}
+
 export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const { survey, surveyLanguage, appearance, onShow, onClose: onCloseProp, androidKeyboardBehavior = 'height' } = props
   const [isSurveySent, setIsSurveySent] = useState(false)
   // The intro screen is a leading page mirroring the trailing confirmation message. Dismissing it
   // only flips local state — no response is recorded and no survey event is sent. It has no
   // default header, so an intro with no copy at all is skipped instead of drawing an empty box.
-  const [showIntro, setShowIntro] = useState(
-    Boolean(appearance.displayIntroScreen) && Boolean(appearance.introScreenHeader || appearance.introScreenDescription)
-  )
-  const [responses, setResponses] = useState<SurveyResponses>({})
+  const [showIntro, setShowIntro] = useState(() => shouldShowIntro(appearance, props.initialProgress))
+  const [responses, setResponses] = useState<SurveyResponses>(props.initialProgress?.responses ?? {})
   const [isVisible, setIsVisible] = useState(true)
   // Two-step hide for RN Fabric snapshot recycling — see
   // https://github.com/facebook/react-native/issues/48245
@@ -166,10 +176,12 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
                     />
                   ) : (
                     <Questions
+                      client={props.client}
+                      initialProgress={props.initialProgress}
+                      onProgressChange={props.onProgressChange}
                       survey={survey}
                       surveyLanguage={surveyLanguage}
                       appearance={appearance}
-                      responses={responses}
                       onResponsesChange={setResponses}
                       onSubmit={() => setIsSurveySent(true)}
                     />

--- a/packages/react-native/src/surveys/components/Surveys.tsx
+++ b/packages/react-native/src/surveys/components/Surveys.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 
 import { getNextSurveyStep, SurveyAppearanceTheme } from '../surveys-utils'
-import { getDisplayOrderQuestions, shouldShuffleQuestions } from '../survey-shuffling'
+import { shouldShuffleQuestions } from '../survey-shuffling'
+import { canCaptureSurvey, createSurveyProgress, SurveyProgress } from '../survey-progress'
 import {
   Survey,
   SurveyAppearance,
@@ -24,13 +25,21 @@ import { usePostHog } from '../../hooks/usePostHog'
 
 // Events receive the configured survey, not its shuffled display copies. Supply
 // positional indices here so legacy response properties do not depend on rendering.
-const buildConfiguredSurveyResponseProperties = (responses: SurveyResponses, survey: Survey) =>
-  buildSurveyResponseProperties(responses, {
-    questions: survey.questions.map((question, originalQuestionIndex) => ({
-      ...question,
-      originalQuestionIndex,
-    })),
-  })
+const buildConfiguredSurveyResponseProperties = (
+  responses: SurveyResponses,
+  survey: Survey,
+  snapshots?: Record<string, string>
+) =>
+  buildSurveyResponseProperties(
+    responses,
+    {
+      questions: survey.questions.map((question, originalQuestionIndex) => ({
+        ...question,
+        originalQuestionIndex,
+      })),
+    },
+    snapshots
+  )
 
 export const sendSurveyShownEvent = (survey: Survey, posthog: PostHog, surveyLanguage?: string | null): void => {
   posthog.capture('survey shown', {
@@ -46,7 +55,9 @@ export const sendSurveyEvent = (
   responses: SurveyResponses = {},
   survey: Survey,
   posthog: PostHog,
-  surveyLanguage?: string | null
+  surveyLanguage?: string | null,
+  progress?: SurveyProgress,
+  completed = true
 ): void => {
   posthog.capture('survey sent', {
     $survey_name: survey.name,
@@ -54,7 +65,8 @@ export const sendSurveyEvent = (
     ...maybeAdd('$survey_iteration', survey.current_iteration),
     ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
     ...(surveyLanguage ? { [SURVEY_LANGUAGE_PROPERTY]: surveyLanguage } : {}),
-    ...buildConfiguredSurveyResponseProperties(responses, survey),
+    ...(progress ? { $survey_submission_id: progress.submissionId, $survey_completed: completed } : {}),
+    ...buildConfiguredSurveyResponseProperties(responses, survey, progress?.questionSnapshots),
     $set: {
       [getSurveyInteractionProperty(survey, 'responded')]: true,
     },
@@ -65,7 +77,8 @@ export const dismissedSurveyEvent = (
   survey: Survey,
   responses: SurveyResponses = {},
   posthog: PostHog,
-  surveyLanguage?: string | null
+  surveyLanguage?: string | null,
+  progress?: SurveyProgress
 ): void => {
   posthog.capture('survey dismissed', {
     $survey_name: survey.name,
@@ -74,34 +87,63 @@ export const dismissedSurveyEvent = (
     ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
     ...(surveyLanguage ? { [SURVEY_LANGUAGE_PROPERTY]: surveyLanguage } : {}),
     $survey_partially_completed: surveyHasResponses(responses),
-    ...buildConfiguredSurveyResponseProperties(responses, survey),
+    ...(progress ? { $survey_submission_id: progress.submissionId } : {}),
+    ...buildConfiguredSurveyResponseProperties(responses, survey, progress?.questionSnapshots),
     $set: {
       [getSurveyInteractionProperty(survey, 'dismissed')]: true,
     },
   })
 }
 
+function nextQuestion(
+  survey: Survey,
+  progress: SurveyProgress,
+  originalQuestionIndex: number,
+  response: string | string[] | number | null
+) {
+  if (!shouldShuffleQuestions(survey)) return getNextSurveyStep(survey, originalQuestionIndex, response)
+  // Shuffled surveys cannot use branching and must advance through display order.
+  // Non-shuffled surveys retain the configured/original-index branching semantics.
+  return progress.questionIndex === progress.questionOrder.length - 1
+    ? SurveyQuestionBranchingType.End
+    : progress.questionIndex + 1
+}
+
 export function Questions({
   survey,
+  client,
   surveyLanguage,
   appearance,
   styleOverrides,
-  responses = {},
+  initialProgress,
+  onProgressChange = () => true,
   onResponsesChange = () => {},
   onSubmit,
 }: {
   survey: Survey
+  client?: PostHog
   surveyLanguage?: string | null
   appearance: SurveyAppearanceTheme
   styleOverrides?: StyleProp<ViewStyle>
-  responses?: SurveyResponses
+  initialProgress?: SurveyProgress
+  onProgressChange?: (progress: SurveyProgress, completed: boolean) => boolean
   onResponsesChange?: (responses: SurveyResponses) => void
   onSubmit: () => void
 }): JSX.Element {
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0)
-  const surveyQuestions = useMemo(() => getDisplayOrderQuestions(survey), [survey])
-  const questionsAreShuffled = shouldShuffleQuestions(survey)
-  const posthog = usePostHog()
+  const [progress, setProgress] = useState(() => initialProgress ?? createSurveyProgress(survey))
+  const completedRef = useRef(false)
+  const progressRef = useRef(progress)
+  const currentQuestionIndex = progress.questionIndex
+  const surveyQuestions = useMemo(
+    () =>
+      progress.questionOrder.map((index) => ({
+        ...survey.questions[index],
+        originalQuestionIndex: index,
+      })),
+    [survey, progress.questionOrder]
+  )
+  const posthogFromHook = usePostHog()
+  const posthog = client ?? posthogFromHook
 
   const onNextButtonClick = ({
     res,
@@ -112,34 +154,30 @@ export function Questions({
     originalQuestionIndex: number
     questionId: string
   }): void => {
+    if (completedRef.current || progressRef.current !== progress || !canCaptureSurvey(posthog)) return
     const responseKey = getSurveyResponseKey(questionId)
-
-    const allResponses = {
-      ...responses,
-      [responseKey]: res,
+    const allResponses = { ...progress.responses, [responseKey]: res }
+    const nextStep = nextQuestion(survey, progress, originalQuestionIndex, res)
+    const completed = nextStep === SurveyQuestionBranchingType.End
+    const nextProgress: SurveyProgress = {
+      ...progress,
+      responses: allResponses,
+      questionIndex: completed ? currentQuestionIndex : nextStep,
+      questionSnapshots: {
+        ...progress.questionSnapshots,
+        [questionId]: surveyQuestions[currentQuestionIndex].question,
+      },
+      surveyLanguage,
     }
+    if (onProgressChange(nextProgress, completed) === false) return
+    progressRef.current = nextProgress
+    completedRef.current = completed
+    setProgress(nextProgress)
     onResponsesChange(allResponses)
-
-    // Shuffled surveys cannot use branching and must advance through display order.
-    // Non-shuffled surveys retain the configured/original-index branching semantics.
-    if (questionsAreShuffled) {
-      if (currentQuestionIndex === surveyQuestions.length - 1) {
-        sendSurveyEvent(allResponses, survey, posthog, surveyLanguage)
-        onSubmit()
-      } else {
-        setCurrentQuestionIndex((index) => index + 1)
-      }
-      return
+    if (survey.enable_partial_responses || completed) {
+      sendSurveyEvent(allResponses, survey, posthog, surveyLanguage, nextProgress, completed)
     }
-
-    const nextStep = getNextSurveyStep(survey, originalQuestionIndex, res)
-
-    if (nextStep === SurveyQuestionBranchingType.End) {
-      sendSurveyEvent(allResponses, survey, posthog, surveyLanguage)
-      onSubmit()
-    } else {
-      setCurrentQuestionIndex(nextStep)
-    }
+    if (completed) onSubmit()
   }
 
   const question = surveyQuestions[currentQuestionIndex]

--- a/packages/react-native/src/surveys/components/Surveys.tsx
+++ b/packages/react-native/src/surveys/components/Surveys.tsx
@@ -13,11 +13,10 @@ import {
   SurveyQuestionBranchingType,
 } from '@posthog/core'
 import {
-  buildSurveyResponseProperties,
+  buildSurveyResponseEventProperties,
   getSurveyInteractionProperty,
-  getSurveyResponseKey,
+  recordSurveyAnswer,
   SURVEY_LANGUAGE_PROPERTY,
-  surveyHasResponses,
 } from '@posthog/core/surveys'
 import { LinkQuestion, MultipleChoiceQuestion, OpenTextQuestion, RatingQuestion } from './QuestionTypes'
 import { PostHog } from '../../posthog-rn'
@@ -25,21 +24,12 @@ import { usePostHog } from '../../hooks/usePostHog'
 
 // Events receive the configured survey, not its shuffled display copies. Supply
 // positional indices here so legacy response properties do not depend on rendering.
-const buildConfiguredSurveyResponseProperties = (
-  responses: SurveyResponses,
-  survey: Survey,
-  snapshots?: Record<string, string>
-) =>
-  buildSurveyResponseProperties(
-    responses,
-    {
-      questions: survey.questions.map((question, originalQuestionIndex) => ({
-        ...question,
-        originalQuestionIndex,
-      })),
-    },
-    snapshots
-  )
+const withOriginalQuestionIndices = (survey: Survey) => ({
+  questions: survey.questions.map((question, originalQuestionIndex) => ({
+    ...question,
+    originalQuestionIndex,
+  })),
+})
 
 export const sendSurveyShownEvent = (survey: Survey, posthog: PostHog, surveyLanguage?: string | null): void => {
   posthog.capture('survey shown', {
@@ -64,9 +54,15 @@ export const sendSurveyEvent = (
     $survey_id: survey.id,
     ...maybeAdd('$survey_iteration', survey.current_iteration),
     ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
-    ...(surveyLanguage ? { [SURVEY_LANGUAGE_PROPERTY]: surveyLanguage } : {}),
-    ...(progress ? { $survey_submission_id: progress.submissionId, $survey_completed: completed } : {}),
-    ...buildConfiguredSurveyResponseProperties(responses, survey, progress?.questionSnapshots),
+    ...buildSurveyResponseEventProperties({
+      event: 'sent',
+      survey: withOriginalQuestionIndices(survey),
+      responses,
+      submissionId: progress?.submissionId,
+      completed: progress ? completed : undefined,
+      surveyLanguage,
+      questionSnapshots: progress?.questionSnapshots,
+    }),
     $set: {
       [getSurveyInteractionProperty(survey, 'responded')]: true,
     },
@@ -85,10 +81,14 @@ export const dismissedSurveyEvent = (
     $survey_id: survey.id,
     ...maybeAdd('$survey_iteration', survey.current_iteration),
     ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
-    ...(surveyLanguage ? { [SURVEY_LANGUAGE_PROPERTY]: surveyLanguage } : {}),
-    $survey_partially_completed: surveyHasResponses(responses),
-    ...(progress ? { $survey_submission_id: progress.submissionId } : {}),
-    ...buildConfiguredSurveyResponseProperties(responses, survey, progress?.questionSnapshots),
+    ...buildSurveyResponseEventProperties({
+      event: 'dismissed',
+      survey: withOriginalQuestionIndices(survey),
+      responses,
+      submissionId: progress?.submissionId,
+      surveyLanguage,
+      questionSnapshots: progress?.questionSnapshots,
+    }),
     $set: {
       [getSurveyInteractionProperty(survey, 'dismissed')]: true,
     },
@@ -155,27 +155,22 @@ export function Questions({
     questionId: string
   }): void => {
     if (completedRef.current || progressRef.current !== progress || !canCaptureSurvey(posthog)) return
-    const responseKey = getSurveyResponseKey(questionId)
-    const allResponses = { ...progress.responses, [responseKey]: res }
+    const answer = recordSurveyAnswer(progress, questionId, res, surveyQuestions[currentQuestionIndex])
     const nextStep = nextQuestion(survey, progress, originalQuestionIndex, res)
     const completed = nextStep === SurveyQuestionBranchingType.End
     const nextProgress: SurveyProgress = {
       ...progress,
-      responses: allResponses,
+      ...answer,
       questionIndex: completed ? currentQuestionIndex : nextStep,
-      questionSnapshots: {
-        ...progress.questionSnapshots,
-        [questionId]: surveyQuestions[currentQuestionIndex].question,
-      },
       surveyLanguage,
     }
     if (onProgressChange(nextProgress, completed) === false) return
     progressRef.current = nextProgress
     completedRef.current = completed
     setProgress(nextProgress)
-    onResponsesChange(allResponses)
+    onResponsesChange(answer.responses)
     if (survey.enable_partial_responses || completed) {
-      sendSurveyEvent(allResponses, survey, posthog, surveyLanguage, nextProgress, completed)
+      sendSurveyEvent(answer.responses, survey, posthog, surveyLanguage, nextProgress, completed)
     }
     if (completed) onSubmit()
   }

--- a/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
+++ b/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
@@ -31,10 +31,12 @@ export function getActiveMatchingSurveys(
   surveys: Survey[],
   flags: Record<string, FeatureFlagValue>,
   seenSurveys: string[],
-  activatedSurveys: ReadonlySet<string>
+  activatedSurveys: ReadonlySet<string>,
+  inProgressSurveys: ReadonlySet<string> = new Set()
   // lastSeenSurveyDate: Date | undefined
 ): Survey[] {
   return surveys.filter((survey: Survey) => {
+    const hasProgress = inProgressSurveys.has(getSurveyIterationKey(survey))
     // Is Active
     if (!survey.start_date || survey.end_date) {
       return false
@@ -45,7 +47,7 @@ export function getActiveMatchingSurveys(
       return false
     }
 
-    if (seenSurveys.includes(getSurveyIterationKey(survey)) && !canSurveyActivateRepeatedly(survey)) {
+    if (seenSurveys.includes(getSurveyIterationKey(survey)) && !canSurveyActivateRepeatedly(survey) && !hasProgress) {
       return false
     }
 
@@ -66,6 +68,10 @@ export function getActiveMatchingSurveys(
     ) {
       return false
     }
+
+    const eventBasedTargetingFlagCheck =
+      !doesSurveyActivateByEvent(survey) || hasProgress || activatedSurveys.has(survey.id)
+    if (!eventBasedTargetingFlagCheck) return false
 
     if (
       !survey.linked_flag_key &&
@@ -89,10 +95,8 @@ export function getActiveMatchingSurveys(
 
     const targetingFlagCheck = isSurveyFlagEnabled(survey.targeting_flag_key, flags)
 
-    const eventBasedTargetingFlagCheck = doesSurveyActivateByEvent(survey) ? activatedSurveys.has(survey.id) : true
-
     const internalTargetingFlagCheck =
-      survey.internal_targeting_flag_key && !canSurveyActivateRepeatedly(survey)
+      survey.internal_targeting_flag_key && !canSurveyActivateRepeatedly(survey) && !hasProgress
         ? isSurveyFlagEnabled(survey.internal_targeting_flag_key, flags)
         : true
     const flagsCheck = survey.feature_flag_keys?.length

--- a/packages/react-native/src/surveys/survey-progress.ts
+++ b/packages/react-native/src/surveys/survey-progress.ts
@@ -1,0 +1,186 @@
+import {
+  PostHogPersistedProperty,
+  Survey,
+  SurveyQuestion,
+  SurveyQuestionType,
+  SurveyResponses,
+  uuidv7,
+} from '@posthog/core'
+import { getSurveyIterationKey, getSurveyResponseKey } from '@posthog/core/surveys'
+import type { PostHog } from '../posthog-rn'
+import { getDisplayOrderQuestions } from './survey-shuffling'
+
+export type SurveyProgress = {
+  submissionId: string
+  questionIndex: number
+  questionOrder: number[]
+  responses: SurveyResponses
+  questionSnapshots: Record<string, string>
+  surveyLanguage?: string | null
+}
+
+export function createSurveyProgress(survey: Survey): SurveyProgress {
+  return {
+    submissionId: uuidv7(),
+    questionIndex: 0,
+    questionOrder: getDisplayOrderQuestions(survey).map((question) => question.originalQuestionIndex),
+    responses: {},
+    questionSnapshots: {},
+  }
+}
+
+// Copy changes (including translations) do not invalidate answers. Changes to
+// question identity, response shape or branching must start a new submission.
+function questionShape(question: SurveyQuestion): object {
+  const base = { id: question.id, type: question.type, optional: question.optional, branching: question.branching }
+  switch (question.type) {
+    case SurveyQuestionType.SingleChoice:
+    case SurveyQuestionType.MultipleChoice:
+      return { ...base, choices: question.choices, hasOpenChoice: question.hasOpenChoice }
+    case SurveyQuestionType.Rating:
+      return { ...base, scale: question.scale, display: question.display }
+    case SurveyQuestionType.Link:
+      return { ...base, link: question.link }
+    default:
+      return base
+  }
+}
+
+function surveyShape(survey: Survey): string {
+  return JSON.stringify([
+    survey.current_iteration_start_date,
+    survey.enable_partial_responses,
+    survey.appearance?.shuffleQuestions,
+    survey.questions.map(questionShape),
+  ])
+}
+
+type SavedProgress = {
+  project: string
+  surveyKey: string
+  shape: string
+  updatedAt: number
+  progress: SurveyProgress
+}
+
+const MAX_PROGRESS = 20
+const MAX_AGE = 30 * 24 * 60 * 60 * 1000
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function isQuestionIndex(value: unknown, count: number): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value < count
+}
+
+function isQuestionOrder(value: unknown, count: number): value is number[] {
+  if (!Array.isArray(value) || value.length !== count || new Set(value).size !== count) return false
+  return value.every((index) => isQuestionIndex(index, count))
+}
+
+function isResponse(value: unknown): boolean {
+  if (value === null || typeof value === 'string') return true
+  if (typeof value === 'number') return Number.isFinite(value)
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+function validResponses(value: unknown, survey: Survey): boolean {
+  if (!isRecord(value)) return false
+  const keys = new Set(survey.questions.map((question) => getSurveyResponseKey(question.id)))
+  return Object.entries(value).every(([key, response]) => keys.has(key) && isResponse(response))
+}
+
+function validSnapshots(value: unknown, survey: Survey): boolean {
+  if (!isRecord(value)) return false
+  const ids = new Set(survey.questions.map((question) => question.id))
+  return Object.entries(value).every(([id, text]) => ids.has(id) && typeof text === 'string')
+}
+
+function validProgress(value: unknown, survey: Survey): value is SurveyProgress {
+  if (!isRecord(value)) return false
+  const { submissionId, questionIndex, questionOrder, responses, questionSnapshots, surveyLanguage } = value
+  const languageIsValid = surveyLanguage == null || typeof surveyLanguage === 'string'
+  return (
+    isNonEmptyString(submissionId) &&
+    languageIsValid &&
+    isQuestionIndex(questionIndex, survey.questions.length) &&
+    isQuestionOrder(questionOrder, survey.questions.length) &&
+    validResponses(responses, survey) &&
+    validSnapshots(questionSnapshots, survey)
+  )
+}
+
+function isRecent(value: unknown): boolean {
+  return typeof value === 'number' && value > Date.now() - MAX_AGE && value <= Date.now()
+}
+
+function isSavedProgress(value: unknown, project: string): value is SavedProgress {
+  if (!isRecord(value)) return false
+  return (
+    value.project === project &&
+    typeof value.surveyKey === 'string' &&
+    isNonEmptyString(value.shape) &&
+    isRecent(value.updatedAt) &&
+    isRecord(value.progress)
+  )
+}
+
+export function canCaptureSurvey(posthog: PostHog): boolean {
+  return !posthog.optedOut && !posthog.isDisabled
+}
+
+export class SurveyProgressStore {
+  constructor(private readonly posthog: PostHog) {}
+
+  private read(): SavedProgress[] {
+    const raw = this.posthog.getPersistedProperty<unknown>(PostHogPersistedProperty.SurveysInProgress)
+    if (!Array.isArray(raw)) return []
+    return raw
+      .filter((entry): entry is SavedProgress => isSavedProgress(entry, this.posthog.apiKey))
+      .slice(0, MAX_PROGRESS)
+  }
+
+  load(survey: Survey): SurveyProgress | undefined {
+    const entry = this.read().find((entry) => entry.surveyKey === getSurveyIterationKey(survey))
+    return entry?.shape === surveyShape(survey) && validProgress(entry.progress, survey) ? entry.progress : undefined
+  }
+
+  save(survey: Survey, progress: SurveyProgress): void {
+    const surveyKey = getSurveyIterationKey(survey)
+    this.posthog.setPersistedProperty(
+      PostHogPersistedProperty.SurveysInProgress,
+      [
+        {
+          project: this.posthog.apiKey,
+          surveyKey,
+          shape: surveyShape(survey),
+          updatedAt: Date.now(),
+          progress,
+        },
+        ...this.read().filter((entry) => entry.surveyKey !== surveyKey),
+      ].slice(0, MAX_PROGRESS)
+    )
+  }
+
+  remove(survey: Survey): void {
+    this.posthog.setPersistedProperty(
+      PostHogPersistedProperty.SurveysInProgress,
+      this.read().filter((entry) => entry.surveyKey !== getSurveyIterationKey(survey))
+    )
+  }
+
+  reconcile(surveys: Survey[]): void {
+    const validKeys = new Set(
+      surveys.filter((survey) => survey.start_date && !survey.end_date && this.load(survey)).map(getSurveyIterationKey)
+    )
+    this.posthog.setPersistedProperty(
+      PostHogPersistedProperty.SurveysInProgress,
+      this.read().filter((entry) => validKeys.has(entry.surveyKey))
+    )
+  }
+}

--- a/packages/react-native/src/surveys/survey-shuffling.ts
+++ b/packages/react-native/src/surveys/survey-shuffling.ts
@@ -1,13 +1,9 @@
 import { MultipleSurveyQuestion, Survey, SurveyQuestion } from '@posthog/core'
 
-type SurveyWithPartialResponses = Survey & {
-  enable_partial_responses?: boolean | null
-}
-
 const hasBranching = (survey: Survey): boolean => survey.questions.some((question) => !!question.branching?.type)
 
 export const shouldShuffleQuestions = (survey: Survey): boolean => {
-  const partialResponsesEnabled = (survey as SurveyWithPartialResponses).enable_partial_responses
+  const partialResponsesEnabled = survey.enable_partial_responses
 
   return !!survey.appearance?.shuffleQuestions && !partialResponsesEnabled && !hasBranching(survey)
 }

--- a/packages/react-native/src/surveys/useActivatedSurveys.ts
+++ b/packages/react-native/src/surveys/useActivatedSurveys.ts
@@ -14,6 +14,11 @@ interface EventSurveyConfig {
 export function useActivatedSurveys(posthog: PostHog, surveys: Survey[]): ReadonlySet<string> {
   const [activatedSurveys, setActivatedSurveys] = useState<ReadonlySet<string>>(new Set())
 
+  useEffect(() => {
+    setActivatedSurveys(new Set())
+    return posthog.on('surveysReset', () => setActivatedSurveys(new Set()))
+  }, [posthog])
+
   const eventMap = useMemo(() => {
     const newEventMap = new Map<string, EventSurveyConfig[]>()
     for (const survey of surveys.filter(doesSurveyActivateByEvent)) {

--- a/packages/react-native/src/surveys/useSurveyStorage.ts
+++ b/packages/react-native/src/surveys/useSurveyStorage.ts
@@ -2,8 +2,10 @@ import { PostHogPersistedProperty } from '@posthog/core'
 import { getSurveyIterationKey, isSurveyKeyForSurvey, SurveyWithIteration } from '@posthog/core/surveys'
 import { useCallback, useEffect, useState } from 'react'
 import { usePostHog } from '../hooks/usePostHog'
+import type { PostHog } from '../posthog-rn'
 
 type SurveyStorage = {
+  isReady: boolean
   // Iteration-qualified keys (getSurveyIterationKey) so repeating surveys re-show when a new iteration starts
   seenSurveys: string[]
   setSeenSurvey: (survey: SurveyWithIteration) => void
@@ -21,13 +23,18 @@ export function updateSeenSurveys(current: string[], survey: SurveyWithIteration
   return [surveyKey, ...current.filter((key) => !isSurveyKeyForSurvey(key, survey.id))].slice(0, MAX_SEEN_SURVEYS)
 }
 
-export function useSurveyStorage(): SurveyStorage {
-  const posthogStorage = usePostHog()
+export function useSurveyStorage(client?: PostHog): SurveyStorage {
+  const fromHook = usePostHog()
+  const posthogStorage = client ?? fromHook
+  const [isReady, setIsReady] = useState(false)
   const [lastSeenSurveyDate, setLastSeenSurveyDate] = useState<Date | undefined>(undefined)
   const [seenSurveys, setSeenSurveys] = useState<string[]>([])
 
   useEffect(() => {
-    posthogStorage.ready().then(() => {
+    let mounted = true
+    setIsReady(false)
+    const load = () => {
+      if (!mounted) return
       const lastSeenSurveyDate = posthogStorage.getPersistedProperty(PostHogPersistedProperty.SurveyLastSeenDate)
       if (typeof lastSeenSurveyDate === 'string') {
         setLastSeenSurveyDate(new Date(lastSeenSurveyDate))
@@ -35,15 +42,32 @@ export function useSurveyStorage(): SurveyStorage {
 
       const serialisedSeenSurveys = posthogStorage.getPersistedProperty(PostHogPersistedProperty.SurveysSeen)
       if (typeof serialisedSeenSurveys === 'string') {
-        const parsedSeenSurveys: unknown = JSON.parse(serialisedSeenSurveys)
+        let parsedSeenSurveys: unknown
+        try {
+          parsedSeenSurveys = JSON.parse(serialisedSeenSurveys)
+        } catch {
+          parsedSeenSurveys = []
+        }
         if (Array.isArray(parsedSeenSurveys)) {
           setSeenSurveys(parsedSeenSurveys.filter((key): key is string => typeof key === 'string'))
         }
+      } else {
+        setSeenSurveys([])
       }
+      setIsReady(true)
+    }
+    void posthogStorage.ready().then(load)
+    const unsubscribe = posthogStorage.on('surveysReset', () => {
+      void posthogStorage.ready().then(load)
     })
+    return () => {
+      mounted = false
+      unsubscribe()
+    }
   }, [posthogStorage])
 
   return {
+    isReady,
     seenSurveys,
     setSeenSurvey: useCallback(
       (survey: SurveyWithIteration) => {

--- a/packages/react-native/test/PostHogSurveyProvider.translations.spec.tsx
+++ b/packages/react-native/test/PostHogSurveyProvider.translations.spec.tsx
@@ -128,7 +128,7 @@ it.each(['unset', 'reset properties', 'reset', 'unmatched'])(
     const ui = await mount()
     act(() => posthog.setPersonPropertiesForFlags({ language: 'es' }, false))
     expect(ui.queryByText('Pregunta 0')).not.toBeNull()
-    act(() => {
+    await act(async () => {
       if (operation === 'unset') posthog.unsetPersonProperties('language', false)
       else if (operation === 'reset properties') posthog.resetPersonPropertiesForFlags(false)
       else if (operation === 'reset') posthog.reset()
@@ -142,7 +142,9 @@ it.each(['unset', 'reset properties', 'reset', 'unmatched'])(
     const sent = vi.mocked(posthog.capture).mock.calls.find(([event]) => event === 'survey sent')
     expect(sent).toBeDefined()
     expect(sent![1]).not.toHaveProperty('$survey_language')
-    expectOnlyOneShown()
+    expect(vi.mocked(posthog.capture).mock.calls.filter(([event]) => event === 'survey shown')).toHaveLength(
+      operation === 'reset' ? 2 : 1
+    )
   }
 )
 
@@ -284,4 +286,25 @@ it('preserves a selected rating when translating', async () => {
     })
   )
   expectOnlyOneShown()
+})
+
+it('preserves answer-time question text across partial responses and language changes', async () => {
+  const ui = await mount({ ...makeSurvey(), enable_partial_responses: true })
+  fireEvent.change(ui.getByRole('textbox'), { target: { value: 'First answer' } })
+  fireEvent.click(ui.getByText('Next'))
+  act(() => posthog.setPersonPropertiesForFlags({ language: 'es' }, false))
+  fireEvent.change(ui.getByRole('textbox'), { target: { value: 'Second answer' } })
+  fireEvent.click(ui.getByText('Siguiente'))
+  const sent = vi.mocked(posthog.capture).mock.calls.filter(([event]) => event === 'survey sent')
+  expect(sent).toHaveLength(2)
+  expect(sent[0][1]).toMatchObject({ $survey_completed: false })
+  expect(sent[1][1]).toMatchObject({
+    $survey_completed: true,
+    $survey_submission_id: sent[0][1]?.$survey_submission_id,
+    $survey_language: 'es',
+    $survey_questions: [
+      { id: 'q0', question: 'Question 0', response: 'First answer' },
+      { id: 'q1', question: 'Pregunta 1', response: 'Second answer' },
+    ],
+  })
 })

--- a/packages/react-native/test/Questions.shuffling.spec.tsx
+++ b/packages/react-native/test/Questions.shuffling.spec.tsx
@@ -60,7 +60,7 @@ afterEach(() => {
 
 describe('Questions shuffling', () => {
   it('advances through shuffled display order without skipping questions', () => {
-    vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0)
+    vi.spyOn(Math, 'random').mockReturnValue(0)
     const onSubmit = vi.fn()
     const onResponsesChange = vi.fn()
     const { getByTestId, queryByTestId } = render(

--- a/packages/react-native/test/SurveyModal.spec.tsx
+++ b/packages/react-native/test/SurveyModal.spec.tsx
@@ -342,6 +342,27 @@ describe('SurveyModal intro screen', () => {
       />
     )
 
+  it('skips the intro when restoring an answered survey', () => {
+    const { queryByTestId } = render(
+      <SurveyModal
+        survey={baseSurvey}
+        surveyLanguage={null}
+        appearance={appearanceWithIntro}
+        onShow={vi.fn()}
+        onClose={vi.fn()}
+        initialProgress={{
+          submissionId: 'saved',
+          questionIndex: 0,
+          questionOrder: [0],
+          responses: { $survey_response_q1: 'saved' },
+          questionSnapshots: {},
+        }}
+      />
+    )
+    expect(queryByTestId('intro-stub')).toBeNull()
+    expect(queryByTestId('questions-stub')).not.toBeNull()
+  })
+
   it('renders the intro screen before the questions and advances on start', () => {
     const { queryByTestId, getByTestId } = renderWithAppearance(appearanceWithIntro)
 

--- a/packages/react-native/test/getActiveMatchingSurveys.spec.ts
+++ b/packages/react-native/test/getActiveMatchingSurveys.spec.ts
@@ -291,6 +291,7 @@ describe('getActiveMatchingSurveys', () => {
         }),
       ]
 
+      mockActivatedSurveys.add('seen-survey-1')
       const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
 
       expect(result).toHaveLength(1)

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -543,6 +543,20 @@ describe('PostHog React Native', () => {
       await rnStorage.preloadPromise
     })
 
+    it.each(['reset', 'optOut'] as const)('clears unfinished survey storage on %s before restart', async (action) => {
+      posthog = new PostHog('1', { customStorage: storage, captureAppLifecycleEvents: false, flushInterval: 0 })
+      await posthog.ready()
+      posthog.setPersistedProperty(PostHogPersistedProperty.SurveysInProgress, [{ submissionId: 'old-user' }])
+      const resetListener = vi.fn()
+      posthog.on('surveysReset', resetListener)
+      await posthog[action]()
+      expect(resetListener).toHaveBeenCalledOnce()
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.SurveysInProgress)).toBeUndefined()
+      const restored = createEventsStorage(storage)
+      await restored.preloadPromise
+      expect(restored.getItem(PostHogPersistedProperty.SurveysInProgress)).toBeUndefined()
+    })
+
     it('should allow immediate calls without delay for stored values', async () => {
       posthog = new PostHog('1', {
         customStorage: storage,

--- a/packages/react-native/test/survey-progress.spec.ts
+++ b/packages/react-native/test/survey-progress.spec.ts
@@ -1,0 +1,147 @@
+import { PostHogPersistedProperty, Survey, SurveyQuestionType, SurveyType } from '@posthog/core'
+import type { PostHog } from '../src/posthog-rn'
+import { createEventsStorage } from '../src/storage'
+import { createSurveyProgress, SurveyProgressStore } from '../src/surveys/survey-progress'
+
+const survey: Survey = {
+  id: 'resume',
+  name: 'Resume',
+  type: SurveyType.Popover,
+  start_date: '2026-01-01',
+  questions: ['first', 'last'].map((id, originalQuestionIndex) => ({
+    id,
+    originalQuestionIndex,
+    type: SurveyQuestionType.Open,
+    question: id,
+  })),
+}
+
+function setup() {
+  const disk = new Map<string, string>()
+  const backend = {
+    getItem: async (key: string) => disk.get(key) ?? null,
+    setItem: async (key: string, value: string) => {
+      disk.set(key, value)
+    },
+  }
+  function open(project = 'project') {
+    const storage = createEventsStorage(backend)
+    const client = {
+      apiKey: project,
+      getPersistedProperty: (key: PostHogPersistedProperty) => storage.getItem(key),
+      setPersistedProperty: (key: PostHogPersistedProperty, value: unknown) => storage.setItem(key, value),
+    } as unknown as PostHog
+    return { storage, store: new SurveyProgressStore(client), client }
+  }
+  return { open }
+}
+
+it('restores answers and display order from a new asynchronous storage instance', async () => {
+  const { open } = setup()
+  const first = open()
+  await first.storage.preloadPromise
+  const progress = {
+    ...createSurveyProgress(survey),
+    questionIndex: 1,
+    responses: { $survey_response_first: 'Saved answer' },
+    questionSnapshots: { first: 'Original copy' },
+  }
+  first.store.save(survey, progress)
+  await first.storage.waitForPersist()
+  const second = open()
+  await second.storage.preloadPromise
+  expect(second.store.load(survey)).toEqual(progress)
+  second.store.remove(survey)
+  await second.storage.waitForPersist()
+  const third = open()
+  await third.storage.preloadPromise
+  expect(third.store.load(survey)).toBeUndefined()
+  const otherProject = open('different-project')
+  await otherProject.storage.preloadPromise
+  expect(otherProject.store.load(survey)).toBeUndefined()
+})
+
+it.each([
+  ['iteration', { ...survey, current_iteration: 2 }],
+  ['question removed', { ...survey, questions: survey.questions.slice(1) }],
+  ['question reordered', { ...survey, questions: [...survey.questions].reverse() }],
+  [
+    'response type changed',
+    { ...survey, questions: [{ ...survey.questions[0], type: SurveyQuestionType.Rating }, survey.questions[1]] },
+  ],
+] as const)('does not restore after %s', async (_label, changed) => {
+  const { store, storage } = setup().open()
+  await storage.preloadPromise
+  store.save(survey, createSurveyProgress(survey))
+  expect(store.load(changed as Survey)).toBeUndefined()
+})
+
+it.each([null, 'bad JSON', {}, [null], [{ project: 'project' }]])('ignores malformed storage %j', async (value) => {
+  const { store, storage } = setup().open()
+  await storage.preloadPromise
+  storage.setItem(PostHogPersistedProperty.SurveysInProgress, value)
+  expect(() => store.load(survey)).not.toThrow()
+  expect(store.load(survey)).toBeUndefined()
+})
+
+it.each([
+  { questionIndex: -1 },
+  { questionIndex: 2 },
+  { questionOrder: [0, 0] },
+  { responses: { $survey_response_unknown: 'answer' } },
+  { responses: { $survey_response_first: {} } },
+  { questionSnapshots: { first: null } },
+  { submissionId: '' },
+])('rejects incompatible saved progress %j', async (invalid) => {
+  const { store, storage } = setup().open()
+  await storage.preloadPromise
+  store.save(survey, createSurveyProgress(survey))
+  const entries = storage.getItem(PostHogPersistedProperty.SurveysInProgress)
+  entries[0].progress = { ...entries[0].progress, ...invalid }
+  expect(store.load(survey)).toBeUndefined()
+})
+
+it('keeps copy edits, but removes expired, ended and deleted survey progress', async () => {
+  const { store, storage } = setup().open()
+  await storage.preloadPromise
+  const progress = createSurveyProgress(survey)
+  store.save(survey, progress)
+  expect(store.load({ ...survey, questions: survey.questions.map((q) => ({ ...q, question: 'New copy' })) })).toEqual(
+    progress
+  )
+  store.reconcile([{ ...survey, end_date: '2026-01-02' }])
+  expect(store.load(survey)).toBeUndefined()
+  store.save(survey, progress)
+  store.reconcile([])
+  expect(store.load(survey)).toBeUndefined()
+  store.save(survey, progress)
+  vi.advanceTimersByTime(31 * 24 * 60 * 60 * 1000)
+  expect(store.load(survey)).toBeUndefined()
+})
+
+it("bounds storage and does not restore another project's answers", async () => {
+  const { open } = setup()
+  const { store, storage } = open()
+  await storage.preloadPromise
+  for (let i = 0; i < 25; i++) store.save({ ...survey, id: `s${i}` }, createSurveyProgress(survey))
+  expect(storage.getItem(PostHogPersistedProperty.SurveysInProgress)).toHaveLength(20)
+  expect(store.load({ ...survey, id: 's0' })).toBeUndefined()
+  expect(store.load({ ...survey, id: 's24' })).toBeDefined()
+  await storage.waitForPersist()
+  const other = open('other-project')
+  await other.storage.preloadPromise
+  expect(other.store.load({ ...survey, id: 's24' })).toBeUndefined()
+})
+
+it.each([
+  [{ type: SurveyQuestionType.SingleChoice, choices: ['A', 'B'] }, { choices: ['B', 'A'] }],
+  [{ type: SurveyQuestionType.Rating, scale: 5, display: 'number' }, { scale: 10 }],
+  [{ type: SurveyQuestionType.Open }, { branching: { type: 'end' } }],
+])('invalidates progress when answer meaning or branching changes', async (question, change) => {
+  const { store, storage } = setup().open()
+  await storage.preloadPromise
+  const original = { ...survey, questions: [{ ...survey.questions[0], ...question }, survey.questions[1]] } as Survey
+  store.save(original, createSurveyProgress(original))
+  const edited = { ...original, questions: [{ ...original.questions[0], ...change }, original.questions[1]] } as Survey
+  expect(store.load(edited)).toBeUndefined()
+})

--- a/packages/react-native/test/survey-response-attribution.spec.tsx
+++ b/packages/react-native/test/survey-response-attribution.spec.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import React, { useState } from 'react'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   Survey,
@@ -61,7 +61,6 @@ function SurveySession({ survey, onSubmit }: { survey: Survey; onSubmit: () => v
       <Questions
         survey={survey}
         appearance={defaultSurveyAppearance}
-        responses={responses}
         onResponsesChange={setResponses}
         onSubmit={onSubmit}
       />
@@ -97,6 +96,8 @@ describe('survey response attribution', () => {
     expectCaptured('survey sent', {
       $survey_id: 'attribution',
       $survey_name: 'Response attribution',
+      $survey_submission_id: expect.any(String),
+      $survey_completed: true,
       $survey_questions: ['q1', 'q2', 'q3'].map((id) => ({ id, question: id, response: `answer-${id}` })),
       $survey_response_q1: 'answer-q1',
       $survey_response_q2: 'answer-q2',
@@ -230,4 +231,115 @@ describe('survey response attribution', () => {
       $set: { '$survey_dismissed/attribution': true },
     })
   })
+})
+
+describe('partial survey sessions', () => {
+  it.each([true, false])('restores the next branch and submission ID (partial=%s)', (partial) => {
+    const survey = makeSurvey(false, {
+      enable_partial_responses: partial,
+      questions: [
+        {
+          id: 'q1',
+          type: SurveyQuestionType.Open,
+          question: 'First',
+          branching: { type: SurveyQuestionBranchingType.SpecificQuestion, index: 2 },
+        },
+        { id: 'q2', type: SurveyQuestionType.Open, question: 'Skipped' },
+        { id: 'q3', type: SurveyQuestionType.Open, question: 'Last' },
+      ] as SurveyQuestion[],
+    })
+    let saved: any
+    const save = (progress: any) => {
+      saved = JSON.parse(JSON.stringify(progress))
+      return true
+    }
+    const first = render(
+      <Questions survey={survey} appearance={defaultSurveyAppearance} onSubmit={vi.fn()} onProgressChange={save} />
+    )
+    fireEvent.click(first.getByTestId('q1'))
+    expect(capture).toHaveBeenCalledTimes(partial ? 1 : 0)
+    if (partial)
+      expect(capture).toHaveBeenLastCalledWith(
+        'survey sent',
+        expect.objectContaining({
+          $survey_completed: false,
+          $survey_submission_id: saved.submissionId,
+          $survey_response_q1: 'answer-q1',
+        })
+      )
+    first.unmount()
+    const complete = vi.fn()
+    const second = render(
+      <Questions
+        survey={survey}
+        appearance={defaultSurveyAppearance}
+        initialProgress={saved}
+        onSubmit={complete}
+        onProgressChange={save}
+      />
+    )
+    expect(second.queryByTestId('q1')).toBeNull()
+    fireEvent.click(second.getByTestId('q3'))
+    expect(complete).toHaveBeenCalledOnce()
+    expect(capture).toHaveBeenLastCalledWith(
+      'survey sent',
+      expect.objectContaining({
+        $survey_completed: true,
+        $survey_submission_id: saved.submissionId,
+        $survey_response_q1: 'answer-q1',
+        $survey_response_q3: 'answer-q3',
+      })
+    )
+    expect(capture.mock.lastCall?.[1]).not.toHaveProperty('$survey_response_q2')
+  })
+})
+
+it('does not duplicate partial or final events when a question submits twice before rendering', () => {
+  const survey = makeSurvey(false, { enable_partial_responses: true })
+  const complete = vi.fn()
+  const ui = render(<Questions survey={survey} appearance={defaultSurveyAppearance} onSubmit={complete} />)
+  for (const id of ['q1', 'q2', 'q3']) {
+    const button = ui.getByTestId(id)
+    act(() => {
+      fireEvent.click(button)
+      fireEvent.click(button)
+    })
+  }
+  expect(capture).toHaveBeenCalledTimes(3)
+  expect(complete).toHaveBeenCalledOnce()
+  expect(capture.mock.calls.map(([, props]) => props.$survey_completed)).toEqual([false, false, true])
+})
+
+it('restores shuffled question order without reshuffling after restart', () => {
+  vi.spyOn(Math, 'random').mockReturnValue(0)
+  const survey = makeSurvey(true)
+  let saved: any
+  const first = render(
+    <Questions
+      survey={survey}
+      appearance={defaultSurveyAppearance}
+      onSubmit={vi.fn()}
+      onProgressChange={(progress) => {
+        saved = JSON.parse(JSON.stringify(progress))
+        return true
+      }}
+    />
+  )
+  fireEvent.click(first.getByTestId('q2'))
+  first.unmount()
+  vi.mocked(Math.random).mockReturnValue(0.9)
+  const complete = vi.fn()
+  const second = render(
+    <Questions survey={survey} appearance={defaultSurveyAppearance} initialProgress={saved} onSubmit={complete} />
+  )
+  fireEvent.click(second.getByTestId('q3'))
+  fireEvent.click(second.getByTestId('q1'))
+  expect(complete).toHaveBeenCalledOnce()
+  expect(capture).toHaveBeenLastCalledWith(
+    'survey sent',
+    expect.objectContaining({
+      $survey_submission_id: saved.submissionId,
+      $survey_response_q2: 'answer-q2',
+    })
+  )
 })

--- a/packages/react-native/test/survey-resume-provider.spec.tsx
+++ b/packages/react-native/test/survey-resume-provider.spec.tsx
@@ -1,0 +1,227 @@
+/** @vitest-environment jsdom */
+import React from 'react'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { PostHogPersistedProperty, Survey, SurveyQuestion, SurveyQuestionType, SurveyType } from '@posthog/core'
+import { createEventsStorage } from '../src/storage'
+import { PostHogSurveyProvider } from '../src/surveys/PostHogSurveyProvider'
+import { defaultSurveyAppearance } from '../src/surveys/surveys-utils'
+import type { PostHog } from '../src/posthog-rn'
+
+vi.mock('react-native', async () => {
+  const RealReact = await vi.importActual<typeof import('react')>('react')
+  const Box = RealReact.forwardRef(({ children, testID, ...rest }: any, ref: any) =>
+    RealReact.createElement('div', { ref, 'data-testid': testID, ...rest }, children)
+  )
+  return {
+    View: Box,
+    Modal: Box,
+    Text: Box,
+    Platform: { OS: 'android', select: (o: any) => o.android ?? o.default },
+    StyleSheet: { create: (s: any) => s, flatten: (s: any) => s, absoluteFill: {} },
+    Appearance: { getColorScheme: () => 'light', addChangeListener: () => ({ remove: vi.fn() }) },
+    useColorScheme: () => 'light',
+    useWindowDimensions: () => ({ width: 375, height: 800 }),
+  }
+})
+
+vi.mock('../src/native-deps', () => ({ currentDeviceType: 'Mobile' }))
+
+let client: any
+let lastModalProps: any
+vi.mock('../src/hooks/usePostHog', () => ({ usePostHog: () => client }))
+vi.mock('../src/surveys/components/QuestionTypes', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  const Question = ({ question, onSubmit }: { question: SurveyQuestion; onSubmit: (answer: string) => void }) =>
+    React.createElement('button', { onClick: () => onSubmit('answer-' + question.id) }, question.id)
+  return {
+    OpenTextQuestion: Question,
+    LinkQuestion: Question,
+    RatingQuestion: Question,
+    MultipleChoiceQuestion: Question,
+  }
+})
+vi.mock('../src/surveys/components/SurveyModal', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  const { Questions } = await import('../src/surveys/components/Surveys')
+  return {
+    SurveyModal: (props: any) => {
+      lastModalProps = props
+      const [responses, setResponses] = React.useState(props.initialProgress.responses)
+      const [completed, setCompleted] = React.useState(false)
+      React.useEffect(() => {
+        props.onShow()
+      }, [props.onShow])
+      return React.createElement(
+        React.Fragment,
+        null,
+        completed
+          ? React.createElement('span', null, 'Thank you')
+          : React.createElement(Questions, {
+              ...props,
+              appearance: defaultSurveyAppearance,
+              onResponsesChange: setResponses,
+              onSubmit: () => setCompleted(true),
+            }),
+        React.createElement('button', { onClick: () => props.onClose(completed, responses) }, 'Close')
+      )
+    },
+  }
+})
+
+const survey = {
+  id: 'resume',
+  name: 'Resume',
+  type: SurveyType.Popover,
+  start_date: '2026-01-01',
+  enable_partial_responses: true,
+  internal_targeting_flag_key: 'eligible',
+  conditions: { events: { values: [{ name: 'trigger' }] } },
+  questions: ['q1', 'q2'].map((id, originalQuestionIndex) => ({
+    id,
+    originalQuestionIndex,
+    type: SurveyQuestionType.Open,
+    question: id,
+  })),
+} as Survey
+
+function makeClient(disk: Map<string, string>, surveys = [survey], flags = { eligible: true }) {
+  const storage = createEventsStorage({
+    getItem: async (key) => disk.get(key) ?? null,
+    setItem: async (key, value) => {
+      disk.set(key, value)
+    },
+  })
+  const listeners = new Map<string, Set<(value: any) => void>>()
+  const emit = (event: string, payload?: unknown) => listeners.get(event)?.forEach((listener) => listener(payload))
+  const sdk = {
+    apiKey: 'project',
+    optedOut: false,
+    ready: async () => {
+      await storage.preloadPromise
+    },
+    _onSurveysReady: async () => {},
+    getSurveys: async () => surveys,
+    getFeatureFlags: () => flags,
+    onFeatureFlags: () => () => {},
+    getPersistedProperty: (key: PostHogPersistedProperty) => storage.getItem(key),
+    setPersistedProperty: (key: PostHogPersistedProperty, value: unknown) => storage.setItem(key, value),
+    getCommonEventProperties: () => ({}),
+    getSurveyDisplayLanguageOverride: () => null,
+    capture: vi.fn((event, properties) => emit('capture', { event, properties })),
+    on: (event: string, listener: (value: any) => void) => {
+      const set = listeners.get(event) ?? new Set()
+      set.add(listener)
+      listeners.set(event, set)
+      return () => {
+        set.delete(listener)
+      }
+    },
+    resetSurveyState: () => {
+      storage.removeItem(PostHogPersistedProperty.SurveysInProgress)
+      storage.removeItem(PostHogPersistedProperty.SurveysSeen)
+      emit('surveysReset')
+    },
+    storage,
+  }
+  return sdk
+}
+
+const mount = () =>
+  render(
+    <PostHogSurveyProvider client={client as PostHog}>
+      <span>App</span>
+    </PostHogSurveyProvider>
+  )
+const ready = async () => {
+  await act(async () => {
+    await client.ready()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+beforeEach(() => vi.useRealTimers())
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+it.each([true, false])('resumes after a fresh SDK/provider without retriggering (partial=%s)', async (partial) => {
+  const configured = { ...survey, enable_partial_responses: partial }
+  const disk = new Map<string, string>()
+  client = makeClient(disk, [configured])
+  const first = mount()
+  await ready()
+  expect(first.queryByText('q1')).toBeNull()
+  act(() => client.capture('trigger', {}))
+  await waitFor(() => expect(first.queryByText('q1')).not.toBeNull())
+  fireEvent.click(first.getByText('q1'))
+  const initial = lastModalProps.initialProgress
+  expect(first.queryByText('q2')).not.toBeNull()
+  await client.storage.waitForPersist()
+  first.unmount()
+  client = makeClient(disk, [configured], { eligible: false })
+  const second = mount()
+  await ready()
+  await waitFor(() => expect(second.queryByText('q2')).not.toBeNull())
+  expect(second.queryByText('q1')).toBeNull()
+  expect(client.capture.mock.calls.filter(([event]: any) => event === 'survey sent')).toHaveLength(0)
+  fireEvent.click(second.getByText('q2'))
+  expect(client.capture).toHaveBeenCalledWith(
+    'survey sent',
+    expect.objectContaining({
+      $survey_completed: true,
+      $survey_submission_id: initial.submissionId,
+      $survey_response_q1: 'answer-q1',
+      $survey_response_q2: 'answer-q2',
+    })
+  )
+  expect(second.queryByText('Thank you')).not.toBeNull()
+  expect(client.getPersistedProperty(PostHogPersistedProperty.SurveysInProgress)).toEqual([])
+  await client.storage.waitForPersist()
+  second.unmount()
+  client = makeClient(disk, [configured])
+  const third = mount()
+  await ready()
+  act(() => client.capture('trigger', {}))
+  expect(third.queryByText('q1')).toBeNull()
+})
+
+it('dismisses with saved responses and clears progress without a completion event', async () => {
+  client = makeClient(new Map())
+  const view = mount()
+  await ready()
+  act(() => client.capture('trigger', {}))
+  fireEvent.click(await view.findByText('q1'))
+  fireEvent.click(view.getByText('Close'))
+  expect(client.capture).toHaveBeenCalledWith(
+    'survey dismissed',
+    expect.objectContaining({
+      $survey_submission_id: expect.any(String),
+      $survey_partially_completed: true,
+      $survey_response_q1: 'answer-q1',
+    })
+  )
+  expect(client.getPersistedProperty(PostHogPersistedProperty.SurveysInProgress)).toEqual([])
+  expect(
+    client.capture.mock.calls.filter(([event, props]: any) => event === 'survey sent' && props.$survey_completed)
+  ).toHaveLength(0)
+})
+
+it.each(['reset', 'optOut'])('invalidates mounted and stale callbacks on %s', async (action) => {
+  client = makeClient(new Map())
+  const view = mount()
+  await ready()
+  act(() => client.capture('trigger', {}))
+  fireEvent.click(await view.findByText('q1'))
+  const oldProps = lastModalProps
+  client.capture.mockClear()
+  await act(async () => {
+    client.optedOut = action === 'optOut'
+    client.resetSurveyState()
+  })
+  expect(view.queryByText('q2')).toBeNull()
+  act(() => oldProps.onShow())
+  expect(oldProps.onProgressChange(oldProps.initialProgress, false)).toBe(false)
+  act(() => oldProps.onClose(false, oldProps.initialProgress.responses))
+  expect(client.capture).not.toHaveBeenCalled()
+  expect(client.getPersistedProperty(PostHogPersistedProperty.SurveysInProgress)).toBeUndefined()
+})

--- a/packages/react-native/test/useSurveyStorage.spec.ts
+++ b/packages/react-native/test/useSurveyStorage.spec.ts
@@ -58,6 +58,7 @@ describe('useSurveyStorage', () => {
             : undefined
         ),
         setPersistedProperty: vi.fn(),
+        on: vi.fn(() => () => {}),
       } as unknown as PostHog
       const wrapper = ({ children }: { children: React.ReactNode }) =>
         React.createElement(PostHogContext.Provider, { value: { client: mockPostHog } }, children)


### PR DESCRIPTION
React Native loses unfinished survey answers when the app restarts and sends responses only on completion. This adds partial responses and persistent resume, moving surveys toward feature parity across SDKs.

- With `enable_partial_responses`, send cumulative submitted answers using one `$survey_submission_id`; `$survey_completed` becomes true on the final answer.
- Resume at the next question after restart, preserving answers, question order, branching, and answer-time translations. Resume also works with partial event collection disabled.
- Clear progress on completion, dismissal, reset, or opt-out. Reject incompatible survey edits and stale callbacks; retain up to 20 surveys per project for 30 days.

Web and RN now share answer accumulation, question snapshots, and response event properties through `@posthog/core/surveys`. Storage formats, lifecycle handling, and branching remain platform-specific. The extraction is a separate commit for review; branching consolidation and storage-format changes belong in separate PRs.

**Validation:** 1,041 RN tests, 601 web survey tests, and 149 core survey tests pass after merging current `main`. Web/RN production builds and scoped lint pass. Regression tests cover unavailable survey caches preserving the original submission, core opt-out completion/errors, cross-project preservation, async initialization, and pruning expired or excess other-project entries. The retention and new lifecycle regressions failed before their fixes. CodeScene passes for the fix; the existing large SDK test file stays in its health category. No device/simulator run; RN component tests replace native views with DOM primitives.

Resume persists **submitted answers**, not text still being typed, and requires a persistent SDK storage backend.

Refs #2962. Update the survey SDK support matrix once released.
