### PR TITLE
fix(replay): preserve stale config so recording can restart

### DIFF
--- a/.changeset/three-lemons-kick.md
+++ b/.changeset/three-lemons-kick.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix session recording failing to restart after capturing events while stopped with expired config.

--- a/packages/browser/playwright/mocked/session-recording/session-recording-stale-config.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-stale-config.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test, WindowWithPostHog } from '../utils/posthog-playwright-test-base'
+import { start, waitForSessionRecordingToStart } from '../utils/setup'
+
+const configKey = '$session_recording_remote_config'
+const startOptions = {
+    url: '/playground/cypress/index.html',
+    options: {
+        persistence: 'localStorage' as const,
+        strict_script_versioning: false as const,
+        session_recording: { compress_events: false },
+    },
+    flagsResponseOverrides: {
+        sessionRecording: { endpoint: '/ses/' },
+        autocapture_opt_out: true,
+    },
+}
+
+test.beforeEach(async ({ page }) => {
+    await page.route(/\/array\/[^/]+\/config\.js(\?|$)/, (route) =>
+        route.fulfill({ contentType: 'application/javascript', body: '' })
+    )
+})
+
+test('refreshes stale recording config after capturing an event while stopped', async ({ page, context }) => {
+    await start(startOptions, page, context)
+    await waitForSessionRecordingToStart(page)
+
+    const persisted = await page.evaluate((key) => {
+        const ph = (window as WindowWithPostHog).posthog!
+        ph.stopSessionRecording()
+        const staleConfig = { ...ph.get_property(key), cache_timestamp: Date.now() - 60 * 60 * 1000 - 1 }
+        ph.persistence!.register({ [key]: staleConfig })
+        ph.capture('event while recording is stopped')
+        return { expected: staleConfig, actual: ph.get_property(key), started: ph.sessionRecordingStarted() }
+    }, configKey)
+    expect(persisted.actual).toEqual(persisted.expected)
+    expect(persisted.started).toBe(false)
+
+    let releaseConfig!: () => void
+    const configGate = new Promise<void>((resolve) => {
+        releaseConfig = resolve
+    })
+    let refreshRequests = 0
+    await page.route(/\/array\/[^/]+\/config(\?|$)/, async (route) => {
+        refreshRequests++
+        await configGate
+        await route.fulfill({ json: startOptions.flagsResponseOverrides })
+    })
+
+    try {
+        await page.evaluate(() => {
+            const ph = (window as WindowWithPostHog).posthog!
+            ph.startSessionRecording()
+            ph.capture('event while recording config is refreshing')
+            ph.startSessionRecording()
+        })
+        await expect.poll(() => refreshRequests).toBe(1)
+        expect(await page.evaluate(() => (window as WindowWithPostHog).posthog!.sessionRecordingStarted())).toBe(false)
+        expect(
+            await page.evaluate((key) => (window as WindowWithPostHog).posthog!.get_property(key), configKey)
+        ).toEqual(persisted.expected)
+    } finally {
+        releaseConfig()
+    }
+
+    await waitForSessionRecordingToStart(page)
+    expect(
+        await page.evaluate(
+            (key) => (window as WindowWithPostHog).posthog!.get_property(key).cache_timestamp,
+            configKey
+        )
+    ).toBeGreaterThan(persisted.expected.cache_timestamp)
+})
+
+test('preserves legacy persisted recording config during a delayed cold-start config response', async ({
+    page,
+    context,
+}) => {
+    await start(startOptions, page, context)
+    await waitForSessionRecordingToStart(page)
+    const legacyConfig = await page.evaluate((key) => {
+        const ph = (window as WindowWithPostHog).posthog!
+        ph.stopSessionRecording()
+        const config = { ...ph.get_property(key) }
+        delete config.cache_timestamp
+        ph.persistence!.register({ [key]: config })
+        return config
+    }, configKey)
+
+    let releaseConfig!: () => void
+    const configGate = new Promise<void>((resolve) => {
+        releaseConfig = resolve
+    })
+    await page.route(/\/array\/[^/]+\/config(\?|$)/, async (route) => {
+        await configGate
+        await route.fulfill({ json: startOptions.flagsResponseOverrides })
+    })
+
+    try {
+        const recorderResponse = page.waitForResponse(/\/static\/(lazy-)?recorder\.js/)
+        await start({ ...startOptions, type: 'reload', waitForFlags: false }, page, context)
+        await recorderResponse
+        await page.waitForFunction(
+            () => (window as WindowWithPostHog).posthog?.sessionRecording?.status !== 'lazy_loading'
+        )
+        const persisted = await page.evaluate((key) => {
+            const ph = (window as WindowWithPostHog).posthog!
+            ph.capture('event before cold-start config arrives')
+            return ph.get_property(key)
+        }, configKey)
+        expect(persisted).toEqual(legacyConfig)
+    } finally {
+        releaseConfig()
+    }
+
+    await waitForSessionRecordingToStart(page)
+})

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -625,8 +625,8 @@ describe('Lazy SessionRecording', () => {
                     expect(result?.enabled).toBe(true)
                 } else {
                     expect(result).toBeUndefined()
-                    expect(posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG)).toBeUndefined()
                 }
