### PR TITLE
fix(browser): clear register_for_session props when PostHog session rotates

### DIFF
--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -1,4 +1,4 @@
-import { defaultPostHog } from './helpers/posthog-instance'
+import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import type { PostHogConfig } from '../types'
 import { uuidv7 } from '../uuidv7'
 import { SurveyEventName, SurveyEventProperties } from '../posthog-surveys-types'
@@ -611,6 +611,84 @@ describe('posthog core', () => {
             expect(captureSpy).toHaveBeenCalledWith('test-event')
             captureSpy.mockRestore()
             delete (posthog as any).parseInvalidJson
+        })
+    })
+
+    describe('register_for_session()', () => {
+        it('clears session-registered props when PostHog session rotates due to activity timeout', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage' })
+
+            posthog.register_for_session({ link_id: 'abc123', flow: 'signup' })
+            expect(posthog.sessionPersistence?.props['link_id']).toBe('abc123')
+            expect(posthog.sessionPersistence?.props['flow']).toBe('signup')
+
+            // Simulate a session rotation caused by activity timeout
+            const handlers: any[] = []
+            const realOnSessionId = posthog.sessionManager!.onSessionId.bind(posthog.sessionManager)
+            jest.spyOn(posthog.sessionManager!, 'onSessionId').mockImplementation((cb) => {
+                handlers.push(cb)
+                return realOnSessionId(cb)
+            })
+
+            // Fire the change handler directly as if a session timed out
+            ;(posthog as any)._clearSessionRegisteredProps()
+
+            expect(posthog.sessionPersistence?.props['link_id']).toBeUndefined()
+            expect(posthog.sessionPersistence?.props['flow']).toBeUndefined()
+        })
+
+        it('does not clear session-registered props on initial session creation', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage' })
+
+            posthog.register_for_session({ link_id: 'abc123' })
+            expect(posthog.sessionPersistence?.props['link_id']).toBe('abc123')
+
+            // Simulate a session change with noSessionId (first ever session) — should NOT clear
+            const sessionIdChangedHandlers = (posthog.sessionManager as any)._sessionIdChangedHandlers as ((
+                sessionId: string,
+                windowId: string,
+                changeReason: any
+            ) => void)[]
+
+            sessionIdChangedHandlers.forEach((handler) =>
+                handler('new-session-id', 'window-id', {
+                    noSessionId: true,
+                    activityTimeout: false,
+                    sessionPastMaximumLength: false,
+                    crossTabAdoption: false,
+                })
+            )
+
+            // Props should still be present — noSessionId is first-ever init, not a rotation
+            expect(posthog.sessionPersistence?.props['link_id']).toBe('abc123')
+        })
+
+        it('clears only user-registered keys, not system-managed session storage keys', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage' })
+
+            posthog.register_for_session({ my_prop: 'user-value' })
+            // Simulate a system-managed prop being written to sessionPersistence
+            posthog.sessionPersistence?.register({ $referring_domain: 'google.com' })
+
+            ;(posthog as any)._clearSessionRegisteredProps()
+
+            expect(posthog.sessionPersistence?.props['my_prop']).toBeUndefined()
+            // System-managed prop should be untouched
+            expect(posthog.sessionPersistence?.props['$referring_domain']).toBe('google.com')
+        })
+
+        it('removes keys from the tracked set when unregister_for_session is called', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'localStorage' })
+
+            posthog.register_for_session({ link_id: 'abc123', flow: 'signup' })
+            posthog.unregister_for_session('flow')
+
+            ;(posthog as any)._clearSessionRegisteredProps()
+
+            // 'flow' was unregistered before rotation — should already be gone
+            expect(posthog.sessionPersistence?.props['flow']).toBeUndefined()
+            // 'link_id' was still registered — cleared on rotation
+            expect(posthog.sessionPersistence?.props['link_id']).toBeUndefined()
         })
     })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -442,6 +442,8 @@ export class PostHog implements PostHogInterface {
     analyticsDefaultEndpoint: string
     version: string = Config.LIB_VERSION
     _initialPersonProfilesConfig: 'always' | 'never' | 'identified_only' | null
+    // Keys registered via register_for_session — cleared when the PostHog session rotates
+    _sessionRegisteredPropKeys: Set<string> = new Set()
     _cachedPersonProperties: string | null
 
     SentryIntegration: typeof SentryIntegration
@@ -705,6 +707,15 @@ export class PostHog implements PostHogInterface {
         if (!startInCookielessMode) {
             this.sessionManager = new SessionIdManager(this)
             this.sessionPropsManager = new SessionPropsManager(this, this.sessionManager, this.persistence)
+            // Clear user-registered session properties when a new PostHog session starts due to
+            // idle timeout or hitting the max session length. Properties registered via
+            // register_for_session are meant to be session-scoped, but sessionStorage persists
+            // until the browser tab closes — without this they leak into the next session.
+            this.sessionManager.onSessionId((_sessionId, _windowId, changeReason) => {
+                if (changeReason?.activityTimeout || changeReason?.sessionPastMaximumLength) {
+                    this._clearSessionRegisteredProps()
+                }
+            })
         }
 
         // Conditionally defer extension initialization based on config
@@ -1821,6 +1832,7 @@ export class PostHog implements PostHogInterface {
      */
     register_for_session(properties: Properties): void {
         this.sessionPersistence?.register(properties)
+        Object.keys(properties).forEach((key) => this._sessionRegisteredPropKeys.add(key))
     }
 
     /**
@@ -1867,10 +1879,18 @@ export class PostHog implements PostHogInterface {
      */
     unregister_for_session(property: string): void {
         this.sessionPersistence?.unregister(property)
+        this._sessionRegisteredPropKeys.delete(property)
     }
 
     _register_single(prop: string, value: Property) {
         this.register({ [prop]: value })
+    }
+
+    _clearSessionRegisteredProps(): void {
+        this._sessionRegisteredPropKeys.forEach((key) => {
+            this.sessionPersistence?.unregister(key)
+        })
+        this._sessionRegisteredPropKeys.clear()
     }
 
     /**
@@ -2983,6 +3003,7 @@ export class PostHog implements PostHogInterface {
         this.consent.reset()
         this.persistence?.clear()
         this.sessionPersistence?.clear()
+        this._sessionRegisteredPropKeys.clear()
 
         if (!isUndefined(recordingRemoteConfig)) {
             this.persistence?.register({ [SESSION_RECORDING_REMOTE_CONFIG]: recordingRemoteConfig })


### PR DESCRIPTION
## Summary

Properties registered with `register_for_session` are stored in `sessionPersistence` (backed by `sessionStorage`). `sessionStorage` only clears when the browser tab closes — so if PostHog's idle timeout (30 min default) fires, the new `$session_id` is generated but the session-registered props remain and carry over into the next session.

**Fix:** track the keys registered via `register_for_session` in a `_sessionRegisteredPropKeys` Set. When the session manager fires a rotation event (`activityTimeout` or `sessionPastMaximumLength`), unregister only those tracked keys from `sessionPersistence`. System-managed keys (campaign params, referrer) are left untouched since they are re-populated by the capture pipeline anyway.

The set is also cleared on `reset()` since that wipes `sessionPersistence` entirely.

Fixes #3573