### PR TITLE
fix(error-tracking): serialize Date and Error objects in additionalProperties (#1977)

### DIFF
--- a/packages/node/src/__tests__/extensions/error-conversion.spec.ts
+++ b/packages/node/src/__tests__/extensions/error-conversion.spec.ts
@@ -1,4 +1,5 @@
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import ErrorTracking from '@/extensions/error-tracking'
 import { execFileSync } from 'node:child_process'
 import { constants, type ReadStream } from 'node:fs'
 import { mkdtemp, open, rename, rm, symlink, truncate, writeFile } from 'node:fs/promises'
@@ -58,6 +59,35 @@ describe('error conversion', () => {
     expect(exceptionList.length).toEqual(2)
     expect(exceptionList[0].value).toEqual('test error')
     expect(exceptionList[1].value).toEqual('Object captured as exception with keys: error_code')
+  })
+
+  it('should serialize Date and Error objects in additionalProperties', async () => {
+    const customError = new Error('Nested error message')
+    ;(customError as any).customCode = 123
+    const date = new Date('2026-09-12T12:00:00.000Z')
+
+    const message = await ErrorTracking.buildEventMessage(
+      errorPropertiesBuilder,
+      new Error('Primary error'),
+      { syntheticException: new Error('synth') },
+      'test-user',
+      {
+        timestamp: date,
+        nestedError: customError,
+        simple: 'string-val',
+      }
+    )
+
+    expect(message.properties?.timestamp).toEqual('2026-09-12T12:00:00.000Z')
+    expect(message.properties?.nestedError).toEqual(
+      expect.objectContaining({
+        name: 'Error',
+        message: 'Nested error message',
+        customCode: 123,
+      })
+    )
+    expect(message.properties?.nestedError.stack).toBeDefined()
+    expect(message.properties?.simple).toEqual('string-val')
   })
 
   describe('source context file reads', () => {

--- a/packages/node/src/extensions/error-tracking/index.ts
+++ b/packages/node/src/extensions/error-tracking/index.ts
@@ -8,6 +8,47 @@ import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 
 const SHUTDOWN_TIMEOUT = 2000
 
+function sanitizeAdditionalPropertyValue(val: unknown): unknown {
+  if (val instanceof Date) {
+    return val.toISOString()
+  }
+  if (val instanceof Error) {
+    const errorObj: Record<string, any> = {
+      name: val.name,
+      message: val.message,
+      stack: val.stack,
+    }
+    for (const key of Object.keys(val)) {
+      errorObj[key] = (val as any)[key]
+    }
+    return errorObj
+  }
+  if (Array.isArray(val)) {
+    return val.map(sanitizeAdditionalPropertyValue)
+  }
+  if (val !== null && typeof val === 'object' && val.constructor === Object) {
+    const res: Record<string, any> = {}
+    for (const [k, v] of Object.entries(val)) {
+      res[k] = sanitizeAdditionalPropertyValue(v)
+    }
+    return res
+  }
+  return val
+}
+
+export function sanitizeAdditionalProperties(
+  additionalProperties?: Record<string | number, any>
+): Record<string | number, any> | undefined {
+  if (!additionalProperties) {
+    return additionalProperties
+  }
+  const sanitized: Record<string | number, any> = {}
+  for (const [key, val] of Object.entries(additionalProperties)) {
+    sanitized[key] = sanitizeAdditionalPropertyValue(val)
+  }
+  return sanitized
+}
+
 export default class ErrorTracking {
   private client: PostHogBackendClient
   private _exceptionAutocaptureEnabled: boolean
@@ -19,19 +60,9 @@ export default class ErrorTracking {
     this._exceptionAutocaptureEnabled = options.enableExceptionAutocapture || false
     this._logger = _logger
 
-    // Burst protection is scoped PER EXCEPTION TYPE: the rate limiter is keyed by exception type
-    // (see `consumeRateLimit(exceptionType)` below), so each distinct type gets its own fresh
-    // token bucket. There is no aggregate cap across all types — a burst made up of many distinct
-    // types is not throttled in total, only per individual type.
-    //
-    // By default each exception type captures ten exceptions before being rate limited, then
-    // refills at a rate of one token / 10 second period (e.g. captures 1 rate-limited exception of
-    // that type every 10 seconds until the burst ends). The bucket size and refill rate can be
-    // tuned via the `exceptionRateLimiterBucketSize` and `exceptionRateLimiterRefillRate`
-    // options.
     this._rateLimiter = new BucketedRateLimiter({
       ...resolveExceptionRateLimiterConfig(options),
-      refillInterval: 10000, // ten seconds in milliseconds
+      refillInterval: 10000,
       _logger: this._logger,
     })
 
@@ -49,7 +80,7 @@ export default class ErrorTracking {
     distinctId?: string,
     additionalProperties?: Record<string | number, any>
   ): Promise<EventMessage> {
-    const properties: EventMessage['properties'] = { ...additionalProperties }
+    const properties: EventMessage['properties'] = { ...sanitizeAdditionalProperties(additionalProperties) }
 
     const exceptionProperties = builder.buildFromUnknown(error, hint)
     exceptionProperties.$exception_list = await builder.modifyFrames(exceptionProperties.$exception_list)


### PR DESCRIPTION
### Summary
When passing \Date\ or \Error\ instances in \dditionalProperties\ to \captureException\, they could serialize to unhelpful \[object Object]\ or empty objects \{}\ in the PostHog UI.

### Fix
- Added recursive property sanitizer in error-tracking to format \Date\ instances to ISO 8601 strings (\	oISOString()\) and \Error\ instances to structured objects with \
ame\, \message\, \stack\, and custom properties.

Closes #1977