+                expect(posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG)).toEqual(persistedConfig)
             })
 
             it('treats legacy config without cache_timestamp as fresh', () => {
@@ -8306,6 +8306,38 @@ describe('Lazy SessionRecording', () => {
                 expect.anything()
             )
         })
+    })
+
+    describe('stale config reads while stopped', () => {
+        it.each(['status', 'sdkDebugProperties'] as const)(
+            'preserves config and refreshes before restarting after a %s read',
+            (read) => {
+                addRRwebToWindow()
+                sessionRecording.onRemoteConfig(makeFlagsResponse({ sessionRecording: { endpoint: '/s/' } }))
+                expect(sessionRecording.started).toBe(true)
+                sessionRecording.stopRecording()
+                expect(sessionRecording.started).toBe(false)
+
+                const staleConfig = {
+                    enabled: true,
+                    endpoint: '/s/',
+                    cache_timestamp: Date.now() - RECORDING_REMOTE_CONFIG_TTL_MS - 1,
+                }
+                posthog.persistence?.register({ [SESSION_RECORDING_REMOTE_CONFIG]: staleConfig })
+                mockRemoteConfigLoad.mockClear()
+
+                void sessionRecording[read]
+
+                expect(posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG)).toEqual(staleConfig)
+                sessionRecording.startIfEnabledOrStop()
+                sessionRecording.startIfEnabledOrStop()
+                expect(mockRemoteConfigLoad).toHaveBeenCalledTimes(1)
+                expect(sessionRecording.started).toBe(false)
+
+                sessionRecording.onRemoteConfig(makeFlagsResponse({ sessionRecording: { endpoint: '/s/' } }))
+                expect(sessionRecording.started).toBe(true)
+            }
+        )
     })
 
     describe('wait for fresh config before starting', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1166,7 +1166,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
                     cacheTimestamp,
                     persistedConfig,
                 })
-                this._instance.persistence?.unregister(SESSION_RECORDING_REMOTE_CONFIG)
+                // Core needs the persisted config to reach its refresh path when recording restarts.
                 return undefined
             }
         }


### PR DESCRIPTION
## Problem

Fixes #4917.

In long-lived tabs, capturing an event while session recording is stopped can delete recording config older than one hour. A later `startSessionRecording()` then sees no enabled config and never reaches the refresh path, so recording stays off until config is loaded again.

## Changes

Keep expired config in persistence when the recorder reads it. The getter still returns `undefined` for expired config, but core can now request fresh config before restarting. This does not allow recording under expired settings or change sampling, triggers, or idle handling.

Add regression tests for status and debug-property reads, capture while stopped, refresh deduplication, and cold starts with legacy persisted config and a delayed response. Include a patch changeset.

### Testing

- Confirmed three focused unit cases failed before the fix.
- All 984 replay unit tests passed.
- Both browser regressions passed in Chromium, Firefox, and WebKit.
- Both compatibility regressions passed with `posthog-js@1.418.3` core and the newly built recorder.
- The browser production build, focused lint, formatting, and diff checks passed.
- The Playwright-wide typecheck still reports existing errors outside the changed files. Those errors also reproduce on the unchanged base checkout.
- `autoreview --mode branch --base origin/main` reviewed `f7e1417a9924822fdc5ad49f6eafb6dfa388094c` and reported no actionable findings.

### Replay release risk

The recorder can be loaded by older SDK cores. This change adds no cross-bundle API or persisted fields, and the pinned-core tests cover the affected path. It does not change rotation or flush decisions, and the replay volume-invariant tests passed. Recording volume may recover for affected long-lived tabs. Watch the recordings week-over-week anomaly alert for a day after release.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using GitHub CLI, Vitest, Playwright, and autoreview. The fix keeps the existing config freshness policy and removes only the destructive persistence update. It does not add a public API or expand the separate failed-refresh fallback behavior.
