### PR TITLE
feat(metrics): record fetch and XHR durations as a histogram

### DIFF
--- a/.changeset/network-metrics.md
+++ b/.changeset/network-metrics.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+Add `metrics.network` config to record the duration of every `fetch` and `XMLHttpRequest` as a histogram, with optional custom metric name and attributes.

--- a/packages/browser/playwright/mocked/network-metrics.spec.ts
+++ b/packages/browser/playwright/mocked/network-metrics.spec.ts
@@ -1,0 +1,77 @@
+import { BrowserContext, Route } from '@playwright/test'
+import { OtlpHistogramDataPoint, OtlpMetricsPayload } from '@posthog/types'
+import { expect, test } from './utils/posthog-playwright-test-base'
+import { start } from './utils/setup'
+
+const CUSTOMER_URL = '/__network_metrics_test/orders/12345'
+
+function captureMetricsPayloads(context: BrowserContext) {
+    const payloads: OtlpMetricsPayload[] = []
+    void context.route('**/i/v1/metrics*', async (route: Route) => {
+        payloads.push(route.request().postDataJSON())
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    return payloads
+}
+
+const attributesOf = (dataPoint: OtlpHistogramDataPoint): Record<string, string | undefined> =>
+    Object.fromEntries(dataPoint.attributes.map((a) => [a.key, a.value.stringValue]))
+
+test.describe('network metrics', () => {
+    test('records customer fetch and XHR durations without changing them, and skips its own requests', async ({
+        page,
+        context,
+    }) => {
+        await context.route(`**${CUSTOMER_URL}`, (route) =>
+            route.fulfill({ status: 200, contentType: 'text/plain', body: 'ok' })
+        )
+        const metricsPayloads = captureMetricsPayloads(context)
+
+        await start(
+            {
+                options: { metrics: { network: true }, disable_compression: true },
+                url: '/playground/cypress/index.html',
+            },
+            page,
+            context
+        )
+
+        const responses = await page.evaluate(async (url) => {
+            const fetchResponse = await fetch(url)
+            const fetchResult = { status: fetchResponse.status, text: await fetchResponse.text() }
+
+            const xhrResult = await new Promise<{ status: number; text: string }>((resolve) => {
+                const xhr = new XMLHttpRequest()
+                xhr.onloadend = () => resolve({ status: xhr.status, text: xhr.responseText })
+                xhr.open('GET', url)
+                xhr.send()
+            })
+
+            const otherLoadEndListenersHaveRun = new Promise((resolve) => setTimeout(resolve, 0))
+            await otherLoadEndListenersHaveRun
+            await (window as any).posthog.metrics.flush()
+            return { fetchResult, xhrResult }
+        }, CUSTOMER_URL)
+
+        expect(responses).toEqual({
+            fetchResult: { status: 200, text: 'ok' },
+            xhrResult: { status: 200, text: 'ok' },
+        })
+
+        await expect.poll(() => metricsPayloads.length).toBe(1)
+        const metrics = metricsPayloads[0].resourceMetrics.flatMap((r) => r.scopeMetrics.flatMap((s) => s.metrics))
+        const durations = metrics.filter((m) => m.name === 'http.client.request.duration')
+        expect(durations).toHaveLength(1)
+
+        const dataPoints = durations[0].histogram!.dataPoints
+        expect(dataPoints.map((dp) => ({ count: dp.count, ...attributesOf(dp) }))).toEqual([
+            {
+                count: 2,
+                method: 'GET',
+                host: 'localhost',
+                path: '/__network_metrics_test/orders/:id',
+                status_class: '2xx',
+            },
+        ])
+    })
+})

--- a/packages/browser/playwright/mocked/network-metrics.spec.ts
+++ b/packages/browser/playwright/mocked/network-metrics.spec.ts
@@ -60,7 +60,7 @@ test.describe('network metrics', () => {
 
         await expect.poll(() => metricsPayloads.length).toBe(1)
         const metrics = metricsPayloads[0].resourceMetrics.flatMap((r) => r.scopeMetrics.flatMap((s) => s.metrics))
-        const durations = metrics.filter((m) => m.name === 'http.client.request.duration')
+        const durations = metrics.filter((m) => m.name === 'http.client.request.duration_ms')
         expect(durations).toHaveLength(1)
 
         const dataPoints = durations[0].histogram!.dataPoints

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -3147,7 +3147,7 @@
         },
         {
           "description": "Metrics-specific configuration options for the posthog.metrics API.",
-          "type": "MetricsConfig",
+          "type": "BrowserMetricsConfig",
           "name": "metrics"
         },
         {

--- a/packages/browser/src/__tests__/extensions/network-metrics.test.ts
+++ b/packages/browser/src/__tests__/extensions/network-metrics.test.ts
@@ -1,6 +1,7 @@
 import { startNetworkMetrics } from '../../extensions/network-metrics'
 import { PostHog } from '../../posthog-core'
 import type { NetworkMetricsConfig } from '../../types'
+import { markPostHogRequest, unmarkPostHogRequest } from '../../utils/request-tracking'
 
 vi.mock('@posthog/browser-common/utils/logger', () => ({
     createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
@@ -37,6 +38,15 @@ describe('network metrics', () => {
     }
 
     const recorded = (): any[] => histogram.mock.calls
+
+    const fetchAsPostHog = async (url: string): Promise<void> => {
+        markPostHogRequest(url)
+        try {
+            await window.fetch(url)
+        } finally {
+            unmarkPostHogRequest(url)
+        }
+    }
 
     const sendXHR = (method: string, url: string, status: number): void => {
         const xhr = new window.XMLHttpRequest() as unknown as FakeXHR
@@ -79,7 +89,7 @@ describe('network metrics', () => {
     })
 
     describe('fetch', () => {
-        it('returns the exact promise from the original fetch', async () => {
+        it('returns a promise that mirrors the original fetch result', async () => {
             const original = Promise.resolve({ status: 200 })
             const calls: unknown[][] = []
             setWindowFetch((...args: unknown[]) => {
@@ -88,7 +98,9 @@ describe('network metrics', () => {
             })
             start()
 
-            expect(window.fetch('https://api.example.com/things')).toBe(original)
+            const result = window.fetch('https://api.example.com/things')
+            expect(result).not.toBe(original)
+            await expect(result).resolves.toEqual({ status: 200 })
             await original
             expect(calls).toEqual([['https://api.example.com/things']])
         })
@@ -111,7 +123,7 @@ describe('network metrics', () => {
 
             expect(recorded()).toEqual([
                 [
-                    'http.client.request.duration',
+                    'http.client.request.duration_ms',
                     expect.any(Number),
                     {
                         unit: 'ms',
@@ -175,9 +187,45 @@ describe('network metrics', () => {
         ])('does not record requests to PostHog itself: %s', async (url) => {
             start()
 
-            await window.fetch(url)
+            await fetchAsPostHog(url)
 
             expect(recorded()).toEqual([])
+        })
+
+        it('records application requests when api_host is the page origin', async () => {
+            ;(mockPostHog.requestRouter.endpointFor as vi.Mock).mockReturnValue(window.location.origin)
+            start()
+
+            await window.fetch('/customer-api')
+
+            expect(recorded()).toHaveLength(1)
+        })
+
+        it('ignores a marked upload from another named PostHog instance', async () => {
+            const otherHistogram = vi.fn()
+            const other = {
+                config: { metrics: { network: true } },
+                metrics: { histogram: otherHistogram },
+                requestRouter: {
+                    endpointFor: vi.fn(() => 'https://other.example.com'),
+                    isIngestionEndpoint: vi.fn(() => false),
+                },
+            } as unknown as PostHog
+            const firstStop = startNetworkMetrics(mockPostHog)
+            const secondStop = startNetworkMetrics(other)
+            const url = 'https://other.example.com/i/v1/metrics?token=other'
+
+            markPostHogRequest(url)
+            try {
+                await window.fetch(url)
+            } finally {
+                unmarkPostHogRequest(url)
+                firstStop()
+                secondStop()
+            }
+
+            expect(histogram).not.toHaveBeenCalled()
+            expect(otherHistogram).not.toHaveBeenCalled()
         })
 
         it.each([['/ingest/e/?ip=1'], ['http://localhost/ingest/i/v1/metrics']])(
@@ -227,7 +275,7 @@ describe('network metrics', () => {
 
             expect(recorded()).toEqual([
                 [
-                    'http.client.request.duration',
+                    'http.client.request.duration_ms',
                     expect.any(Number),
                     {
                         unit: 'ms',
@@ -414,7 +462,6 @@ describe('network metrics', () => {
 
             const result = window.fetch('https://api.example.com/things')
 
-            expect(result).toBe(original)
             await expect(result).resolves.toEqual({ status: 200 })
             expect(recorded()).toEqual([])
         })

--- a/packages/browser/src/__tests__/extensions/network-metrics.test.ts
+++ b/packages/browser/src/__tests__/extensions/network-metrics.test.ts
@@ -1,0 +1,376 @@
+import { startNetworkMetrics } from '../../extensions/network-metrics'
+import { PostHog } from '../../posthog-core'
+import type { NetworkMetricsConfig } from '../../types'
+
+vi.mock('@posthog/browser-common/utils/logger', () => ({
+    createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}))
+
+class FakeXHR extends EventTarget {
+    status = 0
+    open(..._args: unknown[]): void {}
+    send(_body?: unknown): void {}
+
+    respond(status: number): void {
+        this.status = status
+        this.dispatchEvent(new Event('loadend'))
+    }
+}
+
+describe('network metrics', () => {
+    const originalFetch = window.fetch
+    const originalXHR = window.XMLHttpRequest
+    let fetchMock: vi.Mock
+    let openSpy: vi.SpyInstance
+    let sendSpy: vi.SpyInstance
+    let histogram: vi.Mock
+    let mockPostHog: PostHog
+    let stop: (() => void) | undefined
+
+    const setWindowFetch = (fetchImpl: unknown): void => {
+        Object.defineProperty(window, 'fetch', { configurable: true, value: fetchImpl, writable: true })
+    }
+
+    const start = (network: NetworkMetricsConfig | boolean = true): void => {
+        mockPostHog.config.metrics = { network }
+        stop = startNetworkMetrics(mockPostHog)
+    }
+
+    const recorded = (): any[] => histogram.mock.calls
+
+    const sendXHR = (method: string, url: string, status: number): void => {
+        const xhr = new window.XMLHttpRequest() as unknown as FakeXHR
+        xhr.open(method, url)
+        xhr.send()
+        xhr.respond(status)
+    }
+
+    beforeEach(() => {
+        fetchMock = vi.fn(() => Promise.resolve({ status: 200 }))
+        setWindowFetch(fetchMock)
+        window.XMLHttpRequest = FakeXHR as any
+        openSpy = vi.spyOn(FakeXHR.prototype, 'open')
+        sendSpy = vi.spyOn(FakeXHR.prototype, 'send')
+        histogram = vi.fn()
+        mockPostHog = {
+            config: { metrics: {} },
+            metrics: { histogram },
+            requestRouter: {
+                endpointFor: vi.fn((target: string) =>
+                    target === 'flags' ? 'https://flags.example.com' : 'https://us.i.posthog.com'
+                ),
+                isIngestionEndpoint: vi.fn(() => false),
+            },
+        } as unknown as PostHog
+    })
+
+    afterEach(() => {
+        stop?.()
+        stop = undefined
+        setWindowFetch(originalFetch)
+        window.XMLHttpRequest = originalXHR
+        vi.restoreAllMocks()
+    })
+
+    describe('fetch', () => {
+        it('returns the exact promise from the original fetch', async () => {
+            const original = Promise.resolve({ status: 200 })
+            const calls: unknown[][] = []
+            setWindowFetch((...args: unknown[]) => {
+                calls.push(args)
+                return original
+            })
+            start()
+
+            expect(window.fetch('https://api.example.com/things')).toBe(original)
+            await original
+            expect(calls).toEqual([['https://api.example.com/things']])
+        })
+
+        it.each([
+            ['a string url', ['https://api.example.com/things'], 'GET'],
+            ['a URL object', [new URL('https://api.example.com/things')], 'GET'],
+            ['a relative url', ['/things'], 'GET'],
+            ['an init method', ['https://api.example.com/things', { method: 'post' }], 'POST'],
+            ['a Request', [{ url: 'https://api.example.com/things', method: 'PUT' }], 'PUT'],
+            [
+                'a Request and an init method',
+                [{ url: 'https://api.example.com/things', method: 'PUT' }, { method: 'DELETE' }],
+                'DELETE',
+            ],
+        ])('records the request duration for %s', async (_, args, method) => {
+            start()
+
+            await window.fetch(...(args as [string]))
+
+            expect(recorded()).toEqual([
+                [
+                    'http.client.request.duration',
+                    expect.any(Number),
+                    {
+                        unit: 'ms',
+                        attributes: {
+                            method,
+                            host: args[0] === '/things' ? 'localhost' : 'api.example.com',
+                            path: '/things',
+                            status_class: '2xx',
+                        },
+                    },
+                ],
+            ])
+        })
+
+        it.each([
+            ['/api/projects/123/tasks/550e8400-e29b-41d4-a716-446655440000/', '/api/projects/:id/tasks/:id/'],
+            ['/api/things?limit=10&offset=20', '/api/things'],
+            ['/api/things#section', '/api/things'],
+            ['/api/keys/5f3a9c2e1b4d', '/api/keys/:id'],
+            ['/api/skills/short-name/files/config.ts', '/api/skills/short-name/files/config.ts'],
+            ['/api/v2/things', '/api/v2/things'],
+            ['/', '/'],
+        ])('replaces ids in the path: %s -> %s', async (url, path) => {
+            start()
+
+            await window.fetch(url)
+
+            expect(recorded()[0][2].attributes.path).toBe(path)
+        })
+
+        it.each([
+            [200, '2xx'],
+            [302, '3xx'],
+            [404, '4xx'],
+            [503, '5xx'],
+            [0, 'error'],
+        ])('maps status %s to status class %s', async (status, statusClass) => {
+            fetchMock.mockResolvedValue({ status })
+            start()
+
+            await window.fetch('https://api.example.com/things')
+
+            expect(recorded()[0][2].attributes.status_class).toBe(statusClass)
+        })
+
+        it('records a rejected fetch as an error and leaves the rejection for the caller', async () => {
+            const failure = new TypeError('Failed to fetch')
+            fetchMock.mockRejectedValue(failure)
+            start()
+
+            await expect(window.fetch('https://api.example.com/things')).rejects.toBe(failure)
+
+            expect(recorded()[0][2].attributes.status_class).toBe('error')
+        })
+
+        it.each([
+            ['https://us.i.posthog.com/i/v1/metrics?token=abc'],
+            ['https://us.i.posthog.com/e/?ip=1'],
+            ['https://flags.example.com/flags/?v=2'],
+        ])('does not record requests to PostHog itself: %s', async (url) => {
+            start()
+
+            await window.fetch(url)
+
+            expect(recorded()).toEqual([])
+        })
+
+        it('does not record requests to a proxied PostHog ingestion path', async () => {
+            ;(mockPostHog.requestRouter.isIngestionEndpoint as vi.Mock).mockReturnValue(true)
+            start()
+
+            await window.fetch('https://api.example.com/ingest/e/')
+
+            expect(recorded()).toEqual([])
+        })
+    })
+
+    describe('XMLHttpRequest', () => {
+        it.each([
+            ['get', 200, 'GET', '2xx'],
+            ['POST', 500, 'POST', '5xx'],
+            ['delete', 0, 'DELETE', 'error'],
+        ])('records %s with status %s', (method, status, expectedMethod, statusClass) => {
+            start()
+
+            sendXHR(method, 'https://api.example.com/things/42', status)
+
+            expect(recorded()).toEqual([
+                [
+                    'http.client.request.duration',
+                    expect.any(Number),
+                    {
+                        unit: 'ms',
+                        attributes: {
+                            method: expectedMethod,
+                            host: 'api.example.com',
+                            path: '/things/:id',
+                            status_class: statusClass,
+                        },
+                    },
+                ],
+            ])
+        })
+
+        it('still calls the original open and send', () => {
+            start()
+            const xhr = new window.XMLHttpRequest() as unknown as FakeXHR
+
+            xhr.open('GET', 'https://api.example.com/things', true, 'user', 'pass')
+            xhr.send('body')
+
+            expect(openSpy).toHaveBeenCalledWith('GET', 'https://api.example.com/things', true, 'user', 'pass')
+            expect(sendSpy).toHaveBeenCalledWith('body')
+        })
+    })
+
+    describe('config', () => {
+        it('uses a string name as the metric name', async () => {
+            start({ name: 'storefront.api.duration' })
+
+            await window.fetch('https://api.example.com/things')
+
+            expect(recorded()[0][0]).toBe('storefront.api.duration')
+        })
+
+        it('calls a name function with the request', async () => {
+            const name = vi.fn(() => 'named.by.function')
+            start({ name })
+
+            await window.fetch('https://api.example.com/things?x=1', { method: 'POST' })
+
+            expect(name).toHaveBeenCalledWith({ url: 'https://api.example.com/things?x=1', method: 'POST' })
+            expect(recorded()[0][0]).toBe('named.by.function')
+        })
+
+        it.each([undefined, null, ''])('skips the request when the name function returns %s', async (name) => {
+            start({ name: () => name as any })
+
+            await window.fetch('https://api.example.com/things')
+
+            expect(recorded()).toEqual([])
+        })
+
+        it('merges attributes from the attributes function over the defaults', async () => {
+            fetchMock.mockResolvedValue({ status: 404 })
+            const attributes = vi.fn(() => ({ route: '/tasks/$taskId', path: '/api/things/{id}' }))
+            start({ attributes })
+
+            await window.fetch('https://api.example.com/things/1')
+
+            expect(attributes).toHaveBeenCalledWith(
+                { url: 'https://api.example.com/things/1', method: 'GET' },
+                { status: 404, durationMs: expect.any(Number) }
+            )
+            expect(recorded()[0][2].attributes).toEqual({
+                method: 'GET',
+                host: 'api.example.com',
+                path: '/api/things/{id}',
+                status_class: '4xx',
+                route: '/tasks/$taskId',
+            })
+        })
+
+        it('passes an undefined status to the attributes function when the fetch rejects', async () => {
+            fetchMock.mockRejectedValue(new Error('offline'))
+            const attributes = vi.fn(() => ({}))
+            start({ attributes })
+
+            await window.fetch('https://api.example.com/things').catch(() => {})
+
+            expect(attributes).toHaveBeenCalledWith(expect.anything(), {
+                status: undefined,
+                durationMs: expect.any(Number),
+            })
+        })
+
+        it('records nothing when network metrics are turned off after start', async () => {
+            start()
+            mockPostHog.config.metrics = { network: false }
+
+            await window.fetch('https://api.example.com/things')
+
+            expect(recorded()).toEqual([])
+        })
+
+        it('records nothing after stop', async () => {
+            start()
+            stop?.()
+            stop = undefined
+
+            await window.fetch('https://api.example.com/things')
+            sendXHR('GET', 'https://api.example.com/things', 200)
+
+            expect(recorded()).toEqual([])
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('fails open', () => {
+        it.each([
+            [
+                'the name function throws',
+                {
+                    name: () => {
+                        throw new Error('boom')
+                    },
+                },
+            ],
+            [
+                'the attributes function throws',
+                {
+                    attributes: () => {
+                        throw new Error('boom')
+                    },
+                },
+            ],
+        ])('when %s the fetch result is unchanged', async (_, network) => {
+            const original = Promise.resolve({ status: 200 })
+            setWindowFetch(() => original)
+            start(network as NetworkMetricsConfig)
+
+            const result = window.fetch('https://api.example.com/things')
+
+            expect(result).toBe(original)
+            await expect(result).resolves.toEqual({ status: 200 })
+            expect(recorded()).toEqual([])
+        })
+
+        it('when histogram throws the fetch result is unchanged', async () => {
+            histogram.mockImplementation(() => {
+                throw new Error('boom')
+            })
+            start()
+
+            await expect(window.fetch('https://api.example.com/things')).resolves.toEqual({ status: 200 })
+        })
+
+        it('when the request url cannot be parsed the fetch still runs and is recorded', async () => {
+            start()
+
+            await window.fetch('http://[')
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            expect(recorded()[0][2].attributes).toEqual({ method: 'GET', host: '', path: '', status_class: '2xx' })
+        })
+
+        it('when the original fetch returns a non-promise it is passed through', () => {
+            fetchMock.mockReturnValue('not a promise')
+            start()
+
+            expect(window.fetch('https://api.example.com/things')).toBe('not a promise')
+        })
+
+        it('when XHR open is given no url, the original open still runs', () => {
+            start()
+            const xhr = new window.XMLHttpRequest() as unknown as FakeXHR
+
+            expect(() => (xhr.open as any)()).not.toThrow()
+            expect(openSpy).toHaveBeenCalledTimes(1)
+        })
+
+        it('when fetch is missing, start does not throw', () => {
+            setWindowFetch(undefined)
+
+            expect(() => start()).not.toThrow()
+        })
+    })
+})

--- a/packages/browser/src/__tests__/extensions/network-metrics.test.ts
+++ b/packages/browser/src/__tests__/extensions/network-metrics.test.ts
@@ -173,6 +173,18 @@ describe('network metrics', () => {
             expect(recorded()).toEqual([])
         })
 
+        it.each([['/ingest/e/?ip=1'], ['http://localhost/ingest/i/v1/metrics']])(
+            'does not record requests to a relative PostHog api_host: %s',
+            async (url) => {
+                ;(mockPostHog.requestRouter.endpointFor as vi.Mock).mockReturnValue('/ingest')
+                start()
+
+                await window.fetch(url)
+
+                expect(recorded()).toEqual([])
+            }
+        )
+
         it('does not record requests to a proxied PostHog ingestion path', async () => {
             ;(mockPostHog.requestRouter.isIngestionEndpoint as vi.Mock).mockReturnValue(true)
             start()

--- a/packages/browser/src/__tests__/extensions/network-metrics.test.ts
+++ b/packages/browser/src/__tests__/extensions/network-metrics.test.ts
@@ -220,6 +220,47 @@ describe('network metrics', () => {
             expect(openSpy).toHaveBeenCalledWith('GET', 'https://api.example.com/things', true, 'user', 'pass')
             expect(sendSpy).toHaveBeenCalledWith('body')
         })
+
+        it('records histogram exactly once per response when an XHR instance is reused', () => {
+            start()
+            const xhr = new window.XMLHttpRequest() as unknown as FakeXHR
+
+            xhr.open('GET', 'https://api.example.com/things/1')
+            xhr.send()
+            xhr.respond(200)
+
+            expect(recorded()).toHaveLength(1)
+            expect(recorded()[0][2].attributes.path).toBe('/things/:id')
+
+            xhr.open('GET', 'https://api.example.com/things/2')
+            xhr.send()
+            xhr.respond(201)
+
+            expect(recorded()).toHaveLength(2)
+            expect(recorded()[1][2].attributes.path).toBe('/things/:id')
+        })
+
+        it('handles send() with no prior open()', () => {
+            start()
+            const xhr = new window.XMLHttpRequest() as unknown as FakeXHR
+
+            expect(() => xhr.send()).not.toThrow()
+            expect(recorded()).toEqual([])
+        })
+
+        it('passes through a synchronous throw from the original send', () => {
+            start()
+            const xhr = new window.XMLHttpRequest() as unknown as FakeXHR
+            const error = new Error('InvalidStateError')
+
+            sendSpy.mockImplementationOnce(() => {
+                throw error
+            })
+
+            xhr.open('GET', 'https://api.example.com/things')
+            expect(() => xhr.send()).toThrow(error)
+            expect(recorded()).toEqual([])
+        })
     })
 
     describe('config', () => {

--- a/packages/browser/src/__tests__/extensions/network-metrics.test.ts
+++ b/packages/browser/src/__tests__/extensions/network-metrics.test.ts
@@ -335,6 +335,18 @@ describe('network metrics', () => {
             })
         })
 
+        it('passes an undefined status to the attributes function when the XHR reports no response', () => {
+            const attributes = vi.fn(() => ({}))
+            start({ attributes })
+
+            sendXHR('get', 'https://api.example.com/things', 0)
+
+            expect(attributes).toHaveBeenCalledWith(expect.anything(), {
+                status: undefined,
+                durationMs: expect.any(Number),
+            })
+        })
+
         it('records nothing when network metrics are turned off after start', async () => {
             start()
             mockPostHog.config.metrics = { network: false }

--- a/packages/browser/src/__tests__/extensions/network-metrics.test.ts
+++ b/packages/browser/src/__tests__/extensions/network-metrics.test.ts
@@ -56,9 +56,15 @@ describe('network metrics', () => {
             config: { metrics: {} },
             metrics: { histogram },
             requestRouter: {
-                endpointFor: vi.fn((target: string) =>
-                    target === 'flags' ? 'https://flags.example.com' : 'https://us.i.posthog.com'
-                ),
+                endpointFor: vi.fn((target: string) => {
+                    if (target === 'flags') {
+                        return 'https://flags.example.com'
+                    }
+                    if (target === 'assets') {
+                        return 'https://us-assets.i.posthog.com'
+                    }
+                    return 'https://us.i.posthog.com'
+                }),
                 isIngestionEndpoint: vi.fn(() => false),
             },
         } as unknown as PostHog
@@ -165,6 +171,7 @@ describe('network metrics', () => {
             ['https://us.i.posthog.com/i/v1/metrics?token=abc'],
             ['https://us.i.posthog.com/e/?ip=1'],
             ['https://flags.example.com/flags/?v=2'],
+            ['https://us-assets.i.posthog.com/array/phc_token/config'],
         ])('does not record requests to PostHog itself: %s', async (url) => {
             start()
 

--- a/packages/browser/src/__tests__/extensions/network-metrics.test.ts
+++ b/packages/browser/src/__tests__/extensions/network-metrics.test.ts
@@ -185,6 +185,19 @@ describe('network metrics', () => {
             }
         )
 
+        it.each([['/ingestion-status'], ['/ingest-batch']])(
+            'records an application path that only shares the api_host prefix: %s',
+            async (path) => {
+                ;(mockPostHog.requestRouter.endpointFor as vi.Mock).mockReturnValue('/ingest')
+                start()
+
+                await window.fetch(path)
+
+                expect(recorded()).toHaveLength(1)
+                expect(recorded()[0][2].attributes.path).toBe(path)
+            }
+        )
+
         it('does not record requests to a proxied PostHog ingestion path', async () => {
             ;(mockPostHog.requestRouter.isIngestionEndpoint as vi.Mock).mockReturnValue(true)
             start()

--- a/packages/browser/src/__tests__/posthog-core.shutdown.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.shutdown.test.ts
@@ -44,6 +44,14 @@ describe('shutdown()', () => {
         expect(sessionRecordingDispose).toHaveBeenCalledTimes(1)
     })
 
+    it('disposes metrics, which removes the network wrappers', async () => {
+        const metricsDispose = vi.spyOn(instance.metrics!, 'dispose')
+
+        await instance.shutdown()
+
+        expect(metricsDispose).toHaveBeenCalledTimes(1)
+    })
+
     it('disposes feature flags through the extension runtime', async () => {
         const featureFlagsDispose = vi.spyOn(instance.featureFlags!, 'dispose')
 

--- a/packages/browser/src/__tests__/posthog-metrics.test.ts
+++ b/packages/browser/src/__tests__/posthog-metrics.test.ts
@@ -177,6 +177,16 @@ describe('posthog-metrics', () => {
             expect(isFetchWrapped()).toBe(wrapped)
         })
 
+        it('stops wrapping on dispose, so shutdown leaves no wrapper behind', () => {
+            ;(mockPostHog.config as any).metrics = { network: true }
+            metrics.initialize()
+            expect(isFetchWrapped()).toBe(true)
+
+            metrics.dispose()
+
+            expect(isFetchWrapped()).toBe(false)
+        })
+
         it('starts and stops wrapping when the config changes', () => {
             ;(mockPostHog.config as any).metrics = { network: true }
             metrics.initialize()

--- a/packages/browser/src/__tests__/posthog-metrics.test.ts
+++ b/packages/browser/src/__tests__/posthog-metrics.test.ts
@@ -1,11 +1,11 @@
 import { PostHogMetrics } from '../posthog-metrics'
 import { PostHog } from '../posthog-core'
 
-const mockLogger = {
+const mockLogger = vi.hoisted(() => ({
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
-}
+}))
 
 vi.mock('@posthog/browser-common/utils/logger', () => ({
     createLogger: vi.fn(() => mockLogger),
@@ -148,5 +148,46 @@ describe('posthog-metrics', () => {
 
         const resourceAttrs = sentRequests()[1].data.resourceMetrics[0].resource.attributes
         expect(resourceAttrs).toContainEqual({ key: 'service.name', value: { stringValue: 'renamed-service' } })
+    })
+
+    describe('network metrics', () => {
+        const originalFetch = window.fetch
+        const isFetchWrapped = (): boolean => !!(window.fetch as any).__posthog_wrapped__
+
+        beforeEach(() => {
+            Object.defineProperty(window, 'fetch', { configurable: true, value: vi.fn(), writable: true })
+        })
+
+        afterEach(() => {
+            ;(mockPostHog.config as any).metrics = {}
+            metrics.onConfigChange()
+            Object.defineProperty(window, 'fetch', { configurable: true, value: originalFetch, writable: true })
+        })
+
+        it.each([
+            [undefined, false],
+            [false, false],
+            [true, true],
+            [{ name: 'api.duration' }, true],
+        ])('with metrics.network = %j wraps fetch on initialize: %s', (network, wrapped) => {
+            ;(mockPostHog.config as any).metrics = { network }
+
+            metrics.initialize()
+
+            expect(isFetchWrapped()).toBe(wrapped)
+        })
+
+        it('starts and stops wrapping when the config changes', () => {
+            ;(mockPostHog.config as any).metrics = { network: true }
+            metrics.initialize()
+            metrics.onConfigChange()
+            expect(isFetchWrapped()).toBe(true)
+            ;(mockPostHog.config as any).metrics = { network: false }
+            metrics.onConfigChange()
+            expect(isFetchWrapped()).toBe(false)
+            ;(mockPostHog.config as any).metrics = { network: true }
+            metrics.onConfigChange()
+            expect(isFetchWrapped()).toBe(true)
+        })
     })
 })

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -6,6 +6,7 @@ import { createPosthogInstance } from './helpers/posthog-instance'
 import * as fflate from 'fflate'
 import { extendURLParams, request } from '../request'
 import { Compression, RequestWithOptions } from '../types'
+import { isMarkedPostHogRequest } from '../utils/request-tracking'
 import { logger } from '@posthog/browser-common/utils/logger'
 
 vi.mock('@posthog/browser-common/utils/globals', async (importOriginal) => ({
@@ -156,6 +157,10 @@ describe('request', () => {
         )
 
         it('performs the request with default params', () => {
+            let markedDuringTransport = false
+            mockedXHR.open.mockImplementation((_: string, url: string) => {
+                markedDuringTransport = isMarkedPostHogRequest(url)
+            })
             request(
                 createRequest({
                     url: 'https://any.posthog-instance.com/',
@@ -164,6 +169,8 @@ describe('request', () => {
                     },
                 })
             )
+            expect(markedDuringTransport).toBe(true)
+            expect(isMarkedPostHogRequest('https://any.posthog-instance.com/')).toBe(false)
             expect(mockedXHR.open).toHaveBeenCalledWith('GET', 'https://any.posthog-instance.com/', true)
 
             expect(mockedXHR.setRequestHeader).toHaveBeenCalledWith('x-header', 'value')
@@ -236,6 +243,14 @@ describe('request', () => {
         })
 
         it('performs the request with default params', () => {
+            let markedDuringTransport = false
+            mockedFetch.mockImplementation((url: string) => {
+                markedDuringTransport = isMarkedPostHogRequest(url)
+                return Promise.resolve({
+                    status: 200,
+                    text: () => Promise.resolve('{ "a": 1 }'),
+                }) as any
+            })
             request(
                 createRequest({
                     headers: {
@@ -244,6 +259,8 @@ describe('request', () => {
                 })
             )
 
+            expect(markedDuringTransport).toBe(true)
+            expect(isMarkedPostHogRequest('https://any.posthog-instance.com')).toBe(false)
             const headers = mockedFetch.mock.calls[0][1].headers as Headers
             expect(headers.get('x-header')).toEqual('value')
             expect(mockedFetch).toHaveBeenCalledWith(

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -1,5 +1,6 @@
 import { isFunction, isString } from '@posthog/core'
 import { addEventListener } from '@posthog/browser-common/utils/general-utils'
+import { convertToURL } from '@posthog/browser-common/utils/request-utils'
 import { window } from '@posthog/browser-common/utils/globals'
 import { createLogger } from '@posthog/browser-common/utils/logger'
 import type { PostHog } from '../posthog-core'
@@ -15,7 +16,7 @@ const now = (): number => (window?.performance?.now ? window.performance.now() :
 
 // All-digit segments, or hex/uuid-like segments of 8+ characters that contain a digit.
 const isIdLikeSegment = (segment: string): boolean =>
-    /^\d+$/.test(segment) || (segment.length >= 8 && /^[0-9a-f-]+$/i.test(segment) && /\d/.test(segment))
+    /^\d+$/.test(segment) || (segment.length >= 8 && /^[0-9a-f-]*\d[0-9a-f-]*$/i.test(segment))
 
 const templatePath = (pathname: string): string =>
     pathname
@@ -25,16 +26,7 @@ const templatePath = (pathname: string): string =>
 
 const statusClass = (status: number | undefined): string => (status ? `${Math.floor(status / 100)}xx` : 'error')
 
-const parseUrl = (url: string): URL | undefined => {
-    try {
-        // oxlint-disable-next-line compat/compat
-        return new URL(url, window?.location?.href)
-    } catch {
-        return undefined
-    }
-}
-
-const toAbsoluteUrl = (url: string): string => parseUrl(url)?.href ?? url
+const toAbsoluteUrl = (url: string): string => convertToURL(url)?.href || url
 
 const toRequest = (method: unknown, url: unknown): NetworkMetricsRequest => ({
     url: toAbsoluteUrl(String(url)),
@@ -71,7 +63,7 @@ const record = (instance: PostHog, request: NetworkMetricsRequest, status: numbe
         if (!name) {
             return
         }
-        const url = parseUrl(request.url)
+        const url = convertToURL(request.url)
         const attributes: MetricAttributes = {
             method: request.method,
             host: url?.hostname ?? '',

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -1,0 +1,165 @@
+import { isFunction, isString } from '@posthog/core'
+import { addEventListener } from '@posthog/browser-common/utils/general-utils'
+import { window } from '@posthog/browser-common/utils/globals'
+import { createLogger } from '@posthog/browser-common/utils/logger'
+import type { PostHog } from '../posthog-core'
+import type { MetricAttributes, NetworkMetricsConfig, NetworkMetricsRequest } from '../types'
+import { patch } from './replay/rrweb-plugins/patch'
+
+const logger = createLogger('[NetworkMetrics]')
+
+const DEFAULT_METRIC_NAME = 'http.client.request.duration'
+
+// oxlint-disable-next-line compat/compat
+const now = (): number => (window?.performance?.now ? window.performance.now() : Date.now())
+
+// All-digit segments, or hex/uuid-like segments of 8+ characters that contain a digit.
+const isIdLikeSegment = (segment: string): boolean =>
+    /^\d+$/.test(segment) || (segment.length >= 8 && /^[0-9a-f-]+$/i.test(segment) && /\d/.test(segment))
+
+const templatePath = (pathname: string): string =>
+    pathname
+        .split('/')
+        .map((segment) => (isIdLikeSegment(segment) ? ':id' : segment))
+        .join('/')
+
+const statusClass = (status: number | undefined): string => (status ? `${Math.floor(status / 100)}xx` : 'error')
+
+const parseUrl = (url: string): URL | undefined => {
+    try {
+        // oxlint-disable-next-line compat/compat
+        return new URL(url, window?.location?.href)
+    } catch {
+        return undefined
+    }
+}
+
+const toRequest = (method: unknown, url: unknown): NetworkMetricsRequest => ({
+    url: parseUrl(String(url))?.href ?? String(url),
+    method: String(method).toUpperCase(),
+})
+
+const isPostHogRequest = (instance: PostHog, url: string): boolean => {
+    const router = instance.requestRouter
+    return (
+        url.indexOf(router.endpointFor('api')) === 0 ||
+        url.indexOf(router.endpointFor('flags')) === 0 ||
+        router.isIngestionEndpoint(url)
+    )
+}
+
+const networkConfig = (instance: PostHog): NetworkMetricsConfig | undefined => {
+    const network = instance.config.metrics?.network
+    return network === true ? {} : network || undefined
+}
+
+const record = (instance: PostHog, request: NetworkMetricsRequest, status: number | undefined, start: number): void => {
+    try {
+        const durationMs = now() - start
+        const config = networkConfig(instance)
+        if (!config || isPostHogRequest(instance, request.url)) {
+            return
+        }
+        const name = isFunction(config.name)
+            ? config.name(request)
+            : isString(config.name)
+              ? config.name
+              : DEFAULT_METRIC_NAME
+        if (!name) {
+            return
+        }
+        const url = parseUrl(request.url)
+        const attributes: MetricAttributes = {
+            method: request.method,
+            host: url?.hostname ?? '',
+            path: url ? templatePath(url.pathname) : '',
+            status_class: statusClass(status),
+            ...config.attributes?.(request, { status, durationMs }),
+        }
+        instance.metrics?.histogram(name, durationMs, { unit: 'ms', attributes })
+    } catch (e) {
+        logger.error('Failed to record network metric', e)
+    }
+}
+
+const noop = (): void => {}
+
+const patchFetch = (instance: PostHog): (() => void) => {
+    if (!isFunction(window?.fetch)) {
+        return noop
+    }
+    return patch(window as any, 'fetch', (originalFetch: any) => {
+        return function (this: unknown, ...args: unknown[]) {
+            const start = now()
+            const result = originalFetch.apply(this, args)
+            try {
+                const [input, init] = args
+                const request = toRequest(
+                    (init as RequestInit | undefined)?.method ?? (input as Request)?.method ?? 'GET',
+                    (input as Request)?.url ?? input
+                )
+                result.then(
+                    (response: Response) => record(instance, request, response?.status, start),
+                    () => record(instance, request, undefined, start)
+                )
+            } catch (e) {
+                logger.error('Failed to observe fetch', e)
+            }
+            return result
+        }
+    })
+}
+
+const patchXHR = (instance: PostHog): (() => void) => {
+    const prototype = window?.XMLHttpRequest?.prototype
+    if (!prototype) {
+        return noop
+    }
+    const requests = new WeakMap<XMLHttpRequest, NetworkMetricsRequest>()
+
+    const restoreOpen = patch(prototype, 'open', (originalOpen: any) => {
+        return function (this: XMLHttpRequest, ...args: unknown[]) {
+            try {
+                requests.set(this, toRequest(args[0], args[1]))
+            } catch (e) {
+                logger.error('Failed to observe XHR open', e)
+            }
+            return originalOpen.apply(this, args)
+        }
+    })
+    const restoreSend = patch(prototype, 'send', (originalSend: any) => {
+        return function (this: XMLHttpRequest, ...args: unknown[]) {
+            try {
+                const request = requests.get(this)
+                if (request) {
+                    const start = now()
+                    addEventListener(this as unknown as Element, 'loadend', () =>
+                        record(instance, request, this.status, start)
+                    )
+                }
+            } catch (e) {
+                logger.error('Failed to observe XHR send', e)
+            }
+            return originalSend.apply(this, args)
+        }
+    })
+
+    return () => {
+        restoreOpen()
+        restoreSend()
+    }
+}
+
+/**
+ * Records a duration histogram for every `fetch` and `XMLHttpRequest`.
+ * Observation only: the wrappers never change the arguments or the result,
+ * and every failure inside them is caught and logged.
+ */
+export const startNetworkMetrics = (instance: PostHog): (() => void) => {
+    const restoreFetch = patchFetch(instance)
+    const restoreXHR = patchXHR(instance)
+    return () => {
+        restoreFetch()
+        restoreXHR()
+    }
+}

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -34,16 +34,19 @@ const parseUrl = (url: string): URL | undefined => {
     }
 }
 
+const toAbsoluteUrl = (url: string): string => parseUrl(url)?.href ?? url
+
 const toRequest = (method: unknown, url: unknown): NetworkMetricsRequest => ({
-    url: parseUrl(String(url))?.href ?? String(url),
+    url: toAbsoluteUrl(String(url)),
     method: String(method).toUpperCase(),
 })
 
+// `api_host` may be a relative proxy path like `/ingest`, so resolve it the same way as the request url.
 const isPostHogRequest = (instance: PostHog, url: string): boolean => {
     const router = instance.requestRouter
     return (
-        url.indexOf(router.endpointFor('api')) === 0 ||
-        url.indexOf(router.endpointFor('flags')) === 0 ||
+        url.indexOf(toAbsoluteUrl(router.endpointFor('api'))) === 0 ||
+        url.indexOf(toAbsoluteUrl(router.endpointFor('flags'))) === 0 ||
         router.isIngestionEndpoint(url)
     )
 }

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -151,6 +151,11 @@ const patchXHR = (instance: PostHog): (() => void) => {
  * Records a duration histogram for every `fetch` and `XMLHttpRequest`.
  * Observation only: the wrappers never change the arguments or the result,
  * and every failure inside them is caught and logged.
+ *
+ * Each transport is measured to the boundary its API exposes: a `fetch` promise
+ * settles when the response headers arrive, and `loadend` fires after the whole
+ * XHR response body. Aligning them would mean reading the fetch response body,
+ * which an observer must not do.
  */
 export const startNetworkMetrics = (instance: PostHog): (() => void) => {
     const restoreFetch = patchFetch(instance)

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -47,6 +47,8 @@ const isPostHogRequest = (instance: PostHog, url: string): boolean => {
     return (
         isUnderEndpoint(url, router.endpointFor('api')) ||
         isUnderEndpoint(url, router.endpointFor('flags')) ||
+        // the asset host serves the remote config JSON fallback, which travels over fetch or XHR
+        isUnderEndpoint(url, router.endpointFor('assets')) ||
         router.isIngestionEndpoint(url)
     )
 }

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -130,7 +130,8 @@ const patchXHR = (instance: PostHog): (() => void) => {
                     const start = now()
                     const onLoadEnd = () => {
                         this.removeEventListener('loadend', onLoadEnd)
-                        record(instance, request, this.status, start)
+                        // XHR reports status 0 when no response arrived, which the callback contract calls `undefined`.
+                        record(instance, request, this.status || undefined, start)
                     }
                     addEventListener(this as unknown as Element, 'loadend', onLoadEnd)
                 }

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -34,11 +34,19 @@ const toRequest = (method: unknown, url: unknown): NetworkMetricsRequest => ({
 })
 
 // `api_host` may be a relative proxy path like `/ingest`, so resolve it the same way as the request url.
+// The match stops at a path boundary: with `api_host: '/ingest'`, `/ingest/e/` belongs to PostHog but the
+// application's own `/ingestion-status` does not. A host root matches that whole origin, which is what the
+// subdomain and cloud setups need.
+const isUnderEndpoint = (url: string, endpoint: string): boolean => {
+    const base = toAbsoluteUrl(endpoint).replace(/\/$/, '')
+    return url === base || url.indexOf(base + '/') === 0 || url.indexOf(base + '?') === 0
+}
+
 const isPostHogRequest = (instance: PostHog, url: string): boolean => {
     const router = instance.requestRouter
     return (
-        url.indexOf(toAbsoluteUrl(router.endpointFor('api'))) === 0 ||
-        url.indexOf(toAbsoluteUrl(router.endpointFor('flags'))) === 0 ||
+        isUnderEndpoint(url, router.endpointFor('api')) ||
+        isUnderEndpoint(url, router.endpointFor('flags')) ||
         router.isIngestionEndpoint(url)
     )
 }

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -5,11 +5,12 @@ import { window } from '@posthog/browser-common/utils/globals'
 import { createLogger } from '@posthog/browser-common/utils/logger'
 import type { PostHog } from '../posthog-core'
 import type { MetricAttributes, NetworkMetricsConfig, NetworkMetricsRequest } from '../types'
+import { isMarkedPostHogRequest } from '../utils/request-tracking'
 import { patch } from './replay/rrweb-plugins/patch'
 
 const logger = createLogger('[NetworkMetrics]')
 
-const DEFAULT_METRIC_NAME = 'http.client.request.duration'
+const DEFAULT_METRIC_NAME = 'http.client.request.duration_ms'
 
 // oxlint-disable-next-line compat/compat
 const now = (): number => (window?.performance?.now ? window.performance.now() : Date.now())
@@ -34,10 +35,13 @@ const toRequest = (method: unknown, url: unknown): NetworkMetricsRequest => ({
 })
 
 // `api_host` may be a relative proxy path like `/ingest`, so resolve it the same way as the request url.
-// The match stops at a path boundary: with `api_host: '/ingest'`, `/ingest/e/` belongs to PostHog but the
-// application's own `/ingestion-status` does not. A host root matches that whole origin, which is what the
-// subdomain and cloud setups need.
+// The match stops at a path boundary. Host roots are handled by the request-layer marker instead of matching
+// the entire origin, which keeps same-origin proxy traffic observable.
 const isUnderEndpoint = (url: string, endpoint: string): boolean => {
+    const parsedEndpoint = convertToURL(endpoint)
+    if (!parsedEndpoint || (parsedEndpoint.pathname === '/' && !parsedEndpoint.search && !parsedEndpoint.hash)) {
+        return false
+    }
     const base = toAbsoluteUrl(endpoint).replace(/\/$/, '')
     return url === base || url.indexOf(base + '/') === 0 || url.indexOf(base + '?') === 0
 }
@@ -45,6 +49,7 @@ const isUnderEndpoint = (url: string, endpoint: string): boolean => {
 const isPostHogRequest = (instance: PostHog, url: string): boolean => {
     const router = instance.requestRouter
     return (
+        isMarkedPostHogRequest(url) ||
         isUnderEndpoint(url, router.endpointFor('api')) ||
         isUnderEndpoint(url, router.endpointFor('flags')) ||
         // the asset host serves the remote config JSON fallback, which travels over fetch or XHR
@@ -103,9 +108,18 @@ const patchFetch = (instance: PostHog): (() => void) => {
                     (init as RequestInit | undefined)?.method ?? (input as Request)?.method ?? 'GET',
                     (input as Request)?.url ?? input
                 )
-                result.then(
-                    (response: Response) => record(instance, request, response?.status, start),
-                    () => record(instance, request, undefined, start)
+                if (isPostHogRequest(instance, request.url) || !isFunction(result?.then)) {
+                    return result
+                }
+                return result.then(
+                    (response: Response) => {
+                        record(instance, request, response?.status, start)
+                        return response
+                    },
+                    (error: unknown) => {
+                        record(instance, request, undefined, start)
+                        throw error
+                    }
                 )
             } catch (e) {
                 logger.error('Failed to observe fetch', e)
@@ -138,10 +152,13 @@ const patchXHR = (instance: PostHog): (() => void) => {
                 const request = requests.get(this)
                 if (request) {
                     const start = now()
+                    const shouldRecord = !isPostHogRequest(instance, request.url)
                     const onLoadEnd = () => {
                         this.removeEventListener('loadend', onLoadEnd)
                         // XHR reports status 0 when no response arrived, which the callback contract calls `undefined`.
-                        record(instance, request, this.status || undefined, start)
+                        if (shouldRecord) {
+                            record(instance, request, this.status || undefined, start)
+                        }
                     }
                     addEventListener(this as unknown as Element, 'loadend', onLoadEnd)
                 }
@@ -160,8 +177,9 @@ const patchXHR = (instance: PostHog): (() => void) => {
 
 /**
  * Records a duration histogram for every `fetch` and `XMLHttpRequest`.
- * Observation only: the wrappers never change the arguments or the result,
- * and every failure inside them is caught and logged.
+ * Observation only: the wrappers never change the request arguments or its
+ * settlement. Fetch returns a derived promise so rejected requests remain
+ * observable to the caller and to the browser's unhandled-rejection handling.
  *
  * Each transport is measured to the boundary its API exposes: a `fetch` promise
  * settles when the response headers arrive, and `loadend` fires after the whole

--- a/packages/browser/src/extensions/network-metrics.ts
+++ b/packages/browser/src/extensions/network-metrics.ts
@@ -133,9 +133,11 @@ const patchXHR = (instance: PostHog): (() => void) => {
                 const request = requests.get(this)
                 if (request) {
                     const start = now()
-                    addEventListener(this as unknown as Element, 'loadend', () =>
+                    const onLoadEnd = () => {
+                        this.removeEventListener('loadend', onLoadEnd)
                         record(instance, request, this.status, start)
-                    )
+                    }
+                    addEventListener(this as unknown as Element, 'loadend', onLoadEnd)
                 }
             } catch (e) {
                 logger.error('Failed to observe XHR send', e)

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -4049,6 +4049,7 @@ export class PostHog implements PostHogInterface {
 
             this.exceptionObserver?.onConfigChange()
             this.exceptions?.onConfigChange()
+            this.metrics?.onConfigChange()
 
             this.sessionRecording?.startIfEnabledOrStop()
             this.tracingHeaders?.startIfEnabledOrStop()

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3772,6 +3772,7 @@ export class PostHog implements PostHogInterface {
         // so no buffered events are silently dropped when teardown is explicit.
         this.logs?.flushLogs('sendBeacon')
         void this.metrics?.flush('sendBeacon')
+        this.metrics?.dispose()
         this._requestQueue?.unload()
         this._retryQueue?.unload()
         try {

--- a/packages/browser/src/posthog-metrics.ts
+++ b/packages/browser/src/posthog-metrics.ts
@@ -5,6 +5,7 @@ import { PostHogMetrics as CorePostHogMetrics, resolveMetricsConfig } from '@pos
 import type { SendMetricsBatchOutcome } from '@posthog/core'
 import { createLogger } from '@posthog/browser-common/utils/logger'
 import { Extension } from './extensions/types'
+import { startNetworkMetrics } from './extensions/network-metrics'
 
 const METRICS_ENDPOINT = '/i/v1/metrics'
 // Safety backstop for a `_send_request` that never calls back — same policy
@@ -30,13 +31,25 @@ export class PostHogMetrics implements Extension {
     private _core: CorePostHogMetrics | undefined
     // The `metrics` config the current `_core` was built from; a change rebuilds it.
     private _resolvedFrom: PostHog['config']['metrics']
+    private _stopNetworkMetrics: (() => void) | undefined
 
     constructor(private readonly _instance: PostHog) {}
 
-    // Nothing to set up eagerly — the aggregator builds lazily on the first
-    // capture so it sees post-init config. Present so the class satisfies the
-    // weakly-typed `Extension` contract.
-    initialize(): void {}
+    // The aggregator builds lazily on the first capture so it sees post-init
+    // config; only the network wrappers need to be installed eagerly.
+    initialize(): void {
+        this.onConfigChange()
+    }
+
+    onConfigChange(): void {
+        const enabled = !!this._instance.config.metrics?.network
+        if (enabled && !this._stopNetworkMetrics) {
+            this._stopNetworkMetrics = startNetworkMetrics(this._instance)
+        } else if (!enabled && this._stopNetworkMetrics) {
+            this._stopNetworkMetrics()
+            this._stopNetworkMetrics = undefined
+        }
+    }
 
     // The extension is constructed before `init` applies config, so build the
     // core lazily and rebuild when `config.metrics` is swapped (e.g. via

--- a/packages/browser/src/posthog-metrics.ts
+++ b/packages/browser/src/posthog-metrics.ts
@@ -107,6 +107,18 @@ export class PostHogMetrics implements Extension {
         this._core?.reset()
     }
 
+    /**
+     * Stops everything this extension installed: the global `fetch` and
+     * `XMLHttpRequest` wrappers, and the aggregator's pending window and timer.
+     * `shutdown()` calls this after its final flush, so a shut down instance
+     * leaves nothing behind in the page.
+     */
+    dispose(): void {
+        this._stopNetworkMetrics?.()
+        this._stopNetworkMetrics = undefined
+        this._core?.reset()
+    }
+
     // Host adapter for core's `PostHogMetrics`; structurally checked against
     // `MetricsHost` at the `new CorePostHogMetrics` call.
     private _createHost() {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -24,6 +24,7 @@ import {
     isNativeAsyncGzipReadError,
     isUndefined,
 } from '@posthog/core'
+import { markPostHogRequest, unmarkPostHogRequest } from './utils/request-tracking'
 
 export { jsonStringify }
 
@@ -256,39 +257,44 @@ const xhr = (options: RequestWithOptions) => {
 
     const req = new XMLHttpRequest!()
     const { url, encodedBody } = encodedRequest
-    req.open(options.method || 'GET', url, true)
-    const { contentType, body } = encodedBody ?? {}
+    markPostHogRequest(url)
+    try {
+        req.open(options.method || 'GET', url, true)
+        const { contentType, body } = encodedBody ?? {}
 
-    each(options.headers, function (headerValue, headerName) {
-        req.setRequestHeader(headerName, headerValue)
-    })
+        each(options.headers, function (headerValue, headerName) {
+            req.setRequestHeader(headerName, headerValue)
+        })
 
-    if (contentType) {
-        req.setRequestHeader('Content-Type', contentType)
-    }
-
-    if (options.timeout) {
-        req.timeout = options.timeout
-    }
-    req.onreadystatechange = () => {
-        // XMLHttpRequest.DONE == 4, except in safari 4
-        if (req.readyState === 4) {
-            const response: RequestResponse = {
-                statusCode: req.status,
-                text: req.responseText,
-            }
-            if (req.status === 200) {
-                try {
-                    response.json = JSON.parse(req.responseText)
-                } catch {
-                    // logger.error(e)
-                }
-            }
-
-            options.callback?.(response)
+        if (contentType) {
+            req.setRequestHeader('Content-Type', contentType)
         }
+
+        if (options.timeout) {
+            req.timeout = options.timeout
+        }
+        req.onreadystatechange = () => {
+            // XMLHttpRequest.DONE == 4, except in safari 4
+            if (req.readyState === 4) {
+                const response: RequestResponse = {
+                    statusCode: req.status,
+                    text: req.responseText,
+                }
+                if (req.status === 200) {
+                    try {
+                        response.json = JSON.parse(req.responseText)
+                    } catch {
+                        // logger.error(e)
+                    }
+                }
+
+                options.callback?.(response)
+            }
+        }
+        req.send(body)
+    } finally {
+        unmarkPostHogRequest(url)
     }
-    req.send(body)
 }
 
 const _fetch = (options: RequestWithOptions & { _keepaliveDisabled?: boolean }) => {
@@ -356,43 +362,50 @@ const _fetch = (options: RequestWithOptions & { _keepaliveDisabled?: boolean }) 
     }
 
     try {
-        fetch!(url, {
-            method: options?.method || 'GET',
-            headers,
-            // if body is greater than 64kb, then fetch with keepalive will error
-            // see 8:10:5 at https://fetch.spec.whatwg.org/#http-network-or-cache-fetch,
-            // but we do want to set keepalive sometimes as it can  help with success
-            // when e.g. a page is being closed
-            // so let's get the best of both worlds and only set keepalive for POST requests
-            // where the body is less than 64kb
-            // NB this is fetch keepalive and not http keepalive
-            // _keepaliveDisabled: a beacon-rejected payload would fail a keepalive fetch too (shared quota)
-            keepalive:
-                options.method === 'POST' && !options._keepaliveDisabled && (estimatedSize || 0) < KEEP_ALIVE_THRESHOLD,
-            body,
-            signal: aborter?.signal,
-            ...options.fetchOptions,
-        })
-            .then((response) => {
-                return response.text().then((responseText) => {
-                    const res: RequestResponse = {
-                        statusCode: response.status,
-                        text: responseText,
-                    }
-
-                    if (response.status === 200) {
-                        try {
-                            res.json = JSON.parse(responseText)
-                        } catch (e) {
-                            logger.error(e)
-                        }
-                    }
-
-                    options.callback?.(res)
-                })
+        markPostHogRequest(url)
+        try {
+            fetch!(url, {
+                method: options?.method || 'GET',
+                headers,
+                // if body is greater than 64kb, then fetch with keepalive will error
+                // see 8:10:5 at https://fetch.spec.whatwg.org/#http-network-or-cache-fetch,
+                // but we do want to set keepalive sometimes as it can  help with success
+                // when e.g. a page is being closed
+                // so let's get the best of both worlds and only set keepalive for POST requests
+                // where the body is less than 64kb
+                // NB this is fetch keepalive and not http keepalive
+                // _keepaliveDisabled: a beacon-rejected payload would fail a keepalive fetch too (shared quota)
+                keepalive:
+                    options.method === 'POST' &&
+                    !options._keepaliveDisabled &&
+                    (estimatedSize || 0) < KEEP_ALIVE_THRESHOLD,
+                body,
+                signal: aborter?.signal,
+                ...options.fetchOptions,
             })
-            .catch(handleError)
-            .finally(() => (aborter ? clearTimeout(aborter.timeout) : null))
+                .then((response) => {
+                    return response.text().then((responseText) => {
+                        const res: RequestResponse = {
+                            statusCode: response.status,
+                            text: responseText,
+                        }
+
+                        if (response.status === 200) {
+                            try {
+                                res.json = JSON.parse(responseText)
+                            } catch (e) {
+                                logger.error(e)
+                            }
+                        }
+
+                        options.callback?.(res)
+                    })
+                })
+                .catch(handleError)
+                .finally(() => (aborter ? clearTimeout(aborter.timeout) : null))
+        } finally {
+            unmarkPostHogRequest(url)
+        }
     } catch (error) {
         // `window.fetch` can be monkey-patched by third-party scripts (e.g. a storefront/analytics
         // wrapper) to throw *synchronously* instead of returning a rejected promise. Because we may

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -150,6 +150,9 @@ export type {
     BeforeSendMetricFn,
     OtlpMetricsPayload,
     MetricsConfig,
+    NetworkMetricsConfig,
+    NetworkMetricsRequest,
+    NetworkMetricsResponse,
 } from '@posthog/types'
 
 // Re-export KnownUnsafeEditableEvent from @posthog/core for backwards compatibility

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -150,6 +150,7 @@ export type {
     BeforeSendMetricFn,
     OtlpMetricsPayload,
     MetricsConfig,
+    BrowserMetricsConfig,
     NetworkMetricsConfig,
     NetworkMetricsRequest,
     NetworkMetricsResponse,

--- a/packages/browser/src/utils/request-tracking.ts
+++ b/packages/browser/src/utils/request-tracking.ts
@@ -1,0 +1,33 @@
+import { convertToURL } from '@posthog/browser-common/utils/request-utils'
+
+const activePostHogRequests = new Map<string, number>()
+
+const requestKey = (url: string): string => {
+    try {
+        return convertToURL(url)?.href || url
+    } catch {
+        return url
+    }
+}
+
+/**
+ * Marks a request while the browser transport is being called. This is shared
+ * by all PostHog instances so layered observers can identify SDK traffic even
+ * when instances use different hosts.
+ */
+export const markPostHogRequest = (url: string): void => {
+    const key = requestKey(url)
+    activePostHogRequests.set(key, (activePostHogRequests.get(key) || 0) + 1)
+}
+
+export const unmarkPostHogRequest = (url: string): void => {
+    const key = requestKey(url)
+    const count = activePostHogRequests.get(key)
+    if (count && count > 1) {
+        activePostHogRequests.set(key, count - 1)
+    } else {
+        activePostHogRequests.delete(key)
+    }
+}
+
+export const isMarkedPostHogRequest = (url: string): boolean => activePostHogRequests.has(requestKey(url))

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -866,6 +866,7 @@
         "_stopBuffering",
         "_stopCapturing",
         "_stopConsoleRecorder",
+        "_stopNetworkMetrics",
         "_stopPolling",
         "_stopReattachWatcher",
         "_stopRecorderStartedByPersistedHint",

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -280,6 +280,22 @@ exports[`config > snapshot > for PostHogConfig 1`] = `
   \\"metrics\\": [
     \\"undefined\\",
     {
+      \\"network\\": [
+        \\"undefined\\",
+        \\"false\\",
+        \\"true\\",
+        {
+          \\"name\\": [
+            \\"undefined\\",
+            \\"string\\",
+            \\"(request: NetworkMetricsRequest) => string | null | undefined\\"
+          ],
+          \\"attributes\\": [
+            \\"undefined\\",
+            \\"(request: NetworkMetricsRequest, response: NetworkMetricsResponse) => MetricAttributes | undefined\\"
+          ]
+        }
+      ],
       \\"serviceName\\": [
         \\"undefined\\",
         \\"string\\"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -81,6 +81,9 @@ export type {
     RequestQueueConfig,
     LogCaptureOptions,
     MetricsConfig,
+    NetworkMetricsConfig,
+    NetworkMetricsRequest,
+    NetworkMetricsResponse,
     CapturePageviewOptions,
     PostHogConfig,
 } from './posthog-config'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -81,6 +81,7 @@ export type {
     RequestQueueConfig,
     LogCaptureOptions,
     MetricsConfig,
+    BrowserMetricsConfig,
     NetworkMetricsConfig,
     NetworkMetricsRequest,
     NetworkMetricsResponse,

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1133,14 +1133,15 @@ export interface NetworkMetricsResponse {
 
 /**
  * Options for automatic `fetch` and `XMLHttpRequest` duration metrics.
- * Recording never changes the request or its result.
+ * Recording never changes the request or its settlement. Fetch returns a derived
+ * promise so rejected requests remain observable to the caller.
  */
 export interface NetworkMetricsConfig {
     /**
      * The metric name. A string is used for every request. A function is
      * called once per request; return a falsy value to skip that request.
      *
-     * @default 'http.client.request.duration'
+     * @default 'http.client.request.duration_ms'
      */
     name?: string | ((request: NetworkMetricsRequest) => string | null | undefined)
     /**

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1111,10 +1111,53 @@ export interface LogsConfig extends LogCaptureOptions {
     captureConsoleLogs?: boolean
 }
 
+/** The request a network metric describes. */
+export interface NetworkMetricsRequest {
+    /** The full request URL, including the query string. */
+    url: string
+    /** The HTTP method in upper case, e.g. 'GET'. */
+    method: string
+}
+
+/** How a network request ended. */
+export interface NetworkMetricsResponse {
+    /** The HTTP status code. `undefined` when the request failed before a response arrived. */
+    status: number | undefined
+    durationMs: number
+}
+
+/**
+ * Options for automatic `fetch` and `XMLHttpRequest` duration metrics.
+ * Recording never changes the request or its result.
+ */
+export interface NetworkMetricsConfig {
+    /**
+     * The metric name. A string is used for every request. A function is
+     * called once per request; return a falsy value to skip that request.
+     *
+     * @default 'http.client.request.duration'
+     */
+    name?: string | ((request: NetworkMetricsRequest) => string | null | undefined)
+    /**
+     * Adds attributes to each recorded request. The result is merged over the
+     * default attributes (`method`, `host`, `path`, `status_class`), so it can
+     * also replace them, e.g. to set `path` to a route template.
+     * Keep attribute values low-cardinality.
+     */
+    attributes?: (request: NetworkMetricsRequest, response: NetworkMetricsResponse) => MetricAttributes | undefined
+}
+
 /**
  * Options for the posthog.metrics API (count, gauge, histogram).
  */
 export interface MetricsConfig {
+    /**
+     * Record the duration of every `fetch` and `XMLHttpRequest` as a histogram.
+     * `true` uses the defaults. Requests to PostHog itself are not recorded.
+     *
+     * @default undefined
+     */
+    network?: boolean | NetworkMetricsConfig
     /**
      * The service name for metric series.
      * Maps to the OTel resource attribute 'service.name'.

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1149,15 +1149,9 @@ export interface NetworkMetricsConfig {
 
 /**
  * Options for the posthog.metrics API (count, gauge, histogram).
+ * Shared by every SDK; browser-only options live in `BrowserMetricsConfig`.
  */
 export interface MetricsConfig {
-    /**
-     * Record the duration of every `fetch` and `XMLHttpRequest` as a histogram.
-     * `true` uses the defaults. Requests to PostHog itself are not recorded.
-     *
-     * @default undefined
-     */
-    network?: boolean | NetworkMetricsConfig
     /**
      * The service name for metric series.
      * Maps to the OTel resource attribute 'service.name'.
@@ -1206,6 +1200,20 @@ export interface MetricsConfig {
      * sample (return `null` to drop) before it is aggregated.
      */
     beforeSend?: BeforeSendMetricFn | BeforeSendMetricFn[]
+}
+
+/**
+ * Metrics configuration options for the browser SDK. Adds the options that
+ * only the browser SDK implements to the shared metrics options.
+ */
+export interface BrowserMetricsConfig extends MetricsConfig {
+    /**
+     * Record the duration of every `fetch` and `XMLHttpRequest` as a histogram.
+     * `true` uses the defaults. Requests to PostHog itself are not recorded.
+     *
+     * @default undefined
+     */
+    network?: boolean | NetworkMetricsConfig
 }
 
 // See https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options
@@ -1588,7 +1596,7 @@ export interface PostHogConfig {
      *
      * @default undefined
      */
-    metrics?: MetricsConfig
+    metrics?: BrowserMetricsConfig
 
     /**
      * Determines whether PostHog should disable all conversations functionality.

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1123,6 +1123,11 @@ export interface NetworkMetricsRequest {
 export interface NetworkMetricsResponse {
     /** The HTTP status code. `undefined` when the request failed before a response arrived. */
     status: number | undefined
+    /**
+     * How long the request took, in milliseconds. The end boundary follows the
+     * transport: a `fetch` is measured to its response headers, an
+     * `XMLHttpRequest` to the end of its response body.
+     */
     durationMs: number
 }
 
@@ -1210,6 +1215,8 @@ export interface BrowserMetricsConfig extends MetricsConfig {
     /**
      * Record the duration of every `fetch` and `XMLHttpRequest` as a histogram.
      * `true` uses the defaults. Requests to PostHog itself are not recorded.
+     * Each transport is measured to the boundary its API exposes: a `fetch` to
+     * its response headers, an `XMLHttpRequest` to the end of its response body.
      *
      * @default undefined
      */


### PR DESCRIPTION
> [!NOTE]
> 🤖 Automated update by PostHog Desktop - not written by a human

## Problem

Browser SDK users need request-duration metrics without maintaining custom wrappers around `fetch` and `XMLHttpRequest`.

**Why:** Hand-written wrappers are repetitive and can change request behavior.

## Changes

- Browser SDK users can record HTTP and HTTPS `fetch` and `XMLHttpRequest` durations as histograms.
- The SDK skips `data:`, `blob:`, `file:`, malformed, and custom protocol URLs.
- Default attributes include `method`, `host`, templated `path`, and `status_class`.
- Custom name and attribute functions can rename, enrich, or skip each request.
- The wrappers preserve request arguments and settlement. Shutdown removes the wrappers.
- Requests made by PostHog are excluded.

```ts
posthog.init("<token>", {
    metrics: {
        network: {
            name: (request) => (request.url.includes("/api/") ? "storefront.api.duration" : null),
            attributes: (_request, response) => ({ slow: response.durationMs > 1000 }),
        },
    },
})
```

New `@posthog/types` types define the configuration, request, and response contracts.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop updated the existing implementation after human review. The `writing-tests`, `writing-user-facing-copy`, and `writing-pr-descriptions` skills guided the tests and text.

The URL policy allows only HTTP and HTTPS. This avoids local paths, embedded content, opaque blob IDs, and custom Electron protocols by default.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*