### PR TITLE
fix(traces): share the parent's clock basis across local child spans

### DIFF
--- a/.changeset/traces-child-clock-basis.md
+++ b/.changeset/traces-child-clock-basis.md
@@ -1,0 +1,6 @@
+---
+'posthog-node': patch
+'@posthog/core': patch
+---
+
+Child spans now share their parent's clock, so a child no longer appears to start before or end after its parent by up to a millisecond, or by more when the system clock is adjusted mid-trace.

--- a/packages/core/src/traces/index.spec.ts
+++ b/packages/core/src/traces/index.spec.ts
@@ -194,6 +194,77 @@ describe('PostHogTraces', () => {
     })
   })
 
+  describe('clock basis', () => {
+    const setClocks = (wall: number, mono: number): void => {
+      vi.spyOn(Date, 'now').mockReturnValue(wall)
+      vi.spyOn(performance, 'now').mockReturnValue(mono)
+    }
+
+    const expectWithin = (inner: OtlpSpan, outer: OtlpSpan): void => {
+      expect(BigInt(inner.startTimeUnixNano)).toBeGreaterThanOrEqual(BigInt(outer.startTimeUnixNano))
+      expect(BigInt(inner.endTimeUnixNano)).toBeLessThanOrEqual(BigInt(outer.endTimeUnixNano))
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('keeps a child inside its parent when the wall clock truncates sub-millisecond starts', async () => {
+      const traces = createTraces()
+      setClocks(1_700_000_001_000, 0.9)
+      const parent = traces.startSpan('POST /checkout')
+      setClocks(1_700_000_001_001, 1)
+      const child = traces.startSpan('http.post payments', { parent })
+      setClocks(1_700_000_001_005, 5)
+      child.end()
+      setClocks(1_700_000_001_005, 5.05)
+      parent.end()
+      await traces.flush()
+
+      const [childSpan, parentSpan] = sentSpans()
+      expectWithin(childSpan, parentSpan)
+    })
+
+    it('keeps nested active spans inside their parents across a wall-clock step', async () => {
+      const traces = createTraces()
+      setClocks(1_700_000_001_000, 100)
+      traces.withSpan('root', () => {
+        setClocks(1_700_000_000_510, 110)
+        traces.withSpan('child', () => {
+          setClocks(1_700_000_000_515, 115)
+          traces.withSpan('grandchild', () => {
+            setClocks(1_700_000_000_520, 120)
+          })
+          setClocks(1_700_000_000_525, 125)
+        })
+        setClocks(1_700_000_000_530, 130)
+      })
+      await traces.flush()
+
+      const [grandchild, child, root] = sentSpans()
+      expectWithin(child, root)
+      expectWithin(grandchild, child)
+    })
+
+    it('keeps its own clock under a remote or backdated parent, or when backdated itself', async () => {
+      const traces = createTraces()
+      setClocks(1_700_000_001_000, 100)
+      const parent = traces.startSpan('parent')
+      const backdatedParent = traces.startSpan('backdated parent', { startTime: 1_700_000_000_000 })
+      setClocks(1_700_000_000_500, 110)
+      traces.startSpan('remote child', { parent: `00-${TRACE_ID}-${REMOTE_SPAN_ID}-01` }).end()
+      traces.startSpan('child of backdated', { parent: backdatedParent }).end()
+      traces.startSpan('backdated child', { parent, startTime: 1_700_000_000_200 }).end()
+      await traces.flush()
+
+      expect(sentSpans().map((span) => span.startTimeUnixNano)).toEqual([
+        '1700000000500000000',
+        '1700000000500000000',
+        '1700000000200000000',
+      ])
+    })
+  })
+
   describe('trace continuation', () => {
     it('continues a remote trace from a traceparent string', async () => {
       const traces = createTraces()

--- a/packages/core/src/traces/index.spec.ts
+++ b/packages/core/src/traces/index.spec.ts
@@ -263,6 +263,17 @@ describe('PostHogTraces', () => {
         '1700000000200000000',
       ])
     })
+
+    it('keeps an explicit startTime that equals the current time', async () => {
+      const traces = createTraces()
+      setClocks(1_700_000_001_000, 100)
+      const parent = traces.startSpan('parent')
+      setClocks(1_700_000_000_500, 110)
+      traces.startSpan('child', { parent, startTime: Date.now() }).end()
+      await traces.flush()
+
+      expect(sentSpans()[0].startTimeUnixNano).toBe('1700000000500000000')
+    })
   })
 
   describe('trace continuation', () => {

--- a/packages/core/src/traces/index.ts
+++ b/packages/core/src/traces/index.ts
@@ -276,7 +276,7 @@ export class PostHogTraces {
         maxAttributeValueLength: this._config.maxAttributeValueLength,
         startTime,
         backdated: startTime !== now,
-        clockAnchor: parent?.clockAnchor,
+        clockAnchor: toEpochMs(options?.startTime) === undefined ? parent?.clockAnchor : undefined,
       },
       (record, autoKeys) => this._onSpanEnd(record, autoKeys),
       this._logger

--- a/packages/core/src/traces/index.ts
+++ b/packages/core/src/traces/index.ts
@@ -19,6 +19,7 @@ import {
   runWithActiveSpan,
   truncateAttributes,
 } from './span'
+import type { ClockAnchor } from './span'
 import { newSpanId, newTraceId } from './ids'
 import { parseTraceparent, sanitizeTracestate, traceparentHeader } from './traceparent'
 import { clampEndTime, resolveStartTime, resolveSuppliedTime, sanitizeName, toEpochMs } from './sanitize'
@@ -155,6 +156,7 @@ interface ParentContext {
   traceFlags?: string
   /** True when the parent arrived as a `traceparent` header. */
   isRemote?: boolean
+  clockAnchor?: ClockAnchor
 }
 
 /**
@@ -274,6 +276,7 @@ export class PostHogTraces {
         maxAttributeValueLength: this._config.maxAttributeValueLength,
         startTime,
         backdated: startTime !== now,
+        clockAnchor: parent?.clockAnchor,
       },
       (record, autoKeys) => this._onSpanEnd(record, autoKeys),
       this._logger

--- a/packages/core/src/traces/span.spec.ts
+++ b/packages/core/src/traces/span.spec.ts
@@ -985,6 +985,7 @@ describe('PostHogSpan', () => {
         parentSpanId: SPAN_ID,
         traceState: 'vendor=abc',
         traceFlags: '01',
+        clockAnchor: { wall: Date.now(), mono: performance.now() },
       })
     })
   })

--- a/packages/core/src/traces/span.ts
+++ b/packages/core/src/traces/span.ts
@@ -28,6 +28,12 @@ export function monotonicNow(): number | undefined {
   return typeof perf?.now === 'function' ? perf.now() : undefined
 }
 
+/** A root span's start read on both clocks: the basis its local descendants are placed on. */
+export interface ClockAnchor {
+  wall: number
+  mono: number
+}
+
 export interface SpanInit {
   traceId: string
   spanId: string
@@ -44,6 +50,8 @@ export interface SpanInit {
   startTime: number
   /** True when the caller supplied an explicit `startTime`. */
   backdated: boolean
+  /** Inherited from a local parent; replaces `startTime` unless the span is backdated. */
+  clockAnchor?: ClockAnchor
   /** Keys the SDK attached itself. Exempt from the attribute cap and never evicted. */
   autoAttributeKeys: string[]
   maxAttributes: number
@@ -62,6 +70,7 @@ export class PostHogSpan implements Span {
   private readonly _startTime: number
   // Absent on backdated spans and on platforms with no monotonic source.
   private readonly _startMono?: number
+  private readonly _clockAnchor?: ClockAnchor
 
   private _name: string
   private _kind: SpanKind
@@ -106,8 +115,14 @@ export class PostHogSpan implements Span {
     for (const key of Object.keys(init.attributes)) {
       this._writeAttribute(key, init.attributes[key])
     }
-    this._startTime = init.startTime
     this._startMono = init.backdated ? undefined : monotonicNow()
+    this._startTime =
+      init.clockAnchor && this._startMono !== undefined
+        ? init.clockAnchor.wall + (this._startMono - init.clockAnchor.mono)
+        : init.startTime
+    if (this._startMono !== undefined) {
+      this._clockAnchor = init.clockAnchor ?? { wall: this._startTime, mono: this._startMono }
+    }
   }
 
   /**
@@ -259,13 +274,20 @@ export class PostHogSpan implements Span {
   }
 
   /** Context a child span inherits when this handle is its parent. */
-  childContext(): { traceId: string; parentSpanId: string; traceState?: string; traceFlags: string } {
+  childContext(): {
+    traceId: string
+    parentSpanId: string
+    traceState?: string
+    traceFlags: string
+    clockAnchor?: ClockAnchor
+  } {
     return {
       traceId: this._traceId,
       parentSpanId: this._spanId,
       traceState: this._traceState,
       // A child of a continued trace keeps propagating the caller's decision.
       traceFlags: this._traceFlags,
+      clockAnchor: this._clockAnchor,
     }
   }
 


### PR DESCRIPTION
## Problem

Distributed tracing (#4579) gives each span a start of `Date.now()` (whole milliseconds) and derives its end and event times from `performance.now()` elapsed since that start. Every span anchors to its own truncated `Date.now()`, so a child's timestamps can land up to ~1 ms outside its parent's window. In production, a child `http.post payments` ended 0.6 ms after its root `POST /checkout` ended, though in real time it ended first. A wall-clock step between the parent's start and the child's start (an NTP correction) misplaces the child by the size of the step.

OpenTelemetry JS has the same per-span behaviour (`sdk-trace-base` 1.30.1, `sdk-trace` 2.11 `Span.js`), so this is an improvement over the reference rather than a parity fix.

## Changes

- A span started under a local parent handle takes its start from the root's clock basis: `anchor.wall + (monotonicNow() - anchor.mono)`, where the anchor is the root span's start read on both clocks. The anchor is passed down the local chain through `childContext()` → `SpanInit.clockAnchor`, so grandchildren stay on the same basis instead of re-anchoring.
- The child still records its own `_startMono`, so its end and event times come from its own elapsed time. On a shared basis, child ⊂ parent holds whenever it holds in real time.
- Both explicit `parent: span` and default parenting from the active span (`withSpan`) count as local parents.

Unchanged:

- Root spans anchor to their own `Date.now()`, as before. No process-wide anchor is introduced, so a long-running process doesn't drift from the wall clock.
- Spans whose parent is a `traceparent` string (remote), or a pass-through handle.
- Spans whose parent was backdated with an explicit `startTime`, and spans on platforms without `performance.now` (no monotonic anchor to share).
- Spans given an explicit `startTime` themselves (the caller's value wins).

Verification: three new tests in `index.spec.ts` under `clock basis`. With the source change reverted, the first two fail:

- sub-ms truncation (parent at perf 0.9 / wall 1000, child at perf 1.0 / wall 1001): `expected 1700000001005000000 to be less than or equal to 1700000001004149902`
- wall-clock step, nested `withSpan` root → child → grandchild: `expected 1700000000510000000 to be greater than or equal to 1700000001000000000`

The third (remote parent, backdated parent, backdated child keep their own clock) passes both with and without the change, confirming existing behaviour is preserved. `span.spec.ts`'s `childContext()` expectation gains the anchor field. Full `@posthog/core` suite and `posthog-node` traces specs pass.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

`@posthog/core` also gets a patch bump (the change lives in its traces engine).

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (Opus 5) at the maintainer's request. Session: https://claude.ai/code/session_015L9zQoGEbFSQDe25Mzz2wJ
- The anchor lives on the span and travels through `childContext()`, not as a process-wide anchor, which would drift from the wall clock over long uptimes. The start is computed in the `PostHogSpan` constructor so the child's start and `_startMono` come from one monotonic reading.
- No manual testing beyond the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015L9zQoGEbFSQDe25Mzz2wJ
