### PR TITLE
fix(browser): observe dead clicks before synchronous DOM updates

### DIFF
--- a/.changeset/great-colts-sell.md
+++ b/.changeset/great-colts-sell.md
@@ -1,0 +1,5 @@
+---
+"posthog-js": patch
+---
+
+Avoid false dead clicks after synchronous DOM updates in click handlers.

--- a/packages/browser/playwright/mocked/dead-clicks.spec.ts
+++ b/packages/browser/playwright/mocked/dead-clicks.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './utils/posthog-playwright-test-base'
+import { expect, test, WindowWithPostHog } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
 import { pollUntilEventCaptured } from './utils/event-capture-utils'
 
@@ -28,6 +28,88 @@ test.describe('Dead clicks', () => {
         expect(deadClick.properties.$dead_click_scroll_timeout).toBe(false)
         expect(deadClick.properties.$dead_click_mutation_timeout).toBe(false)
         expect(deadClick.properties.$dead_click_absolute_timeout).toBe(true)
+    })
+
+    test('does not report synchronous DOM updates before a window bubble listener as dead clicks', async ({
+        page,
+        context,
+    }) => {
+        await context.addInitScript(() => {
+            window.onclick = () => {
+                const started = performance.now()
+                while (performance.now() - started < 8) {
+                    // Keep the earlier bubble listener busy for a deterministic ordering regression.
+                }
+            }
+        })
+        await start(
+            {
+                ...startOptions,
+                options: { capture_dead_clicks: { mutation_threshold_ms: 300 } },
+            },
+            page,
+            context
+        )
+        await page.waitForFunction(
+            () => !!(window as WindowWithPostHog).posthog?.deadClicksAutocapture?.lazyLoadedDeadClicksAutocapture
+        )
+        await page.evaluate(() => {
+            const button = document.createElement('button')
+            button.id = 'mutating-button'
+            button.textContent = 'Next day'
+            const label = document.createElement('span')
+            label.id = 'mutating-label'
+            label.textContent = 'Day 1'
+            button.onclick = () => {
+                label.textContent = 'Day 2'
+            }
+            document.body.append(button, label)
+        })
+        await page.waitForTimeout(1100)
+        await page.resetCapturedEvents()
+
+        await page.locator('#mutating-button').click()
+        await expect(page.locator('#mutating-label')).toHaveText('Day 2')
+        await page.waitForTimeout(1500)
+        expect((await page.capturedEvents()).filter((event) => event.event === '$dead_click')).toHaveLength(0)
+
+        await page.locator('[data-cy-not-an-order-button]').click()
+        await pollUntilEventCaptured(page, '$dead_click')
+        expect((await page.capturedEvents()).filter((event) => event.event === '$dead_click')).toHaveLength(1)
+    })
+
+    test('stops capturing dead clicks while disabled and captures once after restarting', async ({ page, context }) => {
+        await start(
+            {
+                ...startOptions,
+                options: { capture_dead_clicks: { mutation_threshold_ms: 300 } },
+            },
+            page,
+            context
+        )
+        await page.waitForFunction(
+            () => !!(window as WindowWithPostHog).posthog?.deadClicksAutocapture?.lazyLoadedDeadClicksAutocapture
+        )
+        await page.evaluate(() => {
+            ;(window as WindowWithPostHog).posthog?.set_config({ capture_dead_clicks: false })
+        })
+        await page.waitForTimeout(1100)
+        await page.resetCapturedEvents()
+
+        await page.locator('[data-cy-not-an-order-button]').click()
+        await page.waitForTimeout(1500)
+        expect((await page.capturedEvents()).filter((event) => event.event === '$dead_click')).toHaveLength(0)
+
+        await page.evaluate(() => {
+            const posthog = (window as WindowWithPostHog).posthog
+            posthog?.set_config({ capture_dead_clicks: { mutation_threshold_ms: 300 } })
+            posthog?.set_config({ capture_dead_clicks: false })
+            posthog?.set_config({ capture_dead_clicks: { mutation_threshold_ms: 300 } })
+        })
+        await page.locator('[data-cy-not-an-order-button]').click()
+        await pollUntilEventCaptured(page, '$dead_click')
+        await page.waitForTimeout(1500)
+        expect((await page.capturedEvents()).filter((event) => event.event === '$dead_click')).toHaveLength(1)
     })
 
     test('does not capture a dead click when a fallback observer sees a DOM update', async ({ page, context }) => {

--- a/packages/browser/src/entrypoints/dead-clicks-autocapture.ts
+++ b/packages/browser/src/entrypoints/dead-clicks-autocapture.ts
@@ -217,7 +217,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
     stop() {
         this._mutationObserver?.disconnect()
         this._mutationObserver = undefined
-        assignableWindow.removeEventListener('click', this._onClick)
+        assignableWindow.removeEventListener('click', this._onClick, { capture: true })
         assignableWindow.removeEventListener('mousedown', this._onMouseDown, { capture: true })
         assignableWindow.removeEventListener('mouseup', this._onMouseUp, { capture: true })
         assignableWindow.removeEventListener('mouseout', this._onMouseOut, { capture: true })
@@ -243,7 +243,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
     }
 
     private _startClickObserver() {
-        addEventListener(assignableWindow, 'click', this._onClick)
+        addEventListener(assignableWindow, 'click', this._onClick, { capture: true })
         addEventListener(assignableWindow, 'mousedown', this._onMouseDown, { capture: true })
         addEventListener(assignableWindow, 'mouseup', this._onMouseUp, { capture: true })
         addEventListener(assignableWindow, 'mouseout', this._onMouseOut, { capture: true })


### PR DESCRIPTION
## Why

Closes #4931.

A synchronous click handler can update the DOM and deliver its MutationObserver callback before the detector's window bubble listener creates the click timestamp. The detector then disregards that mutation and emits a false `$dead_click`.

## Scope

- Register `_onClick` in capture phase and remove it with the matching capture option.
- Add Playwright coverage for a synchronous DOM update followed by an earlier window bubble listener that spends 8 ms doing synchronous work. The native observer and clocks are unchanged. A genuinely inert control must still emit exactly one dead click.
- Add a public `set_config` lifecycle regression. Disabled capture emits nothing, and repeated stop/start cycles do not duplicate the next dead click.
- Add a `posthog-js` patch changeset.

## Tradeoffs and blast radius

This changes the listener order in the lazy-loaded dead-click extension. There are no public API, configuration, persisted-state, threshold, or event-schema changes.

Capture phase also observes clicks whose application handlers later stop propagation. That can change candidate and event volume. An isolated browser smoke check covers both a working and an inert control with stopped propagation. An application listener registered earlier on window in capture phase can still run before the detector. This patch stays limited to target/bubble-handler ordering.

## Verification

The regression failed against unchanged upstream code in Chromium with `Expected length: 0` and `Received length: 1`. The page had already displayed `Day 2`.

With only capture-phase registration changed, the ordering test passed and the disabled-capture test failed. Matching the removal option made both pass. This checks that each production change is necessary.

All of these commands passed:

```sh
pnpm build
pnpm lint
pnpm lint:playground
pnpm test:unit --concurrency=2
pnpm test:functional --concurrency=2
cd packages/browser
pnpm exec playwright test playwright/mocked/dead-clicks.spec.ts --project chromium --project firefox --project webkit --workers=3 --retries=0 --reporter=line
```

The browser suite passed all 141 cases without retries. The browser SDK unit suite passed 6,462 tests, with its eight existing skips unchanged. Its functional suite passed all 10 tests. Existing Node/npm configuration warnings remain in the command output.

The additional workstation React Doctor scan reported Opera Mini compatibility findings for `performance.now()` in the Playwright fixture, plus a direct-null-check finding in an unchanged existing test. The fixture runs only in Chromium, Firefox, and WebKit. The repository lint passes, and no suppressions or unrelated edits were added for those findings.

The standalone reproduction from #4931 was also run with the locally compiled extension in an independently launched Chromium browser. No capture-registration interception was enabled:

```text
normal propagation: working UI=Updated content; working dead clicks=0; broken dead clicks=1
stopped propagation: working UI=Updated content; working dead clicks=0; broken dead clicks=1
```

## Release info

- [x] `posthog-js` requires a patch release.
- [x] Ran `pnpm changeset`.

This PR does not claim a production fix. After release, the consuming application's actual downloaded extension must be checked, the reproduction rerun against those bytes, and fresh events inspected. A package version alone does not establish delivery.

## Agent context

**Autonomy:** Human-driven, agent-assisted.

OpenAI coding agent through Oh My Pi, using GitHub CLI, pnpm, and Playwright. The human directed the investigation and authorized this upstream correction. The session contains private application diagnostics and is not published. The public standalone reproduction is in #4931.

The implementation keeps the existing candidate model and corrects observation order rather than adding application auth state, exclusions, or wider thresholds. Human maintainer review is required before merge.
