### PR TITLE
fix(react-native): require posthog-ios 3.73.3

### DIFF
--- a/.changeset/rn-plugin-replay-masking-fixes.md
+++ b/.changeset/rn-plugin-replay-masking-fixes.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': patch
+---
+
+Require posthog-ios 3.73.3 so React Native apps get the session replay masking fixes shipped in posthog-ios 3.73.2 and 3.73.3.

--- a/packages/react-native-plugin/ios/Package.swift
+++ b/packages/react-native-plugin/ios/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: reactNativeDependencies + [
         .package(
             url: "https://github.com/PostHog/posthog-ios.git",
-            .upToNextMinor(from: "3.70.1")
+            .upToNextMinor(from: "3.73.3")
         ),
     ],
     targets: [

--- a/packages/react-native-plugin/posthog-react-native-plugin.podspec
+++ b/packages/react-native-plugin/posthog-react-native-plugin.podspec
@@ -6,7 +6,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 # Single source of truth for the posthog-ios native dependency version.
 # Used by both the SPM and CocoaPods resolution paths below; bump this
 # line when picking up a new posthog-ios release.
-posthog_ios_version = '3.70.1'
+posthog_ios_version = '3.73.3'
 
 Pod::Spec.new do |s|
   s.name         = "posthog-react-native-plugin"


### PR DESCRIPTION
## Problem

The plugin pins posthog-ios to `~> 3.70.1` for CocoaPods and to `.upToNextMinor(from: "3.70.1")` for Swift Package Manager. Both resolve only 3.70.x, so React Native apps cannot pick up the session replay masking fixes in posthog-ios 3.73.2 and 3.73.3:

- [posthog-ios#826](https://github.com/PostHog/posthog-ios/pull/826) (3.73.3) keeps inherited masking across siblings inside a full-window `ph-no-capture` view. In React Native, a screen-root `PostHogMaskView`, or a view carrying `ph-no-capture`, is often exactly window-sized. Before this fix, a child could clear the inherited mask on its way out, so later siblings were recorded unless another rule masked them. The same release keeps collecting masks inside a clipping view whose frame reaches zero while it is still visible mid-animation.
- [posthog-ios#822](https://github.com/PostHog/posthog-ios/pull/822) (3.73.2) makes three more paths fail closed. A frame whose masked image cannot be rendered is dropped instead of sent unmasked. Masks are collected inside a zero-size parent that does not clip, the wrapper React Native's default `overflow: visible` produces. Masks are also collected inside a view that is fading in or out.

## Changes

- Raise the minimum posthog-ios version to 3.73.3 for CocoaPods (`posthog_ios_version` in the podspec).
- Raise the minimum posthog-ios version to 3.73.3 for Swift Package Manager (`ios/Package.swift`).
- Add a patch changeset for `@posthog/react-native-plugin`.

This is the same shape as #4624. Between 3.70.1 and 3.73.3, posthog-ios made only minor and patch releases. Its public API snapshot (`api/posthog-ios.public-api.txt`) gained one method, `PostHogSDK.prewarmPushNotificationOpenCapture()`, and lost or changed nothing. The behaviour change a reviewer is most likely to care about is 3.73.0's queue retry change: queues are kept across retryable upload failures, and `maxRetries` now bounds only push-subscription registration. The plugin does not set `maxRetries`. The range also brings 3.71.0's opt-in `ph-no-mask` token, which lets React Native unmask known-safe views through `testID`.

#4921 raises the same floor to 3.72.0 for `prewarmPushNotificationOpenCapture()`, which 3.73.3 also has. Whichever PR lands second gets a one-line conflict in each file, and keeping 3.73.3 resolves it.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/openfeature-node-provider
- [ ] @posthog/openfeature-web-provider
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
- [ ] @posthog/browser-common

## Checklist

- [ ] Tests for new code (dependency bump only)
- [x] Accounted for the impact of any changes across different platforms (Apple platforms only; Android is untouched)
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file (added `.changeset/rn-plugin-replay-masking-fixes.md` directly)

## How this was checked

- 3.73.3 is published on CocoaPods trunk and tagged on GitHub, so both resolution paths can resolve it. Its deployment targets are unchanged from 3.70.1.
- Compared posthog-ios's public API snapshot between 3.70.1 and 3.73.3 (see Changes), and checked that every posthog-ios symbol `ios/PosthogReactNativePlugin.swift` uses exists in the 3.73.3 source.
- `node scripts/check-spm-manifest.mjs` passes, so the podspec and `Package.swift` floors match.
- I did not build the plugin inside a React Native app. The React Native Plugin Native CI workflow builds the example app against the new floor with CocoaPods, hybrid SwiftPM, full SwiftPM and macOS, as it did for #4921's 3.72.0 floor.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

DRI: @aramslegit, the PR author. External contributors can't set assignees here, so the field is empty.

- Claude Code, reviewing session replay masking in a React Native app whose masked screen roots are window-sized. Reading the SDK source showed that such a root masked only its first child subtree, which is the bug posthog-ios#826 fixes. We then found that this plugin's pin keeps React Native apps from receiving the fix. None of this was observed in a recording.
- The pin targets 3.73.3 rather than 3.73.2, because only 3.73.3 contains the sibling fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